### PR TITLE
Docs: plan Pascal-era data modernization

### DIFF
--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -35,6 +35,7 @@ Change Log
 - Headless Developer Guides: `planning/phase3/DEVELOPER_QUICKSTART_HEADLESS.md`, `planning/phase3/headless_stubbed_behavior_matrix.md`
 - System Verb Bootstrapping & UI Abstraction: `planning/phase3/system_verbs_bootstrap_plan.md`, `planning/phase3/ui_abstraction/`
 - Frontier.root Headless Bring-up & Kernel Glue Integration: `planning/phase3/frontier_root_headless_plan.md`
+- Legacy Pascal Layouts & Modernization: `planning/phase3/pascal_runtime_modernization.md`, `planning/phase3/headless_legacy_table_loader.md`
 - Headless Daemon Vision & Service Core: `planning/phase3/headless_daemon_vision.md`
 
 ## Phase 4 — String & Text Modernization (`planning/phase4/`)

--- a/planning/README.md
+++ b/planning/README.md
@@ -6,10 +6,11 @@ Status
 - Last Updated: 2025-10-12
 - Notes: See `planning/phase_overview.md` for the roadmap and exit criteria.
 
-Related Docs
+-Related Docs
 - `planning/INDEX.md` – quick links into each phase
 - `planning/Frontier_Refactoring_Plan.md` – narrative goals and risks
 - `planning/phase_gates.md` – readiness checks before advancing phases
+- `planning/phase3/pascal_runtime_modernization.md` – Pascal-era data layout modernization roadmap
 
 Change Log
 - 2025-10-12: Reorganized legacy docs into phase subdirectories and refreshed status.

--- a/planning/phase3/headless_legacy_table_loader.md
+++ b/planning/phase3/headless_legacy_table_loader.md
@@ -1,0 +1,28 @@
+# Headless Legacy Table Loader Plan
+
+## Purpose
+Capture the concrete steps required to decode legacy (Pascal-style) table payloads when running the headless Frontier runtime. This document complements the broader `pascal_runtime_modernization.md` note by focusing on the immediate loader work.
+
+## Current status (2025-10-20)
+- Header migration is fixed; `views[0]` now points to the correct root block in `Frontier-v7.root`.
+- Hydration still crashes inside `tableunpacktable` because the payload returned from disk is in the legacy Pascal format rather than the merged-handle layout the modern code expects.
+- A prototype shim in `tableexternal_common.c` can detect legacy payloads and allocate a replacement handle, but the conversion logic is incomplete.
+
+## Short-term goals
+1. **Reverse-engineer the legacy layout**
+   - Document the byte-level structure of `tydisktablerecord` + `tydisksymbolrecord` + Pascal string pool emitted by `hashpacktable`.
+   - Identify how offsets into the string pool are represented (Pascal length byte vs. classic handles).
+2. **Implement a faithful converter**
+   - Build helper routines to parse the legacy block and synthesise correct `hrecords` and `hstrings` buffers.
+   - Reproduce `mergehandles` semantics so the merged handle matches what desktop Frontier would have produced.
+3. **Add diagnostics and tests**
+   - Instrument the conversion with sanity checks (record count, string bounds, sentinel validation).
+   - Add unit/integration coverage that feeds a known legacy block through the converter and into `tableunpacktable`.
+
+## Open questions / future work
+- How many other payload types (menus, outlines, etc.) rely on the same layout? Enumerate once tables are handled.
+- Decide whether to keep the converter headless-only or factor it into a shared migration utility.
+- Once stable, consider writing a one-off tool to normalise existing `.root` files to the modern layout.
+
+*This is a living document; update as the loader prototypes evolve.*
+

--- a/planning/phase3/pascal_runtime_modernization.md
+++ b/planning/phase3/pascal_runtime_modernization.md
@@ -1,0 +1,30 @@
+# Pascal-Era Data Modernization Plan
+
+## Context
+The original Frontier codebase was written for classic Mac OS (68k → PowerPC) and leans heavily on Pascal conventions:
+- Pascal strings (length byte followed by inline data) are ubiquitous in on-disk tables.
+- Many serialized structures are arranged as handle-based blocks (`mergehandles`/`unmergehandles`) rather than the modern "length + payload" buffers we expect today.
+- Database records and table payloads embed Mac-specific layout assumptions (big-endian fields, Pascal string pools, handle offsets) that newer consumers find hard to decode.
+
+Recent work on the headless loader highlighted these issues: while the v6 → v7 header migration now preserves correct pointers, the system table payload is still emitted in the legacy Pascal format. Our quick shim that attempts to reinterpret the payload as a modern merged-handle crashes because the string pool and record offsets follow the classic Pascal contract.
+
+## Why this matters
+- **Correctness:** Until the headless loader can decode the legacy Pascal layout, hydration fails inside `tableunpacktable`.
+- **Maintainability:** Pascal-era assumptions are scattered through `langhash.c`, `tablepack.c`, and friends; without documentation they’re easy to break.
+- **Modernisation path:** Any future format upgrade (UTF-8 strings, little-endian support, streaming) needs a clear translation layer from these legacy constructs.
+
+## Proposed work
+1. **Document the current layout.**
+   - Capture the exact structure of `tydisktablerecord`, `tydisksymbolrecord`, and the Pascal string pool (`hashpacktable` output).
+   - Annotate the headless shim (`tableexternal_common.c`) once the converter is in place so developers know which invariants must hold.
+
+2. **Introduce helper utilities.**
+   - Write shared functions to read/write Pascal strings and classic symbol records, rather than sprinkling byte math throughout the loader.
+   - Add explicit tests that round-trip a legacy table block using these helpers.
+
+3. **Long-term modernization.**
+   - Once the headless loader is stable, plan a dedicated phase to migrate database payloads away from Pascal constructs (e.g., switch to length-prefixed UTF-8, replace handle-based streams with simple buffers).
+   - Provide tooling/scripts to rewrite older `.root` files if we decide to change the on-disk format.
+
+## Immediate next step
+Focus the current headless work on accurately reconstructing the legacy payload (Pascal strings + records) before calling `tableunpacktable`. Track implementation details in `planning/phase3/headless_legacy_table_loader.md` and update the plan as the converter takes shape.


### PR DESCRIPTION
## Summary
- document the Pascal string/handle assumptions we keep running into while decoding legacy tables
- outline short-term tasks (document layout, utilities, tests) and long-term modernization ideas
- link the new plan from ongoing headless loader work so future sessions pick it up

## Testing
- docs-only