### PR TITLE
feat: Implement Phase 5a op verbs (4 noop verbs for GUI-only features)

### DIFF
--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,1 +1,1 @@
-integration_tests_2026-01-11.opml
+integration_tests_2026-01-12.opml

--- a/reports/integration_tests_2026-01-12.opml
+++ b/reports/integration_tests_2026-01-12.opml
@@ -1,0 +1,7476 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Frontier Integration Tests</title>
+    <dateCreated>Mon, 12 Jan 2026 00:09:07 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="Db Verbs (db_verbs)">
+      <outline text="db.new - create new database file - Create a new ODB database file">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="local(ok = db.new(dbPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.open - open newly created database - Open the database we just created">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="local(ok = db.open(dbPath, false))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.setvalue - write string to root - Set a string value at root level">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.setvalue(dbPath, &quot;testString&quot;, &quot;Hello, DB!&quot;))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.getvalue - read string from root - Set and get a string value (self-contained test)">
+        <outline text="Metadata">
+          <outline text="expected_result: Hello, DB!"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_getvalue_string.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testString&quot;, &quot;Hello, DB!&quot;)"/>
+          <outline text="local(val = db.getvalue(dbPath, &quot;testString&quot;))"/>
+          <outline text="return val"/>
+        </outline>
+      </outline>
+      <outline text="db.defined - check existing value - Verify that a value exists after setting it (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_defined_exists.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testString&quot;, &quot;test&quot;)"/>
+          <outline text="local(exists = db.defined(dbPath, &quot;testString&quot;))"/>
+          <outline text="return exists"/>
+        </outline>
+      </outline>
+      <outline text="db.defined - check nonexistent value - Verify that nonexistent item returns false">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(exists = db.defined(dbPath, &quot;doesNotExist&quot;))"/>
+          <outline text="return exists"/>
+        </outline>
+      </outline>
+      <outline text="db.setvalue - write number to root - Set a numeric value">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.setvalue(dbPath, &quot;testNumber&quot;, 42))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.getvalue - read number from root - Set and get a numeric value (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_getvalue_number.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testNumber&quot;, 42)"/>
+          <outline text="local(val = db.getvalue(dbPath, &quot;testNumber&quot;))"/>
+          <outline text="return val"/>
+        </outline>
+      </outline>
+      <outline text="db.newtable - create table at root - Create a new table in the database">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.newtable(dbPath, &quot;testTable&quot;))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.istable - verify table type - Create table and verify it is a table (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_istable_true.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="local(isTable = db.istable(dbPath, &quot;testTable&quot;))"/>
+          <outline text="return isTable"/>
+        </outline>
+      </outline>
+      <outline text="db.istable - verify string is not a table - Create string and verify it is not a table (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_istable_false.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testString&quot;, &quot;not a table&quot;)"/>
+          <outline text="local(isTable = db.istable(dbPath, &quot;testString&quot;))"/>
+          <outline text="return isTable"/>
+        </outline>
+      </outline>
+      <outline text="db.setvalue - write to nested table - Create table and set values inside it (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_nested_setvalue.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item1&quot;, &quot;first&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item2&quot;, &quot;second&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item3&quot;, &quot;third&quot;)"/>
+          <outline text="return true"/>
+        </outline>
+      </outline>
+      <outline text="db.countitems - count table items - Create table with items and count them (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_countitems.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item1&quot;, &quot;first&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item2&quot;, &quot;second&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item3&quot;, &quot;third&quot;)"/>
+          <outline text="local(count = db.countitems(dbPath, &quot;testTable&quot;))"/>
+          <outline text="return count"/>
+        </outline>
+      </outline>
+      <outline text="db.getnthitem - get first item name - Create table and get first item name (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: item1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_getnthitem.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item1&quot;, &quot;first&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item2&quot;, &quot;second&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item3&quot;, &quot;third&quot;)"/>
+          <outline text="local(name = db.getnthitem(dbPath, &quot;testTable&quot;, 1))"/>
+          <outline text="return name"/>
+        </outline>
+      </outline>
+      <outline text="db.getnthitem - get second item name - Create table and get second item name (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: item2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_getnthitem2.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item1&quot;, &quot;first&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item2&quot;, &quot;second&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item3&quot;, &quot;third&quot;)"/>
+          <outline text="local(name = db.getnthitem(dbPath, &quot;testTable&quot;, 2))"/>
+          <outline text="return name"/>
+        </outline>
+      </outline>
+      <outline text="db.getnthitem - get third item name - Create table and get third item name (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: item3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_getnthitem3.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item1&quot;, &quot;first&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item2&quot;, &quot;second&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item3&quot;, &quot;third&quot;)"/>
+          <outline text="local(name = db.getnthitem(dbPath, &quot;testTable&quot;, 3))"/>
+          <outline text="return name"/>
+        </outline>
+      </outline>
+      <outline text="db.getmoddate - get item modification date - Create value and get its modification date (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_getmoddate.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testString&quot;, &quot;test&quot;)"/>
+          <outline text="local(modDate = db.getmoddate(dbPath, &quot;testString&quot;))"/>
+          <outline text="return (modDate &gt; 0)"/>
+        </outline>
+      </outline>
+      <outline text="db.delete - delete string value - Create and delete a value (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_delete.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testString&quot;, &quot;test&quot;)"/>
+          <outline text="local(ok = db.delete(dbPath, &quot;testString&quot;))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.defined - verify deletion - Verify testString no longer exists">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(exists = db.defined(dbPath, &quot;testString&quot;))"/>
+          <outline text="return exists"/>
+        </outline>
+      </outline>
+      <outline text="db.save - save database changes - Save all changes to disk">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.save(dbPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.close - close database - Close the database file">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.close(dbPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.open - reopen saved database - Reopen the database to verify persistence">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_new.root&quot;)"/>
+          <outline text="local(ok = db.open(dbPath, false))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.getvalue - verify persisted value - Test full persistence cycle: create, save, close, reopen, read">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_persistence_value.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testNumber&quot;, 42)"/>
+          <outline text="db.save(dbPath)"/>
+          <outline text="db.close(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(val = db.getvalue(dbPath, &quot;testNumber&quot;))"/>
+          <outline text="return val"/>
+        </outline>
+      </outline>
+      <outline text="db.countitems - verify persisted table - Test table persistence: create, populate, save, close, reopen, count">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_persistence_table.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.newtable(dbPath, &quot;testTable&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item1&quot;, 1)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item2&quot;, 2)"/>
+          <outline text="db.setvalue(dbPath, &quot;testTable.item3&quot;, 3)"/>
+          <outline text="db.save(dbPath)"/>
+          <outline text="db.close(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(count = db.countitems(dbPath, &quot;testTable&quot;))"/>
+          <outline text="return count"/>
+        </outline>
+      </outline>
+      <outline text="db.defined - verify deletion persisted - Test delete persistence: create, delete, save, close, reopen, verify gone">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_persistence_delete.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;testString&quot;, &quot;test&quot;)"/>
+          <outline text="db.delete(dbPath, &quot;testString&quot;)"/>
+          <outline text="db.save(dbPath)"/>
+          <outline text="db.close(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(exists = db.defined(dbPath, &quot;testString&quot;))"/>
+          <outline text="return exists"/>
+        </outline>
+      </outline>
+      <outline text="db.close - final cleanup - Test close on an open database (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_close_cleanup.root&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.close(dbPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.new - create v7 database - Create new database with v7 format (if .root7 extension triggers v7)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_v7.root7&quot;)"/>
+          <outline text="local(ok = db.new(dbPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.open - open v7 database - Open v7 database">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_v7.root7&quot;)"/>
+          <outline text="local(ok = db.open(dbPath, false))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.setvalue - write to v7 database - Set value in v7 database">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_v7.root7&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.setvalue(dbPath, &quot;v7test&quot;, &quot;V7 works!&quot;))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.getvalue - read from v7 database - Create v7 DB, write value, read it back (self-contained)">
+        <outline text="Metadata">
+          <outline text="expected_result: V7 works!"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_v7_getvalue.root7&quot;)"/>
+          <outline text="db.new(dbPath)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="db.setvalue(dbPath, &quot;v7test&quot;, &quot;V7 works!&quot;)"/>
+          <outline text="local(val = db.getvalue(dbPath, &quot;v7test&quot;))"/>
+          <outline text="return val"/>
+        </outline>
+      </outline>
+      <outline text="db.close - close v7 database - Close v7 database">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_db_v7.root7&quot;)"/>
+          <outline text="db.open(dbPath, false)"/>
+          <outline text="local(ok = db.close(dbPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="db.open - auto-migration of v6 database - Open v6 database in read-write mode, verify auto-migration to v7">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(srcPath = tmpDir + &quot;/&quot; + &quot;v6_automigrate_src.root&quot;)"/>
+          <outline text="local(v7Path = tmpDir + &quot;/&quot; + &quot;v6_automigrate_src.root7&quot;)"/>
+          <outline text="// Copy v6 fixture to temp location"/>
+          <outline text="file.copy(&quot;tests/fixtures/v6/test.root&quot;, srcPath)"/>
+          <outline text="// Open in read-write mode (should trigger auto-migration)"/>
+          <outline text="local(ok = db.open(srcPath, false))"/>
+          <outline text="// Verify .root7 was created"/>
+          <outline text="local(v7Exists = file.exists(v7Path))"/>
+          <outline text="// Verify can read data from migrated database (root table exists in v6 fixture)"/>
+          <outline text="local(rootExists = db.defined(srcPath, &quot;root&quot;))"/>
+          <outline text="db.close(srcPath)"/>
+          <outline text="// Clean up"/>
+          <outline text="file.delete(srcPath)"/>
+          <outline text="if v7Exists">
+            <outline text="file.delete(v7Path)"/>
+          </outline>
+          <outline text="return ok and v7Exists and rootExists"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="File Verbs (file_verbs)">
+      <outline text="file.fileFromPath - extract filename from path - Extract filename component from path string (like basename)">
+        <outline text="Metadata">
+          <outline text="expected_result: test.txt"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fullPath = tmpDir + &quot;/&quot; + &quot;test.txt&quot;)"/>
+          <outline text="local(filename = file.fileFromPath(fullPath))"/>
+          <outline text="return filename"/>
+        </outline>
+      </outline>
+      <outline text="file.exists - nonexistent file - Check that nonexistent file returns false">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;nonexistent_file_12345.txt&quot;)"/>
+          <outline text="return file.exists(fs)"/>
+        </outline>
+      </outline>
+      <outline text="file.new - create new empty file - Create new file in project tmp directory">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;frontier_test_new.txt&quot;)"/>
+          <outline text="local(ok = file.new(filePath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.exists - file created with file.new - Verify file.new created the file">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_new.txt&quot;)"/>
+          <outline text="return file.exists(fs)"/>
+        </outline>
+      </outline>
+      <outline text="file.writeWholeFile - write string to file - Write text content to file">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_write.txt&quot;)"/>
+          <outline text="local(ok = file.writeWholeFile(fs, &quot;Hello, Frontier!&quot;))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.readWholeFile - read back written content - Read file and verify content matches">
+        <outline text="Metadata">
+          <outline text="expected_result: Hello, Frontier!"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_write.txt&quot;)"/>
+          <outline text="local(readData = file.readWholeFile(fs))"/>
+          <outline text="return readData"/>
+        </outline>
+      </outline>
+      <outline text="file.readWholeFile - round trip binary data - Write and read back binary data">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_binary.dat&quot;)"/>
+          <outline text="local(binaryData = &quot;\x00\x01\x02\xFF&quot;)"/>
+          <outline text="file.writeWholeFile(fs, binaryData)"/>
+          <outline text="local(readData = file.readWholeFile(fs))"/>
+          <outline text="return (readData == binaryData)"/>
+        </outline>
+      </outline>
+      <outline text="file.delete - delete existing file - Delete file created in previous test">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_write.txt&quot;)"/>
+          <outline text="local(ok = file.delete(fs))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.exists - file deleted successfully - Verify file.delete removed the file">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_write.txt&quot;)"/>
+          <outline text="return file.exists(fs)"/>
+        </outline>
+      </outline>
+      <outline text="file.readWholeFile - nonexistent file error - Reading nonexistent file should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_result: None"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;does_not_exist_12345.txt&quot;)"/>
+          <outline text="return file.readWholeFile(fs)"/>
+        </outline>
+      </outline>
+      <outline text="file.delete - nonexistent file error - Deleting nonexistent file should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_result: None"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;does_not_exist_12345.txt&quot;)"/>
+          <outline text="return file.delete(fs)"/>
+        </outline>
+      </outline>
+      <outline text="file.size - get file size - Get size of file in bytes">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_size.txt&quot;)"/>
+          <outline text="local(testData = &quot;12345&quot;)"/>
+          <outline text="file.writeWholeFile(fs, testData)"/>
+          <outline text="return file.size(fs)"/>
+        </outline>
+      </outline>
+      <outline text="file.created - get file creation date - Get creation date of file (Frontier epoch)">
+        <outline text="Metadata">
+          <outline text="expected_result: date"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_created.txt&quot;)"/>
+          <outline text="file.new(fs)"/>
+          <outline text="local(createdDate = file.created(fs))"/>
+          <outline text="return typeof(createdDate)"/>
+        </outline>
+      </outline>
+      <outline text="file.modified - get file modification date - Get modification date of file (Frontier epoch)">
+        <outline text="Metadata">
+          <outline text="expected_result: date"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_modified.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;initial content&quot;)"/>
+          <outline text="local(modifiedDate = file.modified(fs))"/>
+          <outline text="return typeof(modifiedDate)"/>
+        </outline>
+      </outline>
+      <outline text="file.copy - copy file to new location - Copy file and verify both exist">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(source = tmpDir + &quot;/&quot; + &quot;frontier_test_copy_source.txt&quot;)"/>
+          <outline text="local(dest = tmpDir + &quot;/&quot; + &quot;frontier_test_copy_dest.txt&quot;)"/>
+          <outline text="file.writeWholeFile(source, &quot;test content for copy&quot;)"/>
+          <outline text="local(ok = file.copy(source, dest))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.copy - verify destination exists with same content - Check copied file has same content as source">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(source = tmpDir + &quot;/&quot; + &quot;frontier_test_copy_source.txt&quot;)"/>
+          <outline text="local(dest = tmpDir + &quot;/&quot; + &quot;frontier_test_copy_dest.txt&quot;)"/>
+          <outline text="local(sourceContent = file.readWholeFile(source))"/>
+          <outline text="local(destContent = file.readWholeFile(dest))"/>
+          <outline text="return (sourceContent == destContent)"/>
+        </outline>
+      </outline>
+      <outline text="file.rename - rename file - Rename file and verify new name exists">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(oldName = tmpDir + &quot;/&quot; + &quot;frontier_test_rename_old.txt&quot;)"/>
+          <outline text="local(newName = tmpDir + &quot;/&quot; + &quot;frontier_test_rename_new.txt&quot;)"/>
+          <outline text="file.writeWholeFile(oldName, &quot;rename test content&quot;)"/>
+          <outline text="local(ok = file.rename(oldName, newName))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.rename - verify old name no longer exists - Check that old filename is gone after rename">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(oldName = tmpDir + &quot;/&quot; + &quot;frontier_test_rename_old.txt&quot;)"/>
+          <outline text="return file.exists(oldName)"/>
+        </outline>
+      </outline>
+      <outline text="file.rename - verify new name exists with same content - Check renamed file has original content">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(newName = tmpDir + &quot;/&quot; + &quot;frontier_test_rename_new.txt&quot;)"/>
+          <outline text="local(content = file.readWholeFile(newName))"/>
+          <outline text="return (content == &quot;rename test content&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="file.move - move file to different location - Move file and verify it appears at destination">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(source = tmpDir + &quot;/&quot; + &quot;frontier_test_move_source.txt&quot;)"/>
+          <outline text="local(dest = tmpDir + &quot;/&quot; + &quot;frontier_test_move_dest.txt&quot;)"/>
+          <outline text="file.writeWholeFile(source, &quot;move test content&quot;)"/>
+          <outline text="local(ok = file.move(source, dest))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.move - verify source no longer exists - Check that source file is gone after move">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(source = tmpDir + &quot;/&quot; + &quot;frontier_test_move_source.txt&quot;)"/>
+          <outline text="return file.exists(source)"/>
+        </outline>
+      </outline>
+      <outline text="file.move - verify destination exists with same content - Check moved file has original content">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(dest = tmpDir + &quot;/&quot; + &quot;frontier_test_move_dest.txt&quot;)"/>
+          <outline text="local(content = file.readWholeFile(dest))"/>
+          <outline text="return (content == &quot;move test content&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="file.newfolder - create new folder - Create new folder in temp directory">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(folderPath = tmpDir + &quot;/&quot; + &quot;frontier_test_newfolder_unique&quot;)"/>
+          <outline text="if file.exists(folderPath) { file.delete(folderPath); }"/>
+          <outline text="local(ok = file.newfolder(folderPath))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.newfolder - verify folder exists - Check that created folder exists">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(folderPath = tmpDir + &quot;/&quot; + &quot;frontier_test_newfolder_unique&quot;)"/>
+          <outline text="return file.exists(folderPath)"/>
+        </outline>
+      </outline>
+      <outline text="file.getpathchar - get path separator character - Get platform-specific path separator (/ on Unix)">
+        <outline text="Metadata">
+          <outline text="expected_result: /"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(pathChar = file.getpathchar())"/>
+          <outline text="return pathChar"/>
+        </outline>
+      </outline>
+      <outline text="file.fullpath - get absolute path - Convert relative or partial path to absolute path">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_fullpath.txt&quot;)"/>
+          <outline text="file.new(fs)"/>
+          <outline text="local(fullPath = file.fullpath(fs))"/>
+          <outline text="return (string.length(fullPath) &gt; 0)"/>
+        </outline>
+      </outline>
+      <outline text="file.fullpath - verify absolute path starts with / - Absolute paths on Unix should start with /">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_fullpath.txt&quot;)"/>
+          <outline text="local(fullPath = file.fullpath(fs))"/>
+          <outline text="return (string.mid(fullPath, 1, 1) == &quot;/&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="file.folderfrompath - extract folder from path - Get folder portion of a file path">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(testPath = tmpDir + &quot;/&quot; + &quot;testfile.txt&quot;)"/>
+          <outline text="local(folder = file.folderfrompath(testPath))"/>
+          <outline text="return (folder == tmpDir)"/>
+        </outline>
+      </outline>
+      <outline text="file.getpath - get current working directory - Get the current working directory path">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(currentPath = file.getpath())"/>
+          <outline text="return (string.length(currentPath) &gt; 0)"/>
+        </outline>
+      </outline>
+      <outline text="file.setpath - set working directory - Change working directory and verify">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(originalPath = file.getpath())"/>
+          <outline text="local(ok = file.setpath(tmpDir))"/>
+          <outline text="local(newPath = file.getpath())"/>
+          <outline text="file.setpath(originalPath)"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.setpath/getpath - round trip working directory - Verify setpath actually changes working directory">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(originalPath = file.getpath())"/>
+          <outline text="file.setpath(tmpDir)"/>
+          <outline text="local(newPath = file.getpath())"/>
+          <outline text="file.setpath(originalPath)"/>
+          <outline text="return (newPath == tmpDir)"/>
+        </outline>
+      </outline>
+      <outline text="file.open/close - open and close file for reading - Open file, verify handle, then close it">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_io.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;test content&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="local(ok = (f != nil))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="file.read - read bytes from file - Open file and read specific number of bytes">
+        <outline text="Metadata">
+          <outline text="expected_result: Hello"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_read.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;Hello World!&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="local(data = file.read(f, 5))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return data"/>
+        </outline>
+      </outline>
+      <outline text="file.readline - read line from file - Read text file line by line">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_readline.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;Line 1\nLine 2\nLine 3&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="local(line1 = file.readline(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return line1"/>
+        </outline>
+      </outline>
+      <outline text="file.endoffile - check if at end of file - Detect EOF condition after reading past end">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_eof.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;AB&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="file.read(f, 2)"/>
+          <outline text="file.read(f, 1)"/>
+          <outline text="local(isEof = file.endoffile(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return isEof"/>
+        </outline>
+      </outline>
+      <outline text="file.getposition - get current file position - Check file position after reading">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_getpos.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;0123456789&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="file.read(f, 5)"/>
+          <outline text="local(pos = file.getposition(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return pos"/>
+        </outline>
+      </outline>
+      <outline text="file.setposition - seek to file position - Move file pointer and read from new position">
+        <outline text="Metadata">
+          <outline text="expected_result: DE"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_setpos.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;ABCDEFGH&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="file.setposition(f, 3)"/>
+          <outline text="local(data = file.read(f, 2))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return data"/>
+        </outline>
+      </outline>
+      <outline text="file.getendoffile - get file size via handle - Get file size using open file handle">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(fs = tmpDir + &quot;/&quot; + &quot;frontier_test_geteof.txt&quot;)"/>
+          <outline text="file.writeWholeFile(fs, &quot;12345&quot;)"/>
+          <outline text="local(f = file.open(fs, &quot;r&quot;))"/>
+          <outline text="local(size = file.getendoffile(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return size"/>
+        </outline>
+      </outline>
+      <outline text="file.isfolder - check if path is folder - Verify folder detection">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(folderPath = tmpDir + &quot;/&quot; + &quot;test_folder_unique2&quot;)"/>
+          <outline text="if file.exists(folderPath) { file.delete(folderPath); }"/>
+          <outline text="file.newfolder(folderPath)"/>
+          <outline text="return file.isfolder(folderPath)"/>
+        </outline>
+      </outline>
+      <outline text="file.isfolder - verify file is not folder - Check that regular file returns false">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_file.txt&quot;)"/>
+          <outline text="file.new(filePath)"/>
+          <outline text="return file.isfolder(filePath)"/>
+        </outline>
+      </outline>
+      <outline text="file.compare - compare identical files - Compare two files with same content">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(file1 = tmpDir + &quot;/&quot; + &quot;compare1.txt&quot;)"/>
+          <outline text="local(file2 = tmpDir + &quot;/&quot; + &quot;compare2.txt&quot;)"/>
+          <outline text="file.writeWholeFile(file1, &quot;same content&quot;)"/>
+          <outline text="file.writeWholeFile(file2, &quot;same content&quot;)"/>
+          <outline text="return file.compare(file1, file2)"/>
+        </outline>
+      </outline>
+      <outline text="file.compare - compare different files - Compare two files with different content">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(file1 = tmpDir + &quot;/&quot; + &quot;diff1.txt&quot;)"/>
+          <outline text="local(file2 = tmpDir + &quot;/&quot; + &quot;diff2.txt&quot;)"/>
+          <outline text="file.writeWholeFile(file1, &quot;content A&quot;)"/>
+          <outline text="file.writeWholeFile(file2, &quot;content B&quot;)"/>
+          <outline text="return file.compare(file1, file2)"/>
+        </outline>
+      </outline>
+      <outline text="file.copy - copy empty file - Copy 0-byte file and verify both exist with same size">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(source = tmpDir + &quot;/&quot; + &quot;empty_source.txt&quot;)"/>
+          <outline text="local(dest = tmpDir + &quot;/&quot; + &quot;empty_dest.txt&quot;)"/>
+          <outline text="file.new(source)"/>
+          <outline text="local(ok = file.copy(source, dest))"/>
+          <outline text="local(sourceSize = file.size(source))"/>
+          <outline text="local(destSize = file.size(dest))"/>
+          <outline text="return ok and (sourceSize == 0) and (destSize == 0)"/>
+        </outline>
+      </outline>
+      <outline text="file.move - move empty file - Move 0-byte file and verify old gone, new exists">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(source = tmpDir + &quot;/&quot; + &quot;empty_move_source.txt&quot;)"/>
+          <outline text="local(dest = tmpDir + &quot;/&quot; + &quot;empty_move_dest.txt&quot;)"/>
+          <outline text="file.new(source)"/>
+          <outline text="local(ok = file.move(source, dest))"/>
+          <outline text="return ok and (not file.exists(source)) and file.exists(dest)"/>
+        </outline>
+      </outline>
+      <outline text="file.compare - compare two empty files - Two 0-byte files should be equal">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(file1 = tmpDir + &quot;/&quot; + &quot;empty1.txt&quot;)"/>
+          <outline text="local(file2 = tmpDir + &quot;/&quot; + &quot;empty2.txt&quot;)"/>
+          <outline text="file.new(file1)"/>
+          <outline text="file.new(file2)"/>
+          <outline text="return file.compare(file1, file2)"/>
+        </outline>
+      </outline>
+      <outline text="file.setposition - position beyond EOF - Test seeking beyond end of file">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;setpos_beyond_eof.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="local(f = file.open(filePath, &quot;r&quot;))"/>
+          <outline text="local(eofPos = file.getendoffile(f))"/>
+          <outline text="local(ok = file.setposition(f, eofPos + 100))"/>
+          <outline text="local(newPos = file.getposition(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return ok and (newPos == (eofPos + 100))"/>
+        </outline>
+      </outline>
+      <outline text="file.readline - Unix line ending (LF) - Read line with \n delimiter">
+        <outline text="Metadata">
+          <outline text="expected_result: line1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;readline_lf.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;line1\nline2&quot;)"/>
+          <outline text="local(f = file.open(filePath, &quot;r&quot;))"/>
+          <outline text="local(line = file.readline(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return line"/>
+        </outline>
+      </outline>
+      <outline text="file.readline - Windows line ending (CRLF) - Read line with \r\n delimiter">
+        <outline text="Metadata">
+          <outline text="expected_result: line1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;readline_crlf.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;line1\r\nline2&quot;)"/>
+          <outline text="local(f = file.open(filePath, &quot;r&quot;))"/>
+          <outline text="local(line = file.readline(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return line"/>
+        </outline>
+      </outline>
+      <outline text="file.readline - Classic Mac line ending (CR) - Read line with \r delimiter">
+        <outline text="Metadata">
+          <outline text="expected_result: line1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;readline_cr.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;line1\rline2&quot;)"/>
+          <outline text="local(f = file.open(filePath, &quot;r&quot;))"/>
+          <outline text="local(line = file.readline(f))"/>
+          <outline text="file.close(f)"/>
+          <outline text="return line"/>
+        </outline>
+      </outline>
+      <outline text="file.folderfrompath - filename with no folder - Extract folder from bare filename">
+        <outline text="Metadata">
+          <outline text="expected_result: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(path = &quot;justfilename.txt&quot;)"/>
+          <outline text="local(folder = file.folderfrompath(path))"/>
+          <outline text="return folder"/>
+        </outline>
+      </outline>
+      <outline text="file.folderfrompath - path with trailing slash - Extract folder from path with trailing slash - should return parent">
+        <outline text="Metadata">
+          <outline text="expected_result: /parent"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(path = &quot;/parent/child/&quot;)"/>
+          <outline text="local(folder = file.folderfrompath(path))"/>
+          <outline text="return folder"/>
+        </outline>
+      </outline>
+      <outline text="file.type - extract extension from .txt file - Get file extension with dot prefix">
+        <outline text="Metadata">
+          <outline text="expected_result: .txt"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_type.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="return file.type(filePath)"/>
+        </outline>
+      </outline>
+      <outline text="file.type - file with no extension - Get type of file without extension returns empty string">
+        <outline text="Metadata">
+          <outline text="expected_result: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;testfile_noext&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="return file.type(filePath)"/>
+        </outline>
+      </outline>
+      <outline text="file.type - file with multiple extensions - Get type of file.tar.gz returns last extension (space-padded OSType)">
+        <outline text="Metadata">
+          <outline text="expected_result: .gz "/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;archive.tar.gz&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="return file.type(filePath)"/>
+        </outline>
+      </outline>
+      <outline text="file.creator - returns empty string in headless mode - Creator codes are Mac-specific, headless returns empty string">
+        <outline text="Metadata">
+          <outline text="expected_result: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_creator.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="return file.creator(filePath)"/>
+        </outline>
+      </outline>
+      <outline text="file.setmodified - set modification time - Set file modification time and verify it changed">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_setmodified.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="local(oldTime = file.modified(filePath))"/>
+          <outline text="local(newTime = clock.now() - (60 * 60 * 24));  // 1 day ago"/>
+          <outline text="local(result = file.setmodified(filePath, newTime))"/>
+          <outline text="local(verifyTime = file.modified(filePath))"/>
+          <outline text="return result and (verifyTime &lt; oldTime)"/>
+        </outline>
+      </outline>
+      <outline text="file.setcreated - behavior on different platforms - Set creation time (works on macOS, returns false on Linux)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_setcreated.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="local(newTime = clock.now() - (60 * 60 * 24));  // 1 day ago"/>
+          <outline text="local(result = file.setcreated(filePath, newTime))"/>
+          <outline text="// Returns true on macOS, false on Linux - both are valid"/>
+          <outline text="return typeof(result) == booleanType"/>
+        </outline>
+      </outline>
+      <outline text="file.islocked - unlocked file returns false - Check that writable file is not locked">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_lock.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="return file.islocked(filePath)"/>
+        </outline>
+      </outline>
+      <outline text="file.lock - lock a file - Lock file and verify islocked returns true">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_lock2.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="local(result = file.lock(filePath))"/>
+          <outline text="local(isLocked = file.islocked(filePath))"/>
+          <outline text="return result and isLocked"/>
+        </outline>
+      </outline>
+      <outline text="file.unlock - unlock a locked file - Lock then unlock a file">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="local(filePath = tmpDir + &quot;/&quot; + &quot;test_lock3.txt&quot;)"/>
+          <outline text="file.writeWholeFile(filePath, &quot;test&quot;)"/>
+          <outline text="file.lock(filePath)"/>
+          <outline text="local(result = file.unlock(filePath))"/>
+          <outline text="local(isUnlocked = !file.islocked(filePath))"/>
+          <outline text="return result and isUnlocked"/>
+        </outline>
+      </outline>
+      <outline text="file.freespaceonvolume - get free space on root volume - Get free space on root filesystem">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(freeBytes = file.freespaceonvolume(&quot;/&quot;))"/>
+          <outline text="return freeBytes &gt; 0"/>
+        </outline>
+      </outline>
+      <outline text="file.volumesize - get total size of root volume - Get total size of root filesystem">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(totalBytes = file.volumesize(&quot;/&quot;))"/>
+          <outline text="return totalBytes &gt; 0"/>
+        </outline>
+      </outline>
+      <outline text="file.volumeblocksize - get block size - Get filesystem block size">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(blockSize = file.volumeblocksize(&quot;/&quot;))"/>
+          <outline text="return blockSize &gt; 0"/>
+        </outline>
+      </outline>
+      <outline text="file.isvolume - root is always a volume - Root path should be detected as a mount point">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="return file.isvolume(&quot;/&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="file.isvolume - regular directory is not a volume - Subdirectory should not be detected as mount point">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+          <outline text="return !file.isvolume(tmpDir)"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Lang Verbs (lang_verbs)">
+      <outline text="lang.double - integer to double - Convert integer to double-precision float">
+        <outline text="Metadata">
+          <outline text="expected_result: 42.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - string to double - Convert string representation to double">
+        <outline text="Metadata">
+          <outline text="expected_result: 3.14159"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(&quot;3.14159&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - negative value - Convert negative number to double">
+        <outline text="Metadata">
+          <outline text="expected_result: -273.15"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(-273.15)"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - boolean true - Convert boolean true to double (1.0)">
+        <outline text="Metadata">
+          <outline text="expected_result: 1.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(true)"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - boolean false - Convert boolean false to double (0.0)">
+        <outline text="Metadata">
+          <outline text="expected_result: 0.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(false)"/>
+        </outline>
+      </outline>
+      <outline text="lang.single - integer to single - Convert integer to single-precision float">
+        <outline text="Metadata">
+          <outline text="expected_result: 42.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.single(42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.single - string to single - Convert string representation to single-precision">
+        <outline text="Metadata">
+          <outline text="expected_result: sing"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.single(&quot;3.14159&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.single - negative value - Convert negative number to single">
+        <outline text="Metadata">
+          <outline text="expected_result: -100.5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.single(-100.5)"/>
+        </outline>
+      </outline>
+      <outline text="lang.single - double to single precision - Convert double to single (may lose precision)">
+        <outline text="Metadata">
+          <outline text="expected_result: sing"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.single(1.23456789))"/>
+        </outline>
+      </outline>
+      <outline text="lang.fixed - integer to fixed - Convert integer to fixed-point">
+        <outline text="Metadata">
+          <outline text="expected_result: 42.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.fixed(42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.fixed - double to fixed - Convert double to fixed-point">
+        <outline text="Metadata">
+          <outline text="expected_result: fixd"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.fixed(3.14159))"/>
+        </outline>
+      </outline>
+      <outline text="lang.fixed - string to fixed - Convert string to fixed-point">
+        <outline text="Metadata">
+          <outline text="expected_result: fixd"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.fixed(&quot;100.25&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.fixed - negative value - Convert negative number to fixed">
+        <outline text="Metadata">
+          <outline text="expected_result: fixd"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.fixed(-50.75))"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - string 'up' - Convert string 'up' to direction">
+        <outline text="Metadata">
+          <outline text="expected_result: up"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;up&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - string 'down' - Convert string 'down' to direction">
+        <outline text="Metadata">
+          <outline text="expected_result: down"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;down&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - string 'left' - Convert string 'left' to direction">
+        <outline text="Metadata">
+          <outline text="expected_result: left"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;left&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - string 'right' - Convert string 'right' to direction">
+        <outline text="Metadata">
+          <outline text="expected_result: right"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;right&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - string 'flatup' - Convert string 'flatup' to direction">
+        <outline text="Metadata">
+          <outline text="expected_result: flatup"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;flatup&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - string 'flatdown' - Convert string 'flatdown' to direction">
+        <outline text="Metadata">
+          <outline text="expected_result: flatdown"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;flatdown&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - invalid direction - Attempt to convert invalid direction string">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction(&quot;invalid&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.string4 - 4-char string - Convert 4-character string to OSType">
+        <outline text="Metadata">
+          <outline text="expected_result: TEXT"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string4(&quot;TEXT&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.string4 - integer code - Convert integer code to OSType">
+        <outline text="Metadata">
+          <outline text="expected_result: type"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.string4(1414745172))"/>
+        </outline>
+      </outline>
+      <outline text="lang.string4 - padded string - Convert short string to OSType (should pad)">
+        <outline text="Metadata">
+          <outline text="expected_result: type"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.string4(&quot;ZIP&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.double roundtrip - Convert to double and back via string">
+        <outline text="Metadata">
+          <outline text="expected_result: 42.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(lang.string(lang.double(42)))"/>
+        </outline>
+      </outline>
+      <outline text="lang.single roundtrip - Convert to single and back via string">
+        <outline text="Metadata">
+          <outline text="expected_result: sing"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.single(lang.string(lang.single(3.14))))"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - zero - Convert zero to double">
+        <outline text="Metadata">
+          <outline text="expected_result: 0.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(0)"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - very large number - Convert large number to double">
+        <outline text="Metadata">
+          <outline text="expected_result: 1234567890.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(1234567890)"/>
+        </outline>
+      </outline>
+      <outline text="lang.single - very small number - Convert very small number to single">
+        <outline text="Metadata">
+          <outline text="expected_result: sing"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.single(0.0001))"/>
+        </outline>
+      </outline>
+      <outline text="lang.fixed - zero - Convert zero to fixed">
+        <outline text="Metadata">
+          <outline text="expected_result: 0.0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.fixed(0)"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double()"/>
+        </outline>
+      </outline>
+      <outline text="lang.double - too many parameters - Parameter validation: extra parameters should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.double(1, 2)"/>
+        </outline>
+      </outline>
+      <outline text="lang.single - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.single()"/>
+        </outline>
+      </outline>
+      <outline text="lang.fixed - too many parameters - Parameter validation: extra parameters should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.fixed(1, 2)"/>
+        </outline>
+      </outline>
+      <outline text="lang.direction - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.direction()"/>
+        </outline>
+      </outline>
+      <outline text="lang.string4 - too many parameters - Parameter validation: extra parameters should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string4(&quot;TEXT&quot;, &quot;EXTRA&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - positive long - Absolute value of positive number (no change)">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - negative long - Absolute value of negative number">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(-42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - zero - Absolute value of zero">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(0)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - negative double - Absolute value of negative double">
+        <outline text="Metadata">
+          <outline text="expected_result: 3.14159"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(-3.14159)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - positive double - Absolute value of positive double (no change)">
+        <outline text="Metadata">
+          <outline text="expected_result: 2.71828"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(2.71828)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - negative single - Absolute value of negative single-precision">
+        <outline text="Metadata">
+          <outline text="expected_result: 100.5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(-100.5)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - very large negative - Absolute value of large negative number">
+        <outline text="Metadata">
+          <outline text="expected_result: 999999999"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(-999999999)"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs()"/>
+        </outline>
+      </outline>
+      <outline text="lang.abs - too many parameters - Parameter validation: extra parameters should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.abs(1, 2)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - in range - Random number should be in valid range [0, max-1]">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (x = lang.random(100))"/>
+          <outline text="return (x &gt;= 0) and (x &lt; 100)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - max=1 - Random(1) should always return 0">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.random(1)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - max=10 - Random(10) should be in [0,9]">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (x = lang.random(10))"/>
+          <outline text="return (x &gt;= 0) and (x &lt;= 9)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - multiple calls differ - Multiple random calls should (usually) produce different values">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (x = lang.random(1000))"/>
+          <outline text="local (y = lang.random(1000))"/>
+          <outline text="local (z = lang.random(1000))"/>
+          <outline text="return (x != y) or (y != z)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - max=0 error - Random(0) should fail (invalid range)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.random(0)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - negative max error - Random with negative max should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.random(-10)"/>
+        </outline>
+      </outline>
+      <outline text="lang.random - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.random()"/>
+        </outline>
+      </outline>
+      <outline text="lang.memavail - returns positive - Available memory should be a positive number">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.memavail() &gt; 0"/>
+        </outline>
+      </outline>
+      <outline text="lang.memavail - returns long - Memory available should return a numeric value">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (m = lang.memavail())"/>
+          <outline text="return typeof(m) == &quot;long&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.memavail - reasonable value - Memory available should be at least 1MB (sanity check)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.memavail() &gt;= (1024 * 1024)"/>
+        </outline>
+      </outline>
+      <outline text="lang.flushmemory - succeeds - Flush memory should always succeed (no-op)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.flushmemory()"/>
+        </outline>
+      </outline>
+      <outline text="lang.flushmemory - returns boolean - Flush memory should return boolean true">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (result = lang.flushmemory())"/>
+          <outline text="return typeof(result) == &quot;bool&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.flushmemory - idempotent - Multiple flush calls should all succeed">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="return lang.flushmemory() and lang.flushmemory() and lang.flushmemory()"/>
+        </outline>
+      </outline>
+      <outline text="lang.delete - simple variable - Delete a simple variable from current scope">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (x = 42)"/>
+          <outline text="lang.delete(@x)"/>
+          <outline text="return true"/>
+        </outline>
+      </outline>
+      <outline text="lang.delete - table entry - Delete an entry from a table">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = &quot;hello&quot;"/>
+          <outline text="t.b = &quot;world&quot;"/>
+          <outline text="lang.delete(@t.a)"/>
+          <outline text="return t.b == &quot;world&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.delete - non-existent variable - Deleting non-existent variable should error (correct UserTalk semantics)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.delete(@nonexistent)"/>
+        </outline>
+      </outline>
+      <outline text="lang.delete - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.delete()"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - simple expression - Evaluate simple arithmetic expression">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.evaluate(&quot;1 + 1&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - string expression - Evaluate string concatenation">
+        <outline text="Metadata">
+          <outline text="expected_result: Hello World"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.evaluate(&quot;\&quot;Hello\&quot; + \&quot; \&quot; + \&quot;World\&quot;&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - boolean expression - Evaluate boolean logic">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.evaluate(&quot;(5 &gt; 3) and (2 &lt; 4)&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - multi-line code - Evaluate multi-line UserTalk code">
+        <outline text="Metadata">
+          <outline text="expected_result: 20"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.evaluate(&quot;local (x = 10); x * 2&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - syntax error - Evaluation with syntax error should fail with scriptError">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.evaluate(&quot;1 + + 1&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - empty string - Evaluate empty string">
+        <outline text="Script">
+          <outline text="lang.evaluate(&quot;&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.evaluate - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.evaluate()"/>
+        </outline>
+      </outline>
+      <outline text="lang.callscript - simple script - Call a simple script that returns a value">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="on testscript() { return 42 }"/>
+          <outline text="return lang.callscript(&quot;testscript&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.callscript - script with side effects - Call a script that modifies state">
+        <outline text="Metadata">
+          <outline text="expected_result: 100"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (result = 0)"/>
+          <outline text="on setresult() { result = 100 }"/>
+          <outline text="lang.callscript(&quot;setresult&quot;)"/>
+          <outline text="return result"/>
+        </outline>
+      </outline>
+      <outline text="lang.callscript - non-existent script - Calling non-existent script should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.callscript(&quot;nonexistentscript&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.callscript - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.callscript()"/>
+        </outline>
+      </outline>
+      <outline text="lang.msg - simple message - Display simple message (should output to stdout and return true)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.msg(&quot;Hello from headless mode&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.msg - empty message - Display empty message (no-op, returns true)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.msg(&quot;&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.msg - message with special characters - Display message with special characters">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.msg(&quot;Test: 1+1=2, \&quot;quoted\&quot;, tab\ttab&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.msg - long message - Display a longer message">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.msg(&quot;This is a longer message to test that lang.msg() can handle strings of various lengths without issue.&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.msg - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.msg()"/>
+        </outline>
+      </outline>
+      <outline text="lang.timecreated - table creation time - Get creation time of a newly created table">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tc = lang.timecreated(@t))"/>
+          <outline text="return typeof(tc) == &quot;date&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.timecreated - timestamp is recent - Creation time should be close to current time">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tc = lang.timecreated(@t))"/>
+          <outline text="local (now = clock.now())"/>
+          <outline text="return (now - tc) &lt; 10"/>
+        </outline>
+      </outline>
+      <outline text="lang.timecreated - timestamp not zero - Creation time should not be zero">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="return lang.timecreated(@t) &gt; 0"/>
+        </outline>
+      </outline>
+      <outline text="lang.timecreated - timestamp not in future - Creation time should not be in the future">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tc = lang.timecreated(@t))"/>
+          <outline text="local (now = clock.now())"/>
+          <outline text="return tc &lt;= now"/>
+        </outline>
+      </outline>
+      <outline text="lang.timecreated - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.timecreated()"/>
+        </outline>
+      </outline>
+      <outline text="lang.timemodified - table modification time - Get modification time of a newly created table">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tm = lang.timemodified(@t))"/>
+          <outline text="return typeof(tm) == &quot;date&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.timemodified - timestamp is recent - Modification time should be close to current time">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tm = lang.timemodified(@t))"/>
+          <outline text="local (now = clock.now())"/>
+          <outline text="return (now - tm) &lt; 10"/>
+        </outline>
+      </outline>
+      <outline text="lang.timemodified - equals timecreated initially - For new table, timemodified should equal timecreated">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tc = lang.timecreated(@t))"/>
+          <outline text="local (tm = lang.timemodified(@t))"/>
+          <outline text="return tc == tm"/>
+        </outline>
+      </outline>
+      <outline text="lang.timemodified - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.timemodified()"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimecreated - set to 1 year ago - Set creation time to 1 year ago and verify">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (oneyearago = clock.now() - (60*60*24*365))"/>
+          <outline text="lang.settimecreated(@t, oneyearago)"/>
+          <outline text="local (tc = lang.timecreated(@t))"/>
+          <outline text="return (tc - oneyearago) &lt; 2"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimecreated - returns boolean true - settimecreated should return true on success">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="return lang.settimecreated(@t, clock.now() - 1000)"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimecreated - custom timestamp persists - Set custom timestamp and verify it persists">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (customtime = 1000000000)"/>
+          <outline text="lang.settimecreated(@t, customtime)"/>
+          <outline text="return lang.timecreated(@t) == customtime"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimecreated - no parameters - Parameter validation: missing parameters should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.settimecreated()"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimecreated - one parameter only - Parameter validation: need both address and date">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settimecreated(@t)"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimemodified - set to 100 days ago - Set modification time to 100 days ago and verify">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (hundreddays = clock.now() - (60*60*24*100))"/>
+          <outline text="lang.settimemodified(@t, hundreddays)"/>
+          <outline text="local (tm = lang.timemodified(@t))"/>
+          <outline text="return (tm - hundreddays) &lt; 2"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimemodified - returns boolean true - settimemodified should return true on success">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="return lang.settimemodified(@t, clock.now() - 5000)"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimemodified - custom timestamp persists - Set custom timestamp and verify it persists">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (customtime = 2000000000)"/>
+          <outline text="lang.settimemodified(@t, customtime)"/>
+          <outline text="return lang.timemodified(@t) == customtime"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimemodified - independent of timecreated - Setting timemodified should not affect timecreated">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="local (tc = lang.timecreated(@t))"/>
+          <outline text="lang.settimemodified(@t, clock.now() - 100000)"/>
+          <outline text="return lang.timecreated(@t) == tc"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimemodified - no parameters - Parameter validation: missing parameters should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.settimemodified()"/>
+        </outline>
+      </outline>
+      <outline text="lang.settimemodified - one parameter only - Parameter validation: need both address and date">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settimemodified(@t)"/>
+        </outline>
+      </outline>
+      <outline text="lang.boolean - integer 1 to true - Convert non-zero integer to boolean true">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.boolean(1))"/>
+        </outline>
+      </outline>
+      <outline text="lang.boolean - integer 0 to false - Convert zero to boolean false">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.boolean(0))"/>
+        </outline>
+      </outline>
+      <outline text="lang.boolean - string 'true' - Convert string 'true' to boolean">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.boolean(&quot;true&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.boolean - string 'false' - Convert string 'false' to boolean">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.boolean(&quot;false&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.boolean - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.boolean()"/>
+        </outline>
+      </outline>
+      <outline text="lang.char - integer to char - Convert ASCII value to character">
+        <outline text="Metadata">
+          <outline text="expected_result: char"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.char(65))"/>
+        </outline>
+      </outline>
+      <outline text="lang.char - string to char - Convert single character string to char">
+        <outline text="Metadata">
+          <outline text="expected_result: char"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.char(&quot;H&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.char - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.char()"/>
+        </outline>
+      </outline>
+      <outline text="lang.short - integer conversion - Convert integer to short (returns 64-bit long type)">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.short(42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.short - typeof returns long - Verify lang.short returns long type (64-bit internally)">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.short(100))"/>
+        </outline>
+      </outline>
+      <outline text="lang.short - double to short - Convert double to short (truncates decimals)">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.short(42.9)"/>
+        </outline>
+      </outline>
+      <outline text="lang.short - string to short - Convert numeric string to short">
+        <outline text="Metadata">
+          <outline text="expected_result: 9999"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.short(&quot;9999&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.short - negative value - Convert negative number to short">
+        <outline text="Metadata">
+          <outline text="expected_result: -123"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.short(-123)"/>
+        </outline>
+      </outline>
+      <outline text="lang.short - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.short()"/>
+        </outline>
+      </outline>
+      <outline text="lang.long - double to long - Convert double to long (truncates decimals)">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.long(42.9))"/>
+        </outline>
+      </outline>
+      <outline text="lang.long - string to long - Convert numeric string to long">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.long(&quot;12345&quot;))"/>
+        </outline>
+      </outline>
+      <outline text="lang.long - boolean true - Convert boolean true to 1">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.long(true))"/>
+        </outline>
+      </outline>
+      <outline text="lang.long - boolean false - Convert boolean false to 0">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.long(false))"/>
+        </outline>
+      </outline>
+      <outline text="lang.long - negative value - Convert negative double to long">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.long(-999.7))"/>
+        </outline>
+      </outline>
+      <outline text="lang.long - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.long()"/>
+        </outline>
+      </outline>
+      <outline text="lang.date - current time - Convert current timestamp to date type">
+        <outline text="Metadata">
+          <outline text="expected_result: date"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.date(clock.now()))"/>
+        </outline>
+      </outline>
+      <outline text="lang.date - long to date - Convert long integer to date">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (timestamp = clock.now())"/>
+          <outline text="local (converted = lang.date(timestamp))"/>
+          <outline text="return typeof(converted) == &quot;date&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.date - post-2038 timestamp - Verify 64-bit date handling (Year 2038+ compatibility)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (future = date.set(1, 1, 2050, 0, 0, 0))"/>
+          <outline text="local (converted = lang.date(future))"/>
+          <outline text="return converted &gt; 0"/>
+        </outline>
+      </outline>
+      <outline text="lang.date - year 2100 timestamp - Verify far-future date handling">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (farFuture = date.set(1, 1, 2100, 0, 0, 0))"/>
+          <outline text="local (converted = lang.date(farFuture))"/>
+          <outline text="return typeof(converted) == &quot;date&quot;"/>
+        </outline>
+      </outline>
+      <outline text="lang.date - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.date()"/>
+        </outline>
+      </outline>
+      <outline text="lang.string - number to string - Convert integer to string">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string(42)"/>
+        </outline>
+      </outline>
+      <outline text="lang.string - boolean to string - Convert boolean true to string">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string(true)"/>
+        </outline>
+      </outline>
+      <outline text="lang.string - double to string - Convert double to string">
+        <outline text="Metadata">
+          <outline text="expected_result: TEXT"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(lang.string(3.14159))"/>
+        </outline>
+      </outline>
+      <outline text="lang.string - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string()"/>
+        </outline>
+      </outline>
+      <outline text="lang.address - table address - Convert table to address type">
+        <outline text="Metadata">
+          <outline text="expected_result: addr"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="return typeof(lang.address(@t))"/>
+        </outline>
+      </outline>
+      <outline text="lang.address - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.address()"/>
+        </outline>
+      </outline>
+      <outline text="lang.binary - string to binary - Convert string to binary data">
+        <outline text="Metadata">
+          <outline text="expected_result: data"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (bin = lang.binary(&quot;test data&quot;))"/>
+          <outline text="return typeof(bin)"/>
+        </outline>
+      </outline>
+      <outline text="lang.binary - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.binary()"/>
+        </outline>
+      </outline>
+      <outline text="lang.point - record to point - Convert point record to point type">
+        <outline text="Metadata">
+          <outline text="expected_result: point"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (pt)"/>
+          <outline text="point.make(100, 200, @pt)"/>
+          <outline text="return typeof(lang.point(pt))"/>
+        </outline>
+      </outline>
+      <outline text="lang.point - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.point()"/>
+        </outline>
+      </outline>
+      <outline text="lang.rect - record to rect - Convert rect record to rect type">
+        <outline text="Metadata">
+          <outline text="expected_result: rect"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (r)"/>
+          <outline text="rectangle.make(10, 20, 110, 220, @r)"/>
+          <outline text="return typeof(lang.rect(r))"/>
+        </outline>
+      </outline>
+      <outline text="lang.rect - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.rect()"/>
+        </outline>
+      </outline>
+      <outline text="lang.rgb - record to rgb - Convert RGB record to rgb type">
+        <outline text="Metadata">
+          <outline text="expected_result: rgb"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (color)"/>
+          <outline text="rgb.make(255, 128, 64, @color)"/>
+          <outline text="return typeof(lang.rgb(color))"/>
+        </outline>
+      </outline>
+      <outline text="lang.rgb - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.rgb()"/>
+        </outline>
+      </outline>
+      <outline text="lang.pattern - binary to pattern - Convert binary data to pattern type">
+        <outline text="Metadata">
+          <outline text="expected_result: pattern"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (pat = lang.pattern(string.filledstring(chr(0xFF), 8)))"/>
+          <outline text="return typeof(pat)"/>
+        </outline>
+      </outline>
+      <outline text="lang.pattern - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.pattern()"/>
+        </outline>
+      </outline>
+      <outline text="lang.filespec - string to filespec - Convert path string to filespec type">
+        <outline text="Metadata">
+          <outline text="expected_result: fss "/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (fspec = lang.filespec(&quot;{FRONTIER_TEST_TMP_DIR}/test.txt&quot;))"/>
+          <outline text="return typeof(fspec)"/>
+        </outline>
+      </outline>
+      <outline text="lang.filespec - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.filespec()"/>
+        </outline>
+      </outline>
+      <outline text="lang.list - string to list - Coerce string to list type">
+        <outline text="Metadata">
+          <outline text="expected_result: list"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (lst = lang.list(&quot;test&quot;))"/>
+          <outline text="return typeof(lst)"/>
+        </outline>
+      </outline>
+      <outline text="lang.list - binary to list - Coerce binary to list type">
+        <outline text="Metadata">
+          <outline text="expected_result: list"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (bin = pack(&quot;test&quot;))"/>
+          <outline text="local (lst = lang.list(bin))"/>
+          <outline text="return typeof(lst)"/>
+        </outline>
+      </outline>
+      <outline text="lang.list - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.list()"/>
+        </outline>
+      </outline>
+      <outline text="lang.record - list to record - Coerce list to record type">
+        <outline text="Metadata">
+          <outline text="expected_result: record"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (lst = {1, 2, 3})"/>
+          <outline text="local (rec = lang.record(lst))"/>
+          <outline text="return typeof(rec)"/>
+        </outline>
+      </outline>
+      <outline text="lang.record - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.record()"/>
+        </outline>
+      </outline>
+      <outline text="lang.enum - string to enum - Coerce string to enum type">
+        <outline text="Metadata">
+          <outline text="expected_result: enum"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local (en = lang.enum(&quot;testvalue&quot;))"/>
+          <outline text="return typeof(en)"/>
+        </outline>
+      </outline>
+      <outline text="lang.enum - no parameters - Parameter validation: missing parameter should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.enum()"/>
+        </outline>
+      </outline>
+      <outline text="lang.calldll - platform error - Windows DLL call should fail with platform error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_contains: not supported"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.calldll(&quot;kernel32.dll&quot;, &quot;GetTickCount&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.callxcmd - platform error - Legacy Mac XCMD call should fail with platform error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_contains: not supported"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.callxcmd(&quot;MyXCMD&quot;, &quot;param&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.coerceappleitem - platform error - AppleEvent coercion should fail with platform error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_contains: AppleEvent"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @x)"/>
+          <outline text="lang.coerceappleitem(@x, &quot;TEXT&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.packwindow - platform error - Window packing should fail with platform error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_contains: Window"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @x)"/>
+          <outline text="lang.packwindow(@x)"/>
+        </outline>
+      </outline>
+      <outline text="lang.rollbeachball - noop succeeds - Beachball animation is a noop in headless mode, returns true">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.rollbeachball()"/>
+        </outline>
+      </outline>
+      <outline text="lang.edit - noop in headless - Edit verb is a noop in headless mode, returns true">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(stringType, @x)"/>
+          <outline text="x = &quot;test&quot;"/>
+          <outline text="return lang.edit(@x)"/>
+        </outline>
+      </outline>
+      <outline text="lang.scripterror - string message - Script error with custom message should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_contains: Custom error message"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.scripterror(&quot;Custom error message&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.scripterror - numeric error code - Script error with numeric code should trigger OS error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.scripterror(-1)"/>
+        </outline>
+      </outline>
+      <outline text="lang.scripterror - terminates execution - Script error should stop execution immediately">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_contains: Should stop here"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(x = 0)"/>
+          <outline text="lang.scripterror(&quot;Should stop here&quot;)"/>
+          <outline text="x = 1"/>
+          <outline text="return x"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Op Verbs (op_verbs)">
+      <outline text="outline creation - lang.new with outlineType - Create new outline object using lang.new(outlineType, @addr)">
+        <outline text="Metadata">
+          <outline text="expected_result: optx"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.testOutline)"/>
+          <outline text="return typeof(workspace.testOutline)"/>
+        </outline>
+      </outline>
+      <outline text="outline target setup - set outline as target - Set outline as target for op verb operations">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.myOutline"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.myOutline)"/>
+          <outline text="target.set(@workspace.myOutline)"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="outline target workflow - full setup cycle - Complete workflow: create outline → set as target → verify">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.opTest)"/>
+          <outline text="target.set(@workspace.opTest)"/>
+          <outline text="local(ok1 = typeof(workspace.opTest) == &quot;optx&quot;)"/>
+          <outline text="local(ok2 = string(target.get()) == &quot;workspace.opTest&quot;)"/>
+          <outline text="return ok1 and ok2"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - insert first line (down) - Insert first line into empty outline using down direction">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return op.insert(&quot;First line&quot;, down)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - insert sibling line (down) - Insert sibling line below current line">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="return op.insert(&quot;Line 2&quot;, down)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - insert child line (right) - Insert child line under current line (indent)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="return op.insert(&quot;Child&quot;, right)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - insert above (up) - Insert line above current position">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="return op.insert(&quot;Line 1&quot;, up)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - insert parent (left) - Insert parent line to the left (outdent and insert)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="return op.insert(&quot;Grandchild&quot;, right)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - cursor moves to inserted headline - After insert, bar cursor should be positioned on the new headline">
+        <outline text="Metadata">
+          <outline text="expected_result: Inserted between 1 and 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.go(up, 2)"/>
+          <outline text="op.insert(&quot;Inserted between 1 and 2&quot;, down)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - read inserted line - Get text of line after insertion">
+        <outline text="Metadata">
+          <outline text="expected_result: Test content"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test content&quot;, down)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - returns string type - getLineText returns stringType">
+        <outline text="Metadata">
+          <outline text="expected_result: TEXT"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Hello&quot;, down)"/>
+          <outline text="return typeof(op.getLineText())"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - empty line text - Get text of empty line (empty string)">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;&quot;, down)"/>
+          <outline text="return sizeOf(op.getLineText())"/>
+        </outline>
+      </outline>
+      <outline text="op.go - navigate down one line - Move cursor down one line in outline">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="op.go(down, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - navigate up one line - Move cursor up one line in outline">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - navigate right (into child) - Move cursor right into first child">
+        <outline text="Metadata">
+          <outline text="expected_result: Child"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.go(right, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - navigate left (to parent) - Move cursor left to parent node">
+        <outline text="Metadata">
+          <outline text="expected_result: Parent"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - navigate multiple units - Navigate down multiple lines at once">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.go(up, 2)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - returns boolean on success - go() returns true when navigation succeeds">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="return op.go(up, 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.go - returns false at boundary - go() returns false when can't move further (at boundary)">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Only line&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.go(up, 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.go - flatup direction (skip children) - Navigate flatup (previous sibling/parent, skipping children)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="return op.go(flatup, 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.go - flatdown direction (skip children) - Navigate flatdown (next sibling, skipping children)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.go(flatdown, 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.firstSummit - go to first top-level node - Navigate to first summit (top-level node, which is initially empty)">
+        <outline text="Metadata">
+          <outline text="expected_result: First"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;First&quot;, down)"/>
+          <outline text="op.insert(&quot;Second&quot;, down)"/>
+          <outline text="op.insert(&quot;Third&quot;, down)"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.go(down, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.firstSummit - returns boolean true - firstSummit returns true on success">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.firstSummit()"/>
+        </outline>
+      </outline>
+      <outline text="op.level - top-level is 1 - Top-level nodes have level 1">
+        <outline text="Metadata">
+          <outline text="expected_result: 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Top level&quot;, down)"/>
+          <outline text="return op.level()"/>
+        </outline>
+      </outline>
+      <outline text="op.level - child is level 2 - Child nodes have level 2">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="return op.level()"/>
+        </outline>
+      </outline>
+      <outline text="op.level - grandchild is level 3 - Grandchild nodes have level 3">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
+          <outline text="return op.level()"/>
+        </outline>
+      </outline>
+      <outline text="op.countSubs - count immediate children (level 1) - Count direct children of current node">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 3&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return op.countSubs(1)"/>
+        </outline>
+      </outline>
+      <outline text="op.countSubs - no children returns 0 - Leaf nodes have 0 children">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Leaf node&quot;, down)"/>
+          <outline text="return op.countSubs(1)"/>
+        </outline>
+      </outline>
+      <outline text="op.countSubs - infinity counts all descendants - Use infinity to count all descendants recursively">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Root&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return op.countSubs(infinity)"/>
+        </outline>
+      </outline>
+      <outline text="op.countSummits - count top-level nodes - Count all summit (top-level) nodes in outline (includes empty root)">
+        <outline text="Metadata">
+          <outline text="expected_result: 4"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Summit 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Summit 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Summit 3&quot;, down)"/>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="op.countSummits - empty outline returns 1 - Empty outline has 1 summit (the empty root node)">
+        <outline text="Metadata">
+          <outline text="expected_result: 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="op.countSummits - children don't count - Child nodes are not counted as summits (empty root + 1 summit)">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Summit&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="op.subsExpanded - collapsed headline returns false - Returns false when current headline's children are collapsed">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.collapse()"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.subsExpanded - expanded headline returns true - Returns true when current headline's children are expanded">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(1)"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.subsExpanded - no children returns false - Returns false when headline has no children">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Leaf Node&quot;, down)"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.subsExpanded - no parameters - Verify op.subsExpanded works with zero parameters on empty outline">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.expand - expand one level - Expand current node one level (show immediate children)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.collapse()"/>
+          <outline text="return op.expand(1)"/>
+        </outline>
+      </outline>
+      <outline text="op.expand - expand all descendants (infinity) - Expand all descendants using infinity">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Root&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
+          <outline text="op.go(left, 2)"/>
+          <outline text="op.collapse()"/>
+          <outline text="return op.expand(infinity)"/>
+        </outline>
+      </outline>
+      <outline text="op.collapse - collapse current node - Collapse current node (hide all children)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="return op.collapse()"/>
+        </outline>
+      </outline>
+      <outline text="op.collapse - returns boolean - collapse returns true only if something was collapsed">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Node&quot;, down)"/>
+          <outline text="return op.collapse()"/>
+        </outline>
+      </outline>
+      <outline text="op.promote - move child to sibling of parent - op.promote() promotes children of current node (moves subheads left one level)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="/* Outline structure:">
+            <outline text="Parent (level 1)">
+              <outline text="Child 1 (level 2)"/>
+              <outline text="Child 2 (level 2)"/>
+            </outline>
+            <outline text="Cursor is on Child 2 */"/>
+          </outline>
+          <outline text="op.go(up, 1)"/>
+          <outline text="/* Cursor on Child 1 - check its level before promoting Parent's children */"/>
+          <outline text="local(child1LevelBefore = op.level())"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="/* Cursor on Parent - promote its children (Child 1 and Child 2) */"/>
+          <outline text="op.promote()"/>
+          <outline text="/* After promote, children move left one level:">
+            <outline text="Parent (level 1)"/>
+            <outline text="Child 1 (level 1) - was level 2"/>
+            <outline text="Child 2 (level 1) - was level 2 */"/>
+          </outline>
+          <outline text="op.go(down, 1)"/>
+          <outline text="/* Cursor on Child 1 - verify it's now level 1 */"/>
+          <outline text="local(child1LevelAfter = op.level())"/>
+          <outline text="return child1LevelBefore == 2 and child1LevelAfter == 1"/>
+        </outline>
+      </outline>
+      <outline text="op.promote - returns boolean - promote returns true when children exist to promote">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="/* Cursor is on Child after inserting it */"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="/* Cursor is on Parent - promote its children */"/>
+          <outline text="return op.promote()"/>
+        </outline>
+      </outline>
+      <outline text="op.promote - top-level cannot promote - Top-level nodes cannot be promoted (already at level 1)">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Top&quot;, down)"/>
+          <outline text="return op.promote()"/>
+        </outline>
+      </outline>
+      <outline text="op.demote - make sibling a child - op.demote() demotes siblings after current node (moves following siblings right to become children)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Sibling 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Sibling 2&quot;, down)"/>
+          <outline text="/* Outline structure:">
+            <outline text="Parent (level 1)"/>
+            <outline text="Sibling 1 (level 1)"/>
+            <outline text="Sibling 2 (level 1)"/>
+            <outline text="Cursor is on Sibling 2 */"/>
+          </outline>
+          <outline text="local(sibling2LevelBefore = op.level())"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="/* Cursor on Sibling 1 - demote following siblings (Sibling 2) */"/>
+          <outline text="op.demote()"/>
+          <outline text="/* After demote:">
+            <outline text="Parent (level 1)"/>
+            <outline text="Sibling 1 (level 1)">
+              <outline text="Sibling 2 (level 2) - was level 1 */"/>
+            </outline>
+          </outline>
+          <outline text="op.go(right, 1)"/>
+          <outline text="/* Cursor on Sibling 2 (now a child of Sibling 1) */"/>
+          <outline text="local(sibling2LevelAfter = op.level())"/>
+          <outline text="return sibling2LevelBefore == 1 and sibling2LevelAfter == 2"/>
+        </outline>
+      </outline>
+      <outline text="op.demote - returns boolean - demote returns true when siblings exist to demote">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="/* Cursor is on Line 2 */"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="/* Cursor is on Line 1 - demote following siblings (Line 2 exists) */"/>
+          <outline text="return op.demote()"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteLine - delete single line - Delete current line, cursor moves to next line">
+        <outline text="Metadata">
+          <outline text="expected_result: Keep me"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Delete me&quot;, down)"/>
+          <outline text="op.insert(&quot;Keep me&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="op.deleteLine()"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteLine - returns boolean true - deleteLine returns true on success">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.deleteLine()"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteLine - delete only node creates empty node - Deleting the only node creates a new blank node (outline minimal state)">
+        <outline text="Metadata">
+          <outline text="expected_result: 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Only node&quot;, down)"/>
+          <outline text="op.deleteLine()"/>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="op.setLineText - modify existing headline - Change text of current headline">
+        <outline text="Metadata">
+          <outline text="expected_result: Modified text"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Original text&quot;, down)"/>
+          <outline text="op.setLineText(&quot;Modified text&quot;)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setLineText - returns boolean true on success - setLineText returns true when successful">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Text&quot;, down)"/>
+          <outline text="return op.setLineText(&quot;New text&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setLineText - set to empty string - Set headline text to empty string (valid operation)">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Something&quot;, down)"/>
+          <outline text="op.setLineText(&quot;&quot;)"/>
+          <outline text="return sizeOf(op.getLineText())"/>
+        </outline>
+      </outline>
+      <outline text="op.setLineText - special characters - Set text with special characters (quotes, newlines, etc.)">
+        <outline text="Metadata">
+          <outline text="expected_result: Special: &quot;quotes&quot; &amp; &lt;tags&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="op.setLineText(&quot;Special: \&quot;quotes\&quot; &amp; &lt;tags&gt;&quot;)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setLineText - missing text parameter - setLineText requires text parameter (should fail)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="op.setLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setLineText - preserves children - Setting line text preserves child nodes">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setLineText(&quot;Modified Parent&quot;)"/>
+          <outline text="local(ok1 = op.getLineText() == &quot;Modified Parent&quot;)"/>
+          <outline text="local(ok2 = op.countSubs(1) == 2)"/>
+          <outline text="return ok1 and ok2"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteSubs - delete all children under parent - Delete all children of current node, parent remains">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 3&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.deleteSubs()"/>
+          <outline text="local(ok1 = op.getLineText() == &quot;Parent&quot;)"/>
+          <outline text="local(ok2 = op.countSubs(1) == 0)"/>
+          <outline text="return ok1 and ok2"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteSubs - returns boolean true - deleteSubs returns true on success">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return op.deleteSubs()"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteSubs - no children is no-op - deleteSubs on node with no children returns true (no-op)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Leaf node&quot;, down)"/>
+          <outline text="local(ok = op.deleteSubs())"/>
+          <outline text="return ok and (op.countSubs(1) == 0)"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteSubs - multi-level children - Delete all descendants (children, grandchildren, etc.)">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Root&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Grandchild 1&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Grandchild 2&quot;, right)"/>
+          <outline text="op.go(left, 2)"/>
+          <outline text="op.deleteSubs()"/>
+          <outline text="return op.countSubs(infinity)"/>
+        </outline>
+      </outline>
+      <outline text="op.deleteSubs - zero parameters required - deleteSubs takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return typeof(op.deleteSubs())"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - move node left (direction=left, count=1) - Move node left one level (promote/outdent)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="local(before = op.level())"/>
+          <outline text="op.reorg(left, 1)"/>
+          <outline text="local(after = op.level())"/>
+          <outline text="return (before == 2) and (after == 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - move node right (direction=right, count=1) - Move node right one level (demote/indent)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(before = op.level())"/>
+          <outline text="op.reorg(right, 1)"/>
+          <outline text="local(after = op.level())"/>
+          <outline text="return (before == 1) and (after == 2)"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - move multiple levels left - Move node left multiple levels (count &gt; 1)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Level 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Level 2&quot;, right)"/>
+          <outline text="op.insert(&quot;Level 3&quot;, right)"/>
+          <outline text="local(before = op.level())"/>
+          <outline text="op.reorg(left, 2)"/>
+          <outline text="local(after = op.level())"/>
+          <outline text="return (before == 3) and (after == 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - move multiple levels right - Move node right as far as possible (goes as far as structure allows)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="local(before = op.level())"/>
+          <outline text="local(result = op.reorg(right, 2))"/>
+          <outline text="local(after = op.level())"/>
+          <outline text="return (before == 1) and (after == 2) and result"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - returns boolean based on success - reorg returns true on successful reorganization">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="return op.reorg(left, 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - missing direction parameter - reorg requires direction parameter (should fail)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="op.reorg()"/>
+        </outline>
+      </outline>
+      <outline text="op.reorg - missing count parameter - reorg requires count parameter (should fail)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="op.reorg(3)"/>
+        </outline>
+      </outline>
+      <outline text="op.find - case-sensitive search (flCase=true) - Find with case sensitivity enabled - exact case match required">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;lowercase text&quot;, down)"/>
+          <outline text="op.insert(&quot;UPPERCASE TEXT&quot;, down)"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(found = op.find(&quot;UPPERCASE&quot;, false, true))"/>
+          <outline text="return found and (op.getLineText() == &quot;UPPERCASE TEXT&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.find - no wrap search (flWrap=false) - Search without wrap stops at end">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="local(found = op.find(&quot;Line 1&quot;, false, false))"/>
+          <outline text="return not found"/>
+        </outline>
+      </outline>
+      <outline text="op.find - not found returns false - Returns false when text not found in outline">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="return op.find(&quot;Nonexistent&quot;, false, false)"/>
+        </outline>
+      </outline>
+      <outline text="op.find - missing searchText parameter - find requires searchText parameter (should fail)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="op.find()"/>
+        </outline>
+      </outline>
+      <outline text="op.find - one parameter (searchText only) - flWrap and flCase are optional, defaults to case-insensitive">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="local(found = op.find(&quot;test&quot;))"/>
+          <outline text="return found and (op.getLineText() == &quot;Test&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.find - two parameters (searchText, flWrap) - flCase is optional, defaults to case-insensitive">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+          <outline text="local(found = op.find(&quot;test&quot;, false))"/>
+          <outline text="return found and (op.getLineText() == &quot;Test&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.go - missing direction parameter - op.go requires direction parameter">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.go()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - missing count parameter - op.go requires count parameter">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.go(down)"/>
+        </outline>
+      </outline>
+      <outline text="op.go - extra parameters should fail - op.go with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.go(down, 1, &quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - missing text parameter - op.insert requires text parameter">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.insert()"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - missing direction parameter - op.insert requires direction parameter">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.insert(&quot;text&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - no parameters - op.getLineText takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: TEXT"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Text&quot;, down)"/>
+          <outline text="return typeof(op.getLineText())"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - extra parameters should fail - op.getLineText with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.getLineText(&quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.level - no parameters - op.level takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.level())"/>
+        </outline>
+      </outline>
+      <outline text="op.countSubs - missing level parameter - op.countSubs requires level parameter">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.countSubs()"/>
+        </outline>
+      </outline>
+      <outline text="op.expand - missing levels parameter - op.expand requires levels parameter">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="op.expand()"/>
+        </outline>
+      </outline>
+      <outline text="op.collapse - no parameters - op.collapse takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.collapse())"/>
+        </outline>
+      </outline>
+      <outline text="op.promote - no parameters - op.promote takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="return typeof(op.promote())"/>
+        </outline>
+      </outline>
+      <outline text="op.demote - no parameters - op.demote takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="return typeof(op.demote())"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - no target set should fail - op.insert requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - no target set should fail - op.getLineText requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.go - no target set should fail - op.go requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.go(down, 1)"/>
+        </outline>
+      </outline>
+      <outline text="op.insert - table target should fail - op verbs require outlineType target, not tableType">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.notOutline)"/>
+          <outline text="target.set(@workspace.notOutline)"/>
+          <outline text="op.insert(&quot;Test&quot;, down)"/>
+        </outline>
+      </outline>
+      <outline text="op.getLineText - wrong target type should fail - op verbs require outlineType target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.table)"/>
+          <outline text="target.set(@workspace.table)"/>
+          <outline text="op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - build and navigate outline structure - Build multi-level outline and navigate through it">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Chapter 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Section 1.1&quot;, right)"/>
+          <outline text="op.insert(&quot;Section 1.2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.insert(&quot;Chapter 2&quot;, down)"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(ok1 = op.getLineText() == &quot;Chapter 1&quot;)"/>
+          <outline text="local(ok2 = op.countSummits() == 2)"/>
+          <outline text="return ok1 and ok2"/>
+        </outline>
+      </outline>
+      <outline text="workflow - insert and modify multiple lines - Insert multiple lines and modify their content">
+        <outline text="Metadata">
+          <outline text="expected_result: Modified Line 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.go(up, 2)"/>
+          <outline text="op.setLineText(&quot;Modified Line 1&quot;)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - promote and demote hierarchy changes - Build hierarchy and reorganize with promote/demote">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="local(level1 = op.level())"/>
+          <outline text="op.promote()"/>
+          <outline text="local(level2 = op.level())"/>
+          <outline text="op.demote()"/>
+          <outline text="local(level3 = op.level())"/>
+          <outline text="return (level1 == 2) and (level2 == 1) and (level3 == 2)"/>
+        </outline>
+      </outline>
+      <outline text="workflow - expand and collapse state - Expand and collapse outline nodes">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Root&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="op.collapse()"/>
+          <outline text="return op.countSubs(1)"/>
+        </outline>
+      </outline>
+      <outline text="stress test - build large outline - Build outline with many nodes (includes empty root)">
+        <outline text="Metadata">
+          <outline text="expected_result: 21"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 20">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+          </outline>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="stress test - deep nesting - Create deeply nested outline structure">
+        <outline text="Metadata">
+          <outline text="expected_result: 10"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(i)"/>
+          <outline text="op.insert(&quot;Level 1&quot;, down)"/>
+          <outline text="for i = 2 to 10">
+            <outline text="op.insert(&quot;Level &quot; + i, right)"/>
+          </outline>
+          <outline text="return op.level()"/>
+        </outline>
+      </outline>
+      <outline text="stress test - rapid insert and delete - Rapidly insert and delete lines">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 10">
+            <outline text="op.insert(&quot;Temp &quot; + i, down)"/>
+          </outline>
+          <outline text="for i = 1 to 5">
+            <outline text="op.deleteLine()"/>
+          </outline>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - returns address type - getCursor returns long type (1-based line number) for current cursor position">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="return typeof(op.getCursor())"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - simple outline cursor position - Get cursor position from simple outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;First line&quot;, down)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="return defined(cursor)"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - cursor changes with navigation - Cursor address changes when navigating outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(cursor1 = op.getCursor())"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="local(cursor2 = op.getCursor())"/>
+          <outline text="return cursor1 != cursor2"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - cursor in nested structure - Get cursor from nested outline hierarchy">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="return typeof(cursor)"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - no parameters required - getCursor takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.getCursor())"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - extra parameters should fail - getCursor with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.getCursor(&quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - set cursor to saved address - Set cursor to previously saved address position">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.go(up, 2)"/>
+          <outline text="local(savedCursor = op.getCursor())"/>
+          <outline text="op.go(down, 2)"/>
+          <outline text="op.setCursor(savedCursor)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - returns boolean true on success - setCursor returns true when cursor is set successfully">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.setCursor(cursor)"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - round-trip cursor position - Get cursor, navigate away, set cursor back - verify position">
+        <outline text="Metadata">
+          <outline text="expected_result: Other line"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Target line&quot;, down)"/>
+          <outline text="op.insert(&quot;Other line&quot;, down)"/>
+          <outline text="local(targetCursor = op.getCursor())"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="op.setCursor(targetCursor)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - cursor in nested hierarchy - Set cursor to child node address">
+        <outline text="Metadata">
+          <outline text="expected_result: Child 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="local(child1Cursor = op.getCursor())"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setCursor(child1Cursor)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - requires address parameter - setCursor requires address parameter (should fail without it)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setCursor()"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - invalid address type should fail - setCursor with non-address type should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setCursor(&quot;not an address&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - cursor from different outline should fail - setCursor with address from different outline should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline1)"/>
+          <outline text="lang.new(outlineType, @workspace.outline2)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="local(cursor1 = op.getCursor())"/>
+          <outline text="target.set(@workspace.outline2)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.setCursor(cursor1)"/>
+        </outline>
+      </outline>
+      <outline text="op.getDisplay - returns boolean type - getDisplay returns boolean for display inhibit state">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return typeof(op.getDisplay())"/>
+        </outline>
+      </outline>
+      <outline text="op.getDisplay - default state is true (display enabled) - New outlines have display enabled by default">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.getDisplay - no parameters required - getDisplay takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return typeof(op.getDisplay())"/>
+        </outline>
+      </outline>
+      <outline text="op.getDisplay - extra parameters should fail - getDisplay with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.getDisplay(&quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - set display to false (inhibit display) - Disable display for performance during bulk operations">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - set display to true (enable display) - Enable display after bulk operations">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - returns boolean true on success - setDisplay returns true when state is set">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="return op.setDisplay(false)"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - round-trip display state - Set display false, verify, set true, verify">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="local(state1 = op.getDisplay())"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="local(state2 = op.getDisplay())"/>
+          <outline text="return (not state1) and state2"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - bulk operations with display off - Disable display during bulk insert operations (performance optimization)">
+        <outline text="Metadata">
+          <outline text="expected_result: 11"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 10">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+          </outline>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - requires boolean parameter - setDisplay requires boolean parameter (should fail without it)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - non-boolean parameter should fail - setDisplay with non-boolean type should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(&quot;true&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - returns address type - getExpansionState returns list containing expansion state data">
+        <outline text="Metadata">
+          <outline text="expected_result: list"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return typeof(op.getExpansionState())"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - simple outline expansion state - Get expansion state from simple outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="return defined(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - no parameters required - getExpansionState takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: list"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.getExpansionState())"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - extra parameters should fail - getExpansionState with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.getExpansionState(&quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - restore saved expansion state - Set expansion state to previously saved state">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(1)"/>
+          <outline text="op.insert(&quot;Parent 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(savedState = op.getExpansionState())"/>
+          <outline text="op.collapse()"/>
+          <outline text="local(isCollapsed = not op.subsExpanded())"/>
+          <outline text="op.setExpansionState(savedState)"/>
+          <outline text="local(isExpanded = op.subsExpanded())"/>
+          <outline text="return isCollapsed and isExpanded"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - returns boolean true on success - setExpansionState returns true when state is set successfully">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="return op.setExpansionState(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - round-trip expansion state - Get state, modify expansion, restore state">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="local(expandedState = op.getExpansionState())"/>
+          <outline text="op.collapse()"/>
+          <outline text="op.setExpansionState(expandedState)"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - complex outline with multiple levels - Save and restore expansion state in multi-level outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Level 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Level 2&quot;, right)"/>
+          <outline text="op.insert(&quot;Level 3&quot;, right)"/>
+          <outline text="op.go(left, 2)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="op.collapse()"/>
+          <outline text="op.setExpansionState(state)"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - requires address parameter - setExpansionState requires address parameter (should fail without it)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setExpansionState()"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - invalid address type should fail - setExpansionState with non-address type should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setExpansionState(&quot;not an address&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - returns address type - getScrollState returns long (1-based line number) for scroll position">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="return typeof(op.getScrollState())"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - simple outline scroll state - Get scroll state from simple outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(state = op.getScrollState())"/>
+          <outline text="return defined(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - no parameters required - getScrollState takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.getScrollState())"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - extra parameters should fail - getScrollState with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.getScrollState(&quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - restore saved scroll state - Set scroll state to previously saved state">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="local(savedState = op.getScrollState())"/>
+          <outline text="return op.setScrollState(savedState)"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - returns boolean true on success - setScrollState returns true when state is set successfully">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(state = op.getScrollState())"/>
+          <outline text="return op.setScrollState(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - round-trip scroll state - Get scroll state, navigate, restore scroll state (noop in headless)">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 10"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 20">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+          </outline>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(topState = op.getScrollState())"/>
+          <outline text="op.go(down, 10)"/>
+          <outline text="op.setScrollState(topState)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - requires address parameter - setScrollState requires address parameter (should fail without it)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setScrollState()"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - invalid address type should fail - setScrollState with non-address type should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setScrollState(&quot;not an address&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - returns long type - getRefcon returns long (32-bit integer) reference constant">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.getRefcon())"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - default refcon is zero - New outline nodes have refcon initialized to 0">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - no parameters required - getRefcon takes no parameters">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return typeof(op.getRefcon())"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - extra parameters should fail - getRefcon with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.getRefcon(&quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - set positive refcon value - Set refcon to positive integer value">
+        <outline text="Metadata">
+          <outline text="expected_result: 12345"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(12345)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - set negative refcon value - Set refcon to negative integer value">
+        <outline text="Metadata">
+          <outline text="expected_result: -9999"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(-9999)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - set zero refcon value - Set refcon to zero (reset to default)">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(100)"/>
+          <outline text="op.setRefcon(0)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - returns boolean true on success - setRefcon returns true when refcon is set successfully">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.setRefcon(42)"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - round-trip refcon value - Set refcon, verify with getRefcon">
+        <outline text="Metadata">
+          <outline text="expected_result: 99999"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(99999)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - different refcon per node - Each node can have independent refcon value">
+        <outline text="Metadata">
+          <outline text="expected_result: 111"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.setRefcon(111)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.setRefcon(222)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.setRefcon(333)"/>
+          <outline text="op.go(up, 2)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - refcon persists across navigation - Refcon value persists when navigating away and back">
+        <outline text="Metadata">
+          <outline text="expected_result: 777"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.setRefcon(777)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - requires long parameter - setRefcon requires long parameter (should fail without it)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - non-long parameter should fail - setRefcon with non-long type should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(&quot;not a number&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - no target set should fail - getCursor requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getCursor()"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - no target set should fail - setCursor requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="target.clear()"/>
+          <outline text="op.setCursor(cursor)"/>
+        </outline>
+      </outline>
+      <outline text="op.getDisplay - no target set should fail - getDisplay requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - no target set should fail - setDisplay requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.setDisplay(false)"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - no target set should fail - getExpansionState requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getExpansionState()"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - no target set should fail - setExpansionState requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="target.clear()"/>
+          <outline text="op.setExpansionState(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - no target set should fail - getScrollState requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getScrollState()"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - no target set should fail - setScrollState requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(state = op.getScrollState())"/>
+          <outline text="target.clear()"/>
+          <outline text="op.setScrollState(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - no target set should fail - getRefcon requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - no target set should fail - setRefcon requires outline set as target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.setRefcon(100)"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - table target should fail - getCursor requires outlineType target, not tableType">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.notOutline)"/>
+          <outline text="target.set(@workspace.notOutline)"/>
+          <outline text="op.getCursor()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - wrong target type should fail - setDisplay requires outlineType target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.table)"/>
+          <outline text="target.set(@workspace.table)"/>
+          <outline text="op.setDisplay(false)"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - wrong target type should fail - getExpansionState requires outlineType target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.table)"/>
+          <outline text="target.set(@workspace.table)"/>
+          <outline text="op.getExpansionState()"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - wrong target type should fail - getRefcon requires outlineType target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.table)"/>
+          <outline text="target.set(@workspace.table)"/>
+          <outline text="op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - save and restore cursor during bulk operations - Save cursor, do bulk operations, restore cursor position">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="local(savedCursor = op.getCursor())"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 5">
+            <outline text="op.insert(&quot;New &quot; + i, down)"/>
+          </outline>
+          <outline text="op.setCursor(savedCursor)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - disable display during bulk insert and restore - Disable display, insert many lines, re-enable display">
+        <outline text="Metadata">
+          <outline text="expected_result: 51"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 50">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+          </outline>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="return op.countSummits()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - save expansion state before collapse and restore - Save expansion state, collapse all, restore state">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1a&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 1b&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="op.insert(&quot;Parent 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 2a&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(savedState = op.getExpansionState())"/>
+          <outline text="op.collapse()"/>
+          <outline text="local(collapsed = not op.subsExpanded())"/>
+          <outline text="op.setExpansionState(savedState)"/>
+          <outline text="local(expanded = op.subsExpanded())"/>
+          <outline text="return collapsed and expanded"/>
+        </outline>
+      </outline>
+      <outline text="workflow - refcon as node identifier - Use refcon to mark and find specific nodes">
+        <outline text="Metadata">
+          <outline text="expected_result: 1002"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Item A&quot;, down)"/>
+          <outline text="op.setRefcon(1001)"/>
+          <outline text="op.insert(&quot;Item B&quot;, down)"/>
+          <outline text="op.setRefcon(1002)"/>
+          <outline text="op.insert(&quot;Item C&quot;, down)"/>
+          <outline text="op.setRefcon(1003)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - multiple state operations combined - Combine cursor, display, expansion, and refcon operations">
+        <outline text="Metadata">
+          <outline text="expected_result: 100"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="op.insert(&quot;Root&quot;, down)"/>
+          <outline text="op.setRefcon(100)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.setRefcon(200)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="local(expState = op.getExpansionState())"/>
+          <outline text="op.expand(1)"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="local(refcon = op.getRefcon())"/>
+          <outline text="return refcon"/>
+        </outline>
+      </outline>
+      <outline text="integration - outline with target.get/set - Switch between multiple outline targets">
+        <outline text="Metadata">
+          <outline text="expected_result: Outline 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline1)"/>
+          <outline text="lang.new(outlineType, @workspace.outline2)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="op.insert(&quot;Outline 1&quot;, down)"/>
+          <outline text="target.set(@workspace.outline2)"/>
+          <outline text="op.insert(&quot;Outline 2&quot;, down)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="integration - outline with typeof - Verify outline type with typeof">
+        <outline text="Metadata">
+          <outline text="expected_result: optx"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="return typeof(workspace.outline)"/>
+        </outline>
+      </outline>
+      <outline text="integration - outline with defined - Check outline existence with defined">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="return defined(workspace.outline)"/>
+        </outline>
+      </outline>
+      <outline text="headless behavior - no window required for outline ops - Outline operations work without GUI windows (headless mode)">
+        <outline text="Metadata">
+          <outline text="expected_result: Headless line"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.headlessOutline)"/>
+          <outline text="target.set(@workspace.headlessOutline)"/>
+          <outline text="op.insert(&quot;Headless line&quot;, down)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="headless behavior - cursor is data structure state - Cursor position is data, not GUI state (headless compatible)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="return op.level() == 1"/>
+        </outline>
+      </outline>
+      <outline text="headless behavior - expansion state is metadata - Expansion state is tree metadata, not visual state">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(1)"/>
+          <outline text="op.collapse()"/>
+          <outline text="return op.countSubs(1) == 1"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - cursor persists during outline modification - Saved cursor remains valid after inserting new nodes elsewhere">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(savedCursor = op.getCursor())"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="op.insert(&quot;Line 1.5&quot;, down)"/>
+          <outline text="op.setCursor(savedCursor)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - cursor to deleted node should fail gracefully - Setting cursor to deleted node should error or return false">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Delete me&quot;, down)"/>
+          <outline text="local(deadCursor = op.getCursor())"/>
+          <outline text="op.insert(&quot;Keep me&quot;, down)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="op.deleteLine()"/>
+          <outline text="return op.setCursor(deadCursor)"/>
+        </outline>
+      </outline>
+      <outline text="op.setCursor - cursor after deleteSubs - Parent cursor remains valid after deleting children">
+        <outline text="Metadata">
+          <outline text="expected_result: Parent"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="local(parentCursor = op.getCursor())"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.deleteSubs()"/>
+          <outline text="op.setCursor(parentCursor)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.getCursor - cursor in deeply nested structure - Cursor correctly identifies position in deep nesting">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;L1&quot;, down)"/>
+          <outline text="op.insert(&quot;L2&quot;, right)"/>
+          <outline text="op.insert(&quot;L3&quot;, right)"/>
+          <outline text="op.insert(&quot;L4&quot;, right)"/>
+          <outline text="op.insert(&quot;L5&quot;, right)"/>
+          <outline text="local(deepCursor = op.getCursor())"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.setCursor(deepCursor)"/>
+          <outline text="return op.level()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - double disable is idempotent - Setting display false twice should work (idempotent)">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - double enable is idempotent - Setting display true twice should work (idempotent)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setDisplay - state persists across operations - Display state remains after outline operations">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.getDisplay - independent across multiple outlines - Each outline has independent display state">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline1)"/>
+          <outline text="lang.new(outlineType, @workspace.outline2)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="target.set(@workspace.outline2)"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - state from different outline should fail - Expansion state is outline-specific">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline1)"/>
+          <outline text="lang.new(outlineType, @workspace.outline2)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="local(state1 = op.getExpansionState())"/>
+          <outline text="target.set(@workspace.outline2)"/>
+          <outline text="op.insert(&quot;Parent 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setExpansionState(state1)"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - empty outline state - Get expansion state from empty outline (edge case)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="return defined(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.setExpansionState - restore after structural changes - Expansion state restoration after adding/removing nodes">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(infinity)"/>
+          <outline text="local(savedState = op.getExpansionState())"/>
+          <outline text="op.collapse()"/>
+          <outline text="op.go(right, 1)"/>
+          <outline text="op.insert(&quot;Child 3&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setExpansionState(savedState)"/>
+          <outline text="return op.subsExpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.getExpansionState - state is independent of cursor - Expansion state captures entire outline, not just cursor position">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(1)"/>
+          <outline text="op.insert(&quot;Parent 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 2&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.collapse();  /* Collapse Parent 2, cursor stays on Parent 2 (Child 2 becomes inaccessible) */"/>
+          <outline text="op.go(up, 1);  /* Move cursor to Parent 1 (away from Parent 2) */"/>
+          <outline text="local(state = op.getExpansionState());  /* Capture state: Parent 1 expanded, Parent 2 collapsed */"/>
+          <outline text="op.collapse();  /* Collapse Parent 1 */"/>
+          <outline text="op.setExpansionState(state);  /* Restore: should re-expand Parent 1, keep Parent 2 collapsed */"/>
+          <outline text="local(expanded1 = op.subsExpanded());  /* Check Parent 1 - should be expanded */"/>
+          <outline text="op.go(down, 1);  /* Move to Parent 2 */"/>
+          <outline text="local(expanded2 = op.subsExpanded());  /* Check Parent 2 - should be collapsed */"/>
+          <outline text="return expanded1 and (not expanded2)"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - empty outline scroll state - Get scroll state from empty outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(state = op.getScrollState())"/>
+          <outline text="return defined(state)"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - scroll state from different outline should fail - Scroll state is outline-specific">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline1)"/>
+          <outline text="lang.new(outlineType, @workspace.outline2)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="local(state1 = op.getScrollState())"/>
+          <outline text="target.set(@workspace.outline2)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.setScrollState(state1)"/>
+        </outline>
+      </outline>
+      <outline text="op.setScrollState - state persists after outline modification - Scroll state remains valid after inserting nodes">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(savedState = op.getScrollState())"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.insert(&quot;Line 4&quot;, down)"/>
+          <outline text="return op.setScrollState(savedState)"/>
+        </outline>
+      </outline>
+      <outline text="op.getScrollState - independent across multiple outlines - Each outline has independent scroll state (always 1 in headless)">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline1)"/>
+          <outline text="lang.new(outlineType, @workspace.outline2)"/>
+          <outline text="target.set(@workspace.outline1)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="local(state1 = op.getScrollState())"/>
+          <outline text="target.set(@workspace.outline2)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="local(state2 = op.getScrollState())"/>
+          <outline text="return state1 != state2"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - large positive value (32-bit boundary) - Test refcon with large positive value near INT32_MAX">
+        <outline text="Metadata">
+          <outline text="expected_result: 2147483647"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(2147483647)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - large negative value (32-bit boundary) - Test refcon with large negative value near INT32_MIN">
+        <outline text="Metadata">
+          <outline text="expected_result: -2147483648"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(-2147483648)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - refcon persists after navigation - Refcon values persist when navigating away and back">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="op.setRefcon(111)"/>
+          <outline text="op.insert(&quot;Line 2&quot;, down)"/>
+          <outline text="op.setRefcon(222)"/>
+          <outline text="op.insert(&quot;Line 3&quot;, down)"/>
+          <outline text="op.setRefcon(333)"/>
+          <outline text="op.go(up, 2)"/>
+          <outline text="local(refcon1 = op.getRefcon())"/>
+          <outline text="op.go(down, 1)"/>
+          <outline text="local(refcon2 = op.getRefcon())"/>
+          <outline text="return (refcon1 == 111) and (refcon2 == 222)"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - refcon survives promote/demote - Refcon value persists when changing node hierarchy">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.setRefcon(999)"/>
+          <outline text="op.promote()"/>
+          <outline text="local(afterPromote = op.getRefcon())"/>
+          <outline text="op.demote()"/>
+          <outline text="local(afterDemote = op.getRefcon())"/>
+          <outline text="return (afterPromote == 999) and (afterDemote == 999)"/>
+        </outline>
+      </outline>
+      <outline text="op.setRefcon - refcon independent across nodes - Each node has independent refcon value (no interference)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 10">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+            <outline text="op.setRefcon(i * 100)"/>
+          </outline>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(ok = true)"/>
+          <outline text="for i = 2 to 11">
+            <outline text="op.go(down, 1)"/>
+            <outline text="if op.getRefcon() != ((i - 1) * 100)">
+              <outline text="ok = false"/>
+            </outline>
+          </outline>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="op.getRefcon - refcon after insert preserves parent refcon - Inserting child doesn't affect parent refcon">
+        <outline text="Metadata">
+          <outline text="expected_result: 555"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.setRefcon(555)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.setRefcon(666)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - save all state before bulk operation and restore - Save cursor, expansion, scroll state, perform operations, restore all state">
+        <outline text="Metadata">
+          <outline text="expected_result: Parent 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 1a&quot;, right)"/>
+          <outline text="op.insert(&quot;Child 1b&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(1)"/>
+          <outline text="op.insert(&quot;Parent 2&quot;, down)"/>
+          <outline text="op.insert(&quot;Child 2a&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="local(savedCursor = op.getCursor())"/>
+          <outline text="local(savedExpansion = op.getExpansionState())"/>
+          <outline text="local(savedScroll = op.getScrollState())"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.collapse()"/>
+          <outline text="op.setCursor(savedCursor)"/>
+          <outline text="op.setExpansionState(savedExpansion)"/>
+          <outline text="op.setScrollState(savedScroll)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - refcon as node metadata during tree reorganization - Use refcon to track nodes during complex reorganization">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Item A&quot;, down)"/>
+          <outline text="op.setRefcon(1001)"/>
+          <outline text="op.insert(&quot;Item B&quot;, down)"/>
+          <outline text="op.setRefcon(1002)"/>
+          <outline text="op.insert(&quot;Item C&quot;, down)"/>
+          <outline text="op.setRefcon(1003)"/>
+          <outline text="op.go(up, 1)"/>
+          <outline text="op.demote()"/>
+          <outline text="local(refconB = op.getRefcon())"/>
+          <outline text="op.go(right, 1)"/>
+          <outline text="local(refconBChild = op.getRefcon())"/>
+          <outline text="return (refconB == 1002) and (refconBChild == 1003)"/>
+        </outline>
+      </outline>
+      <outline text="workflow - display off during state save/restore cycle - Disable display, save state, modify outline, restore state, enable display">
+        <outline text="Metadata">
+          <outline text="expected_result: Line 20"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace)"/>
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 20">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+          </outline>
+          <outline text="local(savedCursor = op.getCursor())"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.go(down, 10)"/>
+          <outline text="op.setCursor(savedCursor)"/>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="workflow - multiple outline state management - Manage state for multiple outlines simultaneously">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.o1)"/>
+          <outline text="lang.new(outlineType, @workspace.o2)"/>
+          <outline text="target.set(@workspace.o1)"/>
+          <outline text="op.insert(&quot;O1 Line 1&quot;, down)"/>
+          <outline text="op.setRefcon(111)"/>
+          <outline text="local(cursor1 = op.getCursor())"/>
+          <outline text="target.set(@workspace.o2)"/>
+          <outline text="op.insert(&quot;O2 Line 1&quot;, down)"/>
+          <outline text="op.setRefcon(222)"/>
+          <outline text="local(cursor2 = op.getCursor())"/>
+          <outline text="target.set(@workspace.o1)"/>
+          <outline text="op.setCursor(cursor1)"/>
+          <outline text="local(refcon1 = op.getRefcon())"/>
+          <outline text="target.set(@workspace.o2)"/>
+          <outline text="op.setCursor(cursor2)"/>
+          <outline text="local(refcon2 = op.getRefcon())"/>
+          <outline text="return (refcon1 == 111) and (refcon2 == 222)"/>
+        </outline>
+      </outline>
+      <outline text="stress test - rapid cursor save/restore cycles - Repeatedly save and restore cursor during navigation">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 20">
+            <outline text="op.insert(&quot;Line &quot; + i, down)"/>
+          </outline>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(ok = true)"/>
+          <outline text="for i = 1 to 10">
+            <outline text="local(saved = op.getCursor())"/>
+            <outline text="op.go(down, 5)"/>
+            <outline text="op.setCursor(saved)"/>
+            <outline text="if op.getLineText() != &quot;Line 20&quot;">
+              <outline text="ok = false"/>
+            </outline>
+          </outline>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="stress test - many refcon assignments - Assign refcon to many nodes in large outline">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(false)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 100">
+            <outline text="op.insert(&quot;Node &quot; + i, down)"/>
+            <outline text="op.setRefcon(i * 10)"/>
+          </outline>
+          <outline text="op.setDisplay(true)"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(ok = true)"/>
+          <outline text="for i = 2 to 101">
+            <outline text="op.go(down, 1)"/>
+            <outline text="if op.getRefcon() != ((i - 1) * 10)">
+              <outline text="ok = false"/>
+            </outline>
+          </outline>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="stress test - expansion state with deep nesting - Save and restore expansion state in deeply nested outline">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;L1&quot;, down)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 2 to 10">
+            <outline text="op.insert(&quot;L&quot; + i, right)"/>
+            <outline text="op.expand(1)"/>
+          </outline>
+          <outline text="op.firstSummit()"/>
+          <outline text="local(savedState = op.getExpansionState())"/>
+          <outline text="op.collapse()"/>
+          <outline text="op.setExpansionState(savedState)"/>
+          <outline text="op.go(right, 1)"/>
+          <outline text="return op.level()"/>
+        </outline>
+      </outline>
+      <outline text="error recovery - setCursor after outline deleted - Setting cursor fails gracefully if outline no longer exists">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="target.clear()"/>
+          <outline text="op.setCursor(cursor)"/>
+        </outline>
+      </outline>
+      <outline text="error recovery - getDisplay with no target - State queries fail gracefully without target">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="error recovery - setRefcon with no current node - Setting refcon on empty outline should fail">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setRefcon(100)"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setCursor with invalid cursor returns false - setCursor returns false when given a cursor that can't be set">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.setCursor(12345)"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setDisplay with non-boolean coerces to boolean - setDisplay coerces non-boolean types via UserTalk type coercion (1 -&gt; true)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.setDisplay(1);  /* UserTalk coerces 1 to true */"/>
+          <outline text="return op.getDisplay()"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setExpansionState requires list of numbers - setExpansionState takes a list of line numbers (coercion error for string)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.setExpansionState(&quot;not a list&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setScrollState is noop in headless - setScrollState returns true and does nothing in headless mode (scroll state is visual)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.setScrollState(42)"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setRefcon accepts any type (boolean) - setRefcon can store boolean values (round-trip test)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(true)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setRefcon accepts any type (string) - setRefcon can store string values (round-trip test)">
+        <outline text="Metadata">
+          <outline text="expected_result: test string"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(&quot;test string&quot;)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setRefcon accepts any type (long) - setRefcon can store long values (round-trip test)">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(42)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="type safety - setRefcon accepts any type (double) - setRefcon can store double values (round-trip test)">
+        <outline text="Metadata">
+          <outline text="expected_result: 3.14159"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="op.setRefcon(3.14159)"/>
+          <outline text="return op.getRefcon()"/>
+        </outline>
+      </outline>
+      <outline text="return type - getCursor returns address - Verify getCursor return type is longType (1-based line number)">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="return typeof(cursor)"/>
+        </outline>
+      </outline>
+      <outline text="return type - getDisplay returns boolean - Verify getDisplay return type is booleanType">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(display = op.getDisplay())"/>
+          <outline text="return typeof(display)"/>
+        </outline>
+      </outline>
+      <outline text="return type - getExpansionState returns address - Verify getExpansionState return type is listType">
+        <outline text="Metadata">
+          <outline text="expected_result: list"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="return typeof(state)"/>
+        </outline>
+      </outline>
+      <outline text="return type - getScrollState returns address - Verify getScrollState return type is longType (1-based line number)">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(state = op.getScrollState())"/>
+          <outline text="return typeof(state)"/>
+        </outline>
+      </outline>
+      <outline text="return type - getRefcon returns long - Verify getRefcon return type is longType">
+        <outline text="Metadata">
+          <outline text="expected_result: long"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(refcon = op.getRefcon())"/>
+          <outline text="return typeof(refcon)"/>
+        </outline>
+      </outline>
+      <outline text="return type - setCursor returns boolean - Verify setCursor return type is booleanType">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(cursor = op.getCursor())"/>
+          <outline text="local(result = op.setCursor(cursor))"/>
+          <outline text="return typeof(result)"/>
+        </outline>
+      </outline>
+      <outline text="return type - setDisplay returns boolean - Verify setDisplay return type is booleanType">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="local(result = op.setDisplay(false))"/>
+          <outline text="return typeof(result)"/>
+        </outline>
+      </outline>
+      <outline text="return type - setExpansionState returns boolean - Verify setExpansionState return type is booleanType">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(state = op.getExpansionState())"/>
+          <outline text="local(result = op.setExpansionState(state))"/>
+          <outline text="return typeof(result)"/>
+        </outline>
+      </outline>
+      <outline text="return type - setScrollState returns boolean - Verify setScrollState return type is booleanType">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(state = op.getScrollState())"/>
+          <outline text="local(result = op.setScrollState(state))"/>
+          <outline text="return typeof(result)"/>
+        </outline>
+      </outline>
+      <outline text="return type - setRefcon returns boolean - Verify setRefcon return type is booleanType">
+        <outline text="Metadata">
+          <outline text="expected_result: bool"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="local(result = op.setRefcon(100))"/>
+          <outline text="return typeof(result)"/>
+        </outline>
+      </outline>
+      <outline text="op.subsexpanded - check expansion state (not expanded) - Verify op.subsexpanded returns false when node has no children">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="return op.subsexpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.subsexpanded - check expansion state (collapsed) - Verify op.subsexpanded returns false when children are collapsed">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.collapse()"/>
+          <outline text="return op.subsexpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.subsexpanded - check expansion state (expanded) - Verify op.subsexpanded returns true when children are expanded">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Child1&quot;, right)"/>
+          <outline text="op.insert(&quot;Child2&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.expand(1)"/>
+          <outline text="return op.subsexpanded()"/>
+        </outline>
+      </outline>
+      <outline text="op.sort - sort siblings alphabetically - Verify op.sort orders sibling nodes alphabetically">
+        <outline text="Metadata">
+          <outline text="expected_result: Alice"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Charlie&quot;, down)"/>
+          <outline text="op.insert(&quot;Alice&quot;, down)"/>
+          <outline text="op.insert(&quot;Bob&quot;, down)"/>
+          <outline text="op.insert(&quot;David&quot;, down)"/>
+          <outline text="op.sort()"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.go(down, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.sort - sort preserves subheads - Verify op.sort keeps children with their parents after sorting">
+        <outline text="Metadata">
+          <outline text="expected_result: Apple,Apple-Child"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Zebra&quot;, down)"/>
+          <outline text="op.insert(&quot;Zebra-Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.insert(&quot;Apple&quot;, down)"/>
+          <outline text="op.insert(&quot;Apple-Child&quot;, right)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.sort()"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.go(down, 1)"/>
+          <outline text="local(parent = op.getLineText())"/>
+          <outline text="op.go(right, 1)"/>
+          <outline text="local(child = op.getLineText())"/>
+          <outline text="return parent + &quot;,&quot; + child"/>
+        </outline>
+      </outline>
+      <outline text="op.sort - sort only siblings at same level - Verify op.sort doesn't sort children, only siblings">
+        <outline text="Metadata">
+          <outline text="expected_result: Zebra"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Parent&quot;, down)"/>
+          <outline text="op.insert(&quot;Zebra&quot;, right)"/>
+          <outline text="op.insert(&quot;Apple&quot;, down)"/>
+          <outline text="op.insert(&quot;Middle&quot;, down)"/>
+          <outline text="op.go(left, 1)"/>
+          <outline text="op.sort()"/>
+          <outline text="op.firstSummit()"/>
+          <outline text="op.go(down, 1)"/>
+          <outline text="op.go(right, 1)"/>
+          <outline text="return op.getLineText()"/>
+        </outline>
+      </outline>
+      <outline text="op.hoist - GUI-only operation returns error - Verify op.hoist returns false in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.hoist()"/>
+        </outline>
+      </outline>
+      <outline text="op.dehoist - GUI-only operation returns error - Verify op.dehoist returns false in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.dehoist()"/>
+        </outline>
+      </outline>
+      <outline text="op.flatcursorkeys - noop returns success - Verify op.flatcursorkeys returns true (noop) in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.flatcursorkeys(true)"/>
+        </outline>
+      </outline>
+      <outline text="op.tabkeyreorg - noop returns success - Verify op.tabkeyreorg returns true (noop) in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.tabkeyreorg(true)"/>
+        </outline>
+      </outline>
+      <outline text="op.visitall - verify verb exists (functional test deferred) - Verify op.visitall exists and is not stubbed (doesn't test actual visiting behavior)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+          <outline text="notes: Full functional test of visiting behavior deferred - requires pre-stored callback script infrastructure"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line 1&quot;, down)"/>
+          <outline text="return true"/>
+        </outline>
+      </outline>
+      <outline text="op.sethtmlformatting - noop returns false - Verify op.sethtmlformatting returns false (noop) in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.sethtmlformatting(true)"/>
+        </outline>
+      </outline>
+      <outline text="op.gethtmlformatting - noop returns false - Verify op.gethtmlformatting returns false (noop) in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.gethtmlformatting()"/>
+        </outline>
+      </outline>
+      <outline text="op.setdynamic - noop returns false - Verify op.setdynamic returns false (noop) in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.setdynamic(true)"/>
+        </outline>
+      </outline>
+      <outline text="op.getdynamic - noop returns false - Verify op.getdynamic returns false (noop) in headless mode">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(outlineType, @workspace.outline)"/>
+          <outline text="target.set(@workspace.outline)"/>
+          <outline text="op.insert(&quot;Line&quot;, down)"/>
+          <outline text="return op.getdynamic()"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Runtime Parameter State (runtime_parameter_state)">
+      <outline text="Runtime: Parameter state - basic if condition evaluation - Verify parameter state is correctly maintained during if condition evaluation">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(x = 1)"/>
+          <outline text="if (x == 1)">
+            <outline text="return true"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - sequential local assignments - Verify parameter state resets correctly between sequential local() declarations in if body">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (true)">
+            <outline text="local(x = 1)"/>
+            <outline text="local(y = 2)"/>
+            <outline text="local(z = x + y)"/>
+            <outline text="return z"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - multiple sequential if statements - Verify parameter state is isolated between separate if statement blocks">
+        <outline text="Metadata">
+          <outline text="expected_result: 10"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (true)">
+            <outline text="local(x = 10)"/>
+            <outline text="return x"/>
+          </outline>
+          <outline text="if (true)">
+            <outline text="local(x = 20)"/>
+            <outline text="return x"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - nested if statements (2 levels) - CRITICAL: Verify parameter state isolation across nested if contexts">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (true)">
+            <outline text="local(x = 1)"/>
+            <outline text="if (true)">
+              <outline text="local(y = 2)"/>
+              <outline text="return x + y"/>
+            </outline>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - nested if statements (3 levels) - CRITICAL: Verify parameter state isolation with deep nesting">
+        <outline text="Metadata">
+          <outline text="expected_result: 6"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (true)">
+            <outline text="local(a = 1)"/>
+            <outline text="if (true)">
+              <outline text="local(b = 2)"/>
+              <outline text="if (true)">
+                <outline text="local(c = 3)"/>
+                <outline text="return a + b + c"/>
+              </outline>
+            </outline>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - if after verb call (string.length) - Verify parameter state resets when entering if after verb call">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(result = string.length(&quot;test&quot;))"/>
+          <outline text="if (result == 4)">
+            <outline text="local(newval = result + 1)"/>
+            <outline text="return newval"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - sequential verbs then if - Verify parameter state resets after multiple sequential verb calls before entering if">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(len1 = string.length(&quot;hello&quot;))"/>
+          <outline text="local(len2 = string.length(&quot;hi&quot;))"/>
+          <outline text="if ((len1 + len2) == 7)">
+            <outline text="return true"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - verb in if condition, verb in body - CRITICAL: Validates fix for ADR-005 issue where verb in condition corrupted verb in body. Pattern: if (verb1()) { verb2(); }">
+        <outline text="Metadata">
+          <outline text="expected_result: TEST"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(str = &quot;test&quot;)"/>
+          <outline text="if (string.length(str) == 4)">
+            <outline text="local(upper = string.upper(str))"/>
+            <outline text="return upper"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - sequential verbs in if body - CRITICAL: Verify parameter state resets between sequential verb calls within same if body">
+        <outline text="Metadata">
+          <outline text="expected_result: 5HELLO"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (true)">
+            <outline text="local(len = string.length(&quot;hello&quot;))"/>
+            <outline text="local(upper = string.upper(&quot;hello&quot;))"/>
+            <outline text="return len + upper"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - complex expression in if condition - CRITICAL: Verify parameter state maintained through complex multi-verb condition expressions">
+        <outline text="Metadata">
+          <outline text="expected_result: TEST"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if ((string.length(&quot;a&quot;) == 1) &amp;&amp; (string.length(&quot;bb&quot;) == 2))">
+            <outline text="local(result = string.upper(&quot;test&quot;))"/>
+            <outline text="return result"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - nested if with verbs at each level - CRITICAL: Verify parameter state isolation when verbs are called at different nesting levels">
+        <outline text="Metadata">
+          <outline text="expected_result: XY"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (string.length(&quot;a&quot;) == 1)">
+            <outline text="local(x = string.upper(&quot;x&quot;))"/>
+            <outline text="if (string.length(&quot;bb&quot;) == 2)">
+              <outline text="local(y = string.upper(&quot;y&quot;))"/>
+              <outline text="return x + y"/>
+            </outline>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - if/else parameter isolation - Verify parameter state isolation in if/else branches">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (false)">
+            <outline text="local(x = 1)"/>
+            <outline text="return x"/>
+          </outline>
+          <outline text="else">
+            <outline text="local(x = 2)"/>
+            <outline text="return x"/>
+          </outline>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - verb in if condition, different verb in else - Verify parameter state isolation between if condition verb and else body verb">
+        <outline text="Metadata">
+          <outline text="expected_result: TEST"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (string.length(&quot;test&quot;) == 5)">
+            <outline text="return &quot;no&quot;"/>
+          </outline>
+          <outline text="else">
+            <outline text="local(result = string.upper(&quot;test&quot;))"/>
+            <outline text="return result"/>
+          </outline>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - outer scope variable access in nested if - Verify that variables from outer scope are accessible in nested if contexts (correct scoping)">
+        <outline text="Metadata">
+          <outline text="expected_result: 15"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(outer = 10)"/>
+          <outline text="if (true)">
+            <outline text="local(inner = 5)"/>
+            <outline text="if (true)">
+              <outline text="return outer + inner"/>
+            </outline>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - verb result stored then used in condition - Verify parameter state correct when verb result is stored and later used in if condition">
+        <outline text="Metadata">
+          <outline text="expected_result: HELLO"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(len = string.length(&quot;hello&quot;))"/>
+          <outline text="if (len &gt; 4)">
+            <outline text="local(upper = string.upper(&quot;hello&quot;))"/>
+            <outline text="return upper"/>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - code after if statement executes correctly - Verify parameter state isolation prevents if statement from affecting code that follows">
+        <outline text="Metadata">
+          <outline text="expected_result: 1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (true)">
+            <outline text="local(x = 1)"/>
+            <outline text="return x"/>
+          </outline>
+          <outline text="local(y = 2)"/>
+          <outline text="return y"/>
+        </outline>
+      </outline>
+      <outline text="Runtime: Parameter state - multiple sequential if conditions with verbs - Verify parameter state isolation when multiple if statements with verb conditions execute sequentially">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="if (string.length(&quot;a&quot;) == 1)">
+            <outline text="if (string.length(&quot;bb&quot;) == 2)">
+              <outline text="if (string.length(&quot;ccc&quot;) == 3)">
+                <outline text="return true"/>
+              </outline>
+            </outline>
+          </outline>
+          <outline text="return false"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="String Verbs (string_verbs)">
+      <outline text="string.length - simple string - Get length of a simple string">
+        <outline text="Metadata">
+          <outline text="expected_result: 5"/>
+          <outline text="expected_result_type: string"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.length(&quot;hello&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.length - empty string - Get length of empty string">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.length(&quot;&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.upper - basic case - Convert string to uppercase">
+        <outline text="Metadata">
+          <outline text="expected_result: HELLO"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.upper(&quot;hello&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.lower - basic case - Convert string to lowercase">
+        <outline text="Metadata">
+          <outline text="expected_result: world"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.lower(&quot;WORLD&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.nthCharacter - first char - Get first character of string">
+        <outline text="Metadata">
+          <outline text="expected_result: h"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.nthCharacter(&quot;hello&quot;, 1)"/>
+        </outline>
+      </outline>
+      <outline text="string.nthCharacter - last char - Get last character of string">
+        <outline text="Metadata">
+          <outline text="expected_result: o"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.nthCharacter(&quot;hello&quot;, 5)"/>
+        </outline>
+      </outline>
+      <outline text="string concatenation with + - Concatenate two strings using +">
+        <outline text="Metadata">
+          <outline text="expected_result: hello world"/>
+        </outline>
+        <outline text="Script">
+          <outline text="&quot;hello&quot; + &quot; &quot; + &quot;world&quot;"/>
+        </outline>
+      </outline>
+      <outline text="string equality - true case - Compare equal strings">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="&quot;test&quot; == &quot;test&quot;"/>
+        </outline>
+      </outline>
+      <outline text="string equality - false case - Compare different strings">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="&quot;test&quot; == &quot;other&quot;"/>
+        </outline>
+      </outline>
+      <outline text="string.mid - extract substring - Extract middle substring">
+        <outline text="Metadata">
+          <outline text="expected_result: world"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.mid(&quot;hello world&quot;, 7, 5)"/>
+        </outline>
+      </outline>
+      <outline text="string.mid - from beginning - Extract from beginning">
+        <outline text="Metadata">
+          <outline text="expected_result: hello"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.mid(&quot;hello world&quot;, 1, 5)"/>
+        </outline>
+      </outline>
+      <outline text="string.patternMatch - found - Find pattern in string">
+        <outline text="Metadata">
+          <outline text="expected_result: 7"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.patternMatch(&quot;world&quot;, &quot;hello world&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.patternMatch - not found - Pattern not found returns 0">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.patternMatch(&quot;xyz&quot;, &quot;hello world&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.trimWhitespace - both sides - Trim whitespace from both sides">
+        <outline text="Metadata">
+          <outline text="expected_result: hello"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.trimWhitespace(&quot;  hello  &quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.trimWhitespace - no whitespace - String with no whitespace unchanged">
+        <outline text="Metadata">
+          <outline text="expected_result: hello"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.trimWhitespace(&quot;hello&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.length - unicode characters - Length with unicode chars (UTF-8 encoding test)">
+        <outline text="Metadata">
+          <outline text="expected_result: 9"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.length(&quot;hello🎉&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="empty string operations - Operations on empty string">
+        <outline text="Metadata">
+          <outline text="expected_result: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.upper(&quot;&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="string.nthCharacter - index out of bounds - Access character beyond string length">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.nthCharacter(&quot;hello&quot;, 10)"/>
+        </outline>
+      </outline>
+      <outline text="string.mid - invalid range - Extract substring with invalid range">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="string.mid(&quot;hello&quot;, 10, 5)"/>
+        </outline>
+      </outline>
+      <outline text="string.numberToString - positive integer - Convert positive number to string">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string(42)"/>
+        </outline>
+      </outline>
+      <outline text="string.numberToString - negative integer - Convert negative number to string">
+        <outline text="Metadata">
+          <outline text="expected_result: -42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.string(-42)"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Table Sorting Verbs (table_sorting_verbs)">
+      <outline text="table.sortby - sort by name (default) - Sort table by name column">
+        <outline text="Metadata">
+          <outline text="expected_result: name"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.zebra = &quot;last&quot;"/>
+          <outline text="t.alpha = &quot;first&quot;"/>
+          <outline text="t.middle = &quot;mid&quot;"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;name&quot;)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - sort by value - Sort table by value column">
+        <outline text="Metadata">
+          <outline text="expected_result: value"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = &quot;zzz&quot;"/>
+          <outline text="t.b = &quot;aaa&quot;"/>
+          <outline text="t.c = &quot;mmm&quot;"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;value&quot;)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - sort by kind - Sort table by kind (type) column">
+        <outline text="Metadata">
+          <outline text="expected_result: kind"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.x = 123"/>
+          <outline text="t.y = &quot;string&quot;"/>
+          <outline text="t.z = true"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;kind&quot;)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - case insensitive NAME - Column names should be case-insensitive">
+        <outline text="Metadata">
+          <outline text="expected_result: name"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;NAME&quot;)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - case insensitive VaLuE - Mixed case should work">
+        <outline text="Metadata">
+          <outline text="expected_result: value"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;VaLuE&quot;)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - case insensitive kind - Lowercase should work">
+        <outline text="Metadata">
+          <outline text="expected_result: kind"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;kind&quot;)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.getsortorder - default is name - New tables default to sorting by name">
+        <outline text="Metadata">
+          <outline text="expected_result: name"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="return table.getsortorder()"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - multiple sequential sorts - Changing sort order multiple times should work">
+        <outline text="Metadata">
+          <outline text="expected_result: name,value,kind"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;name&quot;)"/>
+          <outline text="local(order1 = table.getsortorder())"/>
+          <outline text="table.sortby(&quot;value&quot;)"/>
+          <outline text="local(order2 = table.getsortorder())"/>
+          <outline text="table.sortby(&quot;kind&quot;)"/>
+          <outline text="local(order3 = table.getsortorder())"/>
+          <outline text="return order1 + &quot;,&quot; + order2 + &quot;,&quot; + order3"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - invalid column name - Invalid column name should fail">
+        <outline text="Metadata">
+          <outline text="expected_result: ERROR_CAUGHT"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="try">
+            <outline text="table.sortby(&quot;invalid&quot;)"/>
+            <outline text="return &quot;SHOULD_HAVE_FAILED&quot;"/>
+          </outline>
+          <outline text="else">
+            <outline text="return &quot;ERROR_CAUGHT&quot;"/>
+          </outline>
+        </outline>
+      </outline>
+      <outline text="table.sortby - no target set - Sorting without a target should fail">
+        <outline text="Metadata">
+          <outline text="expected_result: ERROR_CAUGHT"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.cleartarget()"/>
+          <outline text="try">
+            <outline text="table.sortby(&quot;name&quot;)"/>
+            <outline text="return &quot;SHOULD_HAVE_FAILED&quot;"/>
+          </outline>
+          <outline text="else">
+            <outline text="return &quot;ERROR_CAUGHT&quot;"/>
+          </outline>
+        </outline>
+      </outline>
+      <outline text="lang.settarget - set table as target - Set a table as the current target">
+        <outline text="Metadata">
+          <outline text="expected_result: table1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t1)"/>
+          <outline text="lang.new(tableType, @t2)"/>
+          <outline text="lang.settarget(@t1)"/>
+          <outline text="t1.marker = &quot;table1&quot;"/>
+          <outline text="return t1.marker"/>
+        </outline>
+      </outline>
+      <outline text="lang.gettarget - retrieve current target - Get the current target table address (must dereference with ^)">
+        <outline text="Metadata">
+          <outline text="expected_result: test_table"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.identifier = &quot;test_table&quot;"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="local(target = lang.gettarget())"/>
+          <outline text="return target^.identifier"/>
+        </outline>
+      </outline>
+      <outline text="lang.cleartarget - verify target cleared but table still current - lang.cleartarget() clears target but table remains in selection context">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="lang.cleartarget()"/>
+          <outline text="return (lang.gettarget() == nil) and table.sortby(&quot;name&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="lang.settarget - switch between tables - Switch target between multiple tables">
+        <outline text="Metadata">
+          <outline text="expected_result: first,second"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t1)"/>
+          <outline text="lang.new(tableType, @t2)"/>
+          <outline text="t1.name = &quot;first&quot;"/>
+          <outline text="t2.name = &quot;second&quot;"/>
+          <outline text="lang.settarget(@t1)"/>
+          <outline text="local(val1 = lang.gettarget()^.name)"/>
+          <outline text="lang.settarget(@t2)"/>
+          <outline text="local(val2 = lang.gettarget()^.name)"/>
+          <outline text="return val1 + &quot;,&quot; + val2"/>
+        </outline>
+      </outline>
+      <outline text="table.sortby - with explicit target - Combine target setting and sorting">
+        <outline text="Metadata">
+          <outline text="expected_result: name"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.z = 3"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.m = 2"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;name&quot;)"/>
+          <outline text="local(order = table.getsortorder())"/>
+          <outline text="return order"/>
+        </outline>
+      </outline>
+      <outline text="table.getsortorder - persists after setting - Sort order should persist">
+        <outline text="Metadata">
+          <outline text="expected_result: value,kind"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.settarget(@t)"/>
+          <outline text="table.sortby(&quot;value&quot;)"/>
+          <outline text="local(order1 = table.getsortorder())"/>
+          <outline text="table.sortby(&quot;kind&quot;)"/>
+          <outline text="local(order2 = table.getsortorder())"/>
+          <outline text="return order1 + &quot;,&quot; + order2"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Table Verbs (table_verbs)">
+      <outline text="table.assign - simple assignment - Assign a value to a table element">
+        <outline text="Metadata">
+          <outline text="expected_result: value1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="table.assign(@t.key1, &quot;value1&quot;)"/>
+          <outline text="return t.key1"/>
+        </outline>
+      </outline>
+      <outline text="table.assign - numeric value - Assign numeric value to table element">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="table.assign(@t.count, 42)"/>
+          <outline text="return t.count"/>
+        </outline>
+      </outline>
+      <outline text="table.assign - boolean value - Assign boolean to table element">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="table.assign(@t.flag, true)"/>
+          <outline text="return t.flag"/>
+        </outline>
+      </outline>
+      <outline text="table.assign - overwrite existing - Overwriting existing value should work">
+        <outline text="Metadata">
+          <outline text="expected_result: new"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.key1 = &quot;old&quot;"/>
+          <outline text="table.assign(@t.key1, &quot;new&quot;)"/>
+          <outline text="return t.key1"/>
+        </outline>
+      </outline>
+      <outline text="table.goto - navigate to row by number - Move cursor to specific row number">
+        <outline text="Metadata">
+          <outline text="expected_result: b"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.b = 2"/>
+          <outline text="t.c = 3"/>
+          <outline text="table.goto(2)"/>
+          <outline text="return table.getcursor()"/>
+        </outline>
+      </outline>
+      <outline text="table.goto - first row - Navigate to first row (row 1)">
+        <outline text="Metadata">
+          <outline text="expected_result: a"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.b = 2"/>
+          <outline text="t.c = 3"/>
+          <outline text="table.goto(1)"/>
+          <outline text="return table.getcursor()"/>
+        </outline>
+      </outline>
+      <outline text="table.goto - last row - Navigate to last row">
+        <outline text="Metadata">
+          <outline text="expected_result: c"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.b = 2"/>
+          <outline text="t.c = 3"/>
+          <outline text="table.goto(3)"/>
+          <outline text="return table.getcursor()"/>
+        </outline>
+      </outline>
+      <outline text="table.getcursor - no prior goto - Get cursor without prior navigation returns empty">
+        <outline text="Metadata">
+          <outline text="expected_result: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.first = 1"/>
+          <outline text="return table.getcursor()"/>
+        </outline>
+      </outline>
+      <outline text="table.getcursor - after adding items - Cursor without navigation returns empty">
+        <outline text="Metadata">
+          <outline text="expected_result: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.b = 2"/>
+          <outline text="t.c = 3"/>
+          <outline text="return table.getcursor()"/>
+        </outline>
+      </outline>
+      <outline text="table.emptytable - clear contents - Empty table removes all items">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.b = 2"/>
+          <outline text="t.c = 3"/>
+          <outline text="table.emptytable(@t)"/>
+          <outline text="return sizeof(t)"/>
+        </outline>
+      </outline>
+      <outline text="table.emptytable - already empty - Emptying an already empty table">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="table.emptytable(@t)"/>
+          <outline text="return sizeof(t)"/>
+        </outline>
+      </outline>
+      <outline text="pack table - simple table - Pack table to binary using pack() builtin">
+        <outline text="Metadata">
+          <outline text="expected_result: data"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="t.b = &quot;test&quot;"/>
+          <outline text="pack(t, @packedData)"/>
+          <outline text="return typeof(packedData)"/>
+        </outline>
+      </outline>
+      <outline text="pack table - empty table - Packing empty table returns binary data">
+        <outline text="Metadata">
+          <outline text="expected_result: data"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="pack(t, @packedData)"/>
+          <outline text="return typeof(packedData)"/>
+        </outline>
+      </outline>
+      <outline text="pack table - complex table with multiple types - Verify pack() works with tables containing multiple value types">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.number = 42"/>
+          <outline text="t.string = &quot;hello&quot;"/>
+          <outline text="t.bool = true"/>
+          <outline text="t.float = 3.14"/>
+          <outline text="pack(t, @packed)"/>
+          <outline text="local(ok = (typeof(packed) == &quot;data&quot;) and (sizeof(packed) &gt; 0))"/>
+          <outline text="return ok"/>
+        </outline>
+      </outline>
+      <outline text="table.goto - invalid row (zero) - Row 0 is invalid">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="return table.goto(0)"/>
+        </outline>
+      </outline>
+      <outline text="table.goto - out of bounds - Row beyond table size">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="t.a = 1"/>
+          <outline text="return table.goto(10)"/>
+        </outline>
+      </outline>
+      <outline text="table.assign - nil table - Assigning to nil table should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="return table.assign(@t.key, &quot;value&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="sizeof after table.assign - Table size increases after assignment">
+        <outline text="Metadata">
+          <outline text="expected_result: 2"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="table.assign(@t.key1, 1)"/>
+          <outline text="table.assign(@t.key2, 2)"/>
+          <outline text="return sizeof(t)"/>
+        </outline>
+      </outline>
+      <outline text="table.assign with nested table - Assign a table as value">
+        <outline text="Metadata">
+          <outline text="expected_result: 10"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @t)"/>
+          <outline text="lang.new(tableType, @nested)"/>
+          <outline text="nested.x = 10"/>
+          <outline text="table.assign(@t.sub, nested)"/>
+          <outline text="return t.sub.x"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Target Verbs (target_verbs)">
+      <outline text="target.get - no target set returns nil - When no explicit target is set, target.get() returns nil (no implicit target in headless)">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.get - no target set (initial state) - On fresh execution with no prior target.set(), target.get() returns nil">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.set - simple table - Set a table as target and verify it was set">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.testTarget)"/>
+          <outline text="target.set(@workspace.testTarget)"/>
+          <outline text="return defined(workspace.testTarget)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - returns previous target (nil initially) - target.set() returns previous target value (nil if none was set)">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="lang.new(tableType, @workspace.t1)"/>
+          <outline text="return typeof(target.set(@workspace.t1))"/>
+        </outline>
+      </outline>
+      <outline text="target.set - returns previous target (non-nil) - target.set() returns previous target when one was set">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.t1"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t1)"/>
+          <outline text="lang.new(tableType, @workspace.t2)"/>
+          <outline text="target.set(@workspace.t1)"/>
+          <outline text="local(prev = target.set(@workspace.t2))"/>
+          <outline text="return string(prev)"/>
+        </outline>
+      </outline>
+      <outline text="target.get - returns set target - After target.set(), target.get() returns the address that was set">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.myTarget"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.myTarget)"/>
+          <outline text="target.set(@workspace.myTarget)"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.get - returns addresstype - target.get() returns an address type when target is set">
+        <outline text="Metadata">
+          <outline text="expected_result: addr"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.targetTable)"/>
+          <outline text="target.set(@workspace.targetTable)"/>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.get - persists across operations - Target persists across multiple operations until explicitly changed">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.persistent)"/>
+          <outline text="target.set(@workspace.persistent)"/>
+          <outline text="local(first = string(target.get()))"/>
+          <outline text="local(second = string(target.get()))"/>
+          <outline text="return first == second"/>
+        </outline>
+      </outline>
+      <outline text="target.clear - clears set target - After target.clear(), target.get() returns nil">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t)"/>
+          <outline text="target.set(@workspace.t)"/>
+          <outline text="target.clear()"/>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.clear - returns boolean true on success - target.clear() returns true when successful">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t)"/>
+          <outline text="target.set(@workspace.t)"/>
+          <outline text="return target.clear()"/>
+        </outline>
+      </outline>
+      <outline text="target.clear - idempotent (multiple clears) - Clearing an already-clear target returns false (no target to clear)">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="return target.clear()"/>
+        </outline>
+      </outline>
+      <outline text="target.clear - when no target set - Clearing when no target is set should succeed (idempotent)">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="target.clear()"/>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target workflow - full cycle - Complete workflow: clear → set → get → verify → clear → verify">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="lang.new(tableType, @workspace.cycleTest)"/>
+          <outline text="workspace.cycleTest.value = 42"/>
+          <outline text="target.set(@workspace.cycleTest)"/>
+          <outline text="local(retrieved = string(target.get()))"/>
+          <outline text="local(ok1 = retrieved == &quot;workspace.cycleTest&quot;)"/>
+          <outline text="target.clear()"/>
+          <outline text="local(ok2 = typeof(target.get()) == &quot;????&quot;)"/>
+          <outline text="return ok1 and ok2"/>
+        </outline>
+      </outline>
+      <outline text="target workflow - multiple set operations - Setting different targets in sequence works correctly">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.target1)"/>
+          <outline text="lang.new(tableType, @workspace.target2)"/>
+          <outline text="lang.new(tableType, @workspace.target3)"/>
+          <outline text="target.set(@workspace.target1)"/>
+          <outline text="local(ok1 = string(target.get()) == &quot;workspace.target1&quot;)"/>
+          <outline text="target.set(@workspace.target2)"/>
+          <outline text="local(ok2 = string(target.get()) == &quot;workspace.target2&quot;)"/>
+          <outline text="target.set(@workspace.target3)"/>
+          <outline text="local(ok3 = string(target.get()) == &quot;workspace.target3&quot;)"/>
+          <outline text="return ok1 and ok2 and ok3"/>
+        </outline>
+      </outline>
+      <outline text="target.set - nested table - Set a nested table as target">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.parent.child"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.parent)"/>
+          <outline text="lang.new(tableType, @workspace.parent.child)"/>
+          <outline text="target.set(@workspace.parent.child)"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.set - deeply nested table - Set a deeply nested table as target">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.level1.level2.level3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.level1)"/>
+          <outline text="lang.new(tableType, @workspace.level1.level2)"/>
+          <outline text="lang.new(tableType, @workspace.level1.level2.level3)"/>
+          <outline text="target.set(@workspace.level1.level2.level3)"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target operations - read from target - After setting target, can read values from the target table">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.data)"/>
+          <outline text="workspace.data.key = &quot;testValue&quot;"/>
+          <outline text="target.set(@workspace.data)"/>
+          <outline text="local(targetAddr = target.get())"/>
+          <outline text="return defined(workspace.data.key)"/>
+        </outline>
+      </outline>
+      <outline text="target operations - modify target contents - Can modify contents of table that is set as target">
+        <outline text="Metadata">
+          <outline text="expected_result: 100"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.mutable)"/>
+          <outline text="target.set(@workspace.mutable)"/>
+          <outline text="workspace.mutable.field = 100"/>
+          <outline text="return workspace.mutable.field"/>
+        </outline>
+      </outline>
+      <outline text="target operations - target persists after modification - Modifying target contents doesn't affect target itself">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.stable"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.stable)"/>
+          <outline text="target.set(@workspace.stable)"/>
+          <outline text="workspace.stable.x = 1"/>
+          <outline text="workspace.stable.y = 2"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.get - no parameters - target.get() takes no parameters (zero parameters valid)">
+        <outline text="Script">
+          <outline text="typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.get - extra parameters should fail - target.get() with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.get(123)"/>
+        </outline>
+      </outline>
+      <outline text="target.clear - no parameters - target.clear() takes no parameters, returns false when no target set">
+        <outline text="Metadata">
+          <outline text="expected_result: false"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+        </outline>
+      </outline>
+      <outline text="target.clear - extra parameters should fail - target.clear() with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear(123)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - no parameters - target.set() requires exactly one parameter (address)">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.set()"/>
+        </outline>
+      </outline>
+      <outline text="target.set - extra parameters should fail - target.set() with extra parameters should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t)"/>
+          <outline text="target.set(@workspace.t, &quot;extra&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - undefined variable address - Setting target to undefined variable should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.set(@workspace.doesNotExist)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - non-address type (string) - Setting target with non-address type should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.set(&quot;not an address&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - non-address type (number) - Setting target with numeric value should error">
+        <outline text="Metadata">
+          <outline text="expected_success: False"/>
+          <outline text="expected_error_type: script_error"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.set(42)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - nil value clears target - Setting target to nil/noval should clear the target">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t)"/>
+          <outline text="target.set(@workspace.t)"/>
+          <outline text="local(x)"/>
+          <outline text="target.set(@x)"/>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target.set - table with string value - Set target to table containing string value">
+        <outline text="Metadata">
+          <outline text="expected_result: Hello World"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.stringTable)"/>
+          <outline text="workspace.stringTable.text = &quot;Hello World&quot;"/>
+          <outline text="target.set(@workspace.stringTable)"/>
+          <outline text="return workspace.stringTable.text"/>
+        </outline>
+      </outline>
+      <outline text="target.set - table with numeric value - Set target to table containing numeric value">
+        <outline text="Metadata">
+          <outline text="expected_result: 999"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.numTable)"/>
+          <outline text="workspace.numTable.count = 999"/>
+          <outline text="target.set(@workspace.numTable)"/>
+          <outline text="return workspace.numTable.count"/>
+        </outline>
+      </outline>
+      <outline text="target.set - table with boolean value - Set target to table containing boolean value">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.boolTable)"/>
+          <outline text="workspace.boolTable.flag = true"/>
+          <outline text="target.set(@workspace.boolTable)"/>
+          <outline text="return workspace.boolTable.flag"/>
+        </outline>
+      </outline>
+      <outline text="target.set - empty table - Set target to empty table (no entries)">
+        <outline text="Metadata">
+          <outline text="expected_result: 0"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.emptyTable)"/>
+          <outline text="target.set(@workspace.emptyTable)"/>
+          <outline text="return sizeof(workspace.emptyTable)"/>
+        </outline>
+      </outline>
+      <outline text="target.set - table with nested tables - Set target to table containing nested tables">
+        <outline text="Metadata">
+          <outline text="expected_result: 42"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.outer)"/>
+          <outline text="lang.new(tableType, @workspace.outer.inner)"/>
+          <outline text="workspace.outer.inner.value = 42"/>
+          <outline text="target.set(@workspace.outer)"/>
+          <outline text="return workspace.outer.inner.value"/>
+        </outline>
+      </outline>
+      <outline text="target lifecycle - delete target clears it - Deleting the target variable clears the target as a side-effect (legacy behavior)">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.temporary)"/>
+          <outline text="target.set(@workspace.temporary)"/>
+          <outline text="lang.delete(@workspace.temporary)"/>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="target persistence - across multiple scripts - Target set in one operation persists for next operation">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.persist"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.persist)"/>
+          <outline text="workspace.persist.value = &quot;persistent&quot;"/>
+          <outline text="target.set(@workspace.persist)"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="headless behavior - no implicit target from windows - In headless mode, no implicit target fallback (GUI-specific feature)">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="target.clear()"/>
+          <outline text="local(result = target.get())"/>
+          <outline text="return typeof(result)"/>
+        </outline>
+      </outline>
+      <outline text="headless behavior - target.set always succeeds (no window open failure) - In headless, target.set() never fails due to window opening (no windows exist)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.headlessTarget)"/>
+          <outline text="target.set(@workspace.headlessTarget)"/>
+          <outline text="return typeof(target.get()) == &quot;addr&quot;"/>
+        </outline>
+      </outline>
+      <outline text="headless behavior - target.clear no window cleanup - In headless, target.clear() doesn't close hidden windows (no windows exist)">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t)"/>
+          <outline text="target.set(@workspace.t)"/>
+          <outline text="local(cleared = target.clear())"/>
+          <outline text="return cleared and (typeof(target.get()) == &quot;????&quot;)"/>
+        </outline>
+      </outline>
+      <outline text="stress test - rapid set/clear cycle - Rapidly setting and clearing target multiple times">
+        <outline text="Metadata">
+          <outline text="expected_result: ????"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.stress)"/>
+          <outline text="local(i)"/>
+          <outline text="for i = 1 to 10">
+            <outline text="target.set(@workspace.stress)"/>
+            <outline text="target.clear()"/>
+          </outline>
+          <outline text="return typeof(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="stress test - many sequential target changes - Setting many different targets in sequence">
+        <outline text="Metadata">
+          <outline text="expected_result: workspace.t5"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.t1)"/>
+          <outline text="lang.new(tableType, @workspace.t2)"/>
+          <outline text="lang.new(tableType, @workspace.t3)"/>
+          <outline text="lang.new(tableType, @workspace.t4)"/>
+          <outline text="lang.new(tableType, @workspace.t5)"/>
+          <outline text="target.set(@workspace.t1)"/>
+          <outline text="target.set(@workspace.t2)"/>
+          <outline text="target.set(@workspace.t3)"/>
+          <outline text="target.set(@workspace.t4)"/>
+          <outline text="target.set(@workspace.t5)"/>
+          <outline text="return string(target.get())"/>
+        </outline>
+      </outline>
+      <outline text="integration - target with sizeof - Get sizeof() on target table">
+        <outline text="Metadata">
+          <outline text="expected_result: 3"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.sized)"/>
+          <outline text="workspace.sized.a = 1"/>
+          <outline text="workspace.sized.b = 2"/>
+          <outline text="workspace.sized.c = 3"/>
+          <outline text="target.set(@workspace.sized)"/>
+          <outline text="return sizeof(workspace.sized)"/>
+        </outline>
+      </outline>
+      <outline text="integration - target with typeof - Get typeof() on target table">
+        <outline text="Metadata">
+          <outline text="expected_result: tabl"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.typed)"/>
+          <outline text="target.set(@workspace.typed)"/>
+          <outline text="return typeof(workspace.typed)"/>
+        </outline>
+      </outline>
+      <outline text="integration - target with defined - Check defined() on target">
+        <outline text="Metadata">
+          <outline text="expected_result: true"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.exists)"/>
+          <outline text="target.set(@workspace.exists)"/>
+          <outline text="return defined(workspace.exists)"/>
+        </outline>
+      </outline>
+      <outline text="integration - target with table.assign - Use table.assign() on target table">
+        <outline text="Metadata">
+          <outline text="expected_result: assigned"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.assign)"/>
+          <outline text="target.set(@workspace.assign)"/>
+          <outline text="table.assign(@workspace.assign.key, &quot;assigned&quot;)"/>
+          <outline text="return workspace.assign.key"/>
+        </outline>
+      </outline>
+      <outline text="integration - target with pack/unpack - Pack target table to binary">
+        <outline text="Metadata">
+          <outline text="expected_result: data"/>
+        </outline>
+        <outline text="Script">
+          <outline text="lang.new(tableType, @workspace.packable)"/>
+          <outline text="workspace.packable.data = &quot;test&quot;"/>
+          <outline text="target.set(@workspace.packable)"/>
+          <outline text="pack(workspace.packable, @packed)"/>
+          <outline text="return typeof(packed)"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="Xml Verbs (xml_verbs)">
+      <outline text="xml.frontiervaluetotaggedtext - simple string">
+        <outline text="Metadata">
+          <outline text="expected_output: hello"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(s = &quot;hello&quot;)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@s, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - string with XML entities">
+        <outline text="Metadata">
+          <outline text="expected_output: a &amp;lt; b &amp;amp; c &amp;gt; d"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(s = &quot;a &lt; b &amp; c &gt; d&quot;)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@s, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - string with quotes">
+        <outline text="Metadata">
+          <outline text="expected_output: say &quot;hello&quot;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(s = &quot;say \&quot;hello\&quot;&quot;)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@s, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - empty string">
+        <outline text="Metadata">
+          <outline text="expected_output: "/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(s = &quot;&quot;)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@s, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - positive integer">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;i4&gt;42&lt;/i4&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(n = 42)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@n, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - negative integer">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;i4&gt;-100&lt;/i4&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(n = -100)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@n, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - zero">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;i4&gt;0&lt;/i4&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(n = 0)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@n, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - boolean true">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;boolean&gt;1&lt;/boolean&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(b = true)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@b, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - boolean false">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;boolean&gt;0&lt;/boolean&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(b = false)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@b, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - double value">
+        <outline text="Metadata">
+          <outline text="expected_pattern: ^&lt;double&gt;3\.14159.*&lt;/double&gt;$"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(d = 3.14159)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@d, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - negative double">
+        <outline text="Metadata">
+          <outline text="expected_pattern: ^&lt;double&gt;-2\.5.*&lt;/double&gt;$"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(d = -2.5)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@d, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - date value">
+        <outline text="Metadata">
+          <outline text="expected_pattern: ^&lt;dateTime\.iso8601&gt;20240115T10:30:00&lt;/dateTime\.iso8601&gt;$"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(dt = date.set(2024, 1, 15, 10, 30, 0))"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@dt, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - simple table">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;struct&gt;', '&lt;member&gt;', '&lt;name&gt;name&lt;/name&gt;', '&lt;value&gt;&lt;string&gt;John&lt;/string&gt;&lt;/value&gt;', '&lt;name&gt;age&lt;/name&gt;', '&lt;value&gt;&lt;i4&gt;30&lt;/i4&gt;&lt;/value&gt;', '&lt;/member&gt;', '&lt;/struct&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="new(tableType, @t)"/>
+          <outline text="t.name = &quot;John&quot;"/>
+          <outline text="t.age = 30"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@t, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - empty table">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;struct&gt;&lt;/struct&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="new(tableType, @t)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@t, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - nested table">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;struct&gt;', '&lt;member&gt;', '&lt;name&gt;address&lt;/name&gt;', '&lt;value&gt;&lt;struct&gt;', '&lt;name&gt;city&lt;/name&gt;', '&lt;value&gt;&lt;string&gt;Boston&lt;/string&gt;&lt;/value&gt;', '&lt;name&gt;zip&lt;/name&gt;', '&lt;value&gt;&lt;i4&gt;2101&lt;/i4&gt;&lt;/value&gt;', '&lt;/struct&gt;&lt;/value&gt;', '&lt;/member&gt;', '&lt;/struct&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="new(tableType, @t)"/>
+          <outline text="new(tableType, @t.address)"/>
+          <outline text="t.address.city = &quot;Boston&quot;"/>
+          <outline text="t.address.zip = 02101"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@t, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - simple list">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;array&gt;', '&lt;data&gt;', '&lt;value&gt;&lt;i4&gt;10&lt;/i4&gt;&lt;/value&gt;', '&lt;value&gt;&lt;i4&gt;20&lt;/i4&gt;&lt;/value&gt;', '&lt;value&gt;&lt;i4&gt;30&lt;/i4&gt;&lt;/value&gt;', '&lt;/data&gt;', '&lt;/array&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(lst)"/>
+          <outline text="new(listType, @lst)"/>
+          <outline text="lst[1] = 10"/>
+          <outline text="lst[2] = 20"/>
+          <outline text="lst[3] = 30"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@lst, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - empty list">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;array&gt;&lt;data&gt;&lt;/data&gt;&lt;/array&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(lst)"/>
+          <outline text="new(listType, @lst)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@lst, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - mixed type list">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;array&gt;', '&lt;data&gt;', '&lt;value&gt;&lt;string&gt;hello&lt;/string&gt;&lt;/value&gt;', '&lt;value&gt;&lt;i4&gt;42&lt;/i4&gt;&lt;/value&gt;', '&lt;value&gt;&lt;boolean&gt;1&lt;/boolean&gt;&lt;/value&gt;', '&lt;/data&gt;', '&lt;/array&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(lst)"/>
+          <outline text="new(listType, @lst)"/>
+          <outline text="lst[1] = &quot;hello&quot;"/>
+          <outline text="lst[2] = 42"/>
+          <outline text="lst[3] = true"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@lst, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - with indent level 0">
+        <outline text="Metadata">
+          <outline text="expected_output: &lt;string&gt;test&lt;/string&gt;"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(s = &quot;test&quot;)"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@s, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - with indent level 1">
+        <outline text="Metadata">
+          <outline text="expected_output: 6"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="new(tableType, @t)"/>
+          <outline text="t.key = &quot;value&quot;"/>
+          <outline text="local(result = xml.frontiervaluetotaggedtext(@t, 1))"/>
+          <outline text="return string.countFields(result, string.filledString(&quot;\t&quot;, 1))"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - complex nested structure">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;struct&gt;', '&lt;name&gt;title&lt;/name&gt;', '&lt;value&gt;Test Document&lt;/value&gt;', '&lt;name&gt;items&lt;/name&gt;', '&lt;value&gt;&lt;array&gt;', '&lt;data&gt;', '&lt;value&gt;First Item&lt;/value&gt;', '&lt;value&gt;Second Item&lt;/value&gt;', '&lt;/data&gt;', '&lt;/array&gt;&lt;/value&gt;', '&lt;/struct&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="new(tableType, @workspace.xmltest)"/>
+          <outline text="workspace.xmltest.title = &quot;Test Document&quot;"/>
+          <outline text="new(listType, @workspace.xmltest.items)"/>
+          <outline text="workspace.xmltest.items[1] = &quot;First Item&quot;"/>
+          <outline text="workspace.xmltest.items[2] = &quot;Second Item&quot;"/>
+          <outline text="local(result = xml.frontiervaluetotaggedtext(@workspace.xmltest, 0))"/>
+          <outline text="delete(@workspace.xmltest)"/>
+          <outline text="return result"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - table with special chars in keys">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;struct&gt;', '&lt;member&gt;', '&lt;name&gt;key&amp;lt;&amp;gt;&amp;amp;&lt;/name&gt;', '&lt;value&gt;&lt;string&gt;value&lt;/string&gt;&lt;/value&gt;', '&lt;/member&gt;', '&lt;/struct&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="new(tableType, @t)"/>
+          <outline text="t.[&quot;key&lt;&gt;&amp;&quot;] = &quot;value&quot;"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@t, 0)"/>
+        </outline>
+      </outline>
+      <outline text="xml.frontiervaluetotaggedtext - deeply nested tables">
+        <outline text="Metadata">
+          <outline text="expected_contains: ['&lt;struct&gt;', '&lt;name&gt;level1&lt;/name&gt;', '&lt;name&gt;level2&lt;/name&gt;', '&lt;name&gt;level3&lt;/name&gt;', '&lt;name&gt;value&lt;/name&gt;', '&lt;value&gt;&lt;string&gt;deep&lt;/string&gt;&lt;/value&gt;']"/>
+        </outline>
+        <outline text="Script">
+          <outline text="local(t)"/>
+          <outline text="new(tableType, @t)"/>
+          <outline text="new(tableType, @t.level1)"/>
+          <outline text="new(tableType, @t.level1.level2)"/>
+          <outline text="new(tableType, @t.level1.level2.level3)"/>
+          <outline text="t.level1.level2.level3.value = &quot;deep&quot;"/>
+          <outline text="return xml.frontiervaluetotaggedtext(@t, 0)"/>
+        </outline>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/tests/headless_op_verbs.c
+++ b/tests/headless_op_verbs.c
@@ -1416,22 +1416,56 @@ static boolean op_valueproc(short token, hdltreenode hparam1,
             /* Verb #40: op.outlinetoxml - not yet implemented */
             if (bserror) seterrorstring("not implemented", bserror);
             return false;
-        case opv_sethtmlformatting:
-            /* Verb #41: op.sethtmlformatting - not yet implemented */
-            if (bserror) seterrorstring("not implemented", bserror);
-            return false;
-        case opv_gethtmlformatting:
-            /* Verb #42: op.gethtmlformatting - not yet implemented */
-            if (bserror) seterrorstring("not implemented", bserror);
-            return false;
-        case opv_setdynamic:
-            /* Verb #43: op.setdynamic - not yet implemented */
-            if (bserror) seterrorstring("not implemented", bserror);
-            return false;
-        case opv_getdynamic:
-            /* Verb #44: op.getdynamic - not yet implemented */
-            if (bserror) seterrorstring("not implemented", bserror);
-            return false;
+        case opv_sethtmlformatting: {
+            /* Verb #41: op.sethtmlformatting(fl) -> boolean
+             * NOOP in headless mode - HTML formatting is GUI-only feature
+             * Accepts boolean parameter for API compatibility
+             * Always returns false without error
+             */
+            boolean fl;
+
+            flnextparamislast = true;
+            if (!getbooleanvalue(hparam1, 1, &fl))
+                return false;
+
+            (void)fl;  /* Intentionally unused in headless mode */
+            return setbooleanvalue(false, vreturned);
+        }
+        case opv_gethtmlformatting: {
+            /* Verb #42: op.gethtmlformatting() -> boolean
+             * NOOP in headless mode - HTML formatting is GUI-only feature
+             * Always returns false without error
+             */
+            if (!langcheckparamcount(hparam1, 0))
+                return false;
+
+            return setbooleanvalue(false, vreturned);
+        }
+        case opv_setdynamic: {
+            /* Verb #43: op.setdynamic(fl) -> boolean
+             * NOOP in headless mode - dynamic outline mode is GUI-only feature
+             * Accepts boolean parameter for API compatibility
+             * Always returns false without error
+             */
+            boolean fl;
+
+            flnextparamislast = true;
+            if (!getbooleanvalue(hparam1, 1, &fl))
+                return false;
+
+            (void)fl;  /* Intentionally unused in headless mode */
+            return setbooleanvalue(false, vreturned);
+        }
+        case opv_getdynamic: {
+            /* Verb #44: op.getdynamic() -> boolean
+             * NOOP in headless mode - dynamic outline mode is GUI-only feature
+             * Always returns false without error
+             */
+            if (!langcheckparamcount(hparam1, 0))
+                return false;
+
+            return setbooleanvalue(false, vreturned);
+        }
         default:
             return false;
     }

--- a/tests/integration/test_cases/op_verbs.yaml
+++ b/tests/integration/test_cases/op_verbs.yaml
@@ -3204,3 +3204,47 @@ tests:
     expected_success: true
     expected_result: "true"
     notes: "Full functional test of visiting behavior deferred - requires pre-stored callback script infrastructure"
+
+  # ====================================================================
+  # Phase 5a: Noop Verbs (GUI-only features, not applicable in headless)
+  # ====================================================================
+
+  - name: "op.sethtmlformatting - noop returns false"
+    description: "Verify op.sethtmlformatting returns false (noop) in headless mode"
+    script: |
+      lang.new(outlineType, @workspace.outline);
+      target.set(@workspace.outline);
+      op.insert("Line", down);
+      return op.sethtmlformatting(true)
+    expected_success: true
+    expected_result: "false"
+
+  - name: "op.gethtmlformatting - noop returns false"
+    description: "Verify op.gethtmlformatting returns false (noop) in headless mode"
+    script: |
+      lang.new(outlineType, @workspace.outline);
+      target.set(@workspace.outline);
+      op.insert("Line", down);
+      return op.gethtmlformatting()
+    expected_success: true
+    expected_result: "false"
+
+  - name: "op.setdynamic - noop returns false"
+    description: "Verify op.setdynamic returns false (noop) in headless mode"
+    script: |
+      lang.new(outlineType, @workspace.outline);
+      target.set(@workspace.outline);
+      op.insert("Line", down);
+      return op.setdynamic(true)
+    expected_success: true
+    expected_result: "false"
+
+  - name: "op.getdynamic - noop returns false"
+    description: "Verify op.getdynamic returns false (noop) in headless mode"
+    script: |
+      lang.new(outlineType, @workspace.outline);
+      target.set(@workspace.outline);
+      op.insert("Line", down);
+      return op.getdynamic()
+    expected_success: true
+    expected_result: "false"


### PR DESCRIPTION
## Summary

Implemented 4 noop verbs that complete Phase 5a of op verb coverage, bringing the total to 40/45 (89%).

These verbs are GUI-only features that are not applicable in headless mode:
- op.sethtmlformatting(fl) - HTML formatting control (GUI-only)
- op.gethtmlformatting() - HTML formatting state query (GUI-only)
- op.setdynamic(fl) - Dynamic outline mode control (GUI-only)
- op.getdynamic() - Dynamic outline mode query (GUI-only)

## Implementation Pattern

All four verbs follow the established noop pattern for GUI-only features:
- Accept parameters for API compatibility (setXXX verbs take a boolean)
- Return false without raising an error (correct for disabled features in headless mode)
- Include clear documentation explaining why they are noop implementations
- Use consistent error handling and parameter validation

## Changes

### tests/headless_op_verbs.c
- Implemented 4 verb cases in op_valueproc (Verbs #41-44)
- Each case includes inline documentation explaining the noop pattern
- Parameter extraction and validation using existing helpers
- Return false via setbooleanvalue() for consistent API behavior

### tests/integration/test_cases/op_verbs.yaml
- Added 4 integration test cases for Phase 5a verbs
- Tests verify parameters are accepted without error
- Tests verify return values are always false
- Tests cover both get/set pairs for each feature

## Testing

**Unit Tests**: Passed (./tools/run_headless_tests.sh)
- Runtime tests: PASS
- Parser tests: PASS
- Note: Migration tests have pre-existing segfault unrelated to this PR

**Integration Tests**: 4 new Phase 5a tests added
- op.sethtmlformatting - noop returns false: PASS
- op.gethtmlformatting - noop returns false: PASS
- op.setdynamic - noop returns false: PASS
- op.getdynamic - noop returns false: PASS

Pre-existing integration test failures (28 tests) are unrelated to Phase 5a changes.

## Coverage Progress

| Phase | Status | Count | Notes |
|-------|--------|-------|-------|
| Phase 1 | COMPLETE | 10 verbs | insert, getLineText, level, go, firstSummit, countSubs, countSummits, expand, collapse, lastSummit |
| Phase 2 | COMPLETE | 8 verbs | setLineText, promote, demote, deleteLine, getLineRange, setLineRange, expandAll, collapseAll |
| Phase 3 | COMPLETE | 10 verbs | getDisplay, setDisplay, getCursor, setCursor, getRefcon, setRefcon, getExpansionState, setExpansionState, getScrollState, setScrollState |
| Phase 4 | COMPLETE | 8 verbs | hoist, dehoist, subsexpanded, find, sort, visitall, flatcursorkeys, tabkeyreorg |
| Phase 5a | COMPLETE | 4 verbs | sethtmlformatting, gethtmlformatting, setdynamic, getdynamic |
| **Total** | **40/45** | **40 verbs** | **89% coverage** |

## Next Steps

Phase 5b (remaining 5 verbs) covers:
- op.selectAll() - Selection management
- op.toggleExpansion(fl) - Expansion toggle utility
- op.getAncestorPath() - Ancestry query utility
- Plus 2 additional selection/utility verbs

See planning/phase3/op_verb_implementation_plan.md for complete roadmap.

---
Generated with Claude Code
