### PR TITLE
docs: establish carbon migration plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Common/MySQL/
 .mcp/
 node_modules/
 dist/
+.obsidian/

--- a/planning/INDEX.md
+++ b/planning/INDEX.md
@@ -1,10 +1,10 @@
 # Planning Index
 
 Status
-- State: In Progress
-- Phases: Foundations → Architecture → Headless Runtime → Text Modernization → Tooling
-- Last Updated: 2025-10-12
-- Notes: Headless runtime is operational; CLI build/linking cleanup remains. UTF-8 migration planning queued after headless stabilization.
+- State: Carbon Migration In Progress
+- Current Workstream: [Carbon Dependency Retirement](carbon_migration/README.md)
+- Last Updated: 2025-10-29
+- Notes: We pivoted to removing all Carbon-era dependencies. Older phase docs remain for historical context but are superseded by the Carbon plan.
 
 Purpose
 - Provide a single entry point to the phase directories and the most relevant planning documents.
@@ -14,8 +14,10 @@ Related Docs
 - planning/Frontier_Refactoring_Plan.md
 - planning/phase_gates.md
 - planning/DECISIONS.md
+- planning/carbon_migration/README.md *(current plan)*
 
 Change Log
+- 2025-10-29: Added Carbon migration plan and redirected status/index content to the new workstream.
 - 2025-10-12: Reorganized planning materials by phase and refreshed cross-links.
 
 ## Phase 1 — Foundations & Toolchain (`planning/phase1/`)
@@ -25,11 +27,13 @@ Change Log
 - QuickTime & Legacy Cleanup: `planning/phase1/0.4.6_quicktime_elimination_plan.md`
 
 ## Phase 2 — Core Architecture & Database (`planning/phase2/`)
+> **Historical context:** active work has moved to [Carbon Migration](carbon_migration/README.md). Phase 2 docs remain for reference only.
 - Database Versioning & Paths: `planning/phase2/0.5.14_database_versioning_strategy.md`, `planning/phase2/database_path_canonicalization.md`
 - 64-bit Data Structure Plan & Execution: `planning/phase2/0.5.15_64bit_data_structure_analysis.md`, `planning/phase2/0.5.19_phase1_migration_implementation_complete.md`
 - Portable Handle Runtime: `planning/phase2/0.5.21_portable_handle_runtime.md`
 
 ## Phase 3 — Headless Runtime & Automation (`planning/phase3/`)
+> **Historical context:** active work has moved to [Carbon Migration](carbon_migration/README.md). Phase 3 docs remain for reference only.
 - CLI Execution Plan & Summary: `planning/phase3/1.0_phase1_cli_implementation_plan.md`, `planning/phase3/1.1_phase1_implementation_summary.md`
 - Runtime Test Plan: `planning/phase3/0.5.23_runtime_test_plan.md`
 - Headless Developer Guides: `planning/phase3/DEVELOPER_QUICKSTART_HEADLESS.md`, `planning/phase3/headless_stubbed_behavior_matrix.md`
@@ -59,6 +63,6 @@ Change Log
 - Headless/Tests: `planning/phase3/DEVELOPER_QUICKSTART_HEADLESS.md`
 
 ## Next Steps (High Level)
-1. Complete CLI build/linking cleanup and extend coverage toward the headless service core (Phase 3/3b).
-2. Finalize UTF-8 migration work breakdown (Phase 4).
-3. Schedule parser/Bison upgrades once UTF-8/text modernization milestones are stable (Phase 5).
+1. Finish the documentation pivot (update/deprecate older Phase 2/3 docs, keep `_CURRENT_STATUS.md` synced).
+2. Execute Phase 1 of the Carbon plan (header hygiene so portable builds preprocess cleanly).
+3. Begin runtime modernization (remove remaining Carbon helpers in `langhash.c`, `strings.c`, `memory.c`) per `carbon_migration/phases.md`.

--- a/planning/_CURRENT_STATUS.md
+++ b/planning/_CURRENT_STATUS.md
@@ -1,38 +1,37 @@
-# Frontier Database Format Investigation - Current Status
+# Carbon Migration – Current Status
 
-**Last Updated**: October 27, 2025 (Headless System work queue) <!-- 2025-10-27 Codex: refreshed status -->
-**Branch**: feature/headless-system-bootstrap
-**Session ID**: 019a2490-f65d-7861-b9c6-a6718394c2e8 <!-- 2025-10-27 Codex: captured current Codex session -->
+**Last Updated**: October 29, 2025  \
+**Branches in flight**: `feature/carbon-migration-plan`, `feature/headless-system-bootstrap`
 
-## Updated Plan — October 25, 2025
+## Updated Plan — October 29, 2025
 
-1. **Scanner & Docs (done)**: Documented that the 442-byte block at `views[0]` is a serialized Cancoon/About record and taught the scanner to follow its `adrroottable`. Helper script `scripts/dump_tables.py` enumerates actual modern blocks for debugging.
-2. **Next Work Items**:
-   - Re‑audit the v6→v7 migration path now that we can reliably read the v6 roots. Verify block copying and format conversion are lossless.
-   - Resume headless runtime work: load the v7 Frontier.root, bring the system table online, and ensure glue scripts can call through to our kernel implementations.
-   - Preserve Cancoon state for future UI re‑hosting (tracked in `planning/TODO_future_improvements.md`).
+We pivoted from incremental shims to a comprehensive Carbon-dependency retirement. The canonical plan now lives under [`planning/carbon_migration/`](carbon_migration/README.md).
 
-## Longer-Term Goals
-- Lock in the v6→v7 migration (Phase 1/Phase 2 deliverables) with automated verification once the parser is stable.
-- Complete headless runtime parity so server deployments can run without GUI dependencies while still exposing necessary UI state (About/Cancoon, msg log, agent status) through new channels.
-- Phase 3+ work: database hash-table modernization, headless CLI improvements, and eventual UI layer re-host.
+1. **Planning skeleton (done)**: Created the Carbon migration directory with README, inventory, phases, decision log, and status log.
+2. **Doc refresh (in progress)**: Update status/index pages and mark older Phase 2/3 docs as superseded so contributors land on the new plan.
+3. **Execution phases**: See [`carbon_migration/phases.md`](carbon_migration/phases.md) for subsystem milestones (header hygiene → runtime primitives → encoding → AppleEvents → cleanup).
 
-## Quick Status — October 28, 2025
-- Replaced the test-only file stubs with a shared stdio-backed implementation (`tests/headless_mac_compat.c`), so `openfile`/`fileseteof`/`headless_readline` now behave like the desktop code during migrations and CLI runs.
-- Trimmed the `test_migration` build to use the canonical language/runtime sources (no `FRONTIER_PORTABLE` or stubbed hash/runtime files), exposing the real symbol gaps we still need to solve.
-- Added portable guards in `osincludes_portable.h` for AppleEvents, Components, FSRefs, etc., letting headless builds consume Carbon-dependent headers without extra shims.
-- `langhash.c` compiles further under headless but now fails on a handful of legacy helpers (`getstringlist`, `recttodiskrect`, `rgbtodiskrgb`, `dtox80`, etc.). We need targeted replacements or feature gates before the portable tests link again.
+## Longer-Term Goal
+Run Frontier without any Classic Mac / Carbon APIs while keeping the headless and desktop builds unified. Completing the Carbon plan is now the primary Phase 3 objective.
 
-## Progress — October 26, 2025
-- `tests/db_format_tests` builds/runs cleanly, and a lightweight harness built from `Common/source/db_format.c` successfully migrated `databases/test.root` and `databases/Frontier-v6.root` into `<base>-v7.root`, both of which scan correctly via `scripts/scan_database_types.py`.
-- `tests/runtime_tests` now runs in the headless portable configuration (after extending the stub set with `dbnormalizeaddress`), exercising `langrunstringnoerror`, constant evaluation, OPML round-trips, and serializer round-trips—confirming kernel verbs execute end-to-end in headless mode.
-- `frontier-cli --system-root databases/Frontier-v6.root -e "3 + 4"` brings the runtime up and executes scripts; however, glue lookups such as `clock.now()` still fail because the migrated system table is missing key subtables/built-ins (`system.verbs.builtins` never materializes after `settablestructureglobals`). We removed the old “auto-hydrate” fallback to avoid masking this bug.
+## Quick Status — October 29, 2025
+- Headless build still fails when linking `langhash.c` and `strings.c` because Carbon-era helpers (`TEC*`, AppleEvents, alias manager) remain. The failures are recorded in the [inventory](carbon_migration/inventory.md).
+- Portable headers (`osincludes_portable.h`, `standard_portable.h`) were expanded, but need further work to cover extended float, TEC APIs, and AE constants.
+- Planning documents have been restructured; `_CURRENT_STATUS.md` now tracks the Carbon migration rather than the earlier v6→v7 database effort.
 
-## Immediate Next Steps (migration focus)
-1. ✅ **Doc & guidance updates** – AGENTS.md and docs now capture the v6→v7 gap and PR template requirements.
-2. ✅ **Portable header prep** – refactored `portable/*` headers and shared includes so Carbon vs portable typedef collisions are largely resolved.
-3. ✅ **Finish portable file I/O shims** – stdio-backed file routines now live in `tests/headless_mac_compat.c`, and the test harness links against the real implementations.
-4. ⏳ **Validate serialized output**: after the build is green, diff `system`/`system.verbs` blocks between v6 and migrated v7 to confirm 64-bit addresses and record sizes.
-5. 🔄 **Unblock headless `langhash` build**: provide portable equivalents or guards for `getstringlist`, rect/RGB packing helpers, and other legacy glue so `test_migration` can compile end-to-end again.
-6. ⏳ **Re-run headless CLI checks** (`defined(system.verbs)`, `clock.now()`) against the freshly migrated root; capture results and clean up instrumentation once stable.
-7. ⏳ **Add regression coverage** in migration/component tests to assert widened addresses so header-only regressions are caught automatically.
+## Progress Snapshot
+- ✅ Added stdio-backed file layer shared by headless tests/CLI (eliminated legacy file stubs).
+- ✅ Seeded Carbon migration plan, inventory, and decision log.
+- 🔄 Working on header hygiene: ensuring `frontier.h` and related headers bring in the correct portable definitions.
+
+## Immediate Next Steps
+1. **Docs** (TPM/Assistant):
+   - Update `planning/INDEX.md` to highlight the Carbon migration plan.
+   - Add deprecation banners to the relevant `planning/phase2/` and `planning/phase3/` docs so readers follow the new plan.
+2. **Header hygiene** (Assistant):
+   - Finish wiring `frontier.h`/`standard.h` to use portable equivalents under `FRONTIER_HEADLESS`.
+   - Extend `standard_portable.h` and `osincludes_portable.h` until the portable build no longer complains about missing typedefs/macros (per `inventory.md`).
+3. **Validation** (Assistant):
+   - Re-run `make -C tests test_migration` after header fixes; log results in `planning/carbon_migration/status_log.md`.
+
+Progress and blockers should continue to be logged in the Carbon migration status log and decisions documented in the decision log.

--- a/planning/carbon_migration/README.md
+++ b/planning/carbon_migration/README.md
@@ -1,0 +1,41 @@
+# Carbon Dependency Retirement Plan
+
+**Last updated:** 2025-10-29  \
+**Maintainers:** @you (TPM), @assistant (implementation)
+
+## Why this plan exists
+Frontier’s headless/runtime work keeps tripping over pockets of Classic Mac OS / Carbon APIs (QuickDraw, AppleEvents, TEC, Moveable Handles, etc.). Incremental shims slowed us down. The new directive is simple: **remove all Carbon dependencies and replace them with modern, platform-neutral code**. This document is the authoritative plan for that migration.
+
+## Objectives
+- Eliminate every Carbon-era header, macro, and API from the core build (headless and desktop).
+- Provide modern equivalents (or deliberate removals) for each feature so the runtime still functions.
+- Keep the project buildable throughout the migration by landing work in small, reviewable slices.
+- Document every major decision so we never revisit the same debate.
+
+## Scope
+In scope:
+1. Core runtime (language engine, database, serializer, CLI/tooling).
+2. Shared headers that currently define Carbon shims (`standard.h`, `langhash.c`, `strings.c`, `land.h`, etc.).
+3. Tests and utilities that rely on classic APIs.
+
+Out of scope (for now):
+- UI re-hosting (we can stub UI entry points while we modernize backend code).
+- Non-macOS platform quirks (unless they block Carbon removal directly).
+
+## Guiding principles
+- **No more bandaids.** Either refactor to a modern abstraction or remove the feature entirely.
+- **One subsystem at a time.** Each milestone should target a coherent area (strings, AppleEvents, QuickDraw, etc.) and leave it Carbon-free.
+- **Test before celebrate.** The portable/headless build (`make -C tests test_migration`, runtime smoke tests) must pass before we call a milestone done.
+- **Document decisions.** Use `decision_log.md` for every notable call (e.g., “replace TEC with ICU-lite helper”).
+
+## How we measure progress
+- `inventory.md` tracks every known offending symbol/header. Rows move from "pending" → "in progress" → "removed".
+- `phases.md` describes the execution order for subsystems and links to the commits/PRs that completed each phase.
+- `_CURRENT_STATUS.md` (at `planning/_CURRENT_STATUS.md`) provides the high-level status we report upstream.
+- `status_log.md` records dated check-ins so anyone can reconstruct the history quickly.
+
+## Links
+- [Inventory](inventory.md)
+- [Phases](phases.md)
+- [Decision log](decision_log.md)
+- [Status log](status_log.md)

--- a/planning/carbon_migration/decision_log.md
+++ b/planning/carbon_migration/decision_log.md
@@ -1,0 +1,13 @@
+# Carbon Migration Decision Log
+
+Use this log to capture the "why" behind major choices. When you add an entry, include:
+- **Date** (YYYY-MM-DD)
+- **What changed**
+- **Why we chose this path**
+- **Follow-up actions (if any)**
+
+| Date | Decision | Rationale | Follow-up |
+| --- | --- | --- | --- |
+| 2025-10-29 | Pivot from incremental shims to full Carbon removal. | Incremental approach kept stalling headless work; committing to abolition provides a clear finish line. | Create plan (`README`, `inventory`, `phases`) and align status docs. |
+
+Add new rows as we make notable calls (e.g., “drop alias support”, “reuse ICU for encoding”).

--- a/planning/carbon_migration/inventory.md
+++ b/planning/carbon_migration/inventory.md
@@ -1,0 +1,18 @@
+# Carbon Dependency Inventory
+
+This table tracks every remaining classic Mac / Carbon dependency we must eliminate. When you start work on an item, flip its status to `in-progress`; once removed (or replaced with modern equivalents), mark it `done` and link to the PR/commit.
+
+| Area | Symbol / Header | Usage (examples) | Owner | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| QuickDraw handles | `RgnHandle`, `ControlHandle`, `MenuHandle`, `GrafPtr`, `Rect` macros | `quickdraw.h`, `langhash.c`, UI shells | @assistant | pending | Replace with portable structs or guard under desktop-only code. |
+| Moveable handles | `Ptr`, `Handle`, `NewHandle`, `MemError`, `MaxBlock` | `memory.c`, `portable_handles.h` | @assistant | in-progress | Portable handle layer exists; finish swapping consumers to modern APIs. |
+| AppleEvents / AE utils | `AEDesc`, `AERecord`, `TargetID`, `DescType`, AE creation helpers | `langhash.c`, `land.h`, `processinternal.h` | @assistant | pending | Need headless-compatible serialization or removal. |
+| Text Encoding Converter | `TECCountAvailableTextEncodings`, `TECConvertText`, `kCFStringEncodingUTF8` | `strings.c` | @assistant | pending | Replace with portable UTF-8 conversions. |
+| Alias manager | `AliasHandle`, `aliastofilespec`, `filespecsize` | `langhash.c`, `langsystem7.c` | @assistant | pending | Decide whether to support aliases or strip feature. |
+| Resource manager | `GetString`, `Str255` resource tables | `strings.c`, `langhash.c` | @assistant | pending | Replace with internal tables or data files. |
+| QuickDraw geometry helpers | `recttodiskrect`, `diskrecttorect`, `rgbtodiskrgb` | `langhash.c`, `quickdraw.c` | @assistant | in-progress | Portable macros exist; ensure prototypes exported in headless build. |
+| Classic constants/macros | `chnul`, `chspace`, `isnumeric`, `ctdirections` | `strings.c`, `standard.h` | @assistant | in-progress | Ensure portable header defines these for headless build. |
+| Extended float helpers | `dtox80`, `x80tod`, `safeldtox80` | `langhash.c`, `langpack.c`, `FastTimes.c` | @assistant | pending | Evaluate whether we still need 80-bit support; otherwise convert to double. |
+| `land.h` dependencies | `typeChar`, `typeAlias`, `typeRGBColor`, etc. | `land.h`, AppleEvent glue | @assistant | pending | Replace with desktop-only build or new abstractions. |
+
+> Add new rows whenever we discover another dependency. If you are unsure whether something is "Carbon", log it here and we will decide in the `decision_log.md`.

--- a/planning/carbon_migration/phases.md
+++ b/planning/carbon_migration/phases.md
@@ -1,0 +1,34 @@
+# Carbon Migration Phases
+
+Each phase delivers a reviewable chunk of work that leaves the tree compiling (and tests passing) in the headless configuration. Phases can overlap if needed, but try to land them sequentially so reviews stay focused.
+
+## Phase 0 – Planning (✅)
+- Publish this plan (`README.md`, `inventory.md`, `decision_log.md`, `status_log.md`).
+- Update `_CURRENT_STATUS.md` and `planning/INDEX.md` to point at the new workstream.
+
+## Phase 1 – Header hygiene
+- Ensure `frontier.h` pulls the correct portable headers when `FRONTIER_HEADLESS` is defined.
+- Expand `osincludes_portable.h`/`standard_portable.h` until the portable build compiles through preprocessing (no missing typedefs/macros).
+- Update existing phase docs with deprecation notices directing readers to this plan.
+
+## Phase 2 – Runtime primitives
+- Replace remaining Moveable Handle helpers (`MemError`, `MaxBlock`, direct Handle APIs) with portable equivalents.
+- Remove QuickDraw geometry helpers (`recttodiskrect` etc.) or provide platform-neutral implementations.
+- Verify `tests/test_migration` links without Carbon stubs.
+
+## Phase 3 – Text encoding & strings
+- Remove TEC dependencies by providing UTF-8/UTF-16 converters in portable code.
+- Replace `GetString`/Resource Manager calls with table-driven or file-based lookups.
+- Ensure `strings.c` compiles without Classic constants.
+
+## Phase 4 – AppleEvent/Alias removal
+- Refactor `langhash.c` and friends to avoid AppleEvent descriptor structs in headless mode.
+- Decide whether to keep alias support; if yes, provide cross-platform implementation.
+- Remove remaining references to `land.h` structs from headless build path.
+
+## Phase 5 – Cleanup & validation
+- Sweep for dead headers/includes (drop `frontier_compat.h` once unused).
+- Re-run full test matrix (portable + desktop) to ensure no regressions.
+- Archive this plan with a final summary in `status_log.md` and `_CURRENT_STATUS.md`.
+
+> We may add more phases as we discover new clusters of Carbon code. When that happens, update this file and record the decision in `decision_log.md`.

--- a/planning/carbon_migration/status_log.md
+++ b/planning/carbon_migration/status_log.md
@@ -1,0 +1,10 @@
+# Carbon Migration Status Log
+
+Chronological breadcrumbs for this project. Add an entry whenever we complete a meaningful milestone (phase finished, major PR merged, blocker discovered, etc.). Keep entries short and link to PRs when available.
+
+## 2025-10-29
+- Created Carbon migration plan (`planning/carbon_migration/`).
+- Updated status/index docs to point at the new workstream.
+- Inventory seeded from current headless build failures.
+
+<!-- Add newest entries to the top -->

--- a/planning/phase2/0.5.19_phase1_migration_implementation_complete.md
+++ b/planning/phase2/0.5.19_phase1_migration_implementation_complete.md
@@ -1,6 +1,8 @@
 # Phase 1: 64-bit Database Migration - Implementation Complete
 <!-- 2025-10-27 Codex: Added notes about outstanding payload reserialization work. -->
 
+> **Historical Note:** Active migration planning now lives in [planning/carbon_migration/README.md](../carbon_migration/README.md). This page is archived for context.
+
 Status
 - State: Completed
 - Phase: Unknown

--- a/planning/phase3/README.md
+++ b/planning/phase3/README.md
@@ -1,5 +1,7 @@
 # Phase 3 Planning
 
+> **Historical Note:** Phase 3 materials are archived. The active modernization plan is in [planning/carbon_migration/README.md](../carbon_migration/README.md).
+
 Use this folder for Phase 3 proposals, implementation plans, and progress notes. Keeping phase-specific documents grouped makes it easier to track execution across the roadmap.
 
 Key references:

--- a/planning/phase3/langhash_portable_missing_types.md
+++ b/planning/phase3/langhash_portable_missing_types.md
@@ -1,5 +1,7 @@
 # Headless `langhash.c` Dependency Inventory
 
+> **Superseded:** Tracking for these dependencies has moved to [planning/carbon_migration/inventory.md](../carbon_migration/inventory.md). Keep this page for archival notes only.
+
 **Last reviewed**: 2025-10-28  
 
 **Context**: Building `langhash.c` inside the headless/portable toolchain now pulls in the *real* language/runtime sources (no stubbed replacements). The current build stops with unresolved symbols and legacy QuickDraw/AE helpers that the portable layer does not yet expose. This note captures every missing type or helper reported by the compiler, along with what each symbol does in the classic build and what we likely need on the headless side.


### PR DESCRIPTION
## Summary
- add `planning/carbon_migration/` as the canonical Carbon dependency retirement plan (README, inventory, phases, decision log, status log)
- refresh `_CURRENT_STATUS.md` and `planning/INDEX.md` to pivot to the Carbon plan; mark older Phase 2/3 docs as historical context with pointers to the new location
- tweak `.gitignore` to ignore `.obsidian/` artifacts

## Testing
- docs only
