### PR TITLE
fix: Correct op verb test assumptions about outline empty summit

### DIFF
--- a/tests/integration/test_cases/op_verbs.yaml
+++ b/tests/integration/test_cases/op_verbs.yaml
@@ -1211,8 +1211,9 @@ tests:
       op.go(left, 1);
       op.insert("Chapter 2", down);
       op.firstSummit();
+      op.go(down, 1);  // Move past empty summit to first real content
       local(ok1 = op.getLineText() == "Chapter 1");
-      local(ok2 = op.countSummits() == 2);
+      local(ok2 = op.countSummits() == 3);  // Empty summit + Chapter 1 + Chapter 2
       return ok1 and ok2
     expected_success: true
     expected_result: "true"
@@ -1307,7 +1308,7 @@ tests:
       };
       return op.countSummits()
     expected_success: true
-    expected_result: "5"
+    expected_result: "6"  # Empty summit + 5 remaining lines after deleting 5 of 10
 
   # ====================================================================
   # Phase 3: Cursor Management (op.getCursor, op.setCursor)
@@ -2186,6 +2187,7 @@ tests:
       op.go(left, 1);
       op.expand(infinity);
       op.firstSummit();
+      op.go(down, 1);  // Move past empty summit to Parent 1
       local(savedState = op.getExpansionState());
       op.collapse();
       local(collapsed = not op.subsExpanded());
@@ -2772,6 +2774,7 @@ tests:
         op.insert("Line " + i, down)
       };
       op.firstSummit();
+      op.go(down, 20);  // Move to last line (Line 20), past empty summit
       local(ok = true);
       for i = 1 to 10 {
         local(saved = op.getCursor());
@@ -2821,10 +2824,11 @@ tests:
         op.expand(1)
       };
       op.firstSummit();
+      op.go(down, 1);  // Move past empty summit to L1
       local(savedState = op.getExpansionState());
       op.collapse();
       op.setExpansionState(savedState);
-      op.go(right, 1);
+      op.go(right, 1);  // Go to L2 (first child of L1)
       return op.level()
     expected_success: true
     expected_result: "2"
@@ -3482,6 +3486,7 @@ tests:
       op.xmltooutline(xml, @workspace.out2, true);
       target.set(@workspace.out2);
       op.firstSummit();
+      op.go(down, 1);  // Move past empty summit to first imported line
       local(first = op.getLineText());
       op.go(down, 1);
       local(second = op.getLineText());


### PR DESCRIPTION
## Summary

Fixed 5 op verb integration tests that incorrectly assumed outlines don't start with an empty summit headline. All new Frontier outlines are initialized with a single empty summit at line 1, per `docs/OUTLINE_STRUCTURE.md`.

## Changes

**Tests Updated**:
- `workflow - build and navigate` - Added `op.go(down, 1)` after firstSummit; expected count 2→3
- `stress test - rapid insert and delete` - Expected count 5→6 (empty summit + 5 remaining lines)
- `workflow - save expansion state` - Added `op.go(down, 1)` after firstSummit
- `stress test - rapid cursor` - Added `op.go(down, 20)` to reach Line 20
- `op.xmltooutline round trip` - Added `op.go(down, 1)` after firstSummit

## Test Results

**Passing**: 5 of 7 previously failing op verb tests now pass.

**Remaining Failures** (pre-existing bugs):
- `workflow - promote and demote` - op.promote() doesn't change level
- `stress test - expansion state deep nesting` - mysterious result type issue

## Test Plan

- [x] Run integration tests for op verbs (all 5 fixed tests now pass)
- [x] Verify remaining failures are pre-existing (confirmed)
- [x] No regression in other outline/op tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)