### PR TITLE
fix: Critical memory leaks in sys.unixshellcommand (2/3/4-param modes)

### DIFF
--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -669,8 +669,10 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 					return (false);
 				}
 
-				if (!langsetvalue (htable, varname, hstdout, stringvaluetype))
+				if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
+					disposehandle (hstdout);
 					return (false);
+				}
 
 				return (setbooleanvalue (true, v));
 			}

--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -755,6 +755,7 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 			   If langsetvalue() FAILS, the handle is NOT adopted and must be disposed manually.
 			   This error handling pattern correctly disposes handles only when adoption failed. */
 				if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
+					disposehandle (hstdout);
 					disposehandle (hstderr);
 					return (false);
 				}

--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -704,6 +704,7 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 				}
 
 				if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
+					disposehandle (hstdout);
 					disposehandle (hstderr);
 					return (false);
 				}


### PR DESCRIPTION
## Problem

Critical memory leaks identified in PR #192 code review across **all multi-parameter modes**:

### 2-Parameter Leak (Line 672-675)
If `langsetvalue()` fails in the 2-parameter case, `hstdout` is not disposed.

### 3-Parameter Leak (Line 706-710)
When the FIRST `langsetvalue()` fails in the 3-parameter case, `hstdout` is not disposed. The code correctly disposes `hstderr`, but forgets `hstdout`.

### 4-Parameter Leak (Line 757-760)
When the FIRST `langsetvalue()` fails in the 4-parameter case, `hstdout` is not disposed. The code correctly disposes `hstderr`, but forgets `hstdout`.

## Root Cause

Per handle ownership semantics (documented at lines 754-756):
- `langsetvalue()` only adopts handles on **SUCCESS**
- If it **FAILS**, the caller must manually dispose the handle

### Why 3-param and 4-param are different from 1-param
- **1-parameter case**: No handles involved (returns string directly)
- **2-parameter case**: ONE handle at risk (just `hstdout`)
- **3-parameter case**: TWO handles (both `hstdout` and `hstderr`) need disposal on first failure
- **4-parameter case**: TWO handles (both `hstdout` and `hstderr`) need disposal on first failure

## Fixes Applied

### Fix 1: 2-Parameter Case (shellsysverbs.c:672-675)

**Before:**
```c
if (!langsetvalue (htable, varname, hstdout, stringvaluetype))
    return (false);  // BUG: hstdout leaks!
```

**After:**
```c
if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
    disposehandle (hstdout);
    return (false);
}
```

### Fix 2: 3-Parameter Case (shellsysverbs.c:706-710)

**Before:**
```c
if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
    disposehandle (hstderr);  // Disposes hstderr
    return (false);            // BUG: hstdout leaks!
}
```

**After:**
```c
if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
    disposehandle (hstdout);   // Dispose unadopted hstdout
    disposehandle (hstderr);   // Dispose unadopted hstderr
    return (false);
}
```

### Fix 3: 4-Parameter Case (shellsysverbs.c:757-760)

**Before:**
```c
if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
    disposehandle (hstderr);  // Only disposes hstderr
    return (false);            // BUG: hstdout leaks!
}
```

**After:**
```c
if (!langsetvalue (htable, varname, hstdout, stringvaluetype)) {
    disposehandle (hstdout);   // Dispose unadopted hstdout
    disposehandle (hstderr);   // Dispose unadopted hstderr
    return (false);
}
```

## Impact

- **Leak size:** One or two handles per failure (typically small)
- **Frequency:** Only when `langsetvalue()` fails (low probability - hash table insertion failure)
- **Severity:** Critical (memory leaks)
- **Scope:** Affects all multi-parameter modes (2/3/4-param)

## Testing

- ✅ Reviewed all parameter cases (1/2/3/4) for consistency
- ✅ Verified error handling matches documented ownership semantics
- ✅ All multi-parameter modes now have correct error handling
- ✅ No remaining leaks in handle ownership paths

## Follow-Up

Bot review suggests adding error path test coverage (testing `langsetvalue()` failures). This should be tracked in a separate issue as it requires test infrastructure work.

## Related

- PR #192 - Original implementation
- Bot code review comments identifying all three leaks

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)