### PR TITLE
fix: prevent double-free in migration cleanup causing segfault

### DIFF
--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -230,6 +230,8 @@ extern boolean dbstartsaveas_context(db_context *context, hdlfilenum fnum);
 
 extern boolean dbgetdestinationdatabase (hdldatabaserecord *);
 
+/* NOTE: dbendsaveas() and dbendsaveas_context() call dbdispose() internally on the destination database.
+ * Caller MUST set databasedata = nil after these calls to prevent double-free. */
 extern boolean dbendsaveas (void);
 extern boolean dbendsaveas_context(db_context *context);
 

--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -154,6 +154,11 @@ extern hdldatabaserecord databasedata; /*can be set by external user*/
 
 extern boolean fldatabasesaveas;
 
+#ifdef FRONTIER_TESTS
+/* Test-only accessor for cleanup state validation (see db.c) */
+extern boolean db_test_is_saveas_active(void);
+#endif
+
 #if defined(FRONTIER_HEADLESS)
 extern boolean dbnormalizeaddress(dbaddress *adr);
 #endif

--- a/Common/source/cancoon.c
+++ b/Common/source/cancoon.c
@@ -1172,9 +1172,11 @@ boolean ccsavefile (ptrfilespec fs, hdlfilenum fnum, short rnum, boolean flsavea
 	
 	exit:
 
-	if (flsaveas)
-		dbendsaveas ();
-	
+	if (flsaveas) {
+		dbendsaveas (); /* Internally calls dbdispose() on databasedata */
+		databasedata = nil; /* Prevent double-free before reassignment */
+	}
+
 	databasedata = (**cancoonglobals).hdatabase; // may not be same as cancoondata
 	
 	return (fl);

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -196,6 +196,14 @@ static inline boolean db_use64(void) {
 
 boolean fldatabasesaveas = false; /*only true during Save As operation*/
 
+#ifdef FRONTIER_TESTS
+/* Test-only accessor for cleanup state validation (PR #137 regression test).
+ * Provides controlled access to internal state without exposing global directly.
+ * Tests should use this instead of 'extern boolean fldatabasesaveas'. */
+boolean db_test_is_saveas_active(void) {
+	return fldatabasesaveas;
+}
+#endif
 
 
 static hdldatabaserecord databasedestination; /*for Save As*/
@@ -2962,9 +2970,11 @@ static void dbzeroreleasestack_impl (void) {
 	 * (e.g., if a previous disposal attempt failed partway through, or if memory corruption
 	 * occurred during error handling). validhandle() uses OS-level handle validation
 	 * rather than heuristic pointer checks, making this more robust than checking address ranges.
-	 * If invalid, nil it out to prevent crashes - disposal is best-effort during teardown. */
+	 * If invalid, skip disposal entirely - we can't safely access the structure. */
 	if (!validhandle(hstack)) {
-		(**databasedata).releasestack = nil;
+		/* Can't safely nil out releasestack if hstack is invalid - would require
+		 * dereferencing databasedata which might also point to freed memory.
+		 * Best we can do during teardown is return safely. */
 		return;
 	}
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -2957,7 +2957,12 @@ static void dbzeroreleasestack_impl (void) {
 	if (hstack == nil)
 		return;
 
-	/* Defensive: validate handle appears valid before dereferencing during cleanup */
+	/* Defensive: validate handle before dereferencing during cleanup.
+	 * This protects against edge cases where releasestack could contain a stale pointer
+	 * (e.g., if a previous disposal attempt failed partway through, or if memory corruption
+	 * occurred during error handling). validhandle() uses OS-level handle validation
+	 * rather than heuristic pointer checks, making this more robust than checking address ranges.
+	 * If invalid, nil it out to prevent crashes - disposal is best-effort during teardown. */
 	if (!validhandle(hstack)) {
 		(**databasedata).releasestack = nil;
 		return;
@@ -2971,9 +2976,15 @@ static void dbzeroreleasestack_impl (void) {
 static void dbzeroreleasestack (void) {
     /* Direct call - no guards needed during database disposal.
      * Context restoration is meaningless when destroying the database.
+     *
      * The guard pattern previously caused a bug: guard_exit restored
      * databasedata pointer, then dbdispose() freed it, leaving a
-     * dangling pointer that caused segfaults during program exit. */
+     * dangling pointer that caused segfaults during program exit.
+     *
+     * This fix is part of a broader effort to eliminate push/pop anti-patterns
+     * in favor of deterministic, explicit context management (see Issues #135, #136).
+     * The guard removal here aligns with the mode stack refactor (PR #125) which
+     * eliminated similar hidden state restoration during disposal operations. */
     dbzeroreleasestack_impl();
 }
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -2957,6 +2957,12 @@ static void dbzeroreleasestack_impl (void) {
 	if (hstack == nil)
 		return;
 
+	/* Defensive: validate handle appears valid before dereferencing during cleanup */
+	if (!validhandle(hstack)) {
+		(**databasedata).releasestack = nil;
+		return;
+	}
+
 	disposehandle (hstack);
 
 	(**databasedata).releasestack = nil;

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -577,7 +577,8 @@ static void db_sync_use64_to_current_db(void) {
 	if (fldatabasesaveas && dbsaveas_source != nil && db_format_adapter_is_active()) {
 		/* Legacy source stays 32-bit; destination writes are v7 BE64. */
         db_format_mode mode = db_format_mode_current();
-        mode.use_64bit_format = !db_format_is_legacy_db(databasedata);
+        /* Guard against accessing databasedata if it's nil (e.g., after dbdispose in cleanup) */
+        mode.use_64bit_format = (databasedata != nil) && !db_format_is_legacy_db(databasedata);
         db_format_mode_apply(&mode);
 	}
 }
@@ -2948,9 +2949,16 @@ boolean dbflushreleasestack_context(const db_context *context) {
 
 
 static void dbzeroreleasestack_impl (void) {
-	
+
 	if (databasedata == nil)
 		return;
+
+	/* Defensive check: databasedata might point to freed memory during cleanup.
+	 * Check for obviously invalid pointer values before dereferencing. */
+	if ((uintptr_t) databasedata < 0x1000) {
+		databasedata = nil;
+		return;
+	}
 
 	Handle hstack = (**databasedata).releasestack;
 	if (hstack == nil)
@@ -2968,10 +2976,12 @@ static void dbzeroreleasestack_impl (void) {
 	} /*dbzeroreleasestack_impl*/
 
 static void dbzeroreleasestack (void) {
-    db_context_guard guard;
-    db_context_guard_enter(db_context_refresh_default(), &guard);
+    /* Direct call - no guards needed during database disposal.
+     * Context restoration is meaningless when destroying the database.
+     * The guard pattern previously caused a bug: guard_exit restored
+     * databasedata pointer, then dbdispose() freed it, leaving a
+     * dangling pointer that caused segfaults during program exit. */
     dbzeroreleasestack_impl();
-    db_context_guard_exit(&guard);
 }
 
 boolean dbzeroreleasestack_context(const db_context *context) {

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -2953,25 +2953,12 @@ static void dbzeroreleasestack_impl (void) {
 	if (databasedata == nil)
 		return;
 
-	/* Defensive check: databasedata might point to freed memory during cleanup.
-	 * Check for obviously invalid pointer values before dereferencing. */
-	if ((uintptr_t) databasedata < 0x1000) {
-		databasedata = nil;
-		return;
-	}
-
 	Handle hstack = (**databasedata).releasestack;
 	if (hstack == nil)
 		return;
 
-	/* Defensive: guard against stale or invalid handles during Save As teardown. */
-	if ((uintptr_t) hstack < 0x1000) {
-		(**databasedata).releasestack = nil;
-		return;
-	}
-
 	disposehandle (hstack);
-	
+
 	(**databasedata).releasestack = nil;
 	} /*dbzeroreleasestack_impl*/
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -2978,6 +2978,11 @@ static void dbzeroreleasestack (void) {
 }
 
 boolean dbzeroreleasestack_context(const db_context *context) {
+    /* Context-aware wrapper - guards ARE needed here.
+     * Unlike dbzeroreleasestack() which is called during permanent disposal,
+     * this variant is called with an explicit context that must be temporarily
+     * applied and then restored. The caller expects their context to remain
+     * unchanged after this call, so guards are appropriate and necessary. */
     db_context_guard guard;
     db_context_guard_enter(context, &guard);
     dbzeroreleasestack_impl();

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1885,19 +1885,23 @@ cleanup:
     if (hrootvariable != nil)
         tableverbdispose((hdlexternalvariable) hrootvariable, true);
 
+    /* Cleanup: End Save As operation if active.
+     * NOTE: dbendsaveas*() ALWAYS calls dbdispose() on destination database,
+     * even on failure (see dbendsaveas_internal line 3341 in db.c).
+     * We must nil out databasedata immediately to prevent double-free. */
     if (fldatabasesaveas) {
         if (have_dest_context) {
             dbendsaveas_context(&dest_context);
-            /* dbendsaveas_context() calls dbdispose() internally, so clear databasedata
-             * to prevent double-free in cleanup section below. */
             databasedata = nil;
         } else {
             dbendsaveas();
-            /* dbendsaveas() also disposes destination, clear pointer */
             databasedata = nil;
         }
     }
 
+    /* If Save As wasn't active but we opened a destination database for migration,
+     * we still need to dispose it. This handles the case where dbstartsaveas succeeded
+     * but we hit an error before fldatabasesaveas was set. */
     if (databasedata != nil)
         dbdispose();
 

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1902,8 +1902,10 @@ cleanup:
     /* If Save As wasn't active but we opened a destination database for migration,
      * we still need to dispose it. This handles the case where dbstartsaveas succeeded
      * but we hit an error before fldatabasesaveas was set. */
-    if (databasedata != nil)
+    if (databasedata != nil) {
         dbdispose();
+        databasedata = nil;  /* Ensure invariant: databasedata is nil after cleanup */
+    }
 
     if (src_fnum != 0)
         closefile(src_fnum);
@@ -1941,6 +1943,9 @@ cleanup:
 
     db_format_mode_apply(&entry_mode);
     db_saveas_state_apply(&entry_saveas);
+
+    /* Postcondition: databasedata should be nil after cleanup */
+    assert(databasedata == nil);
 
     return ok;
 }

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1878,6 +1878,9 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
 
     ok = true;
 
+    /* Postcondition check: Success path should have nil'd databasedata */
+    assert(databasedata == nil);
+
 cleanup:
     db_format_mode_pop(); /* restore prior mode before exit */
     if (hscript != nil)
@@ -1885,10 +1888,17 @@ cleanup:
     if (hrootvariable != nil)
         tableverbdispose((hdlexternalvariable) hrootvariable, true);
 
-    /* Cleanup: End Save As operation if active.
-     * NOTE: dbendsaveas*() ALWAYS calls dbdispose() on destination database,
+    /* Cleanup: End Save As operation if active (error paths only).
+     * NOTE: If we took the success path (lines 1847-1857), dbendsaveas*() was already
+     * called there, which sets fldatabasesaveas = false (see dbendsaveas_internal line
+     * 3351 in db.c). So this section only executes for error paths where we need to
+     * teardown partial Save As state.
+     *
+     * CRITICAL: dbendsaveas*() ALWAYS calls dbdispose() on destination database,
      * even on failure (see dbendsaveas_internal line 3341 in db.c).
-     * We must nil out databasedata immediately to prevent double-free. */
+     * We must nil out databasedata immediately to prevent double-free.
+     *
+     * Return value ignored: We're in cleanup/error handling, disposal is best-effort. */
     if (fldatabasesaveas) {
         if (have_dest_context) {
             dbendsaveas_context(&dest_context);
@@ -1899,9 +1909,18 @@ cleanup:
         }
     }
 
-    /* If Save As wasn't active but we opened a destination database for migration,
-     * we still need to dispose it. This handles the case where dbstartsaveas succeeded
-     * but we hit an error before fldatabasesaveas was set. */
+    /* Final disposal: If Save As wasn't active but we opened a destination database,
+     * dispose it. This handles the rare case where dbstartsaveas_context() succeeded
+     * (allocating destination database and setting databasedata) but an error occurred
+     * before we set fldatabasesaveas = true (which happens inside the actual migration
+     * logic, not during setup).
+     *
+     * Example failure scenario:
+     * 1. dbstartsaveas_context() succeeds → databasedata = destination, but fldatabasesaveas still false
+     * 2. Early validation fails (e.g., source database corrupt) → goto cleanup
+     * 3. fldatabasesaveas is false, so we skip lines 1892-1900
+     * 4. But databasedata != nil, so we need to dispose it here
+     */
     if (databasedata != nil) {
         dbdispose();
         databasedata = nil;  /* Ensure invariant: databasedata is nil after cleanup */

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1847,9 +1847,13 @@ static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     if (have_dest_context) {
         if (!dbendsaveas_context(&dest_context))
             goto cleanup;
+        /* dbendsaveas_context already disposed the destination database.
+         * Set databasedata to nil to prevent double-free in cleanup. */
+        databasedata = nil;
     } else {
         if (!dbendsaveas())
             goto cleanup;
+        databasedata = nil;
     }
 
     closefile(dst_fnum);
@@ -1882,10 +1886,16 @@ cleanup:
         tableverbdispose((hdlexternalvariable) hrootvariable, true);
 
     if (fldatabasesaveas) {
-        if (have_dest_context)
+        if (have_dest_context) {
             dbendsaveas_context(&dest_context);
-        else
+            /* dbendsaveas_context() calls dbdispose() internally, so clear databasedata
+             * to prevent double-free in cleanup section below. */
+            databasedata = nil;
+        } else {
             dbendsaveas();
+            /* dbendsaveas() also disposes destination, clear pointer */
+            databasedata = nil;
+        }
     }
 
     if (databasedata != nil)

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -1554,6 +1554,38 @@ static boolean db_format_force_materialize_external_tables(
         hroot, context, 0);
 }
 
+/* Helper: Clean up migration database handles to ensure proper disposal and nil-setting.
+ * Addresses PR #137 issue - prevents double-free by handling three disposal scenarios:
+ * 1. Success path already called dbendsaveas*() - nothing to do (fldatabasesaveas=false)
+ * 2. Error path with active Save As - call dbendsaveas*() to teardown
+ * 3. Error path with allocated destination but no active Save As - direct disposal
+ *
+ * NOTE: This is part of addressing Issue #138 - making disposal patterns explicit.
+ * Related to Issue #135/#136 - eliminating push/pop anti-patterns in favor of
+ * deterministic, explicit cleanup. */
+static void cleanup_migration_database(db_context *dest_context, boolean have_dest_context) {
+    if (fldatabasesaveas) {
+        /* Error path: Save As is active, need to teardown partial state.
+         * dbendsaveas*() calls dbdispose() internally and sets fldatabasesaveas = false.
+         * Return value ignored: we're in cleanup/error handling, disposal is best-effort. */
+        if (have_dest_context) {
+            dbendsaveas_context(dest_context);
+        } else {
+            dbendsaveas();
+        }
+        databasedata = nil;
+    } else if (databasedata != nil) {
+        /* Rare error path: destination allocated but Save As not started yet.
+         * Example scenario:
+         * 1. dbstartsaveas_context() succeeds → databasedata = destination
+         * 2. Early validation fails (e.g., source corrupt) → goto cleanup
+         * 3. fldatabasesaveas still false, but databasedata needs disposal */
+        dbdispose();
+        databasedata = nil;
+    }
+    /* else: databasedata already nil (normal success path), nothing to do */
+}
+
 static boolean migrate_internal(const char *db_path, boolean drop_cancoon) {
     if (db_path == NULL || db_path[0] == '\0')
         return false;
@@ -1888,43 +1920,10 @@ cleanup:
     if (hrootvariable != nil)
         tableverbdispose((hdlexternalvariable) hrootvariable, true);
 
-    /* Cleanup: End Save As operation if active (error paths only).
-     * NOTE: If we took the success path (lines 1847-1857), dbendsaveas*() was already
-     * called there, which sets fldatabasesaveas = false (see dbendsaveas_internal line
-     * 3351 in db.c). So this section only executes for error paths where we need to
-     * teardown partial Save As state.
-     *
-     * CRITICAL: dbendsaveas*() ALWAYS calls dbdispose() on destination database,
-     * even on failure (see dbendsaveas_internal line 3341 in db.c).
-     * We must nil out databasedata immediately to prevent double-free.
-     *
-     * Return value ignored: We're in cleanup/error handling, disposal is best-effort. */
-    if (fldatabasesaveas) {
-        if (have_dest_context) {
-            dbendsaveas_context(&dest_context);
-            databasedata = nil;
-        } else {
-            dbendsaveas();
-            databasedata = nil;
-        }
-    }
-
-    /* Final disposal: If Save As wasn't active but we opened a destination database,
-     * dispose it. This handles the rare case where dbstartsaveas_context() succeeded
-     * (allocating destination database and setting databasedata) but an error occurred
-     * before we set fldatabasesaveas = true (which happens inside the actual migration
-     * logic, not during setup).
-     *
-     * Example failure scenario:
-     * 1. dbstartsaveas_context() succeeds → databasedata = destination, but fldatabasesaveas still false
-     * 2. Early validation fails (e.g., source database corrupt) → goto cleanup
-     * 3. fldatabasesaveas is false, so we skip lines 1892-1900
-     * 4. But databasedata != nil, so we need to dispose it here
-     */
-    if (databasedata != nil) {
-        dbdispose();
-        databasedata = nil;  /* Ensure invariant: databasedata is nil after cleanup */
-    }
+    /* Database cleanup: Handle disposal in all three scenarios (see helper for details).
+     * This helper function was extracted to improve testability and make the complex
+     * cleanup logic easier to reason about (PR #137 review feedback). */
+    cleanup_migration_database(&dest_context, have_dest_context);
 
     if (src_fnum != 0)
         closefile(src_fnum);

--- a/tests/save_migration_tests.c
+++ b/tests/save_migration_tests.c
@@ -131,8 +131,8 @@ int main(void) {
     MIGRATION_TEST_PASS("Migration completed without errors");
 
     // Verify cleanup state (PR #137 regression test)
-    extern boolean fldatabasesaveas;  // Exported from db.c
-    if (!fldatabasesaveas)
+    // Use test-only accessor instead of accessing global directly
+    if (!db_test_is_saveas_active())
         MIGRATION_TEST_PASS("Save-as flag properly reset after migration");
     else
         MIGRATION_TEST_FAIL("Save-as flag not reset (cleanup incomplete)");

--- a/tests/save_migration_tests.c
+++ b/tests/save_migration_tests.c
@@ -130,6 +130,13 @@ int main(void) {
     }
     MIGRATION_TEST_PASS("Migration completed without errors");
 
+    // Verify cleanup state (PR #137 regression test)
+    extern boolean fldatabasesaveas;  // Exported from db.c
+    if (!fldatabasesaveas)
+        MIGRATION_TEST_PASS("Save-as flag properly reset after migration");
+    else
+        MIGRATION_TEST_FAIL("Save-as flag not reset (cleanup incomplete)");
+
     // Verify header is now v7 (migrator writes a new file, preserves source)
     char migrated_path[1024];
     if (!db_format_last_backup_path(migrated_path, sizeof migrated_path)) {


### PR DESCRIPTION
## Summary

Fixes segmentation fault in `save_migration_tests` that occurred during cleanup phase when the test exited normally but crashed during C runtime shutdown.

## Root Cause

The migration test calls `dbendsaveas_context()` which internally disposes the database (calls `dbdispose()`). The cleanup code then unconditionally called `dbdispose()` again, causing a double-free.

Additionally, `dbzeroreleasestack()` was using context guard patterns that restored a freed pointer, creating a dangling pointer that crashed during program exit.

## Changes

1. **Common/source/db_format.c**: Set `databasedata = nil` after `dbendsaveas_context()` to prevent double-free
2. **Common/source/db.c**: 
   - Removed context guards from `dbzeroreleasestack()` since context restoration is meaningless during permanent disposal
   - Added nil check in `db_sync_use64_to_current_db()` before dereferencing `databasedata`
   - Added defensive validation in `dbzeroreleasestack_impl()` against invalid pointers

## Testing

✓ Direct execution: `./tests/save_migration_tests` - PASS  
✓ Make execution: `make -C tests test` - PASS  
✓ No segfaults in either execution mode

Relates to Issue #135 (op refactoring) and Issue #136 (external object audit) which identified similar push/pop anti-patterns.