### PR TITLE
refactor: add version-based db reader routing stubs

### DIFF
--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -75,6 +75,11 @@ boolean db_format_prepare_runtime(void);
 boolean detect_database_format(const tydatabaserecord *header);
 boolean convert_32bit_header_to_64bit(const unsigned char *legacy_header, tydatabaserecord_64 *new_header);
 boolean db_format_write_header64(const tydatabaserecord_64 *src, unsigned char *dest, size_t dest_size);
+boolean db_format_decode_header(const unsigned char *rawheader, size_t raw_len, boolean *header_is_modern, tydatabaserecord *out);
+/* 2025-11-24 Codex: Entry points for v7 reader vs legacy adapter. */
+boolean db_format_load_legacy_adapter(const tydatabaserecord *decoded_header, boolean flreadonly);
+boolean db_format_load_v7_reader(const tydatabaserecord *decoded_header, boolean flreadonly);
+boolean db_format_header_version(const unsigned char *rawheader, size_t raw_len, int *out_version);
 boolean create_root_backup(const char *original_path);
 boolean migrate_32bit_to_64bit(const char *db_path);
 boolean ensure_database_modern(const char *db_path, boolean *migrated, char *output_path, size_t output_path_size);

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -58,28 +58,6 @@
 // 2025-11-20 Codex: Write modern headers and record metadata with explicit big-endian encoding for portability.
 // 2025-11-16 Codex: Keep dbgetsize locals wide enough so dbgetsizeandvariance
 // writes don't corrupt the caller's stack on 64-bit builds.
-static uint16_t db_read_be16(const unsigned char *p) {
-	return (uint16_t)((p[0] << 8) | p[1]);
-}
-
-static uint32_t db_read_be32(const unsigned char *p) {
-	return ((uint32_t)p[0] << 24) |
-	       ((uint32_t)p[1] << 16) |
-	       ((uint32_t)p[2] << 8)  |
-	        (uint32_t)p[3];
-}
-
-static uint64_t db_read_be64(const unsigned char *p) {
-	return ((uint64_t)p[0] << 56) |
-	       ((uint64_t)p[1] << 48) |
-	       ((uint64_t)p[2] << 40) |
-	       ((uint64_t)p[3] << 32) |
-	       ((uint64_t)p[4] << 24) |
-	       ((uint64_t)p[5] << 16) |
-	       ((uint64_t)p[6] << 8)  |
-	        (uint64_t)p[7];
-}
-
 static void db_prepare_modern_header(const tydatabaserecord *src, tydatabaserecord_64 *dst) {
 	int i;
 
@@ -2590,6 +2568,8 @@ boolean dbnew (hdlfilenum fnum) {
 	} /*dbnew*/
 	
 
+/* 2025-11-24 Codex: Route dbopenfile through v7 reader or legacy adapter. */
+
 boolean dbopenfile (hdlfilenum fnum, boolean flreadonly) {
 	
 	/*
@@ -2616,9 +2596,9 @@ boolean dbopenfile (hdlfilenum fnum, boolean flreadonly) {
      */
     #define MAX_HEADER_SIZE (sizeof(tydatabaserecord) > sizeof(tydatabaserecord_64) ? sizeof(tydatabaserecord) : sizeof(tydatabaserecord_64))
     unsigned char rawheader[MAX_HEADER_SIZE];
-    tydatabaserecord_64 diskrec64;
-    int i;
     boolean header_is_modern = false;
+	int header_version = 0;
+	
     register hdldatabaserecord hdb;
 	
 	// Version-specific size validation will be done after reading header
@@ -2633,48 +2613,21 @@ boolean dbopenfile (hdlfilenum fnum, boolean flreadonly) {
 	if (!dbread ((dbaddress) 0, sizeof (rawheader), &rawheader))
 		goto error;
 	
-    if (rawheader[1] >= 7) {
-        int i;
-        header_is_modern = true;
-        clearbytes (&diskrec, sizeof diskrec);
-        clearbytes (&diskrec64, sizeof diskrec64);
-        memcpy (&diskrec64, rawheader, sizeof diskrec64);
+	if (!db_format_header_version(rawheader, sizeof rawheader, &header_version))
+		goto error;
 
-        diskrec.systemid = diskrec64.systemid;
-        diskrec.versionnumber = diskrec64.versionnumber;
-        diskrec.availlist = (dbaddress) db_read_be64 ((const unsigned char *) &diskrec64.availlist);
-        diskrec.oldfnumdatabase = (short) db_read_be16 ((const unsigned char *) &diskrec64.oldfnumdatabase);
-        diskrec.flags = (short) db_read_be16 ((const unsigned char *) &diskrec64.flags);
+	header_is_modern = header_version >= 7;
+	
+	if (!db_format_decode_header(rawheader, sizeof rawheader, &header_is_modern, &diskrec))
+		goto error;
 
-        for (i = 0; i < ctviews; i++)
-            diskrec.views[i] = (dbaddress) db_read_be64 ((const unsigned char *) &diskrec64.views[i]);
-
-        diskrec.releasestack = nil;
-        diskrec.fnumdatabase = 0;
-        diskrec.headerLength = (long) db_read_be32 ((const unsigned char *) &diskrec64.headerLength);
-        diskrec.longversionMajor = (short) db_read_be16 ((const unsigned char *) &diskrec64.longversionMajor);
-        diskrec.longversionMinor = (short) db_read_be16 ((const unsigned char *) &diskrec64.longversionMinor);
-
-        diskrec.u.extensions.availlistblock = (dbaddress) db_read_be64 ((const unsigned char *) &diskrec64.u.extensions.availlistblock);
-        diskrec.u.extensions.flreadonly = diskrec64.u.extensions.flreadonly;
-	}
-	else {
-		memcpy (&diskrec, rawheader, sizeof diskrec);
-
-        diskrec.availlist = (dbaddress) db_read_be32(rawheader + 2);
-        for (i = 0; i < ctviews; i++)
-            diskrec.views[i] = (dbaddress) db_read_be32(rawheader + 10 + (size_t) i * 4);
-		
-#ifdef SWAP_BYTE_ORDER
-		{
-		disktomemlong (diskrec.u.extensions.availlistblock);
-		disktomemshort (diskrec.flags);
-//		disktomemlong (diskrec.fnumdatabase);
-		disktomemlong (diskrec.headerLength);
-		disktomemshort (diskrec.longversionMajor);
-		disktomemshort (diskrec.longversionMinor);
-		}
-#endif
+	/* Route to legacy adapter (v6) or strict v7 reader. */
+	if (header_version <= 6) {
+		if (!db_format_load_legacy_adapter(&diskrec, flreadonly))
+			goto error;
+	} else {
+		if (!db_format_load_v7_reader(&diskrec, flreadonly))
+			goto error;
 	}
 	
 	diskrec.fnumdatabase = (long) fnum; /*this just got overwritten*/

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -789,17 +789,23 @@ static uint64_t read_be64(const unsigned char *field) {
 /* 2025-11-24 Codex: Decode raw header into a consistent in-memory record (legacy vs v7). */
 boolean db_format_decode_header(const unsigned char *rawheader, size_t raw_len, boolean *header_is_modern, tydatabaserecord *out) {
     int i;
+    int header_version = 0;
+    size_t needed = 0;
 
     if ((rawheader == NULL) || (header_is_modern == NULL) || (out == NULL))
+        return false;
+
+    if (!db_format_header_version(rawheader, raw_len, &header_version))
         return false;
 
     *header_is_modern = false;
     memset(out, 0, sizeof *out);
 
-    if (raw_len < sizeof(tydatabaserecord_64))
+    needed = (header_version >= 7) ? sizeof(tydatabaserecord_64) : sizeof(tydatabaserecord);
+    if (raw_len < needed)
         return false;
 
-    if (rawheader[1] >= 7) {
+    if (header_version >= 7) {
         tydatabaserecord_64 diskrec64;
 
         *header_is_modern = true;

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -654,7 +654,7 @@ static void db_trace_walk_table(db_trace_context *ctx, dbaddress adr, const char
 
     dbaddress redirected = nildbaddress;
     if (db_trace_detect_cancoon(payload, payload_len, &redirected)) {
-        db_trace_log(1, "%s: [%s] Cancoon header → 0x%08llx",
+        db_trace_log(1, "%s: [%s] Cancoon header â 0x%08llx",
                      ctx->path_label, path, (unsigned long long) redirected);
         free(payload);
         db_trace_walk_table(ctx, redirected, path, depth);
@@ -784,6 +784,89 @@ static uint64_t read_be64(const unsigned char *field) {
            ((uint64_t) field[5] << 16) |
            ((uint64_t) field[6] << 8)  |
             (uint64_t) field[7];
+}
+
+/* 2025-11-24 Codex: Decode raw header into a consistent in-memory record (legacy vs v7). */
+boolean db_format_decode_header(const unsigned char *rawheader, size_t raw_len, boolean *header_is_modern, tydatabaserecord *out) {
+    int i;
+
+    if ((rawheader == NULL) || (header_is_modern == NULL) || (out == NULL))
+        return false;
+
+    *header_is_modern = false;
+    memset(out, 0, sizeof *out);
+
+    if (raw_len < sizeof(tydatabaserecord_64))
+        return false;
+
+    if (rawheader[1] >= 7) {
+        tydatabaserecord_64 diskrec64;
+
+        *header_is_modern = true;
+        memset(&diskrec64, 0, sizeof diskrec64);
+        memcpy(&diskrec64, rawheader, sizeof diskrec64);
+
+        out->systemid = diskrec64.systemid;
+        out->versionnumber = diskrec64.versionnumber;
+        out->availlist = (dbaddress) read_be64((const unsigned char *) &diskrec64.availlist);
+        out->oldfnumdatabase = (short) read_be16((const unsigned char *) &diskrec64.oldfnumdatabase);
+        out->flags = (short) read_be16((const unsigned char *) &diskrec64.flags);
+
+        for (i = 0; i < ctviews; i++)
+            out->views[i] = (dbaddress) read_be64((const unsigned char *) &diskrec64.views[i]);
+
+        out->releasestack = nil;
+        out->fnumdatabase = 0;
+        out->headerLength = (long) db_format_read_be32((const unsigned char *) &diskrec64.headerLength);
+        out->longversionMajor = (short) read_be16((const unsigned char *) &diskrec64.longversionMajor);
+        out->longversionMinor = (short) read_be16((const unsigned char *) &diskrec64.longversionMinor);
+
+        out->u.extensions.availlistblock = (dbaddress) db_format_read_be64((const unsigned char *) &diskrec64.u.extensions.availlistblock);
+        out->u.extensions.flreadonly = diskrec64.u.extensions.flreadonly;
+    } else {
+        memcpy(out, rawheader, sizeof *out);
+
+        out->availlist = (dbaddress) read_legacy_dbaddress32(rawheader + 2);
+        for (i = 0; i < ctviews; i++)
+            out->views[i] = (dbaddress) read_legacy_dbaddress32(rawheader + 10 + (size_t) i * 4);
+
+#ifdef SWAP_BYTE_ORDER
+        {
+        disktomemlong (out->u.extensions.availlistblock);
+        disktomemshort (out->flags);
+//      disktomemlong (out->fnumdatabase);
+        disktomemlong (out->headerLength);
+        disktomemshort (out->longversionMajor);
+        disktomemshort (out->longversionMinor);
+        }
+#endif
+    }
+
+    return true;
+}
+
+boolean db_format_header_version(const unsigned char *rawheader, size_t raw_len, int *out_version) {
+    if (rawheader == NULL || out_version == NULL || raw_len < 2)
+        return false;
+    *out_version = rawheader[1];
+    return true;
+}
+
+/* 2025-11-24 Codex: Stubs for split reader paths (legacy adapter vs v7). */
+boolean db_format_load_legacy_adapter(const tydatabaserecord *decoded_header, boolean flreadonly) {
+    #pragma unused (decoded_header, flreadonly)
+    /* Stub: legacy adapter path; sets global format to legacy for readers.
+       TODO: widen legacy payloads before writing via v7 packers. */
+    use_64bit_format = false;
+    return true;
+}
+
+boolean db_format_load_v7_reader(const tydatabaserecord *decoded_header, boolean flreadonly) {
+    #pragma unused (decoded_header, flreadonly)
+    /* Stub: v7 reader path; sets global format to modern for readers.
+       TODO: enforce strict v7 read path here. */
+    use_64bit_format = true;
+    return true;
 }
 
 boolean db_format_write_header64(const tydatabaserecord_64 *src, unsigned char *dest, size_t dest_size) {

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -654,7 +654,7 @@ static void db_trace_walk_table(db_trace_context *ctx, dbaddress adr, const char
 
     dbaddress redirected = nildbaddress;
     if (db_trace_detect_cancoon(payload, payload_len, &redirected)) {
-        db_trace_log(1, "%s: [%s] Cancoon header â 0x%08llx",
+        db_trace_log(1, "%s: [%s] Cancoon header -> 0x%08llx",
                      ctx->path_label, path, (unsigned long long) redirected);
         free(payload);
         db_trace_walk_table(ctx, redirected, path, depth);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,6 +18,7 @@ endif
 
 # Enable Paige debug instrumentation + wp runtime guards when tests are built
 FRONTIER_TESTS ?= 1
+CWARNING_SUPPRESS ?= -Wno-nonportable-include-path  # Suppress Paige header case warnings (third-party code)
 CFLAGS = -Wall -Wextra -std=c99 -g -O0 -fpascal-strings -Wno-deprecated-non-prototype -fcommon \
          -DFRONTIER_USE_PORTABLE_HANDLES -DFRONTIER_HEADLESS \
          -DFRONTIER_PORTABLE_STRINGS \
@@ -30,6 +31,7 @@ CFLAGS = -Wall -Wextra -std=c99 -g -O0 -fpascal-strings -Wno-deprecated-non-prot
          -DLAND_GENERALLOG_LEVEL=LAND_LOGLEVEL_OFF -DLAND_GENERALLOG_TARGET=LAND_LOGTARGET_NONE \
          -DUNIX_COMPILE -DC_LIBRARY -DNO_OS_INLINE \
          $(SAN_FLAGS) \
+         $(CWARNING_SUPPRESS) \
          -I../generated
 STRINGS_COMPILER_DIR = ../tools/strings_compiler
 STRINGS_COMPILER = $(STRINGS_COMPILER_DIR)/strings_compiler

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -204,6 +204,39 @@ static void test_pict_length_be32(void) {
     assert(db_format_read_be32(encoded) == pict_len);
 }
 
+static void test_header_version_and_loader_switch(void) {
+    const size_t max_header = (sizeof(tydatabaserecord) > sizeof(tydatabaserecord_64) ? sizeof(tydatabaserecord) : sizeof(tydatabaserecord_64));
+    unsigned char legacy_raw[max_header];
+    unsigned char modern_raw[max_header];
+    int version = 0;
+    boolean header_is_modern = false;
+    tydatabaserecord decoded;
+    boolean prev_use64 = use_64bit_format;
+
+    memset(&decoded, 0, sizeof decoded);
+    memset(legacy_raw, 0, sizeof legacy_raw);
+    legacy_raw[1] = 6; /* legacy v6 */
+    assert(db_format_header_version(legacy_raw, sizeof legacy_raw, &version));
+    assert(version == 6);
+    assert(db_format_decode_header(legacy_raw, sizeof legacy_raw, &header_is_modern, &decoded));
+    assert(!header_is_modern);
+    assert(db_format_load_legacy_adapter(&decoded, true));
+    assert(use_64bit_format == false);
+
+    memset(&decoded, 0, sizeof decoded);
+    memset(modern_raw, 0, sizeof modern_raw);
+    modern_raw[1] = 7; /* modern v7 */
+    header_is_modern = false;
+    assert(db_format_header_version(modern_raw, sizeof modern_raw, &version));
+    assert(version == 7);
+    assert(db_format_decode_header(modern_raw, sizeof modern_raw, &header_is_modern, &decoded));
+    assert(header_is_modern);
+    assert(db_format_load_v7_reader(&decoded, true));
+    assert(use_64bit_format == true);
+
+    use_64bit_format = prev_use64;
+}
+
 static void test_procedural_v7_golden_header_and_avail(void) {
     /*
      * Procedural golden for header + avail: fixed byte expectations to ensure BE encoding is stable
@@ -277,6 +310,7 @@ int main(void) {
     test_write_modern_header_big_endian();
     test_large_free_block_be64();
     test_pict_length_be32();
+    test_header_version_and_loader_switch();
     test_procedural_v7_golden_header_and_avail();
     printf("db_format_tests: all checks passed\n");
     return 0;

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -208,6 +208,7 @@ static void test_header_version_and_loader_switch(void) {
     const size_t max_header = (sizeof(tydatabaserecord) > sizeof(tydatabaserecord_64) ? sizeof(tydatabaserecord) : sizeof(tydatabaserecord_64));
     unsigned char legacy_raw[max_header];
     unsigned char modern_raw[max_header];
+    unsigned char truncated_legacy[sizeof(tydatabaserecord_64)]; /* smaller than legacy header */
     int version = 0;
     boolean header_is_modern = false;
     tydatabaserecord decoded;
@@ -222,6 +223,13 @@ static void test_header_version_and_loader_switch(void) {
     assert(!header_is_modern);
     assert(db_format_load_legacy_adapter(&decoded, true));
     assert(use_64bit_format == false);
+
+    /* Decode should fail if buffer is smaller than legacy header size. */
+    memset(truncated_legacy, 0, sizeof truncated_legacy);
+    truncated_legacy[1] = 6;
+    header_is_modern = false;
+    memset(&decoded, 0, sizeof decoded);
+    assert(!db_format_decode_header(truncated_legacy, sizeof truncated_legacy, &header_is_modern, &decoded));
 
     memset(&decoded, 0, sizeof decoded);
     memset(modern_raw, 0, sizeof modern_raw);


### PR DESCRIPTION
## Summary
- Add header version parsing and centralized header decode helpers in db_format.
- Route dbopenfile by version: v6 headers call a legacy adapter stub (keeps use_64bit_format=false), v7+ headers call a v7 reader stub (sets use_64bit_format=true); decode shared for both.
- Add a minimal test to verify version parsing/loader toggling; gate Paige nonportable include warnings via CWARNING_SUPPRESS in tests/Makefile.

## So what
- Establishes the logical fork between legacy and v7 reader paths without changing payload handling yet; sets the stage for real legacy widening and a strict v7 reader in the next PR.

## Tests
- make -C tests db_format_tests
(known warning: __builtin_return_address in memory.c remains)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds header version parsing/decoding and routes `dbopenfile` to legacy adapter or v7 reader stubs; includes targeted tests and test warning suppression.
> 
> - **DB Core**:
>   - **Header handling**: Implement `db_format_header_version`, `db_format_decode_header`, and loader stubs `db_format_load_legacy_adapter`/`db_format_load_v7_reader` (toggle `use_64bit_format`).
>   - **Open path**: Update `dbopenfile` to read raw header, detect version, decode once, and dispatch to legacy (v6) or v7 reader; removes ad-hoc endian reads in favor of shared helpers.
> - **Tracing/Logging**:
>   - Normalize log arrow in Cancoon trace output (`->`).
> - **Tests**:
>   - Add `test_header_version_and_loader_switch` to validate version parsing, decode size checks, and loader toggling.
>   - Suppress nonportable include warnings in `tests/Makefile` via `CWARNING_SUPPRESS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0700578b871b11b9b54cac2e22010ed89300cdbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->