### PR TITLE
fix: Resolve enum redefinition errors in standard headers (Issue #186)

### DIFF
--- a/Common/SystemHeaders/standard.h
+++ b/Common/SystemHeaders/standard.h
@@ -110,46 +110,53 @@ standard.h -- standard types and constants
 
 #endif
 
+#ifndef FRONTIER_PORTABLE_DEFINED_TYBITDIRECTION
 typedef enum tybitdirection {
-	
-	upbit = 0x01, 
-	
-	downbit = 0x02, 
-	
-	leftbit = 0x04, 
-	
+
+	upbit = 0x01,
+
+	downbit = 0x02,
+
+	leftbit = 0x04,
+
 	rightbit = 0x08
 	} tybitdirection;
+#define FRONTIER_PORTABLE_DEFINED_TYBITDIRECTION 1
+#endif
 
-
+#ifndef FRONTIER_PORTABLE_DEFINED_TYLINESPACING
 typedef enum tylinespacing {
-	
+
 	singlespaced = 1,
-	
+
 	oneandalittlespaced = 2,
-	
+
 	oneandaquarterspaced = 3,
-	
+
 	oneandahalfspaced = 4,
-	
+
 	doublespaced = 5,
-	
+
 	triplespaced = 6
 	} tylinespacing;
-	
+#define FRONTIER_PORTABLE_DEFINED_TYLINESPACING 1
+#endif
 
+#ifndef FRONTIER_PORTABLE_DEFINED_TYJUSTIFICATION
 typedef enum tyjustification {
-	
-	leftjustified, 
-	
-	centerjustified, 
-	
+
+	leftjustified,
+
+	centerjustified,
+
 	rightjustified,
-	
+
 	fulljustified,
-	
+
 	unknownjustification
 	} tyjustification;
+#define FRONTIER_PORTABLE_DEFINED_TYJUSTIFICATION 1
+#endif
 	
 
 #define true 1

--- a/portable/standard_portable.h
+++ b/portable/standard_portable.h
@@ -119,6 +119,7 @@ typedef const struct Rect* rectparam; /* minimal for portable prototypes */
 #endif
 
 /* Direction enums and related used widely in headers */
+#ifndef ctdirections
 typedef enum tydirection {
     nodirection = 0,
     up = 1,
@@ -133,14 +134,20 @@ typedef enum tydirection {
     pageleft = 11,
     pageright = 12
 } tydirection;
+#define ctdirections 12 /*for arrays indexed on directions*/
+#endif
 
+#ifndef FRONTIER_PORTABLE_DEFINED_TYBITDIRECTION
 typedef enum tybitdirection {
     upbit = 0x01,
     downbit = 0x02,
     leftbit = 0x04,
     rightbit = 0x08
 } tybitdirection;
+#define FRONTIER_PORTABLE_DEFINED_TYBITDIRECTION 1
+#endif
 
+#ifndef FRONTIER_PORTABLE_DEFINED_TYLINESPACING
 typedef enum tylinespacing {
     singlespaced = 1,
     oneandalittlespaced = 2,
@@ -149,7 +156,10 @@ typedef enum tylinespacing {
     doublespaced = 5,
     triplespaced = 6
 } tylinespacing;
+#define FRONTIER_PORTABLE_DEFINED_TYLINESPACING 1
+#endif
 
+#ifndef FRONTIER_PORTABLE_DEFINED_TYJUSTIFICATION
 typedef enum tyjustification {
     leftjustified,
     centerjustified,
@@ -157,6 +167,8 @@ typedef enum tyjustification {
     fulljustified,
     unknownjustification
 } tyjustification;
+#define FRONTIER_PORTABLE_DEFINED_TYJUSTIFICATION 1
+#endif
 
 /* These types are now defined in portable_types.h */
 


### PR DESCRIPTION
## Summary

This PR resolves enum redefinition compilation errors that were blocking the test suite. The issue occurred because both `Common/SystemHeaders/standard.h` and `portable/standard_portable.h` define the same enumeration types without include guards, causing duplicate definition errors when both files are included in the same translation unit.

## Problem

When translation units include both headers (directly or transitively), the compiler encounters redefinition errors for:
- `tybitdirection` enum (4 bit constants)
- `tylinespacing` enum (text line spacing values)
- `tyjustification` enum (text justification options)
- `tydirection` enum (direction constants)

These errors prevent `core_tests` and other test components from compiling.

## Solution

Added preprocessor guards around enum definitions following the established pattern used in `portable/standard_portable.h` for other portable type definitions:

- `tydirection`: Guard with existing `ctdirections` macro (backward compatible)
- `tybitdirection`: Guard with `FRONTIER_PORTABLE_DEFINED_TYBITDIRECTION`
- `tylinespacing`: Guard with `FRONTIER_PORTABLE_DEFINED_TYLINESPACING`
- `tyjustification`: Guard with `FRONTIER_PORTABLE_DEFINED_TYJUSTIFICATION`

## Key Files Changed

- **Common/SystemHeaders/standard.h** - Added #ifndef guards around 3 enum definitions
- **portable/standard_portable.h** - Added #ifndef guards around 4 enum definitions

## Testing

The CLI successfully compiles without enum redefinition errors. Guard guards prevent duplicate definitions when both headers are included.

## Technical Details

The fix uses conditional compilation guards (`#ifndef FRONTIER_PORTABLE_DEFINED_*`) to ensure each enum is defined exactly once, regardless of header inclusion order. The first included header defines the type; subsequent includes skip the definition.

This pattern is consistent with other portable type definitions in the codebase and allows the test suite to compile without errors.

Generated with [Claude Code](https://claude.com/claude-code)