### PR TITLE
fix: Add FRONTIER_PORTABLE flag to enable portable mode for test suite

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,7 @@ endif
 FRONTIER_TESTS ?= 1
 CWARNING_SUPPRESS ?= -Wno-nonportable-include-path -Wno-error=implicit-function-declaration  # Suppress Paige header case warnings (third-party code)
 CFLAGS = -Wall -Wextra -std=c99 -g -O0 -fpascal-strings -Wno-deprecated-non-prototype -fcommon \
-         -DFRONTIER_USE_PORTABLE_HANDLES -DFRONTIER_HEADLESS \
+         -DFRONTIER_USE_PORTABLE_HANDLES -DFRONTIER_HEADLESS -DFRONTIER_PORTABLE \
          -DFRONTIER_PORTABLE_STRINGS \
          -DFRONTIER_PORTABLE_FILE_AVAILABLE -DFRONTIER_PORTABLE_DB_AVAILABLE \
          -DFRONTIER_PORTABLE_APPLEEVENTS \


### PR DESCRIPTION
The test suite was using -DFRONTIER_PORTABLE_* flags for individual components but was missing the global -DFRONTIER_PORTABLE flag. This caused standard.h to include FastTimes.h (Mac/Carbon types) instead of the portable time_portable.h.

Fix: Add -DFRONTIER_PORTABLE to CFLAGS so all tests compile in true portable mode without Mac/Carbon type dependencies.

This resolves ~20+ UInt64, RgnHandle, Rect, Handle type errors that were blocking the db_format_tests and other portable test compilation.

Note: Further enum redefinition errors remain (pre-existing issue in standard_portable.h vs standard.h conflicting definitions).