### PR TITLE
fix: harden hash pack/unpack and table globals

### DIFF
--- a/Common/source/cancoon.c
+++ b/Common/source/cancoon.c
@@ -506,6 +506,11 @@ static boolean ccloadsystemtable (hdlcancoonrecord hcancoon, dbaddress adr, bool
 	Handle hvariable;
 	hdlhashtable htable;
 	
+#if defined(FRONTIER_HEADLESS)
+	fprintf(stderr, "[headless] ccloadsystemtable adr=0x%llx flcreate=%d\n",
+	        (unsigned long long) adr, (int) flcreate);
+#endif
+
 	fldisablesymbolcallbacks = true; /*so table insertions wont trigger callbacks*/
 	
 	fl = tableloadsystemtable (adr, &hvariable, &htable, flcreate);
@@ -1788,6 +1793,5 @@ boolean ccstart (void) {
 	
 	return (ccwindowstart ());
 	} /*ccstart*/
-
 
 

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1480,6 +1480,7 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     /* Ensure subsequent opens don’t reuse the in-memory system table. */
     cleartablestructureglobals();
     if (hrootvariable != nil) {
+        /* false => dispose contents; handle freed below via cleartablestructureglobals */
         tableverbdispose((hdlexternalvariable) hrootvariable, false);
         hrootvariable = nil;
     }

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1397,7 +1397,6 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
             (**ht).flsubsdirty = true;
             (**hv).oldaddress = nildbaddress; /* force new allocation */
         }
-        (**hv).flinmemory = true;
     }
     /* Load root into memory before switching to 64-bit writes. */
     fail_step = "tableverbinmemory(root)";
@@ -1477,6 +1476,12 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     if (!saved_root) {
         db_context_guard_exit(&save_guard);
         goto cleanup;
+    }
+    /* Ensure subsequent opens don’t reuse the in-memory system table. */
+    cleartablestructureglobals();
+    if (hrootvariable != nil) {
+        tableverbdispose((hdlexternalvariable) hrootvariable, false);
+        hrootvariable = nil;
     }
     if (have_dest_context && dest_context.database != nil) {
         long eof = 0;
@@ -1770,6 +1775,10 @@ boolean hashpacktable_context(const db_context *context, hdlhashtable ht, boolea
 boolean hashunpacktable_context(const db_context *context, Handle hpacked, boolean flmemory, hdlhashtable htable) {
     db_context_guard guard;
     db_context_guard_enter(context, &guard);
+#if defined(FRONTIER_HEADLESS)
+    fprintf(stderr, "[headless] hashunpacktable_context enter htable=%p flmemory=%d\n",
+            (void *) htable, (int) flmemory);
+#endif
     boolean ok = hashunpacktable(hpacked, flmemory, htable);
     db_context_guard_exit(&guard);
     return ok;

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -28,6 +28,7 @@
 /* 2025-11-24 Codex: Normalize BE writes/coverage for v7 portability. */
 /* 2025-12-02 Codex: Skip free-block drops for externals during Save-As repack so migrated scripts persist. */
 /* 2025-12-07 Codex: Add env-gated materialization trace with path logging. */
+/* 2025-12-09 Codex: Harden hashunpack bounds and repack v7 records via manual BE buffer for name-corruption chase. */
 
 
 #include "frontier.h"
@@ -64,6 +65,7 @@
 #if defined(FRONTIER_HEADLESS)
 #include "../portable/wptext_portable.h"
 #include <stdio.h>
+#include <errno.h>
 #define WP_PLACEHOLDER_TEXT "WPText not migrated because it was too old to read."
 extern boolean getstringlist(short listid, short stringid, bigstring bs);
 extern void recttodiskrect(Rect *, diskrect *);
@@ -2587,10 +2589,31 @@ static void hashunpackstring (Handle hget, bigstring bs, long ix) {
 	*/
 
 	register ptrbyte p;
-	
+
+	/* Defensive: ensure ix is within handle before copying. */
+	long hsize = gethandlesize (hget);
+	if (ix < 0 || ix >= hsize) {
+#if defined(FRONTIER_HEADLESS)
+		fprintf(stderr, "[headless] hashunpackstring OOB ix=%ld hsize=%ld\n", ix, hsize);
+#endif
+		setemptystring (bs);
+		return;
+	}
+
 	p = (ptrbyte)(*hget + ix);
-	
-	moveleft (p, bs, (unsigned long) *p + 1);
+
+	/* p[0] is length byte; ensure we don't read past handle. */
+	unsigned long needed = (unsigned long) p[0] + 1;
+	if (ix + (long) needed > hsize) {
+#if defined(FRONTIER_HEADLESS)
+		fprintf(stderr, "[headless] hashunpackstring len OOB ix=%ld len=%lu hsize=%ld\n",
+		        ix, needed, hsize);
+#endif
+		setemptystring (bs);
+		return;
+	}
+
+	moveleft (p, bs, needed);
 	} /*hashunpackstring*/
 
 
@@ -3002,7 +3025,7 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 
 			if (filespectoalias (&fs, true, &halias)) {
 
-				rec.version = 1; /*all versions were zero until now*/
+				rec_version = 1; /*all versions were zero until now*/
 
 				x = (hdlfilespec) halias;
 			}
@@ -3299,7 +3322,9 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 	*/
 
 	typackinforecord *lpi = (typackinforecord *) refcon;
-	tydisksymbolrecord_v7 rec;
+	unsigned char recbuf[sizeof(tydisksymbolrecord_v7)];
+	clearbytes(recbuf, sizeof(recbuf));
+	uint8_t rec_version = 0;
 #if defined(FRONTIER_HEADLESS)
 	const char *hashpack_fail_file = NULL;
 	const char *hashpack_fail_reason = "unknown";
@@ -3331,15 +3356,16 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 
 	langtraperrors (bspackerror, &savecallback, &saverefcon);
 
-	clearbytes (&rec, sizeof (rec));
-
 	if (!hashpackstring (&lpi->s2, bsname, &name_index))
 		HASH_PACK_FAIL("hashpackstring(name)");
 
-	rec.ixkey = host_to_disk_int32 (name_index);
-	rec.valuetype = val.valuetype;
-	rec.version = 0;
-	rec._pad = 0;
+	/* Manually populate packed record buffer (big-endian, fixed layout). */
+	int32_t ix_be = host_to_disk_int32 (name_index);
+	memcpy(recbuf + 0, &ix_be, sizeof(int32_t));
+	recbuf[4] = (uint8_t) val.valuetype;
+	recbuf[5] = rec_version; /* version */
+	recbuf[6] = 0; /* pad */
+	recbuf[7] = 0; /* pad */
 
 #if defined(FRONTIER_HEADLESS)
 	if (val.valuetype == listvaluetype) {
@@ -3382,7 +3408,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			if (!hashpackstring (&lpi->s2, bsvalue, &data_index))
 				HASH_PACK_FAIL("hashpackstring(oldstring)");
 
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 			break;
 		}
 
@@ -3400,7 +3429,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			if (!hashpackstring (&lpi->s2, bsvalue, &data_index))
 				HASH_PACK_FAIL("hashpackstring(address)");
 
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 			break;
 		}
 
@@ -3425,7 +3457,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			if (!hashpackbinary (&lpi->s2, (Handle) x, &data_index))
 				HASH_PACK_FAIL("hashpackbinary(filespec->alias)");
 
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 
 			disposehandle ((Handle) halias); /*3.0.2*/
 
@@ -3442,7 +3477,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			if (!hashpackdata (&lpi->s2, &rdisk, sizeof (rdisk), &data_index))
 				HASH_PACK_FAIL("hashpackdata(rect)");
 
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 			break;
 		}
 
@@ -3455,13 +3493,19 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			if (!hashpackdata (&lpi->s2, &rgbdisk, sizeof (rgbdisk), &data_index))
 				HASH_PACK_FAIL("hashpackdata(rgb)");
 
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 			break;
 		}
 
 		case doublevaluetype: {
 			double x = **val.data.doublevalue;
-			rec.data.doublebits = host_to_disk_double_bits (x);
+			{
+				uint64_t bits = host_to_disk_double_bits (x);
+				memcpy(recbuf + 8, &bits, sizeof(uint64_t));
+			}
 			break;
 		}
 
@@ -3481,13 +3525,13 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 				case recordvaluetype:
 					if (!oppacklist (val.data.listvalue, &hpacked))
 						HASH_PACK_FAIL("oppacklist");
-					rec.version = 2;
+					rec_version = 2;
 					break;
 				case filespecvaluetype:
 				case aliasvaluetype:
 					if (!langpackfileval (&val, &hpacked))
 						HASH_PACK_FAIL("langpackfileval");
-					rec.version = 2;
+					rec_version = 2;
 					break;
 				case codevaluetype:
 					if (!langpacktree (val.data.codevalue, &hpacked))
@@ -3511,7 +3555,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 					disposehandle (hpacked);
 			}
 
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 			break;
 		}
 
@@ -3552,7 +3599,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 				HASH_PACK_FAIL("hashpackexternal");
 
 			lpi->flmustsave = lpi->flmustsave || flnewdbaddress;
-			rec.data.longvalue = host_to_disk_int64 ((int64_t) data_index);
+			{
+				int64_t tmp = host_to_disk_int64 ((int64_t) data_index);
+				memcpy(recbuf + 8, &tmp, sizeof(int64_t));
+			}
 			break;
 		}
 
@@ -3569,7 +3619,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 		case singlevaluetype:
 		case directionvaluetype:
 		case datevaluetype:
-			diskvalue_from_value_v7 (&val, &rec.data);
+			tydiskvaluedata_v7 rec_data_local;
+			clearbytes(&rec_data_local, sizeof(rec_data_local));
+			diskvalue_from_value_v7 (&val, &rec_data_local);
+			memcpy(recbuf + 8, &rec_data_local, sizeof(rec_data_local));
 			break;
 
 		default:
@@ -3577,7 +3630,10 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			HASH_PACK_FAIL("langerror(default)");
 	}
 
-	if (!writehandlestream (&lpi->s1, &rec, sizeof (rec)))
+	/* stamp version byte */
+	recbuf[5] = rec_version;
+
+	if (!writehandlestream (&lpi->s1, recbuf, sizeof (recbuf)))
 		HASH_PACK_FAIL("writehandlestream(record)");
 
 	languntraperrors (savecallback, saverefcon, false);
@@ -3786,7 +3842,11 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 	bigstring bsunpackerror;
 	hdlhashtable prevhashtable = nil;
 #if defined(FRONTIER_HEADLESS)
+	static FILE *hashunpack_log = NULL;
+	static boolean hashunpack_log_init = false;
 	long debug_record_index = 0;
+	fprintf(stderr, "[headless] hashunpacktable enter htable=%p flmemory=%d\n",
+	        (void *) htable, (int) flmemory);
 #endif
 
 	/* v0x04 and earlier use 16-byte header, v0x05 uses 32-byte header */
@@ -3797,6 +3857,18 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 		return (false);
 
 #if defined(FRONTIER_HEADLESS)
+	if (!hashunpack_log_init) {
+		hashunpack_log_init = true;
+		const char *logpath = getenv("FRONTIER_HASHUNPACK_LOG");
+		if (logpath != NULL && *logpath != '\0') {
+			hashunpack_log = fopen(logpath, "w");
+			if (hashunpack_log == NULL) {
+				fprintf(stderr, "[headless] hashunpacktable: failed to open log %s: %s\n",
+				        logpath, strerror(errno));
+			}
+		}
+	}
+
 	fprintf(stderr, "[headless] hashunpacktable split records=%ld strings=%ld\n",
 	        hrecords ? gethandlesize (hrecords) : 0L,
 	        hstrings ? gethandlesize (hstrings) : 0L);
@@ -3816,20 +3888,28 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 
 	/*see if this is a 5.0 table, with a header*/
 
-	/* Peek at version to determine which structure to read */
-	int16_t version_peek;
-	long ix_peek = ix;
-	loadfromhandle (hrecords, &ix_peek, sizeof(int16_t), &version_peek);
-	version_peek = disk_to_host_int16(version_peek);
+	/* Peek at version to determine which structure to read.
+	   If the packed data is too small or version is out of range, treat as no header. */
+	int16_t version_peek = 0;
+	boolean header_present = false;
+	const long total_bytes = gethandlesize(hrecords);
+	const int16_t max_supported_version = 10; /* future headroom */
+	if (total_bytes >= (long) sizeof (tydisktablerecord_v4)) {
+		long ix_peek = ix;
+		if (loadfromhandle (hrecords, &ix_peek, sizeof(int16_t), &version_peek)) {
+			version_peek = disk_to_host_int16(version_peek);
+			if (version_peek >= 1 && version_peek <= max_supported_version)
+				header_present = true;
+		}
+	}
 
-	/* Dispatch based on version */
-	if (version_peek >= 0x05) {
+	if (header_present && version_peek >= 0x05) {
 		/* v0x05+: Modern format with 64-bit timestamps */
 		/* Note: loadfromhandle() performs raw byte copy without byte swapping */
 		loadfromhandle (hrecords, &ix, sizeof (tydisktablerecord), &header);
 		header.version = disk_to_host_int16(header.version);
 	}
-	else {
+	else if (header_present && version_peek >= 0x01) {
 		/* v0x04 and earlier: Legacy format with 32-bit timestamps */
 		/* Note: loadfromhandle() performs raw byte copy without byte swapping */
 		loadfromhandle (hrecords, &ix, sizeof (tydisktablerecord_v4), &header_v4);
@@ -3841,6 +3921,15 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 		header.timecreated = (uint64_t) disk_to_host_int32((int32_t) header_v4.timecreated);
 		header.timelastsave = (uint64_t) disk_to_host_int32((int32_t) header_v4.timelastsave);
 		header.flags = header_v4.flags; /* will be byte-swapped below */
+	}
+	else {
+		/* No valid header present; fall back to legacy no-header behavior */
+		header.version = 0;
+		header.flags = 0;
+		header.sortorder = 0;
+		header.timecreated = 0;
+		header.timelastsave = 0;
+		ix = 0;
 	}
 
 #if TABLE_HEADER_RESERVED_BYTES > 0
@@ -3913,53 +4002,98 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 	long ixrecord = 0;
 	while (true) {
 			tydisksymbolrecord rec;
-			tydisksymbolrecord_v7 rec_v7;
+			unsigned char recbuf[sizeof(tydisksymbolrecord_v7)];
 			tyvaluerecord val;
 			long remaining;
 			boolean modern_rec = modern_records;
 			int32_t name_index = 0;
+			int64_t data_index64 = 0;
+			tydiskvaluedata_v7 rec_data_v7;
+			clearbytes(&rec_data_v7, sizeof(rec_data_v7));
 
 			assert (sizeof (tydisksymbolrecord) == sizeof (tyOLD42disksymbolrecord));
 
 			remaining = gethandlesize (hrecords) - ix;
 			if (modern_records) {
-				if (remaining < (long) sizeof (rec_v7)) /*out of records*/
+				if (remaining < (long) sizeof (tydisksymbolrecord_v7)) /*out of records*/
 					break;
-				if (!loadfromhandle (hrecords, &ix, sizeof (rec_v7), &rec_v7)) /*unexpected failure*/
+				if (!loadfromhandle (hrecords, &ix, sizeof (recbuf), recbuf)) /*unexpected failure*/
 					break;
-				rec.ixkey = disk_to_host_int32 (rec_v7.ixkey);
-				rec.valuetype = rec_v7.valuetype;
-				rec.version = rec_v7.version;
-				/* store index in legacy slot for non-scalar cases */
-				rec.data.longvalue = (int32_t) disk_to_host_int64((int64_t) rec_v7.data.longvalue);
+
+				int32_t ix_be = 0;
+				memcpy(&ix_be, recbuf + 0, sizeof(int32_t));
+				name_index = disk_to_host_int32 (ix_be);
+				rec.valuetype = recbuf[4];
+				rec.version = recbuf[5];
+
+				int64_t data_be = 0;
+				memcpy(&data_be, recbuf + 8, sizeof(int64_t));
+				data_index64 = (int64_t) disk_to_host_int64(data_be);
+				memcpy(&rec_data_v7, recbuf + 8, sizeof(rec_data_v7));
+				rec.data.longvalue = (int32_t) data_index64; /*for legacy debug printing paths*/
 			}
 			else {
 				if (remaining < (long) sizeof (rec)) /*out of records*/
 					break;
 				if (!loadfromhandle (hrecords, &ix, sizeof (rec), &rec)) /*unexpected failure*/
 					break;
+
+				name_index = disk_to_host_int32(rec.ixkey);
+				data_index64 = (int64_t) disk_to_host_int32 (rec.data.longvalue);
 			}
 
-			name_index = disk_to_host_int32 (rec.ixkey);
 //			disktomemshort (rec.valuetype);
 //			disktomemshort (rec.version);
 
-			if (header.version < 2) // shift down from old bitfield position
+			if (!modern_rec && header.version < 2) // shift down from old bitfield position
 				rec.version >>= 4;
 
-			if (modern_rec) {
-				/* Already converted from BE64 above; avoid a second byte swap. */
-				name_index = rec.ixkey;
-				ixstrings = rec.data.longvalue;
+			/* string/binary offsets remain 32-bit but are stored in a widened slot on disk */
+			ixstrings = (long) data_index64;
+
+			/* Inspect raw bytes before converting to a Pascal string. */
+#if defined(FRONTIER_HEADLESS)
+			{
+				long hsize = gethandlesize(hstrings);
+				if (name_index < 0 || name_index >= hsize) {
+					fprintf(stderr, "[headless] hashunpacktable name ix OOB ix=%d hsize=%ld\n",
+					        (int) name_index, hsize);
+				} else {
+					const unsigned char *s = (const unsigned char *)(*hstrings + name_index);
+					unsigned int slen = s[0];
+					long avail = hsize - name_index - 1;
+					if ((long) slen > avail)
+						slen = (unsigned int) (avail < 0 ? 0 : avail);
+					fprintf(stderr, "[headless] hashunpacktable name bytes ix=%d len=%u: ",
+					        (int) name_index, slen);
+					for (unsigned int i = 0; i < slen && i < 32; ++i)
+						fprintf(stderr, "%02x ", s[1 + i]);
+					fprintf(stderr, "\n");
+				}
 			}
-			else {
-				name_index = disk_to_host_int32(rec.ixkey);
-				ixstrings = disk_to_host_int32 (rec.data.longvalue);
-			}
+#endif
 
 			hashunpackstring (hstrings, bsname, name_index);
 
 #if defined(FRONTIER_HEADLESS)
+			if (hashunpack_log != NULL) {
+				unsigned int slen = (unsigned int) bsname[0];
+				fprintf(hashunpack_log,
+				        "rec=%ld name_ix=%d len=%u name=\"%.*s\" modern=%d data_ix=%lld\n",
+				        ixrecord,
+				        (int) name_index,
+				        slen,
+				        (int) slen,
+				        (char *) (bsname + 1),
+				        (int) modern_rec,
+				        (long long) data_index64);
+				fprintf(hashunpack_log, "  raw:");
+				for (unsigned int i = 0; i < slen && i < 32; ++i)
+					fprintf(hashunpack_log, " %02x", (unsigned char) bsname[1 + i]);
+				fprintf(hashunpack_log, "\n");
+				fflush(hashunpack_log);
+			}
+
 			fprintf(stderr, "[headless] hashunpacktable record ix=%ld name='%.*s' valuetype=%d version=%u use64=%d\n",
 			        ixrecord,
 			        bsname[0], bsname + 1,
@@ -3969,12 +4103,33 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 #endif
 
 #if defined(FRONTIER_HEADLESS)
+			if (debug_record_index < 20) {
+				long hsize = gethandlesize(hstrings);
+				if (name_index < 0 || name_index >= hsize) {
+					fprintf(stderr, "[headless] hashunpacktable name ix OOB ix=%d hsize=%ld\n",
+					        (int) name_index, hsize);
+				} else {
+					const unsigned char *s = (const unsigned char *)(*hstrings + name_index);
+					unsigned int slen = s[0];
+					long avail = hsize - name_index - 1;
+					if ((long) slen > avail)
+						slen = (unsigned int) (avail < 0 ? 0 : avail);
+					fprintf(stderr, "[headless] hashunpacktable name bytes ix=%d len=%u: ",
+					        (int) name_index, slen);
+					for (unsigned int i = 0; i < slen && i < 32; ++i)
+						fprintf(stderr, "%02x ", s[1 + i]);
+					fprintf(stderr, "\n");
+				}
+			}
+#endif
+
+#if defined(FRONTIER_HEADLESS)
 			if (debug_record_index++ < 10) {
-				fprintf(stderr, "[headless] hashunpacktable record ixkey=%d type=%d version=%u data=0x%08x name='%.*s'\n",
+				fprintf(stderr, "[headless] hashunpacktable record ixkey=%d type=%d version=%u data=0x%08llx name='%.*s'\n",
 				        (int) name_index,
 				        (int) rec.valuetype,
 				        (unsigned int) rec.version,
-				        (unsigned int) disk_to_host_int32(rec.data.longvalue),
+				        (unsigned long long) data_index64,
 				        (int) bsname[0],
 				        (char *) &bsname[1]);
 			}
@@ -3985,9 +4140,9 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 
 			initvalue (&val, (tyvaluetype) rec.valuetype);
 #ifdef DEBUG_SERIALIZER
-	printf("[unpack] name=%.*s type=%d version=%u raw_ix=0x%08x ix=%ld\n",
+	printf("[unpack] name=%.*s type=%d version=%u raw_ix=0x%08llx ix=%ld\n",
 		(int)bsname[0], bsname+1, val.valuetype, rec.version,
-		(unsigned int) rec.data.longvalue, ixstrings);
+		(unsigned long long) data_index64, ixstrings);
 #endif
 
 			switch (val.valuetype) {
@@ -4133,7 +4288,7 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 					break;
 				}
 
-                case listvaluetype:
+				case listvaluetype:
                 case recordvaluetype:
 #if !defined(FRONTIER_HEADLESS)
                     if (rec.version < 2) {
@@ -4303,7 +4458,7 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 
 				case booleanvaluetype:
 					if (modern_rec) {
-						diskvalue_to_value_v7 (&rec_v7.data, &val);
+						diskvalue_to_value_v7 (&rec_data_v7, &val);
 					} else if (header.version < 2) {
 						int16_t rawbool = disk_to_host_int16 (rec.data.intvalue);
 						val.data.flvalue = (rawbool != 0);
@@ -4327,7 +4482,7 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 				case singlevaluetype:
 				case datevaluetype:
 					if (modern_rec)
-						diskvalue_to_value_v7 (&rec_v7.data, &val);
+						diskvalue_to_value_v7 (&rec_data_v7, &val);
 					else
 						diskvalue_to_value_legacy (&rec.data, &val);
 
@@ -4335,7 +4490,7 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 
 				default:
 					if (modern_rec)
-						diskvalue_to_value_v7 (&rec_v7.data, &val);
+						diskvalue_to_value_v7 (&rec_data_v7, &val);
 					else
 						diskvalue_to_value_legacy (&rec.data, &val);
 

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -3359,7 +3359,8 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 	if (!hashpackstring (&lpi->s2, bsname, &name_index))
 		HASH_PACK_FAIL("hashpackstring(name)");
 
-	/* Manually populate packed record buffer (big-endian, fixed layout). */
+	/* Manually populate packed record buffer (big-endian, fixed layout).
+	   See planning/phase3/big_endian_portability_audit.md for BE64 guidance. */
 	int32_t ix_be = host_to_disk_int32 (name_index);
 	memcpy(recbuf + 0, &ix_be, sizeof(int32_t));
 	recbuf[4] = (uint8_t) val.valuetype;
@@ -3625,12 +3626,12 @@ static boolean hashpackvisit_modern (bigstring bsname, hdlhashnode hnode, tyvalu
 			memcpy(recbuf + 8, &rec_data_local, sizeof(rec_data_local));
 			break;
 
-		default:
-			langerror (cantpackerror);
-			HASH_PACK_FAIL("langerror(default)");
-	}
+	default:
+		langerror (cantpackerror);
+		HASH_PACK_FAIL("langerror(default)");
+}
 
-	/* stamp version byte */
+	/* Stamp final version byte before writing the record. */
 	recbuf[5] = rec_version;
 
 	if (!writehandlestream (&lpi->s1, recbuf, sizeof (recbuf)))
@@ -3894,6 +3895,8 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 	boolean header_present = false;
 	const long total_bytes = gethandlesize(hrecords);
 	const int16_t max_supported_version = 10; /* future headroom */
+	/* Peek at the first two bytes; only treat as a header when the version is in-range
+	   and the packed records area is large enough to hold the corresponding header. */
 	if (total_bytes >= (long) sizeof (tydisktablerecord_v4)) {
 		long ix_peek = ix;
 		if (loadfromhandle (hrecords, &ix_peek, sizeof(int16_t), &version_peek)) {
@@ -3903,7 +3906,7 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 		}
 	}
 
-	if (header_present && version_peek >= 0x05) {
+	if (header_present && version_peek >= 0x05 && total_bytes >= (long) sizeof (tydisktablerecord)) {
 		/* v0x05+: Modern format with 64-bit timestamps */
 		/* Note: loadfromhandle() performs raw byte copy without byte swapping */
 		loadfromhandle (hrecords, &ix, sizeof (tydisktablerecord), &header);
@@ -3929,7 +3932,6 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 		header.sortorder = 0;
 		header.timecreated = 0;
 		header.timelastsave = 0;
-		ix = 0;
 	}
 
 #if TABLE_HEADER_RESERVED_BYTES > 0
@@ -4002,7 +4004,8 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 	long ixrecord = 0;
 	while (true) {
 			tydisksymbolrecord rec;
-			unsigned char recbuf[sizeof(tydisksymbolrecord_v7)];
+	/* Buffer mirrors the manual BE64 layout written in hashpackvisit_modern. */
+	unsigned char recbuf[sizeof(tydisksymbolrecord_v7)];
 			tyvaluerecord val;
 			long remaining;
 			boolean modern_rec = modern_records;
@@ -4100,27 +4103,6 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 			        (int) rec.valuetype,
 			        (unsigned int) rec.version,
 			        (int) modern_rec);
-#endif
-
-#if defined(FRONTIER_HEADLESS)
-			if (debug_record_index < 20) {
-				long hsize = gethandlesize(hstrings);
-				if (name_index < 0 || name_index >= hsize) {
-					fprintf(stderr, "[headless] hashunpacktable name ix OOB ix=%d hsize=%ld\n",
-					        (int) name_index, hsize);
-				} else {
-					const unsigned char *s = (const unsigned char *)(*hstrings + name_index);
-					unsigned int slen = s[0];
-					long avail = hsize - name_index - 1;
-					if ((long) slen > avail)
-						slen = (unsigned int) (avail < 0 ? 0 : avail);
-					fprintf(stderr, "[headless] hashunpacktable name bytes ix=%d len=%u: ",
-					        (int) name_index, slen);
-					for (unsigned int i = 0; i < slen && i < 32; ++i)
-						fprintf(stderr, "%02x ", s[1 + i]);
-					fprintf(stderr, "\n");
-				}
-			}
 #endif
 
 #if defined(FRONTIER_HEADLESS)

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -39,6 +39,7 @@
 #include "strings.h"
 #include "font.h"
 #include "ops.h"
+#include <stddef.h> /* for offsetof static asserts */
 #include <stdlib.h> /* getenv for materialize tracing */
 #include <string.h> /* memcpy for BE64 double/int conversions */
 #if !defined(FRONTIER_HEADLESS)
@@ -62,10 +63,17 @@
 #endif
 // 2025-11-28 Codex: Use db_context when dereferencing externals during hash packing.
 #include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
+
+/* Ensure the manual BE layout matches the on-disk record definition. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(tydisksymbolrecord_v7) == 16, "tydisksymbolrecord_v7 must be 16 bytes");
+_Static_assert(offsetof(tydisksymbolrecord_v7, data) == 8, "tydisksymbolrecord_v7.data offset must be 8");
+#endif
 #if defined(FRONTIER_HEADLESS)
 #include "../portable/wptext_portable.h"
 #include <stdio.h>
 #include <errno.h>
+#include <stdbool.h>
 #define WP_PLACEHOLDER_TEXT "WPText not migrated because it was too old to read."
 extern boolean getstringlist(short listid, short stringid, bigstring bs);
 extern void recttodiskrect(Rect *, diskrect *);
@@ -163,6 +171,27 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 /* Exposed for debug logging in tableunpacktable errors. */
 const char *langhash_materialize_current_path = NULL;
 static char langhash_materialize_path_buf[512];
+#if defined(FRONTIER_HEADLESS)
+/* Hash unpack diagnostics */
+static FILE *hashunpack_log = NULL;
+static boolean hashunpack_log_init = false;
+static void close_hashunpack_log(void) {
+	if (hashunpack_log != NULL) {
+		fclose(hashunpack_log);
+		hashunpack_log = NULL;
+	}
+}
+static boolean is_safe_log_path(const char *path) {
+	if (path == NULL || *path == '\0')
+		return false;
+	/* reject absolute paths and parent traversals */
+	if (path[0] == '/')
+		return false;
+	if (strstr(path, "..") != NULL)
+		return false;
+	return true;
+}
+#endif
 static boolean langhash_materialize_trace_enabled(void) {
 	static short initialized = 0;
 	static boolean enabled = false;
@@ -3843,8 +3872,6 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 	bigstring bsunpackerror;
 	hdlhashtable prevhashtable = nil;
 #if defined(FRONTIER_HEADLESS)
-	static FILE *hashunpack_log = NULL;
-	static boolean hashunpack_log_init = false;
 	long debug_record_index = 0;
 	fprintf(stderr, "[headless] hashunpacktable enter htable=%p flmemory=%d\n",
 	        (void *) htable, (int) flmemory);
@@ -3861,12 +3888,16 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 	if (!hashunpack_log_init) {
 		hashunpack_log_init = true;
 		const char *logpath = getenv("FRONTIER_HASHUNPACK_LOG");
-		if (logpath != NULL && *logpath != '\0') {
+		if (is_safe_log_path(logpath)) {
 			hashunpack_log = fopen(logpath, "w");
 			if (hashunpack_log == NULL) {
 				fprintf(stderr, "[headless] hashunpacktable: failed to open log %s: %s\n",
 				        logpath, strerror(errno));
+			} else {
+				atexit(close_hashunpack_log);
 			}
+		} else if (logpath && *logpath) {
+			fprintf(stderr, "[headless] hashunpacktable: unsafe log path ignored: %s\n", logpath);
 		}
 	}
 
@@ -3926,7 +3957,7 @@ boolean hashunpacktable (Handle hpackedtable, boolean flmemory, hdlhashtable hta
 		header.flags = header_v4.flags; /* will be byte-swapped below */
 	}
 	else {
-		/* No valid header present; fall back to legacy no-header behavior */
+		/* No valid header present (version 0 reserved for headerless legacy tables); fall back to legacy no-header behavior. */
 		header.version = 0;
 		header.flags = 0;
 		header.sortorder = 0;

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -306,6 +306,13 @@ boolean tableverbinmemory_common(hdlexternalvariable hvariable, hdlhashnode hnod
     bigstring bspath, bsunpackerror;
     boolean fl;
 
+#if defined(FRONTIER_HEADLESS)
+    fprintf(stderr, "[headless] tableverbinmemory enter hvariable=%p hnode=%p flinmemory=%d\n",
+            (void *) hvariable,
+            (void *) hnode,
+            (hvariable && *hvariable) ? (**hvariable).flinmemory : -1);
+#endif
+
     if ((**hv).flinmemory) /* nothing to do, it's already in memory */
         return true;
 
@@ -322,6 +329,8 @@ boolean tableverbinmemory_common(hdlexternalvariable hvariable, hdlhashnode hnod
         fprintf(stderr, "[headless] tableverbinmemory nil database for variable adr=0x%llx\n",
                 (unsigned long long) adr);
     }
+    fprintf(stderr, "[headless] tableverbinmemory dbpush database=%p adr=0x%llx\n",
+            (void *)(**hv).hdatabase, (unsigned long long) adr);
 #endif
 
 #if defined(FRONTIER_HEADLESS)

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -164,6 +164,11 @@ boolean tableunpacktable (Handle hpacked, boolean flmemory, hdlhashtable *htable
     db_context context;
     db_context_init(&context);
 	
+	/* Trace which unpacker is reached. */
+#if defined(FRONTIER_HEADLESS)
+	fprintf(stderr, "[headless] tableunpacktable calling hashunpacktable_context ht=%p flmemory=%d\n",
+	        (void *) ht, (int) flmemory);
+#endif
 if (!hashunpacktable_context (&context, hpackedtable, flmemory, ht)) /*always disposes of hpackedtable*/
 	goto error;
 	

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -728,9 +728,6 @@ boolean settablestructureglobals (Handle hvariable, boolean flcreatesubs) {
 	if (ht == nil)
 		return (false);
 
-	/* Ensure the root variable reflects its on-disk residency before we cache globals. */
-	(**hv).flinmemory = false;
-	
 	cleartablestructureglobals ();
 	
 	rootvariable = (Handle) hv;

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -415,7 +415,12 @@ boolean tableloadsystemtable (dbaddress adr, Handle *hvariable, hdlhashtable *ht
 	register hdlexternalvariable hv;
 	register hdlhashtable ht;
 	hdlhashtable hsubtable;
-	
+
+#if defined(FRONTIER_HEADLESS)
+	fprintf(stderr, "[headless] tableloadsystemtable adr=0x%llx flcreate=%d\n",
+	        (unsigned long long) adr, (int) flcreate);
+#endif
+
 	assert (sizeof (tyexternalvariable) == sizeof (tytablevariable));
 	
 	if (adr == nildbaddress) { /*start an empty table*/
@@ -439,12 +444,12 @@ boolean tableloadsystemtable (dbaddress adr, Handle *hvariable, hdlhashtable *ht
 		
 		hv = (hdlexternalvariable) *hvariable;
 		
-		if (!tableverbinmemory (hv, HNoNode)) {
-			
-			disposehandle ((Handle) hv);
-			
-			return (false);
-			}
+	if (!tableverbinmemory (hv, HNoNode)) {
+		
+		disposehandle ((Handle) hv);
+		
+		return (false);
+		}
 		}
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -657,6 +662,9 @@ boolean cleartablestructureglobals (void) {
 	/*
 	dmb 9/24/90: clear globals; root table is about to be disposed
 	*/
+#if defined(FRONTIER_HEADLESS)
+	fprintf(stderr, "[headless] cleartablestructureglobals\n");
+#endif
 	
 	rootvariable = nil;
 	
@@ -719,6 +727,11 @@ boolean settablestructureglobals (Handle hvariable, boolean flcreatesubs) {
 	
 	if (ht == nil)
 		return (false);
+
+#if defined(FRONTIER_HEADLESS)
+	/* Ensure the root variable reflects its on-disk residency before we cache globals. */
+	(**hv).flinmemory = false;
+#endif
 	
 	cleartablestructureglobals ();
 	

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -728,10 +728,8 @@ boolean settablestructureglobals (Handle hvariable, boolean flcreatesubs) {
 	if (ht == nil)
 		return (false);
 
-#if defined(FRONTIER_HEADLESS)
 	/* Ensure the root variable reflects its on-disk residency before we cache globals. */
 	(**hv).flinmemory = false;
-#endif
 	
 	cleartablestructureglobals ();
 	

--- a/docs/database_architecture.md
+++ b/docs/database_architecture.md
@@ -73,6 +73,20 @@ When migrating:
 
 This rewrite guarantees 64-bit hosts see identical tables regardless of whether the source data came from a 32-bit v6 root or was already modernized.
 
+#### v7 hash record layout (big-endian)
+
+Modern hash/table records are written in an explicit big-endian layout to avoid struct padding issues:
+
+```
+Bytes 0-3  : name index (int32_t, BE)
+Byte  4    : valuetype (uint8_t)
+Byte  5    : version   (uint8_t)
+Bytes 6-7  : reserved/padding (must be zero)
+Bytes 8-15 : data union (BE64: long/double/date/etc.; 32-bit indices are stored widened in this slot)
+```
+
+Compile-time asserts enforce `sizeof(tydisksymbolrecord_v7) == 16` and `offsetof(...data) == 8`. Reader and writer both use a manual 16-byte buffer (`recbuf`) to guarantee identical on-disk layout across platforms.
+
 ## UserTalk Addressing
 
 ### Full Address Notation

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -99,6 +99,7 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
+    /* Always hydrate the system root in headless/CLI; defaults to g_cli_options.system_root if provided. */
     if (g_cli_options.upgrade_system_root) {
         boolean migrated = false;
         char output_path[1024];
@@ -114,32 +115,19 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    if (g_cli_options.hydrate_system_root) {
-        if (g_cli_options.system_root == NULL) {
-            fprintf(stderr, "Error: --hydrate-system-root requires --system-root PATH\n");
-            return 1;
-        }
-        const char* hydrate_path = g_cli_options.system_root;
-        g_cli_options.system_root = NULL;
-        if (!initialize_frontier_runtime()) {
-            fprintf(stderr, "Error: Failed to initialize runtime for hydration\n");
-            return 1;
-        }
-        boolean hydrate_ok = hydrate_system_root_database(hydrate_path);
-        cleanup_frontier_runtime();
-        if (!hydrate_ok) {
-            fprintf(stderr, "Error: Failed to hydrate system root: %s\n", hydrate_path);
-            return 1;
-        }
-        return 0;
-    }
-
-    // Initialize Frontier runtime
+    /* Always initialize runtime and hydrate system root (default path). */
     if (!initialize_frontier_runtime()) {
         fprintf(stderr, "Error: Failed to initialize Frontier runtime\n");
         return 1;
     }
-    
+    if (g_cli_options.system_root != NULL) {
+        if (!hydrate_system_root_database(g_cli_options.system_root)) {
+            fprintf(stderr, "Error: Failed to load system root: %s\n", g_cli_options.system_root);
+            cleanup_frontier_runtime();
+            return 1;
+        }
+    }
+
     // Execute based on mode
     boolean success = false;
     
@@ -399,6 +387,12 @@ static void log_system_subtable_status(const char *phase,
 }
 
 static boolean hydrate_system_root_database(const char* path) {
+    /* Always start from a clean slate; useful to confirm entry. */
+#if defined(FRONTIER_HEADLESS)
+    fprintf(stderr, "[headless] hydrate_system_root_database enter path=%s\n", path ? path : "(nil)");
+#endif
+    cleartablestructureglobals();
+
     if (path == NULL) {
         cli_log_error("No system root path provided for hydration");
         return false;
@@ -464,6 +458,9 @@ static boolean hydrate_system_root_database(const char* path) {
 
     Handle hrootvariable = nil;
     hdlhashtable hroot = nil;
+    /* Reset any cached state from previous loads. */
+    cleartablestructureglobals();
+    /* Load directly from disk. */
     if (!tableloadsystemtable(adr, &hrootvariable, &hroot, false)) {
         cli_log_error("Failed to load system table while hydrating %s", path);
         goto cleanup;
@@ -471,7 +468,6 @@ static boolean hydrate_system_root_database(const char* path) {
 
     dispose_rootvariable = true;
 
-    cleartablestructureglobals();
     rootvariable = hrootvariable;
     roottable = hroot;
     currenthashtable = roottable;
@@ -601,6 +597,8 @@ static boolean load_system_root_database_internal(const char* path, boolean allo
     if (migrated) {
         cli_log_info("Migrated legacy system root to v7 format (written to): %s", actual_path);
         path = actual_path;  /* Use the v7 file */
+        /* After migration, tear down any in-memory v6 root before reloading v7. */
+        cleartablestructureglobals();
     }
 
     len = strlen(path);  /* Recalculate length after potential path change */
@@ -652,6 +650,8 @@ static boolean load_system_root_database_internal(const char* path, boolean allo
 
     Handle hrootvariable = nil;
     hdlhashtable hroot = nil;
+    /* Always clear cached globals before loading. */
+    cleartablestructureglobals();
     if (!tableloadsystemtable(adr, &hrootvariable, &hroot, false)) {
         cli_log_error("Failed to load system table from %s", path);
         cleartablestructureglobals();


### PR DESCRIPTION
## Summary
- defensively bound hashunpackstring and harden table header detection; add optional hash unpack logging
- rewrite modern hash pack/unpack to explicit BE buffers (manual ix/version/data) to chase name corruption
- clear cached table globals after migrations and before loads; add headless traces for table/system hydration
- CLI always hydrates the system root (uses --system-root if provided) and clears globals before/after migration

## Testing
- SANITIZE=1 make -C tests test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens serializer (manual BE v7 records, bounds-checked unpack), hardens table header parsing with diagnostics, clears cached table globals around migrations/loads, and makes the CLI always hydrate the system root.
> 
> - **Serializer/Hash Tables (`langhash.c`)**:
>   - Rewrite modern pack/unpack to use explicit 16-byte BE record buffers with compile-time layout checks; store/read `ix/version/data` via `memcpy`.
>   - Bounds-check `hashunpackstring` offsets/lengths; add optional hash-unpack file logging and per-record traces.
>   - Minor fixes (version byte handling, legacy filespec `rec_version`).
> - **Table pack/unpack (`tablepack.c`, `tableexternal_common.c`)**:
>   - Route through `hash*table_context` wrappers; add headless tracing.
>   - Convert legacy table payloads to merged form when detected during load.
> - **DB/migration (`db_format.c`)**:
>   - After `tablesavesystemtable` during migration, clear table-structure globals and dispose root variable to avoid reuse; add context-guard logs.
>   - Expose context-wrapped helpers and tracing; log hash-unpack context entry.
> - **Table globals/structure (`tablestructure.c`, `cancoon.c`)**:
>   - Add headless traces; ensure `cleartablestructureglobals()` is called in more paths (after migration, before loads).
> - **CLI (`frontier-cli/main.c`)**:
>   - Always initialize and hydrate the system root (using `--system-root` if provided); clear globals before/after migration and before loads.
>   - Additional diagnostics during hydration; optional subtable creation.
> - **Docs**:
>   - Document v7 hash record BE layout and enforcement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a26d4bc0fd2630258428228b5cff51ed172d8df7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->