### PR TITLE
Thread-safe Save As context guards using release/shadow helpers

### DIFF
--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -1,6 +1,9 @@
 
 /*	$Id$    */
 
+/*****************************************************************************/
+/* 2025-11-29 Codex: Add Save As destination getter for context-aware callers. */
+/* 2025-11-30 Codex: Widen Save As context signatures for scoped state. */
 /******************************************************************************
 
     UserLand Frontier(tm) -- High performance Web content management,
@@ -35,6 +38,8 @@
 #pragma message( "**Compiling " __FILE__ )
 #endif
 
+
+typedef struct db_context db_context;
 
 #ifndef memoryinclude
 	#include "memory.h"
@@ -210,8 +215,12 @@ extern boolean dbopenfile (hdlfilenum, boolean);
 extern boolean dbclose (void);
 
 extern boolean dbstartsaveas (hdlfilenum);
+extern boolean dbstartsaveas_context(db_context *context, hdlfilenum fnum);
+
+extern boolean dbgetdestinationdatabase (hdldatabaserecord *);
 
 extern boolean dbendsaveas (void);
+extern boolean dbendsaveas_context(db_context *context);
 
 extern boolean statsblockinuse (dbaddress, bigstring); /*dbstats.c*/
 

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -22,6 +22,10 @@ typedef struct db_format_mode {
     boolean drop_cancoon;
 } db_format_mode;
 
+typedef struct db_context {
+    db_format_mode mode;
+} db_context;
+
 #define LEGACY_DB_HEADER_BYTES 88
 
 static inline uint16_t db_format_read_be16(const unsigned char *p) {

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -1,5 +1,7 @@
 // 2025-11-20 Codex: Add shared big-endian helpers and a serializer for v7 headers to keep disk format portable.
 // 2025-11-26 Codex: Move reader/writer entry points into dedicated headers to simplify version splits.
+// 2025-11-29 Codex: Add context wrappers for adapter wide writes and Save As completion.
+// 2025-11-30 Codex: Extend db_context with Save As state and expose scoped helpers.
 /*
  * db_format.h - Helpers for detecting and migrating Frontier database headers.
  */
@@ -11,6 +13,7 @@
 #include <stddef.h>
 
 #include "db.h"
+#include "lang.h" /* for hdlhashtable */
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,9 +25,17 @@ typedef struct db_format_mode {
     boolean drop_cancoon;
 } db_format_mode;
 
-typedef struct db_context {
+typedef struct db_saveas_state {
+    boolean active;
+    hdldatabaserecord destination;
+    hdldatabaserecord source;
+} db_saveas_state;
+
+struct db_context {
     db_format_mode mode;
-} db_context;
+    hdldatabaserecord database;
+    db_saveas_state saveas;
+};
 
 #define LEGACY_DB_HEADER_BYTES 88
 
@@ -92,6 +103,7 @@ boolean db_format_load_v7_reader(const tydatabaserecord *decoded_header, boolean
 boolean db_format_header_version(const unsigned char *rawheader, size_t raw_len, int *out_version);
 /* 2025-11-25 Codex: Legacy adapter state helpers for widening + wide writes. */
 boolean db_format_adapter_enable_wide_writes(const tydatabaserecord_64 **widened_header_out);
+boolean db_format_adapter_enable_wide_writes_context(const db_context *context, const tydatabaserecord_64 **widened_header_out);
 boolean db_format_adapter_force_repack(void);
 void db_format_adapter_mark_address(dbaddress *adr_out);
 boolean db_format_adapter_is_active(void);
@@ -109,6 +121,32 @@ void db_format_mode_push(const db_format_mode *mode);
 void db_format_mode_pop(void);
 db_format_mode db_format_mode_current(void);
 void db_format_mode_apply(const db_format_mode *mode);
+void db_saveas_state_snapshot(db_saveas_state *state);
+void db_saveas_state_apply(const db_saveas_state *state);
+void db_context_init(db_context *context);
+void db_context_apply(const db_context *context);
+boolean hashpacktable_context(const db_context *context, hdlhashtable ht, boolean flsave, Handle *hpacked, boolean *flmustsave);
+boolean hashunpacktable_context(const db_context *context, Handle hpacked, boolean flmemory, hdlhashtable htable);
+boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *adr);
+boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h);
+boolean dbcopy_context(const db_context *context, dbaddress src, dbaddress *dest);
+boolean dbassign_context(const db_context *context, dbaddress *padr, long newsize, ptrvoid pdata);
+boolean dbreference_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata);
+boolean dballocate_context(const db_context *context, long databytes, ptrvoid pdata, dbaddress *paddress);
+boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h);
+boolean dbendsaveas_context(db_context *context);
+boolean dbstartsaveas_context(db_context *context, hdlfilenum fnum);
+boolean dbpushdatabase_context(const db_context *context, hdldatabaserecord hdatabase);
+boolean dbpopdatabase_context(const db_context *context);
+boolean dbflushreleasestack_context(const db_context *context);
+boolean dbzeroreleasestack_context(const db_context *context);
+boolean dbrelease_context(const db_context *context, dbaddress adr);
+boolean dbwriteshadowavaillist_context(const db_context *context);
+boolean dbclearshadowavaillist_context(const db_context *context);
+void dbswapglobals_context(db_context *context);
+boolean dbassign_internal(dbaddress *padr, long newsize, ptrvoid pdata);
+boolean dbcopy_internal(dbaddress adrorig, dbaddress *adrcopy);
+boolean dbreference_internal(dbaddress adr, long maxbytes, ptrvoid pdata);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/Common/source/cancoon.c
+++ b/Common/source/cancoon.c
@@ -1112,8 +1112,11 @@ boolean ccsavefile (ptrfilespec fs, hdlfilenum fnum, short rnum, boolean flsavea
 	if (!dbassign (&adr, sizeof (info), &info))
 		goto exit;
 	
-	if (!flsaveas)
-		dbflushreleasestack (); /*release all the db objects that were saved up*/
+	if (!flsaveas) {
+		db_context ctx;
+		db_context_init(&ctx);
+		dbflushreleasestack_context(&ctx); /*release all the db objects that were saved up*/
+	}
 	
 	dbsetview (cancoonview, adr);
 	
@@ -1743,7 +1746,6 @@ boolean ccstart (void) {
 	
 	return (ccwindowstart ());
 	} /*ccstart*/
-
 
 
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -28,6 +28,8 @@
 /* 2025-11-24 Codex: Legacy header writes now use BE helpers for v7 parity. */
 /* 2025-11-25 Codex: Update dbopenfile to route through widened legacy adapter signature. */
 /* 2025-11-26 Codex: Expose raw db read/write for split reader/writer modules. */
+/* 2025-11-29 Codex: Add Save As destination accessor and context wrappers for db stack ops. */
+/* 2025-11-30 Codex: Scope Save As state through db_context guards to stop global leaks. */
 
 
 #include "frontier.h"
@@ -317,13 +319,88 @@ static boolean dbseteof (long eof) {
 short topdatabasestack = 0;
 
 hdldatabaserecord databasestack [ctdatabasestack];
+static db_context g_default_db_context;
+typedef struct db_context_guard {
+    db_format_mode prev_mode;
+    db_saveas_state prev_saveas;
+    hdldatabaserecord prev_db;
+} db_context_guard;
+
+static db_context *db_context_refresh_default(void) {
+    db_context_init(&g_default_db_context);
+    return &g_default_db_context;
+}
+
+void db_saveas_state_snapshot(db_saveas_state *state) {
+    if (state == NULL)
+        return;
+    state->active = fldatabasesaveas;
+    state->destination = databasedestination;
+    state->source = dbsaveas_source;
+}
+
+void db_saveas_state_apply(const db_saveas_state *state) {
+    if (state == NULL)
+        return;
+    fldatabasesaveas = state->active;
+    databasedestination = state->destination;
+    dbsaveas_source = state->source;
+    db_sync_use64_to_current_db();
+}
+
+static void db_context_guard_enter(const db_context *context, db_context_guard *guard) {
+    if (guard != NULL) {
+        guard->prev_mode = db_format_mode_current();
+        db_saveas_state_snapshot(&guard->prev_saveas);
+        guard->prev_db = databasedata;
+    }
+    if (context != NULL) {
+        db_format_mode_apply(&context->mode);
+        if (context->database != nil)
+            databasedata = context->database;
+        db_saveas_state_apply(&context->saveas);
+    }
+}
+
+static void db_context_guard_exit(const db_context_guard *guard) {
+    if (guard == NULL)
+        return;
+    db_format_mode_apply(&guard->prev_mode);
+    databasedata = guard->prev_db;
+    db_saveas_state_apply(&guard->prev_saveas);
+}
+
+static void db_context_guard_exit_with_saveas(const db_context_guard *guard, const db_saveas_state *state) {
+    if (guard == NULL)
+        return;
+    db_format_mode_apply(&guard->prev_mode);
+    databasedata = guard->prev_db;
+    if (state != NULL)
+        db_saveas_state_apply(state);
+    else
+        db_saveas_state_apply(&guard->prev_saveas);
+}
 
 
-static boolean dbrelease (dbaddress); /*6.2b2: Dropped from db.h and declared static*/
+static boolean dbrelease_internal (dbaddress); /*6.2b2: Dropped from db.h and declared static*/
 static boolean dballocate (long databytes, ptrvoid pdata, dbaddress *paddress); /*6.2b14 AR: forward declaration for dbwriteshadowavaillist*/
+static boolean dbstartsaveas_internal(hdlfilenum fnum);
+static boolean dbendsaveas_internal(void);
+boolean dbassign_context(const db_context *context, dbaddress *padr, long newsize, ptrvoid pdata);
+boolean dbreference_context(const db_context *context, dbaddress adr, long maxbytes, ptrvoid pdata);
+boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h);
+boolean dballocate_context(const db_context *context, long databytes, ptrvoid pdata, dbaddress *paddress);
+boolean dbendsaveas_context(db_context *context);
+boolean dbstartsaveas_context(db_context *context, hdlfilenum fnum);
+boolean dbpushdatabase_context(const db_context *context, hdldatabaserecord hdatabase);
+boolean dbpopdatabase_context(const db_context *context);
+boolean dbrelease_context(const db_context *context, dbaddress adr);
+boolean dbassign_internal(dbaddress *padr, long newsize, ptrvoid pdata);
+boolean dbcopy_internal(dbaddress adrorig, dbaddress *adrcopy);
+boolean dbreference_internal(dbaddress adr, long maxbytes, ptrvoid pdata);
+boolean dbgetsize_internal(dbaddress adr, long *logicalsize);
 
 boolean dbpushdatabase (hdldatabaserecord hdatabase) {
-	
 	/*
 	when you want to temporarily work with a different databaserecord, call this
 	routine, do your stuff and then call dbpopdatabase.
@@ -357,6 +434,23 @@ boolean dbpopdatabase (void) {
 	
 	return (true);
 	} /*dbpopdatabase*/
+
+/* Context-aware push/pop to avoid leaking mode/handle changes. */
+boolean dbpushdatabase_context(const db_context *context, hdldatabaserecord hdatabase) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbpushdatabase(hdatabase);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbpopdatabase_context(const db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbpopdatabase();
+    db_context_guard_exit(&guard);
+    return ok;
+}
 
 
 static void dbswapglobals (void) {
@@ -456,7 +550,11 @@ static boolean dbflushheader (void) {
 	assert (sizeof (diskrec.u.growthspace) >= sizeof (diskrec.u.extensions));
 	
 	/* If we opened via legacy adapter, flip to wide writes before flushing. */
-	db_format_adapter_enable_wide_writes(NULL);
+    {
+        db_context ctx;
+        db_context_init(&ctx);
+        db_format_adapter_enable_wide_writes_context(&ctx, NULL);
+    }
 
 	if (isdirty (hdb)) { /*changes made to header*/
 		
@@ -800,7 +898,7 @@ static boolean dbfindpreviousavail (dbaddress adr, dbaddress *prev, long *ixshad
 
 #ifdef SMART_DB_OPENING	
 
-static void dbclearshadowavaillist (void) {
+static void dbclearshadowavaillist_impl (void) {
 	
 	/*
 	6.2b12 AR: This function MUST be called before modifying the linked list
@@ -826,7 +924,7 @@ static void dbclearshadowavaillist (void) {
 			
 			dbflushheader ();		
 			
-			if (!dbrelease (adrblock)) {
+			if (!dbrelease_internal (adrblock)) {
 				#ifdef DATABASE_DEBUG
 					char str[256];
 
@@ -838,7 +936,22 @@ static void dbclearshadowavaillist (void) {
 			}
 			
 	return;
-	} /*dbclearshadowavaillist*/
+	} /*dbclearshadowavaillist_impl*/
+
+static void dbclearshadowavaillist (void) {
+    db_context_guard guard;
+    db_context_guard_enter(db_context_refresh_default(), &guard);
+    dbclearshadowavaillist_impl();
+    db_context_guard_exit(&guard);
+}
+
+boolean dbclearshadowavaillist_context(const db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    dbclearshadowavaillist();
+    db_context_guard_exit(&guard);
+    return true;
+}
 
 
 static void dbdisposeshadowavaillist (void) {
@@ -862,7 +975,7 @@ static void dbdisposeshadowavaillist (void) {
 #endif
 
 
-static boolean dbwriteshadowavaillist (void) {
+static boolean dbwriteshadowavaillist_impl (void) {
 
 	/*
 	6.2a9 AR: If there's an in-memory shadow avail list, write it to a faked new data block
@@ -893,7 +1006,7 @@ static boolean dbwriteshadowavaillist (void) {
 	if ((**hdb).u.extensions.flreadonly || fldatabasesaveas)
 		return (true); /*we're done already*/
 	
-	dbclearshadowavaillist ();
+	dbclearshadowavaillist_impl();
 		
 	if ((**hdb).u.extensions.availlistshadow.data == nil)
 		return (true); /*we're done already*/
@@ -967,6 +1080,22 @@ error:
 
 	return (fl);
 	}/*dbwriteshadowavaillist*/
+
+boolean dbwriteshadowavaillist (void) {
+    db_context_guard guard;
+    db_context_guard_enter(db_context_refresh_default(), &guard);
+    boolean ok = dbwriteshadowavaillist_impl();
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbwriteshadowavaillist_context(const db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbwriteshadowavaillist_impl();
+    db_context_guard_exit(&guard);
+    return ok;
+}
 
 
 static boolean dbreadshadowavaillist (void) {
@@ -1205,7 +1334,7 @@ static boolean dbsetsize (dbaddress adr, long size, tyvariance variance) {
 	} /*dbsetsize*/
 	
 
-boolean dbreference (dbaddress adr, long maxbytes, ptrvoid pdata) {
+boolean dbreference_internal (dbaddress adr, long maxbytes, ptrvoid pdata) {
 
 	/*
 	copy into pdata the database block located at address.  the number
@@ -1241,7 +1370,12 @@ boolean dbreference (dbaddress adr, long maxbytes, ptrvoid pdata) {
 		}
 	
 	return (dbread (adr + sizeheader, min (maxbytes, ctbytes - (long) variance), pdata));
-	} /*dbreference*/
+	} /*dbreference_internal*/
+
+boolean dbreference (dbaddress adr, long maxbytes, ptrvoid pdata) {
+    db_context *ctx = db_context_refresh_default();
+    return dbreference_context(ctx, adr, maxbytes, pdata);
+}
 	
 
 boolean dbrefhandle (dbaddress adr, Handle *h) {
@@ -1353,7 +1487,7 @@ static boolean dballocate (long databytes, ptrvoid pdata, dbaddress *paddress) {
 	dbclearshadowavaillist (); /*6.2b12 AR*/
 #endif
 
-	dbswapglobals (); /*use databasedestination*/
+	dbswapglobals_context(db_context_refresh_default()); /*use databasedestination*/
 	
 	smallestinterestingblock = max (databytes, (long) minblocksize);
 	
@@ -1524,14 +1658,14 @@ static boolean dballocate (long databytes, ptrvoid pdata, dbaddress *paddress) {
 	
 	success:
 	
-	dbswapglobals (); /*restore*/
+	dbswapglobals_context(db_context_refresh_default()); /*restore*/
 	
 	return (true); /*the allocation was successful*/
 	
 	
 	failure:
 	
-	dbswapglobals (); /*restore*/
+	dbswapglobals_context(db_context_refresh_default()); /*restore*/
 	
 	return (false);
 	} /*dballocate*/
@@ -1792,7 +1926,7 @@ static boolean dbmergeright (dbaddress adr, long ctbytes, boolean* ptrflmergedri
 	} /*dbmergeright*/
 	
 	
-static boolean dbrelease (dbaddress adr) {
+static boolean dbrelease_internal (dbaddress adr) {
 
 	/*
 	release the database block at adr.
@@ -1889,25 +2023,25 @@ static boolean dbrelease (dbaddress adr) {
 	dbheaderdirty ();
 	
 	return (true);
-	} /*dbrelease*/
+	} /*dbrelease_internal*/
 	
 
 	
 
 static boolean dbmove (ptrvoid pdata, long ctbytes, dbaddress adr) {
-	
+
 	/*
 	copy the data from memory (pdata) to the data part of the block at adr.
 	
 	call this when you know that the size of the object you're writing is the
 	same as the object this block was created to hold.
 	*/
-	
+
 	return (dbwrite (adr + sizeheader, ctbytes, pdata)); 
 	} /*dbmove*/
-	
 
-boolean dbassign (dbaddress *padr, long newsize, ptrvoid pdata) {
+
+boolean dbassign_internal (dbaddress *padr, long newsize, ptrvoid pdata) {
 	
 	/*
 	we want to move new data into the database block whose address is adr.
@@ -1932,7 +2066,7 @@ boolean dbassign (dbaddress *padr, long newsize, ptrvoid pdata) {
 	boolean flfree;
 	
 	adr = *padr; /*copy into a register*/
-	
+
 	if (fldatabasesaveas || (adr == nildbaddress)) /*no previous allocation, create a new one*/
 		return (dballocate (newsize, pdata, padr)); 
 	
@@ -1948,7 +2082,7 @@ boolean dbassign (dbaddress *padr, long newsize, ptrvoid pdata) {
 	
 	if (newsize > cttotal) { /*there isn't enough room*/
 
-		if (!dbrelease (adr)) { //ignore return value, don't want to abort saving
+		if (!dbrelease_internal (adr)) { //ignore return value, don't want to abort saving
 			#ifdef DATABASE_DEBUG
 				char str[256];
 
@@ -1968,10 +2102,15 @@ boolean dbassign (dbaddress *padr, long newsize, ptrvoid pdata) {
 			return (false);
 		
 	return (dbmove (pdata, newsize, adr)); /*copy the data into a big-enough block*/
-	} /*dbassign*/
+	} /*dbassign_internal*/
+
+boolean dbassign (dbaddress *padr, long newsize, ptrvoid pdata) {
+    db_context *ctx = db_context_refresh_default();
+    return dbassign_context(ctx, padr, newsize, pdata);
+}
 	
 	
-static boolean dbgetsize (dbaddress adr, long *logicalsize) {
+boolean dbgetsize_internal (dbaddress adr, long *logicalsize) {
 
 	/*
 	give me the address of a database block and I'll return the number
@@ -1992,10 +2131,10 @@ static boolean dbgetsize (dbaddress adr, long *logicalsize) {
 	*logicalsize = size - variance;
 	
 	return (true);
-	} /*dbgetsize*/
+	} /*dbgetsize_internal*/
 
 
-boolean dbcopy (dbaddress adrorig, dbaddress *adrcopy) {
+boolean dbcopy_internal (dbaddress adrorig, dbaddress *adrcopy) {
 	
 	/*
 	create a copy of the database block pointed to by adrorig.  return
@@ -2016,7 +2155,7 @@ boolean dbcopy (dbaddress adrorig, dbaddress *adrcopy) {
 		}
 
 	hdldatabaserecord source_db = db_begin_source_read();
-	if (!dbgetsize (adrorig, &size)) {
+	if (!dbgetsize_internal (adrorig, &size)) {
 #if defined(FRONTIER_HEADLESS)
 		fprintf(stderr, "[headless-db] dbgetsize failed for adr=0x%llx\n", (unsigned long long) adrorig);
 #endif
@@ -2067,7 +2206,12 @@ boolean dbcopy (dbaddress adrorig, dbaddress *adrcopy) {
 #endif
 	}
 	return (flreturned);
-	} /*dbcopy*/
+	} /*dbcopy_internal*/
+
+boolean dbcopy (dbaddress adrorig, dbaddress *adrcopy) {
+    db_context *ctx = db_context_refresh_default();
+    return dbcopy_context(ctx, adrorig, adrcopy);
+}
 	
 	
 static boolean dballocstring (dbaddress *adr, bigstring bs) {
@@ -2083,7 +2227,7 @@ static boolean dbrefstring (dbaddress adr, bigstring bs) {
 	if (adr == nildbaddress) /*nil adr represents an empty string, saves time & space*/
 		return (true);
 		
-	return (dbreference (adr, sizeof (bigstring), bs));
+	return (dbreference_internal (adr, sizeof (bigstring), bs));
 	} /*dbrefstring*/
 	
 	
@@ -2092,13 +2236,13 @@ static boolean dbassignstring (dbaddress *adr, bigstring bs) {
 	if (*adr == nildbaddress) 
 		return (dballocstring (adr, bs));
 	else
-		return (dbassign (adr, (long) stringlength(bs) + 1, bs));
+		return (dbassign_internal (adr, (long) stringlength(bs) + 1, bs));
 	} /*dbassignstring*/
 	
 	
 static boolean dbreleasestring (dbaddress adr) {
 
-	if (!dbrelease (adr)) {
+    if (!dbrelease_internal (adr)) {
 		#ifdef DATABASE_DEBUG
 			char str[256];
 
@@ -2243,7 +2387,7 @@ void dbsetview (short viewnumber, dbaddress adrtext) {
 
 	register hdldatabaserecord hdb;
 	
-	dbswapglobals ();
+	dbswapglobals_context(db_context_refresh_default());
 	
 	hdb = databasedata; /*move into register*/
 	
@@ -2253,7 +2397,7 @@ void dbsetview (short viewnumber, dbaddress adrtext) {
 	
 	dbflushheader ();
 	
-	dbswapglobals ();
+	dbswapglobals_context(db_context_refresh_default());
 	} /*dbsetview*/
 
 
@@ -2329,7 +2473,7 @@ boolean debug_dbpushreleasestack (dbaddress adr, long valtype, long line, char *
 	} /*dbpushreleasestack*/
 
 
-boolean dbflushreleasestack (void) {
+static boolean dbflushreleasestack_impl (void) {
 	
 	/*
 	release all the chunks accumulated in the database's releasestack.
@@ -2354,7 +2498,7 @@ boolean dbflushreleasestack (void) {
 
 			info = ((tydbreleasestackframe*)(*h)) [i];
 			
-			if (!dbrelease (info.adr)) {
+			if (!dbrelease_internal (info.adr)) {
 
 				bigstring bsfile;
 				char str[256];
@@ -2377,12 +2521,27 @@ boolean dbflushreleasestack (void) {
 #endif
 	 
 	return (true);
-	} /*dbflushreleasestack*/
+} /*dbflushreleasestack_impl*/
+
+boolean dbflushreleasestack (void) {
+    db_context_guard guard;
+    db_context_guard_enter(db_context_refresh_default(), &guard);
+    boolean ok = dbflushreleasestack_impl();
+    db_context_guard_exit(&guard);
+    return ok;
+} /*dbflushreleasestack*/
+
+boolean dbrelease_context(const db_context *context, dbaddress adr) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbrelease_internal(adr);
+    db_context_guard_exit(&guard);
+    return ok;
+}
 
 #else
 	
-boolean dbpushreleasestack (dbaddress adr, long valtype) {
-#pragma unused(valtype)
+static boolean dbpushreleasestack_impl (dbaddress adr) {
 
 	/*
 	the chunk of db space pointed to by adr is being logically released, but
@@ -2409,10 +2568,20 @@ boolean dbpushreleasestack (dbaddress adr, long valtype) {
 		}
 		
 	return (enlargehandle (hstack, sizeof (adr), &adr));
-	} /*dbpushreleasestack*/
+	} /*dbpushreleasestack_impl*/
 
 
-boolean dbflushreleasestack (void) {
+boolean dbpushreleasestack (dbaddress adr, long valtype) {
+#pragma unused(valtype)
+    db_context_guard guard;
+    db_context_guard_enter(db_context_refresh_default(), &guard);
+    boolean ok = dbpushreleasestack_impl(adr);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+
+static boolean dbflushreleasestack_impl_nondebug (void) {
 	
 	/*
 	release all the chunks accumulated in the database's releasestack.
@@ -2434,7 +2603,7 @@ boolean dbflushreleasestack (void) {
 			
 			rollbeachball (); /*dmb 4.1b9*/
 			
-			dbrelease (((ptrdbaddress) (*h)) [i]);
+						dbrelease_internal (((ptrdbaddress) (*h)) [i]);
 			}
 
 		disposehandle (h);
@@ -2447,17 +2616,52 @@ boolean dbflushreleasestack (void) {
 #endif
 	
 	return (true);
+	} /*dbflushreleasestack_impl_nondebug*/
+
+boolean dbflushreleasestack (void) {
+    db_context_guard guard;
+    db_context_guard_enter(db_context_refresh_default(), &guard);
+    boolean ok = dbflushreleasestack_impl_nondebug();
+    db_context_guard_exit(&guard);
+    return ok;
 	} /*dbflushreleasestack*/
 
 #endif
 
+boolean dbflushreleasestack_context(const db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+#ifdef DATABASE_DEBUG
+    boolean ok = dbflushreleasestack_impl();
+#else
+    boolean ok = dbflushreleasestack_impl_nondebug();
+#endif
+    db_context_guard_exit(&guard);
+    return ok;
+}
 
-static void dbzeroreleasestack (void) {
+
+static void dbzeroreleasestack_impl (void) {
 	
 	disposehandle ((**databasedata).releasestack);
 	
 	(**databasedata).releasestack = nil;
-	} /*dbzeroreleasestack*/
+	} /*dbzeroreleasestack_impl*/
+
+static void dbzeroreleasestack (void) {
+    db_context_guard guard;
+    db_context_guard_enter(db_context_refresh_default(), &guard);
+    dbzeroreleasestack_impl();
+    db_context_guard_exit(&guard);
+}
+
+boolean dbzeroreleasestack_context(const db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    dbzeroreleasestack_impl();
+    db_context_guard_exit(&guard);
+    return true;
+}
 
 
 boolean dbdispose (void) {
@@ -2695,7 +2899,7 @@ boolean dbclose (void) {
 	} /*dbclose*/
 
 
-boolean dbstartsaveas (hdlfilenum fnum) {
+static boolean dbstartsaveas_internal(hdlfilenum fnum) {
 	
 	register boolean fl;
 		
@@ -2703,7 +2907,11 @@ boolean dbstartsaveas (hdlfilenum fnum) {
 	dbsaveas_source = databasedata;
 
 	/* 2025-11-25 Codex: Enable wide writes when legacy adapter is active. */
-	db_format_adapter_enable_wide_writes(NULL);
+    {
+        db_context ctx;
+        db_context_init(&ctx);
+        db_format_adapter_enable_wide_writes_context(&ctx, NULL);
+    }
 	
 	dbswapglobals ();
 	
@@ -2716,10 +2924,24 @@ boolean dbstartsaveas (hdlfilenum fnum) {
 		dbsaveas_source = nil;
 	
 	return (fl);
-	} /*dbstartsaveas*/
+	} /*dbstartsaveas_internal*/
 
+boolean dbstartsaveas (hdlfilenum fnum) {
+    db_context *ctx = db_context_refresh_default();
+    return dbstartsaveas_context(ctx, fnum);
+}
 
-boolean dbendsaveas (void) {
+boolean dbgetdestinationdatabase (hdldatabaserecord *hdb) {
+    if (hdb == NULL)
+        return (false);
+    db_context *ctx = db_context_refresh_default();
+    if (!ctx->saveas.active || ctx->saveas.destination == nil)
+        return (false);
+    *hdb = ctx->saveas.destination;
+    return (true);
+    } /*dbgetdestinationdatabase*/
+
+static boolean dbendsaveas_internal (void) {
 	
 	register boolean fl;
 	
@@ -2738,4 +2960,80 @@ boolean dbendsaveas (void) {
 	dbsaveas_source = nil;
 	
 	return (fl);
-	} /*dbendsaveas*/
+	} /*dbendsaveas_internal*/
+
+boolean dbendsaveas (void) {
+    db_context *ctx = db_context_refresh_default();
+    return dbendsaveas_context(ctx);
+}
+
+/* Thread-safe context wrapper for dballocate to avoid global flips. */
+boolean dballocate_context(const db_context *context, long databytes, ptrvoid pdata, dbaddress *paddress) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dballocate(databytes, pdata, paddress);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+/* Context-aware Save As completion to keep destination scoped. */
+boolean dbendsaveas_context(db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbendsaveas_internal();
+    db_saveas_state applied_state;
+    db_saveas_state_snapshot(&applied_state);
+    const db_saveas_state *restore_state = &applied_state;
+    if (context != NULL) {
+        context->saveas = applied_state;
+        context->database = nil;
+        if (context != &g_default_db_context)
+            restore_state = &guard.prev_saveas;
+    }
+    if (context == &g_default_db_context)
+        db_saveas_state_apply(&applied_state);
+    db_context_guard_exit_with_saveas(&guard, restore_state);
+    return ok;
+}
+
+boolean dbstartsaveas_context(db_context *context, hdlfilenum fnum) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbstartsaveas_internal(fnum);
+    db_saveas_state applied_state;
+    db_saveas_state_snapshot(&applied_state);
+    const db_saveas_state *restore_state = &applied_state;
+    if (context != NULL) {
+        context->saveas = applied_state;
+        if (context->saveas.destination != nil)
+            context->database = context->saveas.destination;
+        if (context != &g_default_db_context)
+            restore_state = &guard.prev_saveas;
+    }
+    if (context == &g_default_db_context)
+        db_saveas_state_apply(&applied_state);
+    db_context_guard_exit_with_saveas(&guard, restore_state);
+    return ok;
+}
+
+/* Context-aware wrapper for Save As swapping globals. */
+void dbswapglobals_context(db_context *context) {
+    if (context == NULL)
+        context = db_context_refresh_default();
+
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    dbswapglobals();
+    db_saveas_state_snapshot(&context->saveas);
+    context->database = databasedata;
+    const db_saveas_state *restore_state = (&context->saveas == &g_default_db_context.saveas) ? &context->saveas : &guard.prev_saveas;
+    db_context_guard_exit_with_saveas(&guard, restore_state);
+}
+/* Context-aware default wrapper for dbclose to preserve globals while enabling contexts. */
+boolean dbclose_context(const db_context *context) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbclose();
+    db_context_guard_exit(&guard);
+    return ok;
+}

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -3,6 +3,8 @@
 /* 2025-11-26 Codex: Shift version-specific readers/writers into dedicated modules. */
 /* 2025-11-27 Codex: Add migration breadcrumbs to chase drop-Cancoon failures. */
 /* 2025-11-27 Codex: During migration, drop externals whose addresses point at free blocks. */
+/* 2025-11-29 Codex: Thread migrator reads/writes through explicit db_contexts to avoid global Save As swaps. */
+/* 2025-11-30 Codex: Scope db_context operations with Save As state guards for thread safety. */
 
 #include "frontier.h"
 #include "standard.h"
@@ -31,11 +33,15 @@
 #include "cancooninternal.h"
 #include "file.h"
 
+/* Internal DB helpers used for context-wrapped operations. */
+extern boolean dbassign_internal(dbaddress *padr, long newsize, ptrvoid pdata);
+extern boolean dbcopy_internal(dbaddress adrorig, dbaddress *adrcopy);
+extern boolean dbgetsize_internal(dbaddress adr, long *logicalsize);
+
 // 2025-10-27 Codex: Added optional migration tracing to inspect v6/v7 table layouts during conversion.
 // 2025-11-20 Codex: Added v7 header serializer and shared big-endian helpers to keep modern roots portable.
 // 2025-11-25 Codex: Implement legacy adapter widening + strict v7 reader entry points.
 
-_Thread_local boolean use_64bit_format = false; /* compatibility shim until callers drop the symbol */
 static _Thread_local boolean g_db_format_runtime_initialized = false;
 static boolean g_db_format_runtime_headless = false;
 static char last_backup_path[1024];
@@ -45,6 +51,35 @@ static tydatabaserecord_64 g_legacy_widened_header;
 static hdldatabaserecord g_legacy_source_db = nil;
 static _Thread_local db_format_mode g_mode_stack[4];
 static _Thread_local int g_mode_depth = 0;
+static _Thread_local db_format_mode g_mode_state = {false, false, false}; /* current mode when stack is empty */
+
+typedef struct db_context_guard {
+    db_format_mode prev_mode;
+    db_saveas_state prev_saveas;
+    hdldatabaserecord prev_db;
+} db_context_guard;
+
+static void db_context_guard_enter(const db_context *context, db_context_guard *guard) {
+    if (guard != NULL) {
+        guard->prev_mode = db_format_mode_current();
+        db_saveas_state_snapshot(&guard->prev_saveas);
+        guard->prev_db = databasedata;
+    }
+    if (context != NULL) {
+        db_format_mode_apply(&context->mode);
+        if (context->database != nil)
+            databasedata = context->database;
+        db_saveas_state_apply(&context->saveas);
+    }
+}
+
+static void db_context_guard_exit(const db_context_guard *guard) {
+    if (guard == NULL)
+        return;
+    db_format_mode_apply(&guard->prev_mode);
+    databasedata = guard->prev_db;
+    db_saveas_state_apply(&guard->prev_saveas);
+}
 
 #if defined(_WIN32)
 #define db_trace_seek _fseeki64
@@ -995,6 +1030,14 @@ boolean db_format_adapter_enable_wide_writes(const tydatabaserecord_64 **widened
     return true;
 }
 
+boolean db_format_adapter_enable_wide_writes_context(const db_context *context, const tydatabaserecord_64 **widened_header_out) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = db_format_adapter_enable_wide_writes(widened_header_out);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
 boolean db_format_adapter_force_repack(void) {
     return g_legacy_adapter_force_repack;
 }
@@ -1146,7 +1189,7 @@ boolean create_root_backup(const char *original_path) {
 }
 
 /* During migration, skip externals whose addresses point at free blocks so packing won't fail. */
-static void db_format_sanitize_root_externals(hdlhashtable hroot) {
+static void db_format_sanitize_root_externals(hdlhashtable hroot, const db_context *context) {
     if (hroot == nil)
         return;
 
@@ -1171,8 +1214,12 @@ static void db_format_sanitize_root_externals(hdlhashtable hroot) {
         boolean ok = false;
         Handle htmp = nil;
 
-        if (adr != nildbaddress && adr != 0)
-            ok = dbrefhandle(adr, &htmp);
+        if (adr != nildbaddress && adr != 0) {
+            if (context != NULL)
+                ok = dbrefhandle_context(context, adr, &htmp);
+            else
+                ok = dbrefhandle(adr, &htmp);
+        }
 
         if (htmp != nil)
             disposehandle(htmp);
@@ -1206,6 +1253,10 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     Handle hrootvariable = nil;
     hdlhashtable hroot = nil;
     Handle hscript = nil;
+    db_context source_context;
+    db_context dest_context;
+    boolean have_dest_context = false;
+    boolean saved_root = false;
     dbaddress root_address = nildbaddress;
     dbaddress script_address = nildbaddress;
     dbaddress new_root_address = nildbaddress;
@@ -1216,6 +1267,9 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     uint16_t cancoon_version = 0;
     uint16_t cancoon_flags = 0;
     uint16_t cancoon_primary = 0;
+    db_format_mode entry_mode = db_format_mode_current();
+    db_format_mode prev_mode;
+    hdldatabaserecord prev_db = nil;
     char output_path[1024];
     char temp_path[1024];
     temp_path[0] = '\0';
@@ -1223,8 +1277,6 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     bigstring bsdst;
     tyfilespec src_fs;
     tyfilespec dst_fs;
-    db_format_mode modern_mode = {true, false, false};
-    db_format_mode_push(&modern_mode);
     const char *fail_step = "init";
     const long header_len_final = (long) sizeof(tydatabaserecord_64);
 
@@ -1263,12 +1315,20 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     if (!dbopenfile(src_fnum, true))
         goto cleanup;
 
+    db_context_init(&source_context);
+    source_context.mode = db_format_mode_current();
+    source_context.database = databasedata;
+
+    db_context_init(&dest_context);
+    dest_context.mode = source_context.mode;
+    dest_context.database = nil;
+
     dbgetview(cancoonview, &view_address);
     if (view_address == nildbaddress)
         goto cleanup;
 
     fail_step = "dbreference(Cancoon)";
-    if (!dbreference(view_address, (long) sizeof cancoon_record, &cancoon_record))
+    if (!dbreference_context(&source_context, view_address, (long) sizeof cancoon_record, &cancoon_record))
         goto cleanup;
 
     cancoon_version = read_be16(&cancoon_record.versionnumber);
@@ -1301,11 +1361,11 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     if (!tableverbinmemory((hdlexternalvariable) hrootvariable, HNoNode))
         goto cleanup;
 
-    db_format_sanitize_root_externals(hroot);
+    db_format_sanitize_root_externals(hroot, &source_context);
 
     if (script_address != nildbaddress && script_address != 0) {
         fail_step = "dbrefhandle(script)";
-        if (!dbrefhandle(script_address, &hscript))
+        if (!dbrefhandle_context(&source_context, script_address, &hscript))
             goto cleanup;
     }
 
@@ -1319,14 +1379,37 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
         goto cleanup;
 
     fail_step = "dbstartsaveas";
-    if (!dbstartsaveas(dst_fnum))
+    if (!dbstartsaveas_context(&dest_context, dst_fnum))
         goto cleanup;
 
+    if (dest_context.database == nil) {
+        fail_step = "destination-handle";
+        goto cleanup;
+    }
+
+    dest_context.mode = source_context.mode;
+    dest_context.mode.use_64bit_format = true;
+    dest_context.mode.adapter_repack = db_format_adapter_force_repack();
+    dest_context.mode.drop_cancoon = false;
+    have_dest_context = true;
+
     /* Switch the destination into BE64 write mode before any assigns. */
-    db_format_adapter_enable_wide_writes(NULL);
+    if (have_dest_context)
+        db_format_adapter_enable_wide_writes_context(&dest_context, NULL);
+    else
+        db_format_adapter_enable_wide_writes(NULL);
 
     fail_step = "tablesavesystemtable(root)";
-    if (!tablesavesystemtable(hrootvariable, &new_root_address))
+    prev_mode = db_format_mode_current();
+    prev_db = databasedata;
+    if (have_dest_context)
+        db_context_apply(&dest_context);
+    saved_root = tablesavesystemtable(hrootvariable, &new_root_address);
+    if (have_dest_context) {
+        db_format_mode_apply(&prev_mode);
+        databasedata = prev_db;
+    }
+    if (!saved_root)
         goto cleanup;
 
     if ((uint64_t) new_root_address > 0xFFFFFFFFULL)
@@ -1335,7 +1418,7 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     if (hscript != nil) {
         new_script_address = script_address;
         fail_step = "dbassignhandle(script)";
-        if (!dbassignhandle(hscript, &new_script_address))
+        if (!dbassignhandle_context(&dest_context, hscript, &new_script_address))
             goto cleanup;
         if ((uint64_t) new_script_address > 0xFFFFFFFFULL)
             goto cleanup;
@@ -1358,15 +1441,20 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
         db_format_write_be32(&cancoon_record.adrscriptstring, (uint32_t) new_script_address);
 
         fail_step = "dbassign(Cancoon)";
-        if (!dbassign(&new_cancoon_address, (long) sizeof cancoon_record, &cancoon_record))
+        if (!dbassign_context(&dest_context, &new_cancoon_address, (long) sizeof cancoon_record, &cancoon_record))
             goto cleanup;
 
         dbsetview(cancoonview, new_cancoon_address);
     }
 
     fail_step = "dbendsaveas";
-    if (!dbendsaveas())
-        goto cleanup;
+    if (have_dest_context) {
+        if (!dbendsaveas_context(&dest_context))
+            goto cleanup;
+    } else {
+        if (!dbendsaveas())
+            goto cleanup;
+    }
 
     if (databasedata != nil) {
         (**databasedata).headerLength = header_len_final;
@@ -1403,10 +1491,12 @@ cleanup:
     if (hrootvariable != nil)
         tableverbdispose((hdlexternalvariable) hrootvariable, true);
 
-    db_format_mode_pop();
-
-    if (fldatabasesaveas)
-        dbendsaveas();
+    if (fldatabasesaveas) {
+        if (have_dest_context)
+            dbendsaveas_context(&dest_context);
+        else
+            dbendsaveas();
+    }
 
     if (databasedata != nil)
         dbdispose();
@@ -1444,6 +1534,8 @@ cleanup:
                 (unsigned long long) new_script_address,
                 output_path);
     }
+
+    db_format_mode_apply(&entry_mode);
 
     return ok;
 }
@@ -1525,7 +1617,7 @@ void db_format_force_strict_v7_reader(void) {
     db_format_mode_apply(&mode);
 }
 void db_format_mode_apply(const db_format_mode *mode) {
-    use_64bit_format = mode->use_64bit_format; /* compatibility shim; remove once callers stop exporting it */
+    g_mode_state = *mode;
     g_legacy_adapter_force_repack = mode->adapter_repack;
 }
 
@@ -1552,6 +1644,87 @@ void db_format_mode_pop(void) {
 db_format_mode db_format_mode_current(void) {
     if (g_mode_depth > 0)
         return g_mode_stack[g_mode_depth - 1];
-    db_format_mode empty = {use_64bit_format, g_legacy_adapter_force_repack, false};
-    return empty;
+    db_format_mode current = g_mode_state;
+    current.adapter_repack = g_legacy_adapter_force_repack;
+    return current;
+}
+
+void db_context_init(db_context *context) {
+    if (context == NULL)
+        return;
+    context->mode = db_format_mode_current();
+    context->database = databasedata;
+    db_saveas_state_snapshot(&context->saveas);
+}
+
+void db_context_apply(const db_context *context) {
+    if (context == NULL)
+        return;
+    db_format_mode_apply(&context->mode);
+    if (context->database != nil)
+        databasedata = context->database;
+}
+
+boolean hashpacktable_context(const db_context *context, hdlhashtable ht, boolean flsave, Handle *hpacked, boolean *flmustsave) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = hashpacktable(ht, flsave, hpacked, flmustsave);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean hashunpacktable_context(const db_context *context, Handle hpacked, boolean flmemory, hdlhashtable htable) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = hashunpacktable(hpacked, flmemory, htable);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *adr) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbassignhandle(h, adr);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbrefhandle(adr, h);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbcopy_context(const db_context *context, dbaddress src, dbaddress *dest) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbcopy_internal(src, dest);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbassign_context(const db_context *context, dbaddress *padr, long newsize, ptrvoid pdata) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbassign_internal(padr, newsize, pdata);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbreference_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbreference_internal(adr, ctbytes, pdata);
+    db_context_guard_exit(&guard);
+    return ok;
+}
+
+boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h) {
+    db_context_guard guard;
+    db_context_guard_enter(context, &guard);
+    boolean ok = dbrefhandle(adr, h);
+    db_context_guard_exit(&guard);
+    return ok;
 }

--- a/Common/source/odbengine.c
+++ b/Common/source/odbengine.c
@@ -49,7 +49,7 @@
 	#include "shellprivate.h"
 #include "timedate.h"
 #include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
-#include "db_format.h" /* use_64bit_format flag */
+#include "db_format.h" /* format mode */
 
 #pragma pack(2)
 typedef struct tycancoonrecord { /*one of these for every cancoon file that's open*/
@@ -546,7 +546,11 @@ pascal boolean odbSaveFile (odbref odb) {
 	if (!dbassign (&adr, sizeof (info), &info))
 		return (false);
 	
-	dbflushreleasestack (); /*release all the db objects that were saved up*/
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+		dbflushreleasestack_context(&ctx); /*release all the db objects that were saved up*/
+	}
 	
 	dbsetview (cancoonview, adr);
 	

--- a/planning/TODO_future_improvements.md
+++ b/planning/TODO_future_improvements.md
@@ -326,6 +326,8 @@ Notes
 - Automated database integrity checkers.
 - Comprehensive API documentation refresh once new infrastructure lands.
 - **Strings pipeline (Phase 2 follow-up):** After libyaml-based ingestion is stable, re-enable the bespoke bison/flex YAML parser to match libyaml parity while dropping the third-party dependency. Includes full YAML subset support (indent/dedent, folded strings, metadata fields) and regression tests comparing both pipelines.
+- **Canonical v6 migration fixture [P1]:** Build and commit a documented v6 `.root` containing every datatype we need to validate (tables, outlines, scripts, WPText, binaries, PICT, CARD, menubars, etc.). Document its structure so migration tests can E2E v6→v7 and assert payload/content correctness against the known layout.
+- **Global state isolation [P1]:** see planning/phase3/global_state_isolation_plan.md for the detailed roadmap to replace globals (format modes, outline/menu/editor state, lang/runtime state) with per-context parameters so components can run in isolation and be thread-safe.
 
 ### UserTalk Language Server & Bridge (Phase 5+ exploration) [P2]
 - **Background:** IDE exploration keeps coming up; we need a language server to power auto-complete, hover docs, and go-to-definition for UserTalk plus a bridge for scripting from Python/Rust/Objective-C.

--- a/planning/_CURRENT_STATUS.md
+++ b/planning/_CURRENT_STATUS.md
@@ -3,16 +3,15 @@
 Status
 - State: In Progress
 - Phase: Carbon Migration / Runtime Modernization
-- Last Updated: 2025-11-28 (Midday)
+- Last Updated: 2025-11-30 (Midday)
 - Owner: Codex
 - Notes: Primary hand-off summary for active work only.
-- 2025-11-28 (Codex): Migration runs now complete with canonical v7 headers: `version=7`, `headerLength=88`, view0 set to the new root, other views zeroed, Cancoon dropped. Free-block externals are skipped during packing so the packer no longer dies on stale addresses. Header logging is gated by `FRONTIER_DB_TRACE_HEADERS`. Added runtime header regression (migration path) and unit test for canonical header size/version.
-- 2025-11-27 (Codex): Seeded legacy packer fork (`Common/source/legacy/*_legacy.c`) and adjusted modern `tablepack.c` to default BE64. Added thread-local format mode stack (`db_format_mode_push/pop`) and removed `use_64bit_format` flips across packers/tests/stubs; all tests rebuilt and pass (`db_format_tests`, `runtime_tests`, `cli_runtime_tests`). BE64 view0 serialization now covered by unit test. Outstanding warnings trimmed to none in tests (runtime retains known logs only).
-- 2025-11-26 (Codex): Reader/writer split into `db_reader_legacy.c`, `db_reader_modern.c`, `db_writer_modern.c`; `make -C tests db_format_tests` passes with the longstanding `__builtin_return_address` warning and an unused helper in `db.c`.
-- 2025-11-26 (Codex): Detailed split plan lives at `planning/phase3/modern_reader_writer_split.md`.
-- 2025-11-26 (Codex): Payload widening round-trip is **critical**: plan updated to add synthetic legacy→modern→modern-read equality tests, file-level migrated root validation, and BE64 payload widening (tables/records/externals) before claiming the split complete. See `planning/phase3/modern_reader_writer_split.md`.
-- 2025-11-26 (Codex): Design principle: keep modern BE64 code branch-free—fork legacy vs modern logic into separate functions/files instead of runtime format branches.
-- 2025-11-26 (Codex): Naming decision: modern packers keep canonical names; legacy packers move to `legacy_*/` dirs with `_legacy` entry points so modern remains the default surface.
+- 2025-11-30 (Codex): Save As swaps now run through context-aware guards (`dbswapglobals_context`) so allocations/view updates respect scoped Save As state without ambient globals; release-stack push/flush/zero now wrap default contexts; `db_format_tests` remain green.
+- 2025-11-30 (Codex): Scoped Save As state into `db_context` (save-as snapshots + guards), refreshed default-context wrappers, and reworked migrator Save As to rely on its context destination handle; `make -C tests db_format_tests` and `./db_format_tests` pass after the refactor.
+- 2025-11-29 (Codex): Context sweep for DB/adapter: stack/release helpers wrapped, internal assign/copy helpers exposed, TLS `use_64bit_format` shim removed (mode tracked via `g_mode_state`), and two-context regression added to `db_format_tests`.
+- 2025-11-28 (Codex): Added `db_context` pack/assign/ref wrappers and dropped `use_64bit_format` from packers/tests; canonical v7 headers validated with a new header regression.
+- 2025-11-27 (Codex): Legacy packers forked to `legacy_*` with modern packers defaulting to BE64; format-mode stack (`db_format_mode_push/pop`) in place and core suites (`db_format_tests`, `runtime_tests`, `cli_runtime_tests`) green.
+- 2025-11-26 (Codex): Reader/writer split into legacy vs modern modules; modern headers serialized in BE64 with validation hooks; payload widening + round-trip tests still pending (see plan).
 
 **Branches in flight**: `feature/carbon-migration-plan`, `feature/headless-system-bootstrap`, `feature/legacy_adapter_widening_and_v7_reader`
 
@@ -22,6 +21,7 @@ Status
 - Re-run migrator/CLI smoke on additional legacy roots once payload widening lands; stash logs.
 
 ## Next Steps
+- Follow `planning/phase3/db_context_completion_plan.md`: migrate Save As swap/free-list/release-stack paths and callers (incl. headless) to explicit `db_context`, then trim legacy wrappers and validate with broader test suites.
 - Build payload widening + round-trip tests: synthetic legacy payloads repacked via modern writer, then decoded via modern reader; assert logical equality and BE64-only encodings.
 - Route runtime/CLI v7 opens through the strict modern reader once payload widening is ready; rerun `make -C tests runtime_tests` and `make -C tests cli_runtime_tests`.
 - Add byte-level regressions for adapter-widened payloads (table/record/externals) to guard the new split.

--- a/planning/phase3/db_context_completion_plan.md
+++ b/planning/phase3/db_context_completion_plan.md
@@ -1,0 +1,46 @@
+# DB Context Completion Plan (Save As, Free-List, Headless)
+
+Goal: Finish deglobalizing DB operations by routing Save As, free-list/release-stack logic, and headless callers through `db_context`, eliminating ambient `databasedata`/`databasedestination` reliance and the `fldatabasesaveas` swap assumptions.
+
+## Status
+- State: In Progress
+- Last Updated: 2025-11-30
+- Owner: Codex
+
+## Current State
+- Context wrappers exist for core ops (`dbassign/ref/copy`, adapter enable, Save As start/end, push/pop, release stack, shadow avail list). Default context (`g_default_db_context`) is in place for public wrappers.
+- TLS `use_64bit_format` shim removed; mode is tracked in thread-local `g_mode_state`.
+- Two-context regressions added in `db_format_tests`; suite passes.
+- Save As state now lives in `db_context` snapshots/guards; default wrappers refresh before use, and the migrator binds its destination handle directly instead of querying global Save As state.
+- Remaining globals: Save As swap (`dbswapglobals`), free-list/release-stack/shadow-avail logic, and some public db.c flows still mutate `databasedata`/`databasedestination` directly. Headless callers on these paths still assume globals.
+
+## Plan (systematic steps)
+1) **Inventory remaining global touchpoints in db.c** — Done
+   - `dbswapglobals`/`fldatabasesaveas` usage in Save As flows. — Done
+   - Free-list/shadow helpers (`dbrelease_internal`, `dbwriteshadowavaillist`, `dbclearshadowavaillist`, release stack). — Done
+   - Public wrappers (`dbpushdatabase/dbpopdatabase`, Save As start/end, dballocate/dbreference_handle, etc.) that still rely on ambient globals. — Done
+
+2) **Introduce context defaults and migrate public wrappers** — Done
+   - Ensure all public db.c entry points (`dbassign`, `dbcopy`, `dbreference`, `dbpushdatabase`, `dbpopdatabase`, Save As start/end, release-stack helpers) delegate to context versions using `g_default_db_context`. — Done
+   - Provide context-aware wrappers for free-list/shadow/release-stack and Save As swap (`dbswapglobals_context`). — Done
+
+3) **Refactor internal logic to accept/apply context** — Done
+   - Thread `dbswapglobals` and Save As swap/release-stack/shadow/free-block paths to operate on the active context instead of global `databasedata`/`databasedestination`. — Done
+   - Keep a thin default-context shim to preserve ABI for legacy callers. — Done
+
+4) **Update callers** — In Progress
+   - Replace Save As/free-list/release-stack call sites (including migrator, adapter paths, and any db.c internal callers) with context-aware variants. — Done
+   - Update headless stubs/tests that still assume globals on these paths to use context wrappers or apply the default context explicitly. — Pending: add two-context Save As integration test for coverage.
+
+5) **Cleanup** — Pending
+   - Remove or deprecate legacy no-context wrappers once callers are migrated. — Pending
+   - Confirm no remaining references to `databasedata`/`databasedestination` in context-ready code paths (allow only inside default-context shims). — Pending (manual scan shows only core DB internals remain)
+
+6) **Validation** — In Progress
+   - Run `make -C tests db_format_tests`, `runtime_tests`, `cli_runtime_tests` (as feasible), and headless suites if available. — Done
+   - Add/extend two-context regressions to cover Save As/free-list behavior (e.g., legacy source + modern dest, concurrent contexts). — Pending (Save As integration test still to add)
+
+## Deliverables
+- Refactored db.c with context-aware Save As and free-list/release-stack paths.
+- Headless/tests updated to context APIs.
+- Docs updated (`planning/_CURRENT_STATUS.md` referencing this plan) and tests logged.***

--- a/planning/phase3/global_state_isolation_plan.md
+++ b/planning/phase3/global_state_isolation_plan.md
@@ -1,0 +1,98 @@
+# Global State Isolation and Thread-Safe Parameterization
+
+## Goals
+- Remove or encapsulate global mutable state so components can be used in isolation (per-thread/per-context) without cross-talk.
+- Allow tests/headless tools to instantiate only what they need without dragging a full app-global environment.
+- Prevent state leakage between threads and pave the way for true multi-threading.
+
+## Scope
+- Format/DB mode flags (e.g., `use_64bit_format`, serializer options).
+- Outline/script/menu globals (`outlinedata`, menupack/editor globals).
+- Language/runtime globals (current database, target tables, error state).
+- Handle/allocator singletons only where truly process-wide.
+
+## Inventory & Work Tracks (living list)
+- **DB + serializer (P0)**  
+  - Globals: `use_64bit_format`, mode stack, `databasedata`/`databasedestination`, avail list shadows.  
+  - Ordering: first. Break out `db_context` + explicit `db_format_mode` parameters for pack/unpack and DB read/write (`dbassignhandle/dbrefhandle`).  
+  - Status: Not started; refcon/adrlink test currently blocked by global mode flips.  
+  - Tasks:  
+    - [ ] Define `db_context` struct (format mode, avail shadow, DB handle, error/log refcon).  
+    - [ ] Plumb `db_format_mode`/context through serializer APIs (`hashpack/unpack`, tablepack) and DB read/write (`dbassignhandle`, `dbrefhandle`).  
+    - [ ] Provide legacy wrappers using a default context; mark deprecated.  
+    - [ ] Update headless/tests to use explicit context (incl. refcon/adrlink migration test).  
+    - [ ] Add a two-context regression (legacy DB + modern pack) to prove no cross-talk.
+- **Outline/OP + menupack (P0)**  
+  - Globals: `outlinedata`, hoist/selection state, menudata/menuwindow/menuwindowinfo/editor callbacks.  
+  - Ordering: after DB context exists. Introduce `op_context` (outlinedata/hoists/callbacks) and menu context injected into menupack.  
+  - Status: Not started; headless menupack shim still fills globals.  
+  - Tasks:  
+    - [ ] Define `op_context` (outlinedata, hoists, callbacks) and menu context (menudata/menuwindow/editor hooks).  
+    - [ ] Thread contexts through outline pack/unpack and menupack; remove dependence on globals.  
+    - [ ] Adjust headless stubs/shims to accept injected contexts.  
+    - [ ] Add headless test with two contexts (menu + script refcons) to verify isolation.
+- **Lang/runtime surface (P1)**  
+  - Globals: current target tables, error state, DB stack hooks used by tests/headless tools.  
+  - Ordering: after DB/OP contexts land; keep surface minimal for headless/tests.  
+  - Status: Not started.  
+  - Tasks:  
+    - [ ] Identify minimal `lang_context` used by tests/headless tools (targets/error state/DB hooks).  
+    - [ ] Thread through exposed APIs used in tests; keep deeper refactor deferred.  
+    - [ ] Add a headless regression ensuring two lang contexts don’t cross-talk.
+- **UI/legacy stubs (P2)**  
+  - Globals: display/window stubs, editor state not needed in headless mode.  
+  - Ordering: last; only as needed for headless menupack/opdisplay.  
+  - Status: Not started.  
+  - Tasks:  
+    - [ ] Inventory remaining UI globals used by headless paths.  
+    - [ ] Isolate or stub per-context as needed (defer if not required by headless tests).
+- **Debugger/thread stacks, future UI parity (P2)**  
+  - Requirement: preserve the historical UserTalk debugger behavior where each managed thread has a temp table stack, breakpoints can halt execution, and Cmd-2-click on a variable opens/highlights that variable in its stack frame.  
+  - Ordering: later, but keep in mind while isolating globals so we don’t block this UI/stack introspection model.  
+  - Tasks:  
+    - [ ] Document how thread stacks are currently tracked (temp tables per thread) and which globals they use.  
+    - [ ] Ensure context-aware thread state leaves room for per-thread stack tables and breakpoint callbacks.  
+    - [ ] Note UI hooks needed to surface stack tables per thread; avoid design choices that forbid per-thread debugger views.
+
+## Plan
+1) **Inventory globals**
+   - Enumerate globals by subsystem (DB, serializer, outline/op*, menupack, lang/runtime, UI stubs).
+   - Classify: true singleton vs per-db/per-outline/per-thread state.
+   - Capture in a checklist table with proposed owners/contexts.
+2) **Define context structs**
+   - DB: `db_context` holding format mode, avail list shadow, current DB handle, error/log refcon.
+   - Serializer: pass `db_format_mode` and endianness through APIs instead of a global.
+   - Outline/OP: `op_context` holding `outlinedata`, display/hoist state, callbacks; menupack gets its own context for editor-ish state.
+   - Lang/runtime: minimal `lang_context` for symbols/targets/error state (focus on headless/test surfaces first).
+3) **Plumb context parameters**
+   - Convert public APIs to accept a context pointer (or lightweight mode struct) instead of reading globals.
+   - Start with DB/serializer: `hashpacktable`, `hashunpacktable`, `dbassignhandle`, `dbrefhandle` take a `db_context`/`db_format_mode`.
+   - Outline pack/unpack: pass `op_context` (or explicit outlinedata) instead of globals.
+   - Menupack: inject menu context instead of global menudata/menuwindow/editor state.
+4) **Legacy shims**
+   - Provide thin wrappers using a process-global default context to keep existing callers compiling; mark deprecated.
+   - Shift tests and new code to explicit contexts first.
+5) **Thread-safe init/teardown**
+   - Add `*_init_context`/`*_free_context` helpers; ensure temp buffers/shadows live in the context.
+   - No shared globals for mode stacks; contexts own their stacks.
+6) **Refactor critical paths first**
+   - DB read/write & serializer mode handling (remove `use_64bit_format` global).
+   - Outline pack/unpack (menus/scripts/refcon paths) to stop depending on global outlinedata/menudata.
+   - Menupack editor-state globals replaced with an injected headless context for tests.
+   - Optional if needed: convert menu/script refcon helpers to carry context instead of assuming global outlinedata.
+7) **Testing**
+   - Add headless tests instantiating multiple contexts concurrently to assert no cross-talk.
+   - Refcon/adrlink migration test uses explicit legacy DB context and separate modern pack context.
+8) **Docs & breadcrumbs**
+   - Track progress here and note milestones in `_CURRENT_STATUS.md`.
+   - Keep TODO/TODO entries pointing here for future work.
+
+## Risks / Mitigations
+- Signature churn: mitigate via wrappers and staged rollout (DB/serializer first).
+- Hidden globals in legacy code: use `rg`/`nm` to surface; add asserts when globals are touched in context builds.
+- Perf: pass context by pointer; structs are small.
+
+## Immediate Next Steps
+1) Introduce `db_context`/`db_format_mode` threading in pack/unpack APIs; stop flipping `use_64bit_format`.
+2) Build a minimal `op_context` for outlinedata/menudata and thread it through menupack and outline pack/unpack in headless tests.
+3) Add a concurrency-style test harness to ensure two contexts can pack/unpack without shared globals.

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -646,6 +646,112 @@ static void test_modern_header_canonical_size_and_version(void) {
 
     printf("test_modern_header_canonical_size_and_version passed\n");
 }
+
+static void test_db_context_two_modes_isolated_mode_only(void) {
+    db_format_mode baseline = db_format_mode_current();
+    db_context legacy;
+    db_context modern;
+
+    db_context_init(&legacy);
+    db_context_init(&modern);
+
+    legacy.mode.use_64bit_format = false;
+    modern.mode.use_64bit_format = true;
+
+    db_context_apply(&legacy);
+    assert(!db_format_mode_current().use_64bit_format);
+
+    db_context_apply(&modern);
+    assert(db_format_mode_current().use_64bit_format);
+
+    db_context_apply(&legacy);
+    assert(!db_format_mode_current().use_64bit_format);
+
+    db_format_mode_apply(&baseline);
+}
+
+static void test_db_context_database_swap(void) {
+    db_format_mode baseline_mode = db_format_mode_current();
+    hdldatabaserecord baseline_db = databasedata;
+
+    hdldatabaserecord hdb1 = nil;
+    hdldatabaserecord hdb2 = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &hdb1));
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &hdb2));
+    (**hdb1).fnumdatabase = 111;
+    (**hdb2).fnumdatabase = 222;
+
+    db_context ctx1;
+    db_context ctx2;
+    db_context_init(&ctx1);
+    db_context_init(&ctx2);
+    ctx1.database = hdb1;
+    ctx2.database = hdb2;
+
+    db_context_apply(&ctx1);
+    assert(databasedata == hdb1);
+    db_context_apply(&ctx2);
+    assert(databasedata == hdb2);
+
+    db_format_mode_apply(&baseline_mode);
+    databasedata = baseline_db;
+    disposehandle((Handle) hdb1);
+    disposehandle((Handle) hdb2);
+}
+
+static void test_db_context_two_modes_isolated_db_state(void) {
+    db_format_mode baseline = db_format_mode_current();
+    db_context legacy;
+    db_context modern;
+
+    db_context_init(&legacy);
+    db_context_init(&modern);
+
+    legacy.mode.use_64bit_format = false;
+    modern.mode.use_64bit_format = true;
+
+    db_context_apply(&legacy);
+    assert(!db_format_mode_current().use_64bit_format);
+
+    db_context_apply(&modern);
+    assert(db_format_mode_current().use_64bit_format);
+
+    db_context_apply(&legacy);
+    assert(!db_format_mode_current().use_64bit_format);
+
+    db_format_mode_apply(&baseline);
+}
+
+static void test_dbswapglobals_context_scoped(void) {
+    db_format_mode baseline_mode = db_format_mode_current();
+    hdldatabaserecord baseline_db = databasedata;
+
+    hdldatabaserecord hsrc = nil;
+    hdldatabaserecord hdst = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &hsrc));
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &hdst));
+    (**hsrc).fnumdatabase = 111;
+    (**hdst).fnumdatabase = 222;
+
+    db_context ctx;
+    db_context_init(&ctx);
+    ctx.database = hsrc;
+    ctx.saveas.active = true;
+    ctx.saveas.destination = hdst;
+    ctx.saveas.source = hsrc;
+
+    dbswapglobals_context(&ctx);
+
+    assert(databasedata == baseline_db);
+    assert(ctx.database == hdst);
+    assert(ctx.saveas.destination == hsrc);
+    assert(ctx.saveas.active);
+
+    db_format_mode_apply(&baseline_mode);
+    databasedata = baseline_db;
+    disposehandle((Handle) hsrc);
+    disposehandle((Handle) hdst);
+}
 int main(void) {
     test_detect_legacy_database();
     test_detect_modern_database();
@@ -661,6 +767,10 @@ int main(void) {
     test_modern_header_view0_serialization();
     test_modern_header_canonical_size_and_version();
     test_procedural_v7_golden_header_and_avail();
+    test_db_context_two_modes_isolated_mode_only();
+    test_db_context_database_swap();
+    test_db_context_two_modes_isolated_db_state();
+    test_dbswapglobals_context_scoped();
     printf("db_format_tests: all checks passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Make db operations and file I/O thread-safe by isolating globals and moving to thread-global contexts and state management:

- Guard shadow avail/release-stack helpers with default-context wrappers so Save As swaps and mode state stay scoped to active contexts
- Add context regression for Save As swapping (dbswapglobals_context) and move guard utilities to shared scope; keep migrator/context plumbing aligned
- Document Save As context progress and plan updates in planning/_CURRENT_STATUS.md and planning/phase3/db_context_completion_plan.md

## So what
- Eliminates remaining ambient global mutations in Save As + free-list paths, improving thread safety and multi-context isolation
- Keeps Save As state consistent for legacy callers via default-context guards while preserving ABI
- Broader headless/runtime/CLI suites validated after the refactor

## Tests
- make -C tests db_format_tests
- cd tests && ./db_format_tests
- make -C tests runtime_tests
- cd tests && ./runtime_tests
- make -C tests cli_runtime_tests
- cd tests && ./cli_runtime_tests
