### PR TITLE
docs: record v7 migration requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,20 @@ This document is a concise contributor guide for Frontier’s C/C toolchain and 
 - Sanitize for personal data/config before commit (sanitization will be performed by in‑app UserTalk tooling once modern builds run).
 
 ## Agent‑Specific Notes
-- Follow this file’s guidance across the repo; place new cross‑platform code in `portable/` when feasible.
+- Follow this file’s guidance across the repo; place new cross-platform code in `portable/` when feasible.
 - Do not reformat unrelated files; avoid editing generated `build_*` outputs.
 - When adding files, mirror existing naming and include patterns.
+- Always use built-in shell-based tools for debugging on-disk files and formats instead of writing your own code to parse the file. Only write code for this purpose if built-in shell-based utilities are unavailable, and only after asking the user first to install the tool(s) you need.
+- When new technical details surface (format quirks, runtime behavior, etc.), document them immediately in the most relevant markdown reference (e.g., `docs/database_architecture.md`) so future sessions can pick up the thread quickly.
+- <!-- 2025-10-27 Codex --> When touching the database migrator, remember the current implementation only updates the header; ensure follow-up work reserializes tables so migrated roots become fully 64-bit.
 - When starting a new session, ask the user if you should try to pick up from where the previous session ended. If the user says so, you can either do what the user asks, or propose the following: 1) check the README.md, planning docs (in the planning directory), 2) review recent commits to understand where we're at in the project, 3) read the last hundred or so lines of the most recent couple of files in codex_sessions to pick up context from the most recent sessions. If the user tells you to do something different, always follow their guidance instead.
 - If the user or Codex PR Bot says follow-up fixes are already being handled, stop and confirm before making new changes—avoid duplicating or racing their work.
+- In general, avoid creating or maintaining shims that potentially mask underlying issues unless specifically asked to do so by the user.
+- Always run tests before pushing PRs to origin. If you encounter new or unexpected test failures, stop and ask the user what to do.
+- Whenever making changes to code, make sure to summarize the change with a dated comment near the top of the file, attributed to Codex.
+- Frontier’s database allocator (headers/trailers, variance fields, avail list merging) follows the Boundary Tag Method from Knuth’s *The Art of Computer Programming* (per Dave Winer); keep that lineage in mind when debugging allocation logic or documenting format quirks.
 
 ## Sandbox & Approvals
 - Escalation: Always request escalated execution when needed (e.g., writing outside workspace, network access, package installs, GUI commands, or when sandboxing blocks progress).
 - Granting access: If escalation is required, ask the user to run `/approvals` to grant full access so the agent can run tests and necessary build steps.
+- When writing PR descriptions, include three sections: summary of changes (what/why per file or area), a "so what" explaining the impact, and clear next steps if follow-up work is expected.

--- a/docs/database_architecture.md
+++ b/docs/database_architecture.md
@@ -1,4 +1,5 @@
 # Frontier Database Architecture
+<!-- 2025-10-27 Codex: Documented v6→v7 migration constraints and 32-bit payload carry-over. -->
 
 ## Database Structure
 
@@ -146,7 +147,20 @@ When scanning databases:
 When migrating v6→v7:
 1. The minimal root table structure is **correct and expected**
 2. Migration must preserve the external table references
-3. All sub-tables are migrated when their blocks are copied
+3. Legacy payloads store 32-bit `dbaddress` values (and 10-byte `tydisksymbolrecord` entries). Simply copying those bytes forward leaves the migrated root in a “v7 header + v6 body” state that still depends on 32-bit readers.
+4. A true v7 database must be re-serialized with `use_64bit_format == true` so that every external record and table payload widens to 64-bit addresses. This requires loading each table with the legacy reader, flipping the format flag, and saving back through `tableverbpack()`/`hashpacktable()` before writing the new file.
+
+#### Migration Pitfalls (32-bit payloads)
+
+- The sample migrator in `Common/source/db_format.c:874-1054` only writes a new 116-byte header and then copies the remainder of the legacy file byte-for-byte into the v7 output. All block payloads—including `system`, `system.verbs`, and `system.verbs.builtins`—remain 32-bit serialized.
+- Runtime code such as `tableverbunpack()` decides how many bytes to consume based on the global `use_64bit_format` flag (set once the v7 header is seen). When a copied legacy payload arrives, the loader tries to read an 8-byte address, overruns the 4-byte legacy field, and errors out unless additional heuristics patch things up.
+- To avoid accruing more compatibility shims, the migrator must take ownership of widening those payloads. The recommended approach is:
+  1. Load each legacy table/verb through the existing 32-bit readers.
+  2. Set `use_64bit_format = true` before packing.
+  3. Re-pack with `tableverbpack()` or `hashpacktable()` so all nested addresses are emitted as 64-bit values.
+  4. Write the resulting blocks into the new file, ensuring block headers/trailers match their new sizes.
+
+Once this reserialization is in place, no runtime path outside the migrator should need to special-case 32-bit layouts.
 
 ### For CLI/Runtime
 
@@ -156,6 +170,22 @@ When loading databases:
 3. Register top-level table entries in the namespace
 4. Load external tables on-demand as accessed
 5. Register database in `system.temp.databases` (except system root)
+
+### External Table Value Record (v6 Disk Format)
+
+When a v6 table stores a child table (value type 13) the string pool slot referenced by `dataval` encodes the external record:
+
+```
+[u32 length][u16 externaldiskversionnumber][u8 tyexternalid][u8 flags][u32 dbaddress]
+```
+
+- `length` is written by `hashpackexternal()` and covers the remaining payload bytes.
+- `externaldiskversionnumber` is currently `1`.
+- `tyexternalid` identifies the processor (`idtableprocessor` = `3` for table values).
+- `flags` is the on-disk copy of the `tyexternalvariable` bitfield (`flinmemory`, `flpacked`, `flsystemtable`, etc.). Frontier does not clear these bits before persisting the record, so whatever combination was active during save is recorded verbatim.
+- `dbaddress` is the big-endian address of the child table block that `tableverbpack()` appended after the header.
+
+At load time `langexternalunpack()` consumes the version/id pair, ignores the flag byte, and passes the address to `tableverbunpack()` which rehydrates the child table.
 
 ## Scanner Findings Re-Interpreted
 

--- a/docs/legacy_frontier_bootstrap.md
+++ b/docs/legacy_frontier_bootstrap.md
@@ -1,4 +1,5 @@
 # Legacy Frontier Bootstrap
+<!-- 2025-10-27 Codex: Added 64-bit migration notes for persisted tables. -->
 
 ## Purpose
 - Capture the sequence the classic Frontier desktop application follows to initialise the language runtime, hydrate the persisted object database, and expose the `system.verbs.builtins` glue that forwards into the kernel.
@@ -131,3 +132,8 @@ This conversion allows both v6 and v7 databases to load correctly in the headles
 - Runtime linking: `Common/source/tablestructure.c:233`
 - Startup scripts: `Common/source/scripts.c:675`
 - Kernel dispatch: `Common/source/langstartup.c:188`, `Common/source/langverbs.c:3562`, `Common/source/langvalue.c:7488`
+
+## Migration Considerations (2025-10-27 Codex)
+- `Common/source/db_format.c:migrate_32bit_to_64bit()` currently rewrites only the database header (bumping it to version 7) and streams the remainder of the v6 file into the output unchanged. The resulting root keeps every table payload in the legacy 32-bit layout.
+- Once the runtime sees the v7 header it enables `use_64bit_format`, so routines like `tableverbunpack()` expect 8-byte `dbaddress` fields. When they encounter copied 4-byte payloads they spill past the record unless patched with ad hoc fallbacks.
+- The long-term fix is to have the migrator load each legacy table, flip `use_64bit_format = true`, and save it back via `tableverbpack()`/`hashpacktable()` before writing it to the new file. That emits widened addresses, refreshed block sizes, and lets the CLI/runtime operate without special cases for migrated roots.


### PR DESCRIPTION
## Summary
- capture newly discovered v6→v7 migration gap in docs/database_architecture.md, including how legacy payloads encode external tables and why header-only migrations fail
- add matching note in docs/legacy_frontier_bootstrap.md so future headless work mirrors legacy behaviour without relying on 32-bit shims
- remind future agents via AGENTS.md to document discoveries and to reserialize tables when touching the migrator

## Why
Teams kept assuming the shipped v7 roots were fully modern, but the migrator still copies 32-bit payloads. Documenting the pitfall now prevents future debugging churn and gives clear guidance before we rework the migrator.

## Next Steps
- Finish the new migrator implementation that reserializes tables under use_64bit_format once the build issues are resolved
- Add regression tests that verify migrated roots contain 64-bit addresses (e.g., system.verbs) and rerun CLI glue verb checks