### PR TITLE
docs: clarify gnu build status

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -82,11 +82,9 @@ F. GNU Tools (initially for Mac OS X only)
    
 Build directory : build_GNU
 
-Building the Frontier kernel currently requires the Mac OS X Developer
-Tools to be installed on Mac OS X. Older tools using Project Builder, or
-newer tools using Xcode should work, using 'gcc' v3.3. Other versions of
-'gcc' might work, too, but have not been tested (on Mac OS X).
-
+The historical GNU makefiles expect the early Mac OS X developer tools and
+`gcc` 3.x. They have not been updated for the modern headless build, so expect
+setup failures unless you recreate that environment.
 Getting Started
 ---------------
 

--- a/planning/phase1/0.5.10_complete_project_organization.md
+++ b/planning/phase1/0.5.10_complete_project_organization.md
@@ -100,7 +100,7 @@ Frontier/                          # Project root
 
 ### **Build Artifacts** ✅
 - **`build_Xcode_modern/`**: Modern Xcode builds
-- **`build_GNU/`**: GNU/Linux builds
+- **`build_GNU/`**: legacy GNU makefiles (require modernization)
 - **(removed)** `build_VC*`: Legacy Visual Studio projects (pending replacement)
 - **(removed)** `build_CWPro8/`: Metrowerks CodeWarrior project
 


### PR DESCRIPTION
## Summary
- note in docs that the GNU makefiles assume ancient Mac developer tools and are effectively legacy
- update planning entry to mark build_GNU as needing modernization

## Testing
- not run (docs only)