### PR TITLE
docs: document headless loader blocker

### DIFF
--- a/planning/phase3/DEVELOPER_QUICKSTART_HEADLESS.md
+++ b/planning/phase3/DEVELOPER_QUICKSTART_HEADLESS.md
@@ -3,8 +3,9 @@
 Status
 - State: In Progress
 - Phase: 1–2
-- Last Updated: 2025-10-12
+- Last Updated: 2025-10-22
 - Notes: Headless tests are green; parser_tests included. CLI builds headless with script execution only (database/network modes pending).
+  Current blocker: legacy `dbrefhandle` still needs the classic address→offset translation so the headless loader can hydrate `system.verbs.builtins` (e.g., pointer `0x00580006` lands inside the block we read, but unpacking still fails).
 
 Related Docs
 - planning/INDEX.md
@@ -13,6 +14,7 @@ Related Docs
 - planning/no_ui_linkage_policy.md
 
 Change Log
+- 2025-10-22: Documented the outstanding headless loader blocker and where to find Codex transcripts.
 - 2025-09-29: Initialized template sections (Status/Related Docs/Change Log).
 
 What You Can Do
@@ -41,6 +43,13 @@ Notes
   - CLI migration flags (`--auto-migrate`, `--query`, etc.) are planned but currently disabled in the headless build.
 - `--system-root` opens the specified database read-only and exits if the system table cannot be loaded; use the sanitized sample under `databases/` for quick testing.
 - Expect warnings about missing legacy tables (`system.misc`, `system.menus`, etc.) when loading the sanitized Frontier.root. The CLI hydrates temporary replacements so scripts still run, but the warnings are a reminder that full migration work remains.
+
+Codex Session Logs
+- Primary archive: `../Frontier-codex-sessions/codex_sessions`. `README.md` in that directory explains the workflow and `current_status.md` + `last_session_tail.txt` summarize the latest investigations.
+- If you do not see the worktree, fetch and attach it locally:
+  - `git fetch origin codex-sessions`
+  - `git worktree add ../Frontier-codex-sessions codex-sessions`
+- Browse online via https://github.com/jsavin/Frontier/tree/codex-sessions/codex_sessions when you only need a quick reference.
 
 Parser Regeneration (Maintainers)
 - You do not need Bison to build. The generated parser C is committed.


### PR DESCRIPTION
## Purpose & Impact
- document the active headless loader blocker in the quickstart so engineers know what to pick up next
- point to the Codex session log archive and instructions for attaching the worktree

## Key Files
- planning/phase3/DEVELOPER_QUICKSTART_HEADLESS.md

## Test Plan
- not applicable (docs only)
