### PR TITLE
Fix monitor script documentation inconsistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,13 +138,11 @@ Several archive branches exist independently and should **never be merged** to d
      - **NEVER run `git push origin develop`** without explicit user instruction
      - All changes to develop MUST go through PR review process
   5. Use pull-request agent to create PR
-  6. **CRITICAL: Run PR monitor in BACKGROUND** ⚠️⚠️⚠️:
-     - **NEVER use `./tools/monitor_pr_review.sh` directly** (blocks session for 15 minutes)
-     - **ALWAYS use**: `./tools/monitor_pr_review_bg.sh <PR_NUMBER>`
-     - This returns immediately and runs monitoring in background
+  6. **Start PR monitoring in background** ⚠️:
+     - Run: `./tools/monitor_pr_review.sh <PR_NUMBER>`
+     - Script auto-backgrounds itself and returns immediately (always non-blocking)
      - Monitor automatically detects merge conflicts and exits with error (rebase required)
      - Watch log with: `tail -f tests/tmp/pr_monitor_<PR_NUMBER>.log`
-     - See `docs/PR_MONITOR_BLOCKING_ISSUE.md` for full details
   7. **ALWAYS discuss bot feedback with user before addressing** - Never make changes autonomously
   8. **NEVER merge PRs without explicit user approval** - User must review and approve merge
 - Always create branch for new development work when on develop


### PR DESCRIPTION
## Summary
- Fixed monitor script documentation inconsistency identified in PR #340 bot review
- Updated lines 141-147 to use `monitor_pr_review.sh` instead of deprecated `monitor_pr_review_bg.sh`
- Removed incorrect warning about script blocking session
- Documentation now consistent with deprecation note at line 309

## Changes Made
- **Before**: Lines 141-147 referenced `monitor_pr_review_bg.sh` with warning about blocking
- **After**: Updated to use `monitor_pr_review.sh` with correct description of auto-backgrounding behavior
- Aligns with iac-mcp's already-correct documentation pattern

## Rationale
The `monitor_pr_review.sh` script auto-backgrounds itself (as noted in line 309 and implemented in the script). The old documentation incorrectly warned users to avoid using it directly and instead use a deprecated `monitor_pr_review_bg.sh` script that no longer exists.

This inconsistency was identified by the bot review in PR #340.

## Test Plan
- [x] Verified iac-mcp CLAUDE.md already uses correct pattern
- [x] Confirmed monitor_pr_review.sh exists in both Frontier and iac-mcp
- [x] Documentation now consistent across both repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
