### PR TITLE
feat: auto-migrate system root during CLI load

### DIFF
--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -433,6 +433,14 @@ static boolean load_system_root_database(const char* path) {
         cli_log_error("System root path is empty");
         return false;
     }
+    boolean migrated = false;
+    if (!ensure_database_modern(path, &migrated)) {
+        cli_log_error("Failed to ensure system root is modern: %s", path);
+        return false;
+    }
+    if (migrated) {
+        cli_log_info("Migrated legacy system root to v7 format (backup created): %s", path);
+    }
     if (len > lenbigstring) {
         cli_log_error("System root path exceeds %d characters (got %zu)", lenbigstring, len);
         return false;

--- a/tests/headless_table_stubs.c
+++ b/tests/headless_table_stubs.c
@@ -7,8 +7,6 @@
 
 #ifdef FRONTIER_HEADLESS
 
-#include "tablepack.h"
-
 hdltableformats tableformatsdata = nil;
 
 #if defined(HEADLESS_USE_REAL_TABLEPACK)


### PR DESCRIPTION
## Summary
- call  on  before opening the database
- log when a legacy v6 root is promoted and reuse the existing backup tracking

## Testing
- make -C tests runtime_tests
- tests/runtime_tests