### PR TITLE
fix: Prevent null pointer dereference in EFP augmentation (Issue #199)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,61 @@ See `planning/phase3/MIGRATION_VALIDATION_REPORT.md` for detailed test procedure
 
 ## Architectural Patterns to Avoid
 
+### Hash Table Lookup API - Null Pointer Gotcha ⚠️
+
+**Issue #199 Root Cause**: Frontier has two hash lookup functions with subtle differences that can cause segfaults:
+
+**Correct API Usage**:
+```c
+// When you need BOTH the value and the node:
+tyvaluerecord val;
+hdlhashnode node;
+if (hashtablelookup(htable, name, &val, &node)) {
+    // Safe: val and node are both populated
+}
+
+// When you ONLY need the node (NOT the value):
+hdlhashnode node;
+if (hashtablelookupnode(htable, name, &node)) {
+    // Safe: only node is populated
+}
+```
+
+**WRONG - Causes Segfault**:
+```c
+// ❌ NEVER pass nil for vreturned:
+hdlhashnode node;
+if (hashtablelookup(htable, name, nil, &node)) {  // CRASHES!
+    // hashtablelookup unconditionally dereferences vreturned
+    // *vreturned = value;  ← segfault when vreturned is nil
+}
+```
+
+**Why This Happens**:
+- `hashtablelookup()` at `langhash.c:2244` unconditionally writes: `*vreturned = (***hnode).val`
+- If `vreturned` is `nil`, this is an immediate segfault
+- The function doesn't check if `vreturned` is non-null before dereferencing
+
+**The Fix**:
+Use `hashtablelookupnode()` when you only need the node pointer, not the value.
+
+**Real Bug Example** (Fixed in Issue #199):
+```c
+// BEFORE (crashed):
+if (hashtablelookup(htable_target, bs_entryname, nil, &existing_node)) {
+    // ...
+}
+
+// AFTER (correct):
+if (hashtablelookupnode(htable_target, bs_entryname, &existing_node)) {
+    // ...
+}
+```
+
+**Test Coverage**: `tests/test_efp_augmentation.c` exercises this code path to prevent regression.
+
+**See**: Issue #199, `Common/source/tablestructure.c:517,531`
+
 ### Mode Stack Push/Pop Issues ⚠️
 
 The `db_format_mode_current()` push/pop pattern has proven problematic and has caused multiple bugs:

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -514,7 +514,7 @@ boolean augment_database_tables_with_efp (hdlhashtable hroot) {
 
 			// Check if entry already exists in database table
 			hdlhashnode existing_node;
-			if (hashtablelookup (htable_target, bs_entryname, nil, &existing_node)) {
+			if (hashtablelookupnode (htable_target, bs_entryname, &existing_node)) {
 				log_trace(LOG_COMP_LANG, "Entry '%.*s' already exists in database table, skipping",
 				          (int)bs_entryname[0], bs_entryname+1);
 				continue; // Don't overwrite existing entries
@@ -528,7 +528,7 @@ boolean augment_database_tables_with_efp (hdlhashtable hroot) {
 			if (hashinsert (bs_entryname, entry_val)) {
 				// Mark as fldontsave (C pointers shouldn't persist)
 				hdlhashnode new_node;
-				if (hashtablelookup (htable_target, bs_entryname, nil, &new_node)) {
+				if (hashtablelookupnode (htable_target, bs_entryname, &new_node)) {
 					(**new_node).fldontsave = true;
 					entries_copied++;
 					log_trace(LOG_COMP_LANG, "Copied entry '%.*s' (marked fldontsave)",

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -225,7 +225,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_verb_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_verb_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs
 
 # Prebuilt or auxiliary test binaries that may be present
 RUN_PREBUILT = test_64bit_direct test_migration_verification test_real_databases test_runner verify_migration_success
@@ -298,6 +298,10 @@ parser_tests: parser_tests.c $(LANG_RUNTIME_SOURCES) headless_shell.c
 
 save_migration_tests: save_migration_tests.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c headless_odb_stubs.c headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -DHEADLESS_TEST_PORTABLE_FILE -DHEADLESS_LINKS_REAL_DB -I../Common/headers -I../Common/SystemHeaders -I../portable save_migration_tests.c \
+		$(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c headless_odb_stubs.c headless_shell.c -o $@ $(LINK_LIBS)
+
+test_efp_augmentation: test_efp_augmentation.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c headless_odb_stubs.c headless_shell.c
+	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -DHEADLESS_TEST_PORTABLE_FILE -DHEADLESS_LINKS_REAL_DB -I../Common/headers -I../Common/SystemHeaders -I../portable test_efp_augmentation.c \
 		$(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c headless_odb_stubs.c headless_shell.c -o $@ $(LINK_LIBS)
 
 test_dump_system_paths: test_dump_system_paths.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c headless_odb_stubs.c headless_shell.c

--- a/tests/test_efp_augmentation.c
+++ b/tests/test_efp_augmentation.c
@@ -1,0 +1,180 @@
+/*
+ * Test for EFP Augmentation Path (Issue #199)
+ *
+ * This test verifies that loading a v7 database and exercising the EFP
+ * augmentation path does not crash with a segfault.
+ *
+ * Root Cause (Fixed): Null pointer dereference in augment_database_tables_with_efp()
+ *   - hashtablelookup(..., nil, &node) unconditionally dereferences the nil parameter
+ *   - Fix: Use hashtablelookupnode(..., &node) instead
+ *
+ * See: planning/architectural_decision_records/ADR-004-dynamic-verb-binding-architecture.md
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "frontier.h"
+#include "memory.h"
+#include "strings.h"
+#include "lang.h"
+#include "tablestructure.h"
+#include "file.h"
+#include "odbinternal.h"
+#include "db_format.h"
+#include "logging.h"
+
+static int test_count = 0;
+static int test_passed = 0;
+
+#define TEST_PASS(desc) do { test_count++; test_passed++; log_info(LOG_COMP_DB, "PASS: %s", desc); } while(0)
+#define TEST_FAIL(desc) do { test_count++; log_error(LOG_COMP_DB, "FAIL: %s", desc); } while(0)
+
+int main(void) {
+    log_init();
+
+    log_info(LOG_COMP_DB, "=== EFP Augmentation Path Test (Issue #199) ===");
+
+    assert(initmemory());
+    initstrings();
+    assert(initlang());
+    assert(inittablestructure());
+    assert(langinitverbs());
+
+    // Use the migrated v7 database from save_migration_tests
+    const char *db_path = "test_save_migration-v7.root";
+    FILE *check = fopen(db_path, "rb");
+    if (!check) {
+        log_error(LOG_COMP_DB, "Test database not found: %s", db_path);
+        log_error(LOG_COMP_DB, "Run save_migration_tests first to create v7 database");
+        return 1;
+    }
+    fclose(check);
+
+    log_info(LOG_COMP_DB, "Phase 1: Load v7 database with EFP augmentation");
+
+    // Convert path to filespec
+    bigstring bspath;
+    copyctopstring(db_path, bspath);
+
+    tyfilespec fs;
+    memset(&fs, 0, sizeof fs);
+    if (!pathtofilespec(bspath, &fs)) {
+        log_error(LOG_COMP_DB, "Failed to convert path to filespec: %s", db_path);
+        TEST_FAIL("Path conversion");
+        return 1;
+    }
+
+    // Open database file
+    hdlfilenum fnum = 0;
+    if (!openfile(&fs, &fnum, true)) {
+        log_error(LOG_COMP_DB, "Failed to open database: %s", db_path);
+        TEST_FAIL("Database open");
+        return 1;
+    }
+    TEST_PASS("Database file opened");
+
+    // Open database
+    if (!dbopenfile(fnum, true)) {
+        log_error(LOG_COMP_DB, "dbopenfile failed for: %s", db_path);
+        closefile(fnum);
+        TEST_FAIL("Database open");
+        return 1;
+    }
+    TEST_PASS("Database opened successfully");
+
+    // Get root table address
+    dbaddress adr = nildbaddress;
+    dbgetview(cancoonview, &adr);
+    if (adr == nildbaddress) {
+        log_error(LOG_COMP_DB, "Failed to get root table address");
+        dbdispose();
+        closefile(fnum);
+        TEST_FAIL("Root table address");
+        return 1;
+    }
+    TEST_PASS("Root table address obtained");
+
+    // Load root table
+    Handle hrootvariable = nil;
+    hdlhashtable hroot = nil;
+    if (!tableloadsystemtable(adr, &hrootvariable, &hroot, false)) {
+        log_error(LOG_COMP_DB, "Failed to load system table");
+        dbdispose();
+        closefile(fnum);
+        TEST_FAIL("System table load");
+        return 1;
+    }
+    TEST_PASS("System table loaded");
+
+    // Set table structure globals
+    rootvariable = hrootvariable;
+    roottable = hroot;
+
+    // Check table structure
+    if (!checktablestructure(true)) {
+        log_warn(LOG_COMP_DB, "checktablestructure reported issues (expected for minimal database)");
+    }
+
+    // Link system table structure (creates EFP tables in memory)
+    if (!linksystemtablestructure(hroot)) {
+        log_error(LOG_COMP_DB, "linksystemtablestructure failed");
+        TEST_FAIL("System table structure link");
+        goto cleanup;
+    }
+    TEST_PASS("System table structure linked (EFP tables created)");
+
+    // Resolve system.paths addresses
+    if (!resolve_system_paths(hroot)) {
+        log_error(LOG_COMP_DB, "resolve_system_paths failed");
+        TEST_FAIL("System paths resolution");
+        goto cleanup;
+    }
+    TEST_PASS("System paths resolved");
+
+    log_info(LOG_COMP_DB, "Phase 2: Exercise EFP augmentation path");
+
+    // THIS IS THE CRITICAL TEST: augment_database_tables_with_efp must not crash
+    // Bug (Issue #199): hashtablelookup(..., nil, &node) caused segfault
+    // Fix: Use hashtablelookupnode(..., &node) instead
+    if (!augment_database_tables_with_efp(hroot)) {
+        log_error(LOG_COMP_DB, "augment_database_tables_with_efp failed");
+        TEST_FAIL("EFP augmentation");
+        goto cleanup;
+    }
+    TEST_PASS("EFP augmentation completed without crash");
+
+    // Verify that augmentation actually did something
+    // Check if system table has valueroutines after augmentation
+    if (systemtable != nil) {
+        log_info(LOG_COMP_DB, "System table exists at %p", (void*)systemtable);
+        TEST_PASS("System table accessible after augmentation");
+    } else {
+        log_warn(LOG_COMP_DB, "System table is nil after augmentation");
+        TEST_FAIL("System table accessibility");
+    }
+
+    log_info(LOG_COMP_DB, "Phase 3: Cleanup");
+
+cleanup:
+    // Clean up
+    cleartablestructureglobals();
+    dbdispose();
+    closefile(fnum);
+
+    // Print summary
+    log_info(LOG_COMP_DB, "=== EFP Augmentation Test Summary ===");
+    log_info(LOG_COMP_DB, "Tests passed: %d/%d", test_passed, test_count);
+
+    if (test_passed == test_count) {
+        log_info(LOG_COMP_DB, "✓ ALL TESTS PASSED");
+        printf("test_efp_augmentation: PASSED - EFP augmentation path works without crash\n");
+        return 0;
+    } else {
+        log_error(LOG_COMP_DB, "✗ SOME TESTS FAILED");
+        printf("test_efp_augmentation: FAILED - %d/%d tests passed\n", test_passed, test_count);
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Issue #199 - EFP augmentation crash caused by null pointer dereference in `hashtablelookup()` when called with nil parameter during v7 database loading.

## Root Cause

The `hashtablelookup()` function unconditionally dereferences the value parameter, even when only the node pointer is needed. When callers pass `nil` for the value parameter to get just the node, the function crashes immediately:

```c
// hashtablelookup unconditionally does: *vreturned = (***hnode).val
// If vreturned is nil, this is a segfault
```

This bug occurred in `augment_database_tables_with_efp()` in `Common/source/tablestructure.c` at lines 517 and 531, where external table variables are being processed during EFP initialization.

## Changes

1. **Common/source/tablestructure.c** (2 lines)
   - Line 517: Change `hashtablelookup(htable_target, bs_entryname, nil, &existing_node)` to `hashtablelookupnode(htable_target, bs_entryname, &existing_node)`
   - Line 531: Same fix for checking if new node exists after insertion

2. **tests/test_efp_augmentation.c** (180 lines - NEW)
   - New regression test that exercises the EFP augmentation path
   - Loads v7 database and calls the buggy code path
   - Verifies no crash occurs and augmentation completes successfully

3. **tests/Makefile**
   - Add `test_efp_augmentation` to `RUN_BUILDABLE` tests
   - Add build rule for compiling the new test

4. **CLAUDE.md**
   - Document the `hashtablelookup()` API gotcha for future developers
   - Explain correct usage patterns and common mistakes
   - Link to Issue #199 and affected code locations

## API Usage Gotcha Documented

The fix surfaces an important API design issue: `hashtablelookup()` and `hashtablelookupnode()` have subtly different contracts:

- **`hashtablelookup(htable, name, &val, &node)`** - Use when you need BOTH value AND node
- **`hashtablelookupnode(htable, name, &node)`** - Use when you ONLY need the node
- **NEVER call `hashtablelookup(..., nil, &node)`** - This crashes

This has been documented in CLAUDE.md to prevent similar bugs in the future.

## Test Coverage

- `tests/test_efp_augmentation.c` exercises the exact code path that was crashing
- Test loads v7 database with full EFP augmentation workflow
- Verifies system table structure, path resolution, and augmentation all complete without crash
- Integrated into standard test suite (RUN_BUILDABLE tests)

## Testing

The test has been integrated into the headless test suite and exercises the full EFP initialization path when loading a v7 database. No additional test results to report at this time pending bot code review feedback.

Fixes #199

🤖 Generated with Claude Code

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>