### PR TITLE
feat: make v7 block metadata big-endian

### DIFF
--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -1,9 +1,13 @@
+// 2025-11-20 Codex: Add shared big-endian helpers and a serializer for v7 headers to keep disk format portable.
 /*
  * db_format.h - Helpers for detecting and migrating Frontier database headers.
  */
 
 #ifndef FRONTIER_DB_FORMAT_H
 #define FRONTIER_DB_FORMAT_H
+
+#include <stdint.h>
+#include <stddef.h>
 
 #include "db.h"
 
@@ -15,9 +19,62 @@ extern boolean use_64bit_format;
 
 #define LEGACY_DB_HEADER_BYTES 88
 
+static inline uint16_t db_format_read_be16(const unsigned char *p) {
+    return (uint16_t) ((p[0] << 8) | p[1]);
+}
+
+static inline uint32_t db_format_read_be32(const unsigned char *p) {
+    return ((uint32_t) p[0] << 24) |
+           ((uint32_t) p[1] << 16) |
+           ((uint32_t) p[2] << 8)  |
+            (uint32_t) p[3];
+}
+
+static inline uint64_t db_format_read_be64(const unsigned char *p) {
+    return ((uint64_t) p[0] << 56) |
+           ((uint64_t) p[1] << 48) |
+           ((uint64_t) p[2] << 40) |
+           ((uint64_t) p[3] << 32) |
+           ((uint64_t) p[4] << 24) |
+           ((uint64_t) p[5] << 16) |
+           ((uint64_t) p[6] << 8)  |
+            (uint64_t) p[7];
+}
+
+static inline void db_format_write_be16(void *ptr, uint16_t value) {
+    unsigned char *p = (unsigned char *) ptr;
+    p[0] = (unsigned char) ((value >> 8) & 0xFF);
+    p[1] = (unsigned char) (value & 0xFF);
+}
+
+static inline void db_format_write_be32(void *ptr, uint32_t value) {
+    unsigned char *p = (unsigned char *) ptr;
+    p[0] = (unsigned char) ((value >> 24) & 0xFF);
+    p[1] = (unsigned char) ((value >> 16) & 0xFF);
+    p[2] = (unsigned char) ((value >> 8) & 0xFF);
+    p[3] = (unsigned char) (value & 0xFF);
+}
+
+static inline void db_format_write_be64(void *ptr, uint64_t value) {
+    unsigned char *p = (unsigned char *) ptr;
+    p[0] = (unsigned char) ((value >> 56) & 0xFF);
+    p[1] = (unsigned char) ((value >> 48) & 0xFF);
+    p[2] = (unsigned char) ((value >> 40) & 0xFF);
+    p[3] = (unsigned char) ((value >> 32) & 0xFF);
+    p[4] = (unsigned char) ((value >> 24) & 0xFF);
+    p[5] = (unsigned char) ((value >> 16) & 0xFF);
+    p[6] = (unsigned char) ((value >> 8) & 0xFF);
+    p[7] = (unsigned char) (value & 0xFF);
+}
+
+static inline void db_format_write_dbaddress64(void *ptr, dbaddress value) {
+    db_format_write_be64(ptr, (uint64_t) value);
+}
+
 boolean db_format_prepare_runtime(void);
 boolean detect_database_format(const tydatabaserecord *header);
 boolean convert_32bit_header_to_64bit(const unsigned char *legacy_header, tydatabaserecord_64 *new_header);
+boolean db_format_write_header64(const tydatabaserecord_64 *src, unsigned char *dest, size_t dest_size);
 boolean create_root_backup(const char *original_path);
 boolean migrate_32bit_to_64bit(const char *db_path);
 boolean ensure_database_modern(const char *db_path, boolean *migrated, char *output_path, size_t output_path_size);

--- a/Common/headers/dbinternal.h
+++ b/Common/headers/dbinternal.h
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 
+// 2025-11-23 Codex: Added 64-bit block header/trailer layout for v7 roots; legacy sizes remain for v6.
 
 #define SMART_DB_OPENING	1
 //#undef SMART_DB_OPENING
@@ -55,8 +56,6 @@
 
 
 #define minblocksize 32L
-#define sizeheader (long)sizeof(tyheader)
-#define sizetrailer (long)sizeof(tytrailer)
 #define firstphysicaladdress (long)sizeof(tydatabaserecord)
 
 
@@ -68,23 +67,47 @@ typedef enum {
 typedef int32_t tyvariance;
 
 #pragma pack(2)
-typedef struct tysizefreeword {
+typedef struct tysizefreeword32 {
 	int32_t size;
-	} tysizefreeword;
+	} tysizefreeword32;
+
+typedef struct tysizefreeword64 {
+	int64_t size;
+	} tysizefreeword64;
 
 
-typedef struct tyheader {
+typedef struct tyheader32 {
 
-	tysizefreeword sizefreeword;
+	tysizefreeword32 sizefreeword;
 	
 	tyvariance variance;
-	} tyheader, *ptrheader, **hdlheader;
+	} tyheader32, *ptrheader32, **hdlheader32;
 	
-	
-typedef struct tytrailer {
+typedef struct tyheader64 {
 
-	tysizefreeword sizefreeword;
-	} tytrailer, *ptrtrailer, **hdltrailer;
+	tysizefreeword64 sizefreeword;
+	
+	tyvariance variance;
+	} tyheader64, *ptrheader64, **hdlheader64;
+	
+typedef struct tytrailer32 {
+
+	tysizefreeword32 sizefreeword;
+	} tytrailer32, *ptrtrailer32, **hdltrailer32;
+
+typedef struct tytrailer64 {
+
+	tysizefreeword64 sizefreeword;
+	} tytrailer64, *ptrtrailer64, **hdltrailer64;
+
+extern boolean use_64bit_format;
+
+#define sizeheader_v6 (long) sizeof (tyheader32)
+#define sizeheader_v7 (long) sizeof (tyheader64)
+#define sizetrailer_v6 (long) sizeof (tytrailer32)
+#define sizetrailer_v7 (long) sizeof (tytrailer64)
+#define sizeheader (use_64bit_format ? sizeheader_v7 : sizeheader_v6)
+#define sizetrailer (use_64bit_format ? sizetrailer_v7 : sizetrailer_v6)
 
 
 #define dbshadow
@@ -107,4 +130,3 @@ extern boolean dbreadtrailer (dbaddress, boolean *, long *);
 extern boolean dbreadheader (dbaddress, boolean *, long *, tyvariance *);
 
 extern boolean dbreadavailnode (dbaddress, boolean *, long *, dbaddress *);
-

--- a/Common/headers/dbinternal.h
+++ b/Common/headers/dbinternal.h
@@ -115,8 +115,8 @@ extern boolean use_64bit_format;
 typedef struct availnodeshadow {
 	
 	dbaddress adr;
-	
-	long size;
+
+	int64_t size;
 	// next record in this array is the next free block
 	} tyavailnodeshadow, ** hdlavaillistshadow;
 #pragma options align=reset

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -1077,10 +1077,10 @@ static boolean dbreadshadowavaillist (void) {
 		for (ix = 0; ix < ct; ix++) {
 			if (use_64bit_format) {
 				p[ix].adr = (dbaddress) db_format_read_be64((unsigned char *) &p[ix].adr);
-				p[ix].size = (long) db_format_read_be64((unsigned char *) &p[ix].size);
+				p[ix].size = (int64_t) db_format_read_be64((unsigned char *) &p[ix].size);
 			} else {
 				p[ix].adr = (dbaddress) db_format_read_be32((unsigned char *) &p[ix].adr);
-				p[ix].size = (long) db_format_read_be32((unsigned char *) &p[ix].size);
+				p[ix].size = (int64_t) db_format_read_be32((unsigned char *) &p[ix].size);
 			}
 		}
 	}
@@ -1157,9 +1157,10 @@ static boolean dbshadowavaillist (void) {
 	
 	while (availrec.adr != nildbaddress) {
 		
-		if (!dbreadavailnode (availrec.adr, &flfree, &availrec.size, &nextavail) ||
+		long avail_size = 0;
+		if (!dbreadavailnode (availrec.adr, &flfree, &avail_size, &nextavail) ||
 			!flfree ||
-			availrec.adr + availrec.size > dbeof) {
+			availrec.adr + avail_size > dbeof) {
 
 			availrec.adr = nildbaddress;
 			
@@ -1168,6 +1169,7 @@ static boolean dbshadowavaillist (void) {
 			break;
 			}
 		
+		availrec.size = (int64_t) avail_size;
 		if (!writehandlestream (&s, &availrec, sizeof (availrec)))
 			goto error;
 		
@@ -1200,8 +1202,7 @@ static boolean dbinsertavailshadow (long ixshadow, dbaddress adr, long ctbytes) 
 	assert ((ixshadow >= 0) && (ixshadow <= s.eof / (long) sizeof (tyavailnodeshadow)));
 	
 	avail.adr = adr;
-	
-	avail.size = ctbytes;
+	avail.size = (int64_t) ctbytes;
 	
 	s.pos = ixshadow * sizeof (tyavailnodeshadow);
 	
@@ -1240,7 +1241,7 @@ static boolean dbsetavailshadow (long ixshadow, dbaddress adr, long ctbytes) {
 	
 	avail.adr = adr;
 	
-	avail.size = ctbytes;
+	avail.size = (int64_t) ctbytes;
 	
 	s.pos = ixshadow * sizeof (tyavailnodeshadow);
 	

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -32,6 +32,27 @@
 #include <stdio.h>
 #endif
 
+
+#include "memory.h"
+#include "cursor.h"
+#include "dialogs.h"
+#include "error.h"
+#include "file.h"
+#include "resources.h"
+#include "strings.h"
+#include "shell.h"
+#include "db.h"
+#include "db_format.h"
+#include "dbinternal.h"
+#include "ops.h" //6.2b3 AR: for numbertostring
+#include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
+
+#include "frontierdebug.h" //6.2b7 AR
+
+#define dberrorlist 256
+
+// 2025-11-23 Codex: Widened block header/trailer to 64-bit BE and updated avail links for v7 roots.
+// 2025-11-20 Codex: Write modern headers and record metadata with explicit big-endian encoding for portability.
 // 2025-11-16 Codex: Keep dbgetsize locals wide enough so dbgetsizeandvariance
 // writes don't corrupt the caller's stack on 64-bit builds.
 static uint16_t db_read_be16(const unsigned char *p) {
@@ -56,23 +77,29 @@ static uint64_t db_read_be64(const unsigned char *p) {
 	        (uint64_t)p[7];
 }
 
-#include "memory.h"
-#include "cursor.h"
-#include "dialogs.h"
-#include "error.h"
-#include "file.h"
-#include "resources.h"
-#include "strings.h"
-#include "shell.h"
-#include "db.h"
-#include "db_format.h"
-#include "dbinternal.h"
-#include "ops.h" //6.2b3 AR: for numbertostring
-#include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
+static void db_prepare_modern_header(const tydatabaserecord *src, tydatabaserecord_64 *dst) {
+	int i;
 
-#include "frontierdebug.h" //6.2b7 AR
+	clearbytes(dst, sizeof *dst);
+	dst->systemid = src->systemid;
+	dst->versionnumber = src->versionnumber;
+	dst->availlist = src->availlist;
+	dst->oldfnumdatabase = src->oldfnumdatabase;
+	dst->flags = src->flags;
 
-#define dberrorlist 256
+	for (i = 0; i < ctviews; ++i)
+		dst->views[i] = src->views[i];
+
+	dst->releasestack = nil;
+	dst->fnumdatabase = 0;
+	dst->headerLength = src->headerLength;
+	dst->longversionMajor = src->longversionMajor;
+	dst->longversionMinor = src->longversionMinor;
+
+	dst->u.extensions.availlistblock = src->u.extensions.availlistblock;
+	dst->u.extensions.availlistshadow = nildbaddress;
+	dst->u.extensions.flreadonly = src->u.extensions.flreadonly;
+}
 
 #define setdirty(hdb) 		((**hdb).flags |= dbdirtymask)
 #define cleardirty(hdb)		((**hdb).flags &= ~dbdirtymask)
@@ -86,7 +113,6 @@ static boolean dbread (dbaddress adr, long ctbytes, ptrvoid pdata);
 #if defined(FRONTIER_HEADLESS)
 static boolean dbfindblockforaddress(dbaddress adr, dbaddress *blockstart, long *nodebytes, tyvariance *variance, boolean *flfree) {
 	long eof = 0;
-	tyheader diskheader;
 
 	if (adr == nildbaddress)
 		return false;
@@ -98,34 +124,35 @@ static boolean dbfindblockforaddress(dbaddress adr, dbaddress *blockstart, long 
 		return false;
 
 	for (dbaddress candidate = adr; candidate >= firstphysicaladdress && (adr - candidate) <= 0x100000; --candidate) {
-		if (!dbread(candidate, sizeheader, &diskheader))
+		boolean freeflag = false;
+		long node_size = 0;
+		tyvariance node_variance = 0;
+
+		if (!dbreadheader(candidate, &freeflag, &node_size, &node_variance))
 			continue;
-
-		tyheader header = diskheader;
-		disktomemlong(header.variance);
-		disktomemlong(header.sizefreeword.size);
-
-		long node_size = header.sizefreeword.size & 0x7FFFFFFF;
-		boolean freeflag = (header.sizefreeword.size & 0x80000000L) != 0;
 
 		if (node_size <= 0 || node_size > eof)
 			continue;
 
-		if ((header.variance < 0) || (header.variance > node_size))
+		if ((node_variance < 0) || (node_variance > node_size))
 			continue;
 
 		dbaddress data_start = candidate + sizeheader;
-		dbaddress data_end = data_start + (node_size - header.variance);
+		dbaddress data_end = data_start + (node_size - node_variance);
 
 		if (adr < candidate || adr >= data_end)
 			continue;
 
-		tytrailer trailer;
-		if (!dbread(candidate + sizeheader + node_size, sizetrailer, &trailer))
+		boolean trailer_free = false;
+		long trailer_size = 0;
+
+		if (!dbreadtrailer(candidate + sizeheader + node_size, &trailer_free, &trailer_size))
 			continue;
 
-		disktomemlong(trailer.sizefreeword.size);
-		if ((trailer.sizefreeword.size & 0x7FFFFFFF) != node_size)
+		if (trailer_size != node_size)
+			continue;
+
+		if (trailer_free != freeflag)
 			continue;
 
 		if (blockstart != NULL)
@@ -133,7 +160,7 @@ static boolean dbfindblockforaddress(dbaddress adr, dbaddress *blockstart, long 
 		if (nodebytes != NULL)
 			*nodebytes = node_size;
 		if (variance != NULL)
-			*variance = header.variance;
+			*variance = node_variance;
 		if (flfree != NULL)
 			*flfree = freeflag;
 		return true;
@@ -421,68 +448,6 @@ static boolean dbread (dbaddress adr, long ctbytes, ptrvoid pdata) {
 	} /*dbread*/
 	
 
-static boolean dbwriteswap (dbaddress adr, long ctbytes, ptrvoid pdata) {
-	boolean res;
-
-	if (!dbseek (adr))
-		return (false);
-
-#ifdef SWAP_BYTE_ORDER
-	if (ctbytes == sizeof (long))
-		{
-		memtodisklong (*((long *)pdata));
-		}
-
-	if (ctbytes == sizeof(short))
-		{
-		memtodiskshort (*((short*)pdata));
-		}
-#endif
-	
-	res = filewrite ((hdlfilenum)((**databasedata).fnumdatabase), ctbytes, pdata);
-
-#ifdef SWAP_BYTE_ORDER
-	if (ctbytes == sizeof (long))
-		{
-		disktomemlong (*((long *)pdata));
-		}
-
-	if (ctbytes == sizeof(short))
-		{
-		disktomemshort (*((short*)pdata));
-		}
-#endif
-
-	return (res);
-	} /*dbwriteswap*/
-	
-
-static boolean dbreadswap (dbaddress adr, long ctbytes, ptrvoid pdata) {
-	boolean res;
-
-	if (!dbseek (adr))
-		return (false);
-				
-	res = fileread ((hdlfilenum)((**databasedata).fnumdatabase), ctbytes, pdata); 
-
-#ifdef SWAP_BYTE_ORDER
-	if (ctbytes == sizeof (long))
-		{
-		disktomemlong (*((long *)pdata));
-		}
-	else
-		{
-		if (ctbytes == sizeof(short))
-			{
-			disktomemshort (*((short*)pdata));
-			}
-		}
-#endif
-
-	return (res);
-	} /*dbreadswap*/
-	
-
 boolean dbgeteof (long *eof) {
 
 	return (filegeteof ((hdlfilenum)((**databasedata).fnumdatabase), eof));
@@ -525,24 +490,36 @@ static boolean dbflushheader (void) {
 			clearbytes (&diskrec.u.growthspace, sizeof (diskrec.u.growthspace)); /*in-memory structure only*/
 		#endif
 
-		#ifdef SWAP_BYTE_ORDER
-			{
-			short i;
-			memtodisklong (diskrec.availlist);
-			memtodisklong (diskrec.u.extensions.availlistblock);
-			memtodiskshort (diskrec.flags);
-			for (i = 0; i < ctviews; i++)
+		if (use_64bit_format) {
+			unsigned char diskheader[sizeof (tydatabaserecord_64)];
+			tydatabaserecord_64 diskrec64;
+
+			db_prepare_modern_header(&diskrec, &diskrec64);
+
+			if (!db_format_write_header64(&diskrec64, diskheader, sizeof (diskheader)))
+				return (false);
+
+			fl = dbwrite ((dbaddress) 0, (long) sizeof (diskheader), diskheader);
+		} else {
+			#ifdef SWAP_BYTE_ORDER
 				{
-				memtodisklong (diskrec.views[i]);
+				short i;
+				memtodisklong (diskrec.availlist);
+				memtodisklong (diskrec.u.extensions.availlistblock);
+				memtodiskshort (diskrec.flags);
+				for (i = 0; i < ctviews; i++)
+					{
+					memtodisklong (diskrec.views[i]);
+					}
+			//	memtodisklong (diskrec.fnumdatabase);
+				memtodisklong (diskrec.headerLength);
+				memtodiskshort (diskrec.longversionMajor);
+				memtodiskshort (diskrec.longversionMinor);
 				}
-		//	memtodisklong (diskrec.fnumdatabase);
-			memtodisklong (diskrec.headerLength);
-			memtodiskshort (diskrec.longversionMajor);
-			memtodiskshort (diskrec.longversionMinor);
-			}
-		#endif
-		
-		fl = dbwrite ((dbaddress) 0, sizeof (tydatabaserecord), &diskrec);
+			#endif
+			
+			fl = dbwrite ((dbaddress) 0, sizeof (tydatabaserecord), &diskrec);
+		}
 		
 		#ifndef FRONTIER_HEADLESS
 		/*flush file buffers*/ {
@@ -564,54 +541,80 @@ static boolean dbflushheader (void) {
 	
 
 boolean dbreadheader (dbaddress adr, boolean *flfree, long *ctbytes, tyvariance *variance) {
-	
-	tyheader header;
-	
-	if (!dbread (adr, sizeheader, &header))
-		return (false);
+
+	uint64_t raw_size = 0;
+	tyvariance disk_variance = 0;
+
+	if (use_64bit_format) {
+		tyheader64 header;
+
+		if (!dbread (adr, sizeheader_v7, &header))
+			return (false);
+
+		raw_size = db_format_read_be64((unsigned char *) &header.sizefreeword.size);
+		disk_variance = (tyvariance) db_format_read_be32((unsigned char *) &header.variance);
+	}
+	else {
+		tyheader32 header;
+
+		if (!dbread (adr, sizeheader_v6, &header))
+			return (false);
+
+		raw_size = (uint64_t) db_format_read_be32((unsigned char *) &header.sizefreeword.size);
+		disk_variance = (tyvariance) db_format_read_be32((unsigned char *) &header.variance);
+	}
 
 #if defined(FRONTIER_HEADLESS)
 	{
-	unsigned char *raw = (unsigned char *) &header;
-	fprintf(stderr, "[headless] dbreadheader raw adr=0x%llx bytes=%02x%02x%02x%02x%02x%02x%02x%02x\n",
-		(unsigned long long) adr,
-		raw[0], raw[1], raw[2], raw[3],
-		raw[4], raw[5], raw[6], raw[7]);
+	unsigned long long raw_dbg = (unsigned long long) raw_size;
+	fprintf(stderr, "[headless] dbreadheader parsed raw=0x%016llx variance=0x%08x\n",
+		raw_dbg,
+		(unsigned int) disk_variance);
 	}
 #endif
 
-	disktomemlong (header.variance);
-	disktomemlong (header.sizefreeword.size);
+	{
+		uint64_t freeflag = use_64bit_format ? 0x8000000000000000ULL : 0x80000000ULL;
+		uint64_t sizemask = use_64bit_format ? 0x7FFFFFFFFFFFFFFFULL : 0x7FFFFFFFULL;
 
-#if defined(FRONTIER_HEADLESS)
-    fprintf(stderr, "[headless] dbreadheader parsed size=0x%08lx variance=0x%08lx (ct=%ld)\n",
-            (unsigned long) header.sizefreeword.size,
-            (unsigned long) header.variance,
-            (long) ((header.sizefreeword.size & 0x7FFFFFFF) - header.variance));
-#endif
+		*flfree = (raw_size & freeflag) != 0;
+		*ctbytes = (long) (raw_size & sizemask);
+	}
 
-	*flfree = (header.sizefreeword.size & 0x80000000L) == 0x80000000L ? true : false;
-	
-	*ctbytes = header.sizefreeword.size & 0x7FFFFFFFL;
-	
-	*variance = header.variance;
-	
+	*variance = disk_variance;
+
 	return (true);
 	} /*dbreadheader*/
 	
 
 boolean dbreadtrailer (dbaddress adr, boolean *flfree, long *ctbytes) {
 
-	tytrailer trailer;
-	
-	if (!dbread (adr, sizetrailer, &trailer))
-		return (false);
-		
-	disktomemlong (trailer.sizefreeword.size);
+	uint64_t raw_size = 0;
 
-	*flfree = (trailer.sizefreeword.size & 0x80000000L) == 0x80000000L ? true : false;
-	
-	*ctbytes = trailer.sizefreeword.size & 0x7FFFFFFFL;
+	if (use_64bit_format) {
+		tytrailer64 trailer;
+
+		if (!dbread (adr, sizetrailer_v7, &trailer))
+			return (false);
+		
+		raw_size = db_format_read_be64((unsigned char *) &trailer.sizefreeword.size);
+	}
+	else {
+		tytrailer32 trailer;
+
+		if (!dbread (adr, sizetrailer_v6, &trailer))
+			return (false);
+		
+		raw_size = (uint64_t) db_format_read_be32((unsigned char *) &trailer.sizefreeword.size);
+	}
+
+	{
+		uint64_t freeflag = use_64bit_format ? 0x8000000000000000ULL : 0x80000000ULL;
+		uint64_t sizemask = use_64bit_format ? 0x7FFFFFFFFFFFFFFFULL : 0x7FFFFFFFULL;
+
+		*flfree = (raw_size & freeflag) != 0;
+		*ctbytes = (long) (raw_size & sizemask);
+	}
 	
 	return (true);
 	} /*dbreadtrailer*/
@@ -619,34 +622,55 @@ boolean dbreadtrailer (dbaddress adr, boolean *flfree, long *ctbytes) {
 
 static boolean dbwriteheader (dbaddress adr, boolean flfree, long ctbytes, tyvariance variance) {
 
-	tyheader header;
-	
-	header.sizefreeword.size = ctbytes;
+	uint64_t raw_size = (uint64_t) ctbytes;
 
 	if (flfree)
-		header.sizefreeword.size |= 0x80000000L;
-	
-	header.variance = variance;
-	
-	memtodisklong (header.variance);
-	memtodisklong (header.sizefreeword.size);
+		raw_size |= (use_64bit_format ? 0x8000000000000000ULL : 0x80000000ULL);
 
-	return (dbwrite (adr, sizeheader, &header));
+	if (use_64bit_format) {
+		tyheader64 header;
+
+		clearbytes(&header, sizeof header);
+		db_format_write_be64(&header.sizefreeword.size, raw_size);
+		db_format_write_be32(&header.variance, (uint32_t) variance);
+
+		return (dbwrite (adr, sizeheader_v7, &header));
+	}
+	else {
+		tyheader32 header;
+
+		clearbytes(&header, sizeof header);
+		db_format_write_be32(&header.sizefreeword.size, (uint32_t) raw_size);
+		db_format_write_be32(&header.variance, (uint32_t) variance);
+
+		return (dbwrite (adr, sizeheader_v6, &header));
+	}
 	} /*dbwriteheader*/
 	
 	
 static boolean dbwritetrailer (dbaddress adr, boolean flfree, long ctbytes) {
 
-	tytrailer trailer;
-	
-	trailer.sizefreeword.size = ctbytes; 
+	uint64_t raw_size = (uint64_t) ctbytes; 
 
 	if (flfree)
-		trailer.sizefreeword.size |= 0x80000000L;
-	
-	memtodisklong (trailer.sizefreeword.size);
+		raw_size |= (use_64bit_format ? 0x8000000000000000ULL : 0x80000000ULL);
 
-	return (dbwrite (adr, sizetrailer, &trailer));
+	if (use_64bit_format) {
+		tytrailer64 trailer;
+
+		clearbytes(&trailer, sizeof trailer);
+		db_format_write_be64(&trailer.sizefreeword.size, raw_size);
+
+		return (dbwrite (adr, sizetrailer_v7, &trailer));
+	}
+	else {
+		tytrailer32 trailer;
+
+		clearbytes(&trailer, sizeof trailer);
+		db_format_write_be32(&trailer.sizefreeword.size, (uint32_t) raw_size);
+
+		return (dbwrite (adr, sizetrailer_v6, &trailer));
+	}
 	} /*dbwritetrailer*/
 
 
@@ -671,8 +695,21 @@ boolean dbreadavailnode (dbaddress adr, boolean *flfree, long *ctbytes, dbaddres
 	
 	if (!dbreadheader (adr, flfree, ctbytes, &variance))
 		return (false);
-			
-	return (dbreadswap (adr + sizeheader, sizeof (dbaddress), link));
+
+	{
+		long link_bytes = use_64bit_format ? (long) sizeof (uint64_t) : (long) sizeof (uint32_t);
+		unsigned char raw[sizeof (uint64_t)];
+
+		if (!dbread (adr + sizeheader, link_bytes, raw))
+			return (false);
+
+		if (use_64bit_format)
+			*link = (dbaddress) db_format_read_be64(raw);
+		else
+			*link = (dbaddress) db_format_read_be32(raw);
+	}
+
+	return (true);
 	} /*dbreadavailnode*/
 	
 
@@ -684,9 +721,19 @@ static boolean dbwriteavailnode (dbaddress adr, long ctbytes, dbaddress nextlink
 	
 	if (!dbwriteheader (adr, true, ctbytes, 0L))
 		return (false);
-	
-	if (!dbwriteswap (adr + sizeheader, sizeof (dbaddress), &nextlink))
-		return (false);
+
+	{
+		long link_bytes = use_64bit_format ? (long) sizeof (uint64_t) : (long) sizeof (uint32_t);
+		unsigned char raw[sizeof (uint64_t)];
+
+		if (use_64bit_format)
+			db_format_write_be64(raw, (uint64_t) nextlink);
+		else
+			db_format_write_be32(raw, (uint32_t) nextlink);
+
+		if (!dbwrite (adr + sizeheader, link_bytes, raw))
+			return (false);
+	}
 
 	if (!dbwritetrailer (adr + sizeheader + ctbytes, true, ctbytes))
 		return (false);
@@ -713,7 +760,17 @@ static boolean dbsetavaillink (dbaddress adr, dbaddress link) {
 		return (true);
 		}
 		
-	return (dbwriteswap (adr + sizeheader, sizeof (dbaddress), &link));
+	{
+		long link_bytes = use_64bit_format ? (long) sizeof (uint64_t) : (long) sizeof (uint32_t);
+		unsigned char raw[sizeof (uint64_t)];
+
+		if (use_64bit_format)
+			db_format_write_be64(raw, (uint64_t) link);
+		else
+			db_format_write_be32(raw, (uint32_t) link);
+
+		return (dbwrite (adr + sizeheader, link_bytes, raw));
+	}
 	} /*dbsetavaillink*/
 	
 	
@@ -913,7 +970,8 @@ static boolean dbwriteshadowavaillist (void) {
 	if ((**hdb).u.extensions.availlistshadow.eof > 0) { /*there's something to be saved*/
 	
 		long nodebytes = (**hdb).u.extensions.availlistshadow.eof;
-		long databytes, dummy;
+		long databytes;
+		tyvariance variance = 0;
 		Handle h = nil;
 		
 		if (!dballocate (nodebytes, nil, &adrblock))
@@ -931,22 +989,28 @@ static boolean dbwriteshadowavaillist (void) {
 		assert (databytes == nodebytes || databytes == nodebytes - (long) sizeof (tyavailnodeshadow));
 
 		
-		#ifdef SWAP_BYTE_ORDER
-			/*switch byte order*/ {
-			long ix;
-			long ct = databytes / sizeof (tyavailnodeshadow);
-			register tyavailnodeshadow* p = (tyavailnodeshadow *) *h;
+		{
+		long ix;
+		long ct = databytes / sizeof (tyavailnodeshadow);
+		register tyavailnodeshadow* p = (tyavailnodeshadow *) *h;
 
-			for (ix = 0; ix < ct; ix++) {
-				memtodisklong (p[ix].adr);
-				memtodisklong (p[ix].size);
-				}
+		for (ix = 0; ix < ct; ix++) {
+			dbaddress adr_be = p[ix].adr;
+			uint64_t size_be = (uint64_t) p[ix].size;
+
+			if (use_64bit_format) {
+				db_format_write_be64((unsigned char *) &p[ix].adr, (uint64_t) adr_be);
+				db_format_write_be64((unsigned char *) &p[ix].size, size_be);
+			} else {
+				db_format_write_be32((unsigned char *) &p[ix].adr, (uint32_t) adr_be);
+				db_format_write_be32((unsigned char *) &p[ix].size, (uint32_t) size_be);
 			}
-		#endif
+			}
+		}
 
 		lockhandle (h);
 		
-		fl = dbreadheader (adrblock, &flfree, &nodebytes, &dummy);
+		fl = dbreadheader (adrblock, &flfree, &nodebytes, &variance);
 		
 		assert (databytes <= nodebytes);
 		
@@ -1005,18 +1069,21 @@ static boolean dbreadshadowavaillist (void) {
 	if (!dbrefhandle (adrblock, (Handle*) &h))
 		return (false);
 
-#ifdef SWAP_BYTE_ORDER
-	/*switch byte order*/ {
+	{
 		long ix;
 		long ct = gethandlesize ((Handle) h) / sizeof (tyavailnodeshadow);
 		register tyavailnodeshadow* p = *h;
 
 		for (ix = 0; ix < ct; ix++) {
-			disktomemlong (p[ix].adr);
-			disktomemlong (p[ix].size);
+			if (use_64bit_format) {
+				p[ix].adr = (dbaddress) db_format_read_be64((unsigned char *) &p[ix].adr);
+				p[ix].size = (long) db_format_read_be64((unsigned char *) &p[ix].size);
+			} else {
+				p[ix].adr = (dbaddress) db_format_read_be32((unsigned char *) &p[ix].adr);
+				p[ix].size = (long) db_format_read_be32((unsigned char *) &p[ix].size);
 			}
 		}
-#endif
+	}
 
 	/*Test consistency of cached shadow avail list*/
 	

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -25,6 +25,7 @@
 #include "file.h"
 
 // 2025-10-27 Codex: Added optional migration tracing to inspect v6/v7 table layouts during conversion.
+// 2025-11-20 Codex: Added v7 header serializer and shared big-endian helpers to keep modern roots portable.
 
 boolean use_64bit_format = false;
 static boolean g_db_format_runtime_initialized = false;
@@ -783,31 +784,32 @@ static uint64_t read_be64(const unsigned char *field) {
             (uint64_t) field[7];
 }
 
-static void write_be16(void *ptr, uint16_t value) {
-    unsigned char *p = (unsigned char *) ptr;
-    p[0] = (unsigned char)((value >> 8) & 0xFF);
-    p[1] = (unsigned char)(value & 0xFF);
-}
+boolean db_format_write_header64(const tydatabaserecord_64 *src, unsigned char *dest, size_t dest_size) {
+    if ((src == NULL) || (dest == NULL) || (dest_size < sizeof(tydatabaserecord_64)))
+        return false;
 
-static void write_be32(void *ptr, uint32_t value) {
-    unsigned char *p = (unsigned char *) ptr;
-    p[0] = (unsigned char)((value >> 24) & 0xFF);
-    p[1] = (unsigned char)((value >> 16) & 0xFF);
-    p[2] = (unsigned char)((value >> 8) & 0xFF);
-    p[3] = (unsigned char)(value & 0xFF);
-}
+    memset(dest, 0, dest_size);
+    dest[0] = src->systemid;
+    dest[1] = src->versionnumber;
 
-static void write_dbaddress64(void *ptr, dbaddress value) {
-    unsigned char *p = (unsigned char *) ptr;
-    uint64_t v = (uint64_t) value;
-    p[0] = (unsigned char)((v >> 56) & 0xFF);
-    p[1] = (unsigned char)((v >> 48) & 0xFF);
-    p[2] = (unsigned char)((v >> 40) & 0xFF);
-    p[3] = (unsigned char)((v >> 32) & 0xFF);
-    p[4] = (unsigned char)((v >> 24) & 0xFF);
-    p[5] = (unsigned char)((v >> 16) & 0xFF);
-    p[6] = (unsigned char)((v >> 8) & 0xFF);
-    p[7] = (unsigned char)(v & 0xFF);
+    db_format_write_dbaddress64(dest + offsetof(tydatabaserecord_64, availlist), src->availlist);
+    db_format_write_be16(dest + offsetof(tydatabaserecord_64, oldfnumdatabase), (uint16_t) src->oldfnumdatabase);
+    db_format_write_be16(dest + offsetof(tydatabaserecord_64, flags), (uint16_t) src->flags);
+
+    for (int i = 0; i < ctviews; ++i) {
+        size_t offset = offsetof(tydatabaserecord_64, views) + (size_t) i * sizeof(dbaddress);
+        db_format_write_dbaddress64(dest + offset, src->views[i]);
+    }
+
+    db_format_write_be32(dest + offsetof(tydatabaserecord_64, headerLength), (uint32_t) src->headerLength);
+    db_format_write_be16(dest + offsetof(tydatabaserecord_64, longversionMajor), (uint16_t) src->longversionMajor);
+    db_format_write_be16(dest + offsetof(tydatabaserecord_64, longversionMinor), (uint16_t) src->longversionMinor);
+
+    db_format_write_dbaddress64(dest + offsetof(tydatabaserecord_64, u.extensions.availlistblock), src->u.extensions.availlistblock);
+    db_format_write_dbaddress64(dest + offsetof(tydatabaserecord_64, u.extensions.availlistshadow), src->u.extensions.availlistshadow);
+    dest[offsetof(tydatabaserecord_64, u.extensions.flreadonly)] = src->u.extensions.flreadonly ? 1u : 0u;
+
+    return true;
 }
 
 boolean detect_database_format(const tydatabaserecord *header) {
@@ -1031,11 +1033,11 @@ boolean migrate_32bit_to_64bit(const char *db_path) {
         new_script_address = 0;
     }
 
-    write_be16(&cancoon_record.versionnumber, cancoon_version);
-    write_be16(&cancoon_record.flags, cancoon_flags);
-    write_be16(&cancoon_record.ixprimaryagent, cancoon_primary);
-    write_be32(&cancoon_record.adrroottable, (uint32_t) new_root_address);
-    write_be32(&cancoon_record.adrscriptstring, (uint32_t) new_script_address);
+    db_format_write_be16(&cancoon_record.versionnumber, cancoon_version);
+    db_format_write_be16(&cancoon_record.flags, cancoon_flags);
+    db_format_write_be16(&cancoon_record.ixprimaryagent, cancoon_primary);
+    db_format_write_be32(&cancoon_record.adrroottable, (uint32_t) new_root_address);
+    db_format_write_be32(&cancoon_record.adrscriptstring, (uint32_t) new_script_address);
 
     if (!dbassign(&new_cancoon_address, (long) sizeof cancoon_record, &cancoon_record))
         goto cleanup;

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -42,50 +42,7 @@
 #include "byteorder.h"
 
 // 2025-10-27 Codex: Handle 64-bit dbaddress packing/unpacking for headless workloads.
-
-static inline dbaddress tablepack_host_to_disk_dbaddress(dbaddress value) {
-#if defined(SWAP_BYTE_ORDER)
-	if (sizeof (dbaddress) == 8) {
-		unsigned long long temp = (unsigned long long) value;
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-		temp = __builtin_bswap64(temp);
-#else
-		temp = ((temp & 0x00000000000000FFULL) << 56) |
-		       ((temp & 0x000000000000FF00ULL) << 40) |
-		       ((temp & 0x0000000000FF0000ULL) << 24) |
-		       ((temp & 0x00000000FF000000ULL) << 8)  |
-		       ((temp & 0x000000FF00000000ULL) >> 8)  |
-		       ((temp & 0x0000FF0000000000ULL) >> 24) |
-		       ((temp & 0x00FF000000000000ULL) >> 40) |
-		       ((temp & 0xFF00000000000000ULL) >> 56);
-#endif
-		return (dbaddress) temp;
-	}
-#endif
-	return value;
-}
-
-static inline dbaddress tablepack_disk_to_host_dbaddress(dbaddress value) {
-#if defined(SWAP_BYTE_ORDER)
-	if (sizeof (dbaddress) == 8) {
-		unsigned long long temp = (unsigned long long) value;
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-		temp = __builtin_bswap64(temp);
-#else
-		temp = ((temp & 0x00000000000000FFULL) << 56) |
-		       ((temp & 0x000000000000FF00ULL) << 40) |
-		       ((temp & 0x0000000000FF0000ULL) << 24) |
-		       ((temp & 0x00000000FF000000ULL) << 8)  |
-		       ((temp & 0x000000FF00000000ULL) >> 8)  |
-		       ((temp & 0x0000FF0000000000ULL) >> 24) |
-		       ((temp & 0x00FF000000000000ULL) >> 40) |
-		       ((temp & 0xFF00000000000000ULL) >> 56);
-#endif
-		return (dbaddress) temp;
-	}
-#endif
-	return value;
-}
+// 2025-11-20 Codex: Emit table addresses in canonical big-endian form for portable v7 roots.
 #include "tableinternal.h"
 #include "tableverbs.h"
 #include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
@@ -414,14 +371,11 @@ boolean tableverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdba
 	long adrsize;
 
 	if (use_64bit_format && ((int)sizeof (dbaddress) == 8)) {
-		dbaddress diskadr = tablepack_host_to_disk_dbaddress(adr);
-		memcpy(adrbuffer, &diskadr, sizeof (dbaddress));
+		db_format_write_be64(adrbuffer, (uint64_t) adr);
 		adrsize = (long) sizeof (dbaddress);
 	} else {
-		int32_t disk32 = (int32_t) adr;
-		memtodisklong (disk32);
-		memcpy(adrbuffer, &disk32, sizeof (disk32));
-		adrsize = (long) sizeof (disk32);
+		db_format_write_be32(adrbuffer, (uint32_t) adr);
+		adrsize = (long) sizeof (uint32_t);
 	}
 
 	if (!enlargehandle (*hpacked, adrsize, (ptrchar) adrbuffer)) {
@@ -445,22 +399,24 @@ boolean tableverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, b
 		fprintf(stderr, "[headless] tableverbunpack use_64bit_format=true sizeof(dbaddress)=%zu remaining=%ld\n",
 		        sizeof(dbaddress), remaining);
 		if (remaining >= (long) sizeof (dbaddress)) {
-			dbaddress diskadr = 0;
-			if (!loadfromhandle (hpacked, ixload, (long) sizeof (dbaddress), &diskadr))
+			unsigned char adrbytes[sizeof (dbaddress)];
+			if (!loadfromhandle (hpacked, ixload, (long) sizeof (dbaddress), adrbytes))
 				return (false);
-			rawadr = tablepack_disk_to_host_dbaddress(diskadr);
+			rawadr = (dbaddress) db_format_read_be64(adrbytes);
 #if defined(FRONTIER_HEADLESS)
 			fprintf(stderr, "[headless] tableverbunpack 64-bit address=0x%016llx\n", (unsigned long long) rawadr);
 #endif
 		} else if (remaining == (long) sizeof (int32_t)) {
-			uint32_t raw32 = 0;
-			if (!loadfromhandle (hpacked, ixload, (long) sizeof (raw32), &raw32))
+			unsigned char raw32[sizeof (uint32_t)];
+			if (!loadfromhandle (hpacked, ixload, (long) sizeof (raw32), raw32))
 				return (false);
-			disktomemlong (raw32);
-			rawadr = (dbaddress) raw32;
+			{
+				uint32_t raw32_val = db_format_read_be32(raw32);
+				rawadr = (dbaddress) raw32_val;
 #if defined(FRONTIER_HEADLESS)
-			fprintf(stderr, "[headless] tableverbunpack fallback 32-bit address=0x%08x\n", raw32);
+				fprintf(stderr, "[headless] tableverbunpack fallback 32-bit address=0x%08x\n", raw32_val);
 #endif
+			}
 		} else {
 #if defined(FRONTIER_HEADLESS)
 			fprintf(stderr, "[headless] tableverbunpack unexpected remaining bytes=%ld\n", remaining);
@@ -468,13 +424,16 @@ boolean tableverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, b
 			return (false);
 		}
 	} else {
-		long raw32 = 0;
-		if (!loadlongfromdiskhandle (hpacked, ixload, &raw32))
+		unsigned char raw32[sizeof (uint32_t)];
+		if (!loadfromhandle (hpacked, ixload, (long) sizeof (raw32), raw32))
 			return (false);
-		rawadr = (dbaddress) raw32;
+		{
+			uint32_t raw32_val = db_format_read_be32(raw32);
+			rawadr = (dbaddress) raw32_val;
 #if defined(FRONTIER_HEADLESS)
-		fprintf(stderr, "[headless] tableverbunpack legacy 32-bit address=0x%08lx\n", raw32);
+			fprintf(stderr, "[headless] tableverbunpack legacy 32-bit address=0x%08lx\n", (unsigned long) raw32_val);
 #endif
+		}
 	}
 
 	return (newtablevariable (false, rawadr, (hdltablevariable *) h, flxml));

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Frontier Refactoring Project (develop branch status)
 
-**Last updated:** 2025-10-18  
-**State:** Modernization wave 1 delivered; headless + 64-bit aligned; headless service core vision documented  
+**Last updated:** 2025-11-23  
+**State:** Modernization wave 2 in progress; headless + 64-bit aligned; v7 on-disk format moving to portable big-endian  
 **Primary contacts:** planning/INDEX.md (owners per phase)
 
 This repository is actively modernising the Frontier runtime and toolchain. The
@@ -12,19 +12,10 @@ tests can exercise real UserTalk without `system.verbs.*` being loaded.
 
 ## Highlights
 
-- **64-bit/ARM readiness** – All core builds and tests compile cleanly on both
-  architectures. Database headers were revved for 64-bit alignment; migration
-  coverage lives in `tests/save_migration_tests`.
-- **Portable/headless runtime** – The `portable/` layer + headless stubs power
-  CLI/testing without UI dependencies (see planning/EFP_HEADLESS_NOTES.md for
-  scope/removal criteria).
-- **Modernised test harness** – Cross-platform C test suite with sanitiser
-  presets (`SANITIZE=1 make -C tests`). New test binaries:
-  - `file_portable_tests`
-  - `file_readline_tests`
-  - `file_verb_tests` (UserTalk `file.*` exercises headless EFP routing)
-- **Branch hygiene** – Large Codex session logs moved off `develop` and live in
-  the dedicated `codex-sessions` branch (see below for how to fetch).
+- **64-bit/ARM + big-endian v7** – Core builds/tests compile on `arm64`/`x86_64`; v7 headers/trailers and table addresses now write big-endian for cross-arch parity (see `docs/database_architecture.md`).
+- **Paige-free headless runtime** – The `portable/` layer + headless stubs power CLI/testing without UI deps; wptext now uses the Paige-free extractor/RTF path.
+- **Modernised test harness** – Cross-platform C test suite with sanitiser presets (`SANITIZE=1 make -C tests`). Key binaries: `file_portable_tests`, `file_readline_tests`, `file_verb_tests`, `runtime_tests`, `db_format_tests`.
+- **Branch hygiene** – Large Codex session logs live on the `codex-sessions` branch (see below).
 
 ## Quick start
 
@@ -33,6 +24,7 @@ tests can exercise real UserTalk without `system.verbs.*` being loaded.
 make -C tests file_verb_tests && ./tests/file_verb_tests
 ./tests/file_portable_tests
 ./tests/file_readline_tests
+make -C tests runtime_tests
 
 # sanitiser run
 SANITIZE=1 make -C tests test
@@ -59,9 +51,6 @@ integration. Prebuilt binaries are no longer stored in the repo.
 See `docs/mysql_client_setup.md` for detailed guidance.
 ```
 
-> `make -C tests test` currently hits a pre-existing duplicate-symbol linker
-> issue in `runtime_tests`; tracked in planning/ISSUES.md.
-
 ## Planning & docs (read these first)
 
 - `planning/INDEX.md` – roadmap + ownership
@@ -72,6 +61,7 @@ See `docs/mysql_client_setup.md` for detailed guidance.
   call routing
 - `planning/Frontier_Refactoring_Plan.md` – original modernisation plan
 - `planning/phase3/headless_daemon_vision.md` – target architecture for the headless daemon/service core
+- `planning/big_endian_portability_audit.md` – current BE v7 portability audit/tasks
 - `codex_sessions/README.md` – how to fetch/view Codex transcript logs
 
 For daily notes and context, see the Codex session branch (instructions below).
@@ -84,7 +74,8 @@ For daily notes and context, see the Codex session branch (instructions below).
 | arm64 build         | ✅     | `make -C frontier-cli` builds universal binary |
 | Headless runtime    | ✅     | Portable stubs cover runtime/IO; EFP shim in place |
 | Tests (targeted)    | ✅     | `file_portable`, `file_readline`, `file_verb` |
-| Tests (full suite)  | ⚠️     | `runtime_tests` link failure (known issue) |
+| Tests (runtime/db)  | ✅     | `runtime_tests`, `db_format_tests` (warnings remain) |
+| CLI runtime         | ⚠️     | `cli_runtime_tests` built; re-enable `clock.now()` once v7 BE work finishes |
 | Docs/Planning       | ✅     | Planning/ADR files updated alongside code |
 | Codex transcripts   | ✅     | Stored on `codex-sessions` branch/worktree |
 
@@ -128,12 +119,9 @@ Frontier/
 
 ## Next milestone snapshot
 
-- Remove temporary headless shim once `Frontier.root` can load in headless
-  builds (restores classic `system.verbs.* → kernelcall → EFP` routing).
-- Fix duplicate-symbol linker issue in `runtime_tests` so `make -C tests test`
-  is green.
-- Bring CI online (provider TBD) and enable coverage/static analysis once tool
-  chain is finalised.
+- Finish big-endian v7 portability (header/trailer/table/avail) and add cross-arch goldens.
+- Re-enable full CLI runtime coverage (e.g., `clock.now()` regression).
+- Bring CI online (provider TBD) and enable coverage/static analysis once tool chain is finalised.
 
 For day-by-day progress see the `codex-sessions` branch and
 planning/INDEX.md.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ tests can exercise real UserTalk without `system.verbs.*` being loaded.
 
 ## Highlights
 
-- **64-bit/ARM + big-endian v7** – Core builds/tests compile on `arm64`/`x86_64`; v7 headers/trailers and table addresses now write big-endian for cross-arch parity (see `docs/database_architecture.md`).
-- **Paige-free headless runtime** – The `portable/` layer + headless stubs power CLI/testing without UI deps; wptext now uses the Paige-free extractor/RTF path.
-- **Modernised test harness** – Cross-platform C test suite with sanitiser presets (`SANITIZE=1 make -C tests`). Key binaries: `file_portable_tests`, `file_readline_tests`, `file_verb_tests`, `runtime_tests`, `db_format_tests`.
-- **Branch hygiene** – Large Codex session logs live on the `codex-sessions` branch (see below).
+- **64-bit/ARM + big-endian v7** – Core builds/tests compile on `arm64`/`x86_64`; v7 headers/trailers and table addresses now write big-endian for cross-arch parity (see `docs/database_architecture.md`). Migration coverage lives in `tests/save_migration_tests` and `tests/runtime_tests`.
+- **Portable/headless + Paige-free** – The `portable/` layer + headless stubs power CLI/testing without UI deps; wptext now uses the Paige-free extractor/RTF path while still allowing tests to link the real Paige for parity checks.
+- **Modernised test harness** – Cross-platform C test suite with sanitiser presets (`SANITIZE=1 make -C tests`). Key binaries: `file_portable_tests`, `file_readline_tests`, `file_verb_tests`, `runtime_tests`, `db_format_tests`, `cli_runtime_tests`.
+- **Branch hygiene** – Large Codex session logs live on the `codex-sessions` branch; planning docs capture status/decisions in `planning/_CURRENT_STATUS.md`, `planning/DECISIONS.md`, and `planning/big_endian_portability_audit.md`.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ tests can exercise real UserTalk without `system.verbs.*` being loaded.
 - **64-bit/ARM + big-endian v7** – Core builds/tests compile on `arm64`/`x86_64`; v7 headers/trailers and table addresses now write big-endian for cross-arch parity (see `docs/database_architecture.md`). Migration coverage lives in `tests/save_migration_tests` and `tests/runtime_tests`.
 - **Portable/headless + Paige-free** – The `portable/` layer + headless stubs power CLI/testing without UI deps; wptext now uses the Paige-free extractor/RTF path while still allowing tests to link the real Paige for parity checks.
 - **Modernised test harness** – Cross-platform C test suite with sanitiser presets (`SANITIZE=1 make -C tests`). Key binaries: `file_portable_tests`, `file_readline_tests`, `file_verb_tests`, `runtime_tests`, `db_format_tests`, `cli_runtime_tests`.
-- **Branch hygiene** – Large Codex session logs live on the `codex-sessions` branch; planning docs capture status/decisions in `planning/_CURRENT_STATUS.md`, `planning/DECISIONS.md`, and `planning/big_endian_portability_audit.md`.
+- **Paige → portable milestone** – v6→v7 migrator now converts wptexts via the C extractor/RTF helpers; canonical `Frontier-v6.root` migration succeeds (`FRONTIER_REGEN_ROOT=databases/Frontier-v6.root ./tests/runtime_tests`), logs under `/tmp/…`. See `planning/progress_reports/2025-11-20-paige_portable_milestone.md`.
+- **Planning/status ledger** – Current work lives in `planning/_CURRENT_STATUS.md`; decisions and BE audit in `planning/DECISIONS.md` and `planning/big_endian_portability_audit.md`. Historical milestone summaries live in `planning/progress_reports/README.md`.
 
 ## Quick start
 
@@ -55,10 +56,8 @@ See `docs/mysql_client_setup.md` for detailed guidance.
 
 - `planning/INDEX.md` – roadmap + ownership
 - `planning/DECISIONS.md` – current decisions/TBDs
-- `planning/EFP_HEADLESS_NOTES.md` – headless shim, success criteria, removal
-  plan
-- `planning/adr/ADR-0010-headless-efp-routing.md` – decision record for dotted
-  call routing
+- `planning/EFP_HEADLESS_NOTES.md` – headless shim, success criteria, removal plan
+- `planning/adr/ADR-0010-headless-efp-routing.md` – decision record for dotted call routing
 - `planning/Frontier_Refactoring_Plan.md` – original modernisation plan
 - `planning/phase3/headless_daemon_vision.md` – target architecture for the headless daemon/service core
 - `planning/big_endian_portability_audit.md` – current BE v7 portability audit/tasks
@@ -68,16 +67,16 @@ For in-flight work/status, see `planning/_CURRENT_STATUS.md`. Historical session
 
 ## Current status matrix
 
-| Area                | Status | Notes |
-|---------------------|:------:|-------|
-| 64-bit alignment    | ✅     | DB header rev complete; save/migration tests green |
-| arm64 build         | ✅     | `make -C frontier-cli` builds universal binary |
-| Headless runtime    | ✅     | Portable stubs cover runtime/IO; EFP shim in place |
-| Tests (targeted)    | ✅     | `file_portable`, `file_readline`, `file_verb` |
-| Tests (runtime/db)  | ✅     | `runtime_tests`, `db_format_tests` (warnings remain) |
-| CLI runtime         | ⚠️     | `cli_runtime_tests` built; re-enable `clock.now()` once v7 BE work finishes |
-| Docs/Planning       | ✅     | Planning/ADR files updated alongside code |
-| Codex transcripts   | ✅     | Stored on `codex-sessions` branch/worktree |
+| Area               | Status | Notes                                                                                   |
+| ------------------ | :----: | --------------------------------------------------------------------------------------- |
+| 64-bit alignment   |   ✅    | DB header rev complete; save/migration tests green                                      |
+| arm64 build        |   ✅    | `make -C frontier-cli` builds universal binary                                          |
+| Headless runtime   |   ✅    | Portable stubs cover runtime/IO; EFP shim in place                                      |
+| Tests (targeted)   |   ✅    | `file_portable`, `file_readline`, `file_verb`                                           |
+| Tests (runtime/db) |   ✅    | `runtime_tests`, `db_format_tests` (Paige warnings remain, needed for data validation)  |
+| CLI runtime        |   ⚠️   | `cli_runtime_tests` built; re-enable `clock.now()` once v7 endianness work is completed |
+| Docs/Planning      |   ✅    | Planning/ADR files updated alongside code                                               |
+| Codex transcripts  |   ✅    | Stored on `codex-sessions` branch/worktree                                              |
 
 ## Historical progress
 
@@ -94,7 +93,7 @@ Frontier/
 ├── frontier-cli/         # Multi-arch CLI build
 ├── tests/                # Cross-platform C test suite
 ├── planning/             # Roadmap, ADRs, decisions, quickstarts
-├── codex_sessions/       # README pointer (actual logs in codex-sessions branch)
+├── codex_sessions/       # README pointer (actual logs in codex-sessions branch, no longer used)
 └── build_*               # Build scaffolding (Xcode/GNU)
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See `docs/mysql_client_setup.md` for detailed guidance.
 - `planning/big_endian_portability_audit.md` – current BE v7 portability audit/tasks
 - `codex_sessions/README.md` – how to fetch/view Codex transcript logs
 
-For daily notes and context, see the Codex session branch (instructions below).
+For in-flight work/status, see `planning/_CURRENT_STATUS.md`. Historical session context lives in `planning/progress_reports/README.md`.
 
 ## Current status matrix
 
@@ -79,18 +79,9 @@ For daily notes and context, see the Codex session branch (instructions below).
 | Docs/Planning       | ✅     | Planning/ADR files updated alongside code |
 | Codex transcripts   | ✅     | Stored on `codex-sessions` branch/worktree |
 
-## Codex session logs
+## Historical progress
 
-Large transcript files live on the `codex-sessions` branch. Fetch once and keep
-them in a separate worktree so they do not clutter `develop`:
-
-```bash
-git fetch origin codex-sessions
-git worktree add ../Frontier-codex-sessions codex-sessions   # once
-```
-
-Drop new transcripts into `../Frontier-codex-sessions/codex_sessions/`, commit
-there, and push. Details are in `codex_sessions/README.md`.
+Historical session summaries live under `planning/progress_reports/README.md`.
 
 ## Repository layout (quick tour)
 

--- a/docs/database_architecture.md
+++ b/docs/database_architecture.md
@@ -42,6 +42,11 @@ Modern (rewritten) v7/v8 databases skip this entire dance: `views[0]` already co
 
 See `databases/test-root-contents.png` for the intended UI view of `test.root` once the Cancoon record is resolved and real tables like `myTable` are traversed.
 
+### Block headers/trailers (modern vs legacy)
+
+- **Legacy (v6)**: 4-byte size with the high bit marking free nodes; 4-byte variance; 4-byte trailer (size word only). Sizes are big-endian 32-bit and cap at 4 GB.
+- **Modern (v7, 2025-11-23 Codex)**: 8-byte size with the high bit marking free nodes; 4-byte variance; 8-byte trailer (size word only). Sizes are big-endian 64-bit, so free blocks can exceed 4 GB without truncation. Avail-list links are stored as big-endian 64-bit addresses.
+
 ### Table payload layouts (legacy vs modern)
 
 All tables eventually serialize to the same logical pieces:

--- a/planning/DECISIONS.md
+++ b/planning/DECISIONS.md
@@ -3,7 +3,7 @@
 Status
 - State: In Progress
 - Phase: Multi-Phase
-- Last Updated: 2025-11-20
+- Last Updated: 2025-11-23
 - Owner: Codex
 - Notes: Central index of ADR topics; update when decisions move between Draft/Proposed/Accepted.
 
@@ -21,8 +21,9 @@ Decisions & Topics
 - Global State Boundaries — ADR 0006 (TBD)
 - File I/O & Path Policy — ADR 0007 (Draft; see database_path_canonicalization.md)
 - Unicode Strategy — ADR 0008 (TBD)
-- WPText → RTF Migration — ADR 0009 (TBD)
+- WPText → RTF Migration — ADR 0009 (Accepted; Paige is conversion-only, portable RTF/UTF-8 pipeline is canonical)
 - EFP Routing in Headless — ADR 0010 (Proposed)
+- V7 On-Disk Endianness — (Accepted; v7 headers/trailers/table/avail write big-endian; see `planning/big_endian_portability_audit.md`, `docs/database_architecture.md`)
 
 Related Indexes
 - Overall plan: planning/Frontier_Refactoring_Plan.md
@@ -40,7 +41,12 @@ Related Indexes
 | Global State Boundaries         | 0006   | Proposed | TBD   | Phase 2      |
 | OSA/IPC Strategy                | 0004   | Proposed | TBD   | Phase 2      |
 | Unicode Strategy                | 0008   | Proposed | TBD   | Phase 4      |
-| WPText → RTF Migration          | 0009   | Proposed | TBD   | Phase 4      |
+| WPText → RTF Migration          | 0009   | Accepted | Codex | Phase 4      |
 | EFP Routing in Headless         | 0010   | Proposed | TBD   | Phase 1      |
+| V7 On-Disk Endianness           | —      | Accepted | Codex | Phase 2      |
+
+### Notes
+- WPText decision: Paige is conversion-only; headless/CLI/runtime paths use the portable extractor + RTF/UTF-8 helpers. Portable `WPRT` is the canonical on-disk format (see `planning/progress_reports/2025-11-20-paige_portable_milestone.md`).
+- V7 endianness: modern roots write big-endian for headers/trailers/table addresses and avail list links; sizes are 64-bit BE. Tracking and tests in `planning/big_endian_portability_audit.md` and `tests/db_format_tests.c`.
 
 Pre‑issue stubs (to copy to GitHub later) live in `planning/issues/`.

--- a/planning/_CURRENT_STATUS.md
+++ b/planning/_CURRENT_STATUS.md
@@ -7,7 +7,7 @@ Status
 - Owner: Codex
 - Notes: Primary hand-off summary; update whenever major milestones land.
 
-**Last Updated**: November 20, 2025 (evening)  \
+**Last Updated**: November 23, 2025  \
 **Branches in flight**: `feature/carbon-migration-plan`, `feature/headless-system-bootstrap`
 
 - Headless builds no longer include or link any Paige headers: `portable/wptext_portable.{c,h}` collapsed to no-op bootstrap stubs, and the entire `portable/wptext_runtime.c` path now uses the new `paige_text_extractor` + UTF‑8⇄RTF helpers for packed blobs.
@@ -20,6 +20,11 @@ Status
 - `wp_portable_diskheader`/`wp_portable_header` switched to fixed-width integer fields, which fixed the `utf8bytelen` bookkeeping and unblocked all WP text smoke tests. Added `wp_portable_load_portable_blob_for_test` so the runtime regression harness can validate `WPRT` blobs directly.
 - Regression coverage: `tests/paige_text_tests` and `tests/runtime_tests` both pass locally (see `/tmp/runtime_tests.log` for the latest run). The migrator now succeeds on the canonical `Frontier-v6.root` sample.
 - Serializer round-trip logging tightened: `hashunpacktable` now checks remaining bytes before calling `loadfromhandle`, so the expected end-of-records path no longer emits `[headless] loadfromhandle fail` noise. Re-ran the full migrator afterward; fresh logs live at `/tmp/runtime_tests.log`.
+- Database portability gap: v7 headers now write with explicit big-endian helpers. `dbflushheader` serializes `tydatabaserecord_64` via `db_format_write_header64` (runtime-only fields zeroed), `tableverbpack/tableverbunpack` emit/consume big-endian dbaddresses regardless of host endianness, and block headers/trailers now store 64-bit big-endian sizes/links (avail nodes write/read BE64 links). `make -C tests db_format_tests -B` and `make -C tests runtime_tests`/`cli_runtime_tests` pass locally (warnings only). Follow-ups:
+  1. Extend table/record packers to emit big-endian lengths/addresses (the decoder already does this for legacy payloads). **Table dbaddress packing is fixed; double-check any remaining record-length writers that still rely on `memtodisklong`.**
+  2. Add regression tests that open a root written on one architecture and verify the header/record bytes match a golden big-endian reference (include >4 GB free-span simulation/sparse file and clean up artifacts on success). In-memory >4 GB free-span encode/decode added to `tests/db_format_tests`.
+  3. Update docs (`docs/database_architecture.md`, `planning/TODO_future_improvements.md`) once the on-disk format is guaranteed portable.
+- CLI regression: `tests/cli_runtime_tests` currently skips the `clock.now()` check because `frontier-cli --system-root databases/Frontier-v6-v7.root` fails to load v7 databases (same endianness issue above). Once the header writes are fixed, re-run the CLI tests so the `clock.now()` path becomes a real regression instead of a skip.
 
 ### Migrator status – `Frontier-v6.root`
 - Repro: `FRONTIER_REGEN_ROOT=databases/Frontier-v6.root ./tests/runtime_tests`
@@ -43,3 +48,5 @@ Status
 - Audit additional legacy roots (e.g., customer saves) with `FRONTIER_REGEN_ROOT=… ./tests/runtime_tests` and stash each log under `/tmp` with a timestamp so regressions stand out quickly.
 - Keep expanding fixture coverage for wptext parsing—every time we dump a new Paige blob, add it to `tests/fixtures/wptext/` and update `tests/components/paige_text_tests.c`.
 - Continue running `make -C tests runtime_tests` + the migrator smoke after each change, attaching the latest log paths here so the next session can pick up immediately.
+- Re-run the full CLI/runtime suites once the big-endian header changes land in the reader path to confirm `clock.now()` and v7 opens behave the same on arm64/x86.
+- New plan doc: `planning/big_endian_portability_audit.md` tracks the remaining BE audit (avail list serialization, record metadata, reader parity, cross-arch regression, docs).

--- a/planning/big_endian_portability_audit.md
+++ b/planning/big_endian_portability_audit.md
@@ -1,0 +1,35 @@
+# Big-Endian Portability Audit (v7)
+**Last Updated:** 2025-11-23 — Codex  
+**Purpose:** Lock down v7 on-disk byte order (big-endian) across all writers/readers so arm64/x86 outputs match bit-for-bit.
+
+## Scope & Goals
+- Enforce big-endian encoding for all v7 database writes (header, tables, records, avail list, block metadata).
+- Keep readers symmetric with writers; avoid mixed host-order fields.
+- Add regression coverage to catch cross-arch drift (goldens/log comparisons).
+- Document the final on-disk layout and migration expectations.
+
+## Work Items
+1. **Avail list serialization (P0)**
+   - Decision: use BE 64-bit `adr` + BE 64-bit `size` (no 4 GB cap) to avoid future format bumps and protect large roots (6–10 GB). Rationale: single-maintainer risk; don’t want to revisit v7 → v8 for the free list.
+   - Progress: block headers/trailers now store 64-bit sizes in BE, avail links read/write in BE64. Next: audit any remaining 32-bit size math and shadow flush paths to ensure end-to-end 64-bit.
+   - Regression: added in-memory >4 GB free-span encode/decode in `tests/db_format_tests.c` (no artifacts). If a file-based variant is added later, use sparse temp files, unlink on success, and log loudly with path on failure for cleanup.
+2. **Record/block metadata audit (P0)**
+   - Find any remaining `memtodisklong`/host-order writes for record lengths/addresses in save paths (`dbwritedatablock`, packers).
+   - Apply BE helpers uniformly; confirm header/trailer variance paths already BE.
+3. **Reader parity (P0)**
+   - Ensure all v7 read paths mirror the BE writes (headers, tables, avail list, block metadata).
+   - Add defensive logging where mixed-endian data is encountered.
+4. **CLI/runtime validation (P0)**
+   - Re-enable `tests/cli_runtime_tests` `clock.now()` once v7 reads/writes match across arch.
+   - Re-run migrator/runtime suites and stash logs under `/tmp` with timestamps.
+5. **Documentation (P0)**
+   - Update `docs/database_architecture.md` with the finalized v7 BE layout (field widths, endianness rules).
+   - Note the portability guarantees and test commands in `planning/_CURRENT_STATUS.md` and `planning/TODO_future_improvements.md`.
+6. **Cross-arch regression coverage (P1)**
+   - Add a golden byte-level check: write a minimal v7 DB on host, compare header/table/avail bytes to a saved BE reference.
+   - Add a free-list exercise: allocate/free blocks, persist, reopen, and verify avail list bytes unchanged on arm64/x86.
+
+## Risks / Notes
+- Avoid partial endian flips: change writers/readers together to prevent free-list corruption.
+- Runtime-only fields must stay zeroed on disk (`releasestack`, `fnumdatabase`, in-memory shadows).
+- v7 artifacts in-repo are ephemeral; regenerate after changes to validate byte-for-byte parity.

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -1,10 +1,15 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #include "frontier.h"
 #include "db_format.h"
+#include "dbinternal.h"
 
+// 2025-11-20 Codex: Verify modern header serialization uses fixed big-endian encoding for portability.
 static const size_t legacy_view_base = 10;
 static const size_t legacy_view_stride = 4;
 
@@ -98,10 +103,98 @@ static void test_convert_header(void) {
         assert(new_header.u.extensions.reserved[i] == 0);
 }
 
+static void test_write_modern_header_big_endian(void) {
+    tydatabaserecord_64 header;
+    unsigned char encoded[sizeof header];
+    const unsigned char expected_availlist[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    const unsigned char expected_view0[] = {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11};
+    const unsigned char expected_view1[] = {0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18};
+    const unsigned char expected_view2[] = {0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x00, 0x99};
+    const unsigned char expected_header_len[] = {0x10, 0x20, 0x30, 0x40};
+    const unsigned char expected_major[] = {0x55, 0x66};
+    const unsigned char expected_minor[] = {0x77, 0x88};
+    const unsigned char expected_block[] = {0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xB0, 0x0C};
+    const unsigned char expected_shadow[] = {0x01, 0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    memset(&header, 0, sizeof header);
+    header.systemid = 0x01;
+    header.versionnumber = 7;
+    header.availlist = 0x0102030405060708ULL;
+    header.oldfnumdatabase = (short) 0x1122;
+    header.flags = (short) 0x3344;
+    header.views[0] = 0x0A0B0C0D0E0F1011ULL;
+    header.views[1] = 0x1112131415161718ULL;
+    header.views[2] = 0xFFEEDDCCBBAA0099ULL;
+    header.releasestack = (Handle) 0xDEADBEEF;
+    header.fnumdatabase = 0x13572468;
+    header.headerLength = 0x10203040;
+    header.longversionMajor = (short) 0x5566;
+    header.longversionMinor = (short) 0x7788;
+    header.u.extensions.availlistblock = 0xCAFEBABEDEADB00CULL;
+    header.u.extensions.availlistshadow = 0x0100AABBCCDDEEFFULL;
+    header.u.extensions.flreadonly = true;
+
+    memset(encoded, 0, sizeof encoded);
+    assert(db_format_write_header64(&header, encoded, sizeof encoded));
+
+    assert(encoded[0] == header.systemid);
+    assert(encoded[1] == header.versionnumber);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, availlist), expected_availlist, sizeof expected_availlist) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, oldfnumdatabase), "\x11\x22", 2) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, flags), "\x33\x44", 2) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, views[0]), expected_view0, sizeof expected_view0) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, views[1]), expected_view1, sizeof expected_view1) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, views[2]), expected_view2, sizeof expected_view2) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, headerLength), expected_header_len, sizeof expected_header_len) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, longversionMajor), expected_major, sizeof expected_major) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, longversionMinor), expected_minor, sizeof expected_minor) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, u.extensions.availlistblock), expected_block, sizeof expected_block) == 0);
+    assert(memcmp(encoded + offsetof(tydatabaserecord_64, u.extensions.availlistshadow), expected_shadow, sizeof expected_shadow) == 0);
+    assert(encoded[offsetof(tydatabaserecord_64, u.extensions.flreadonly)] == 1);
+
+    /* Runtime-only fields must be zeroed on disk */
+    for (size_t i = 0; i < sizeof(Handle); ++i)
+        assert(encoded[offsetof(tydatabaserecord_64, releasestack) + i] == 0);
+    for (size_t i = 0; i < sizeof(long); ++i)
+        assert(encoded[offsetof(tydatabaserecord_64, fnumdatabase) + i] == 0);
+}
+
+static void test_large_free_block_be64(void) {
+    /* Simulate a free block >4GB to ensure size/link encode to BE64 without truncation. */
+    use_64bit_format = true;
+
+    const uint64_t data_bytes = (1ULL << 33) + 0x1234ULL; /* 8GB+ */
+    const uint64_t freeflag = 0x8000000000000000ULL;
+    const uint64_t raw_size = data_bytes | freeflag;
+    const dbaddress next_link = (dbaddress) 0x0FEDCBA987654321ULL;
+
+    unsigned char header[sizeheader_v7];
+    unsigned char trailer[sizetrailer_v7];
+    unsigned char link_bytes[sizeof(uint64_t)];
+    memset(header, 0, sizeof header);
+    memset(trailer, 0, sizeof trailer);
+    memset(link_bytes, 0, sizeof link_bytes);
+
+    db_format_write_be64(header + offsetof(tyheader64, sizefreeword) + offsetof(tysizefreeword64, size), raw_size);
+    db_format_write_be64(trailer + offsetof(tytrailer64, sizefreeword) + offsetof(tysizefreeword64, size), raw_size);
+    db_format_write_be64(link_bytes, (uint64_t) next_link);
+
+    assert(db_format_read_be64(header + offsetof(tyheader64, sizefreeword) + offsetof(tysizefreeword64, size)) == raw_size);
+    assert(db_format_read_be64(trailer + offsetof(tytrailer64, sizefreeword) + offsetof(tysizefreeword64, size)) == raw_size);
+    assert(db_format_read_be64(link_bytes) == (uint64_t) next_link);
+
+    uint64_t parsed_size = db_format_read_be64(header + offsetof(tyheader64, sizefreeword) + offsetof(tysizefreeword64, size)) & 0x7FFFFFFFFFFFFFFFULL;
+    assert(parsed_size == data_bytes);
+
+    use_64bit_format = false; /* leave global in legacy mode for other tests */
+}
+
 int main(void) {
     test_detect_legacy_database();
     test_detect_modern_database();
     test_convert_header();
+    test_write_modern_header_big_endian();
+    test_large_free_block_be64();
     printf("db_format_tests: all checks passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- write v7 block headers/trailers and avail links as big-endian 64-bit, with format-specific header/trailer sizes
- add shared BE helpers and an in-memory >4GB free-span regression; table address packing already BE
- refresh docs/planning (README highlights, current status, BE audit, decisions) and document modern header/trailer layout

## Testing
- make -C tests db_format_tests -B
- make -C tests runtime_tests
- make -C tests cli_runtime_tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Writes v7 headers/trailers and avail-list links as big-endian 64-bit, adds shared BE helpers/serializer, updates table address packing, and refreshes tests/docs.
> 
> - **Database format (v7, big-endian 64-bit)**
>   - Add shared BE read/write helpers and `db_format_write_header64` in `Common/headers/db_format.h` and `Common/source/db_format.c`.
>   - Define 32/64-bit block header/trailer structs and size macros in `Common/headers/dbinternal.h`; select sizes via `use_64bit_format`.
>   - Update `Common/source/db.c`:
>     - Read/write block headers/trailers as BE32 (v6) or BE64 (v7), incl. free-bit handling and variance.
>     - Write modern file header via `db_format_write_header64`; zero runtime-only fields.
>     - Read/write avail-list links in BE32/BE64; shadow avail-list bytes encoded/decoded accordingly.
>   - Update table packing to emit/consume dbaddresses in canonical BE (`Common/source/tablepack.c`).
> - **Tests**
>   - Extend `tests/db_format_tests.c` to validate v7 header serialization and >4GB free-span BE64 encoding.
> - **Docs/Planning**
>   - Refresh `README.md`, `docs/database_architecture.md` (v7 BE layout), and add `planning/big_endian_portability_audit.md`; update `planning/_CURRENT_STATUS.md` and `planning/DECISIONS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae4a3d25f6a3fe1e65921a4d1528d567bed155fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->