### PR TITLE
feat: Add timenow64() helper to centralize Frontier time conversion (Issue #167)

### DIFF
--- a/Common/headers/timedate.h
+++ b/Common/headers/timedate.h
@@ -98,6 +98,18 @@ extern void timestamp (long *);
 
 extern unsigned long timenow (void);
 
+/*
+ * Get current time as 64-bit Frontier timestamp (seconds since 1904-01-01 00:00:00 UTC)
+ * This is the recommended function for all new code that stores timestamps.
+ * Returns frontier_time_t (int64_t) for cross-platform portability.
+ *
+ * Use this instead of time(NULL) + manual epoch conversion to ensure boundary
+ * conversions happen in one place (the timedate module).
+ *
+ * See: docs/frontier_time_t_standard.md
+ */
+extern frontier_time_t timenow64 (void);
+
 extern boolean setsystemclock (unsigned long);
 
 extern boolean timegreaterthan (unsigned long, unsigned long);

--- a/Common/source/table_context.c
+++ b/Common/source/table_context.c
@@ -10,10 +10,10 @@
 #include "table_context.h"
 #include "logging.h"
 #include "lang.h"
+#include "timedate.h"  /* for timenow64() function */
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#include <time.h>  /* for time() function */
 
 /* ============================================================================
    INLINE HELPERS FOR TYPE-SAFE CONTEXT ACCESS
@@ -103,8 +103,8 @@ void table_context_record_mutation(struct hdlhashtable *htable,
 	/* Record mutation metadata */
 	ctx->version_number++;
 	ctx->last_mutation_type = (uint8_t)type;
-	/* Convert Unix time (time_t) to Frontier time (int64_t, 1904 epoch) for portability */
-	ctx->last_mutation_time = (frontier_time_t)time(NULL) + FRONTIER_EPOCH_TO_UNIX_OFFSET;
+	/* Record current time using portable 64-bit Frontier timestamp */
+	ctx->last_mutation_time = timenow64();
 	ctx->flpendingchanges = true;
 
 	log_debug(LOG_COMP_TABLE, "table_context_record_mutation: type=%d version=%llu",

--- a/Common/source/timedate.c
+++ b/Common/source/timedate.c
@@ -199,17 +199,42 @@ void timestamp (long *ptime) {
 	
 	
 unsigned long timenow (void) {
-	
+
 	/*
 	2.1b4 dmb; more convenient than timestamp for most callers
 	*/
-    
+
     unsigned long now = (CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1904);
-	
+
 	return (now);
 	} /*timenow*/
-	
-	
+
+
+frontier_time_t timenow64 (void) {
+
+	/*
+	Get current time as frontier_time_t (64-bit timestamp since 1904).
+	This is the recommended function for all new code that stores timestamps.
+
+	For FRONTIER_HEADLESS builds: Use portable time() + epoch conversion
+	For macOS builds: Use CFAbsoluteTimeGetCurrent() which already uses 1904 epoch
+
+	Returns: Seconds since 1904-01-01 00:00:00 UTC as int64_t
+
+	See: docs/frontier_time_t_standard.md
+	*/
+
+	#if defined(FRONTIER_HEADLESS)
+		/* Portable implementation: Unix time() + epoch conversion */
+		time_t unix_time = time(NULL);
+		return (frontier_time_t)unix_time + FRONTIER_EPOCH_TO_UNIX_OFFSET;
+	#else
+		/* macOS implementation: Use CoreFoundation */
+		return (frontier_time_t)(CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1904);
+	#endif
+	} /*timenow64*/
+
+
 boolean setsystemclock (unsigned long secs) {
 
 	/*

--- a/docs/frontier_time_t_standard.md
+++ b/docs/frontier_time_t_standard.md
@@ -94,12 +94,20 @@ Use system `time_t` only for:
 ```c
 #include "timedate.h"
 
-/* Get current time as frontier_time_t */
-frontier_time_t now = timenow();
+/* Get current time as frontier_time_t (RECOMMENDED) */
+frontier_time_t now = timenow64();
 
 /* Store in database table context */
 tytableformats *formats = &(**htable).tformats;
 formats->timelastmodify = now;
+```
+
+**Note**: Use `timenow64()` instead of the legacy `timenow()` function. While `timenow()` returns `unsigned long` (32-bit on most systems), `timenow64()` returns `frontier_time_t` (64-bit) and centralizes epoch conversion in the timedate module, following the architectural principle that boundary conversions should happen in one place.
+
+**Legacy alternative (not recommended for new code)**:
+```c
+/* Legacy: timenow() returns unsigned long (32-bit) */
+unsigned long legacy_now = timenow();
 ```
 
 ### Example: Comparing Timestamps


### PR DESCRIPTION
## Summary

Implements Issue #167 by adding `timenow64()`, a helper function that centralizes Unix→Frontier epoch conversion for 64-bit timestamps. This addresses the architectural principle that boundary conversions (between different time representations) should happen in one place—the timedate module—rather than scattered throughout the codebase.

**Impact**: Ensures consistent, portable timestamp handling across all platforms and future-proofs Frontier against 32-bit time_t overflow beyond 2038.

## Key Files Changed

### Core Implementation
- **`Common/headers/timedate.h`**: Added `timenow64()` declaration and comprehensive inline documentation
- **`Common/source/timedate.c`**: Implemented portable `timenow64()` supporting both FRONTIER_HEADLESS (Unix time API) and macOS (CoreFoundation) builds

### Integration
- **`Common/source/table_context.c`**: Updated to use `timenow64()` instead of manual `time(NULL) + FRONTIER_EPOCH_TO_UNIX_OFFSET` pattern

### Documentation
- **`docs/frontier_time_t_standard.md`**: Added example showing recommended usage of `timenow64()` with code sample and best practices

## Design & Architecture

### The Problem
Before this change, epoch conversion logic was scattered:
```c
// Old pattern (scattered across codebase)
frontier_time_t now = (frontier_time_t)time(NULL) + FRONTIER_EPOCH_TO_UNIX_OFFSET;
```

This violates the single-responsibility principle and creates multiple points of failure if the conversion logic needs to change.

### The Solution
Centralized conversion in the timedate module:
```c
// New pattern (recommended for all code)
frontier_time_t now = timenow64();
```

**Implementation details**:
- Returns `frontier_time_t` (int64_t) for cross-platform portability
- For FRONTIER_HEADLESS: Uses portable `time()` + epoch offset
- For macOS: Uses `CFAbsoluteTimeGetCurrent()` which already uses 1904 epoch (avoids double conversion)
- Encapsulates the 2,082,844,800-second offset between Unix (1970) and Frontier (1904) epochs

### Alignment with Architecture

This change implements the pattern documented in:
- `docs/frontier_time_t_standard.md` - Developer guidelines for time type usage
- `planning/phase3/date_time_format_standard.md` - Architectural decision context

Follows the principle stated in project CLAUDE.md: "boundary conversions should happen in one place (the timedate module)."

## Testing

All core tests pass:
- Migration validation (v6→v7 database)
- 64-bit timestamp operations
- Epoch boundary handling
- Portable time conversion

**Test Coverage**:
```bash
./tools/run_headless_tests.sh
# All tests in: oppack, hashpack, hash_corruption, langvalue_64 pass
# Ready for code review and bot verification
```

## Related Issues & PRs

- Fixes: #167 (time_t portability architecture pattern)
- Related to: #165 (code review feedback)
- Related to: #159 (time portability migration work)

## Next Steps

After merge:
1. This establishes the pattern for centralizing time conversions
2. Future work should use `timenow64()` instead of manual epoch conversions
3. Candidates for future migration: any remaining `time(NULL)` + manual conversion patterns in the codebase