### PR TITLE
fix: ensure header buffer size accommodates both v6 and v7 formats

### DIFF
--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -2469,7 +2469,15 @@ boolean dbopenfile (hdlfilenum fnum, boolean flreadonly) {
 	*/
 
     tydatabaserecord diskrec;
-    unsigned char rawheader[sizeof (tydatabaserecord)];
+    /*
+     * Allocate buffer large enough for both v6 and v7 headers.
+     * We need to read the header before we know which version it is,
+     * so we size the buffer to accommodate whichever is larger.
+     * Currently tydatabaserecord (116 bytes) > tydatabaserecord_64 (88 bytes)
+     * due to larger growthspace despite 64-bit addresses.
+     */
+    #define MAX_HEADER_SIZE (sizeof(tydatabaserecord) > sizeof(tydatabaserecord_64) ? sizeof(tydatabaserecord) : sizeof(tydatabaserecord_64))
+    unsigned char rawheader[MAX_HEADER_SIZE];
     tydatabaserecord_64 diskrec64;
     boolean header_is_modern = false;
     register hdldatabaserecord hdb;


### PR DESCRIPTION
## Summary
Addresses code review feedback from PR #33 regarding potential buffer over-read in database header loading.

## Changes
- Modified `dbopenfile()` in `Common/source/db.c` to use `MAX_HEADER_SIZE` macro
- Ensures `rawheader` buffer is sized to accommodate whichever struct is larger
- Added detailed comment explaining the defensive sizing strategy

## Analysis
While testing showed `tydatabaserecord` (116 bytes) is currently larger than `tydatabaserecord_64` (88 bytes), this defensive change ensures correctness regardless of platform or compiler settings.

## Testing
- ✅ Compiles without errors
- ✅ frontier-cli executes simple expressions correctly
- ✅ System root database loads successfully

## Reference
- Code review: https://github.com/jsavin/Frontier/pull/33#pullrequestreview-3368335163

🤖 Generated with [Claude Code](https://claude.com/claude-code)