### PR TITLE
fix: Exclude script-only processors from EFP whitelist

### DIFF
--- a/tools/kernelverbs_parser/analyzer.py
+++ b/tools/kernelverbs_parser/analyzer.py
@@ -488,6 +488,17 @@ class VerbImplementationAnalyzer:
         # Platform-specific flag
         platform_specific = annotations.get('platform_specific', False)
 
+        # Script-implemented flag - override impl_file to indicate UserTalk implementation
+        # This is critical for whitelist generation: processors where ALL verbs are
+        # script-implemented should NOT be registered as EFPs (they shadow database tables)
+        is_script_impl = annotations.get('script_implemented', False)
+        if is_script_impl:
+            actual_impl_file = "<UserTalk script>"
+            actual_line_num = 0
+        else:
+            actual_impl_file = impl_file
+            actual_line_num = line_num
+
         # Estimate complexity
         complexity = estimate_complexity(source) if is_implemented else 1
 
@@ -496,8 +507,8 @@ class VerbImplementationAnalyzer:
             verb_name=verb_name,
             token=token,
             is_implemented=is_implemented,
-            impl_file=impl_file,
-            impl_line=line_num,
+            impl_file=actual_impl_file,
+            impl_line=actual_line_num,
             has_carbon_deps=has_carbon,
             uses_ui_adapter=uses_ui_adapter,
             platform_specific=platform_specific,

--- a/tools/kernelverbs_parser/metadata_writer.py
+++ b/tools/kernelverbs_parser/metadata_writer.py
@@ -116,8 +116,20 @@ class VerbMetadataWriter:
         Generate HEADLESS_REGISTERED whitelist from implemented verbs.
 
         Returns:
-            List of processor names that have at least one implemented verb
+            List of processor names that have at least one C-implemented verb
             and are headless-compatible (no Carbon dependencies).
+
+        Note:
+            Processors where ALL verbs are script-implemented (impl_file contains
+            "<UserTalk script>") are EXCLUDED. Such processors have no C code to
+            dispatch to - the database table (builtins.*) already has the full
+            implementation. Registering an EFP for them would shadow the database
+            table, causing defined(processor.item) to fail for items not in the
+            EFP stub.
+
+            Example: webserver has 7 verbs, all script-implemented. Without this
+            exclusion, defined(webserver.init) fails because the EFP stub (7 items)
+            shadows builtins.webserver (21 items including 'init').
         """
         # Group verbs by processor
         by_processor = {}
@@ -128,14 +140,20 @@ class VerbMetadataWriter:
 
         whitelist = []
         for processor, verbs in sorted(by_processor.items()):
-            # Check if processor has any implemented verbs
-            has_impl = any(v.is_implemented for v in verbs)
+            # Check if processor has any C-implemented verbs (not just script-implemented)
+            # A verb is C-implemented if is_implemented=True AND impl_file is NOT "<UserTalk script>"
+            has_c_impl = any(
+                v.is_implemented and v.impl_file != "<UserTalk script>"
+                for v in verbs
+            )
 
             # Check if processor has Carbon dependencies
             has_carbon = any(v.has_carbon_deps for v in verbs if v.is_implemented)
 
-            # Include if implemented and no Carbon dependencies
-            if has_impl and not has_carbon:
+            # Include only if has C implementation and no Carbon dependencies
+            # Processors with ONLY script-implemented verbs should NOT be registered
+            # (they use the database table builtins.* instead of EFP)
+            if has_c_impl and not has_carbon:
                 whitelist.append(processor)
 
         return whitelist


### PR DESCRIPTION
## Summary

- **Fixes `defined(webserver.init)` returning `false`** - webserver processor was incorrectly included in the EFP whitelist despite having only script-implemented verbs
- **Analyzer now properly marks script-implemented verbs** - sets `impl_file="<UserTalk script>"` when `@SCRIPT_IMPLEMENTED` annotation is detected
- **Whitelist generator now distinguishes C vs script implementations** - only includes processors with actual C-implemented verbs

## Root Cause

Processors where ALL verbs are implemented in UserTalk scripts (marked with `@SCRIPT_IMPLEMENTED` annotation) should NOT be registered as EFPs. When registered:

1. The EFP stub creates a hash table with only the kernel verb names (e.g., 7 for webserver)
2. This shadows the database table `builtins.webserver` (which has 21 items including `init`)
3. `defined(webserver.init)` looks in the EFP stub, doesn't find `init`, returns `false`

## Changes

**`tools/kernelverbs_parser/analyzer.py`**:
- When `@SCRIPT_IMPLEMENTED` annotation is detected, set `impl_file="<UserTalk script>"` instead of keeping the C stub file path

**`tools/kernelverbs_parser/metadata_writer.py`**:
- `generate_whitelist()` now checks for C-implemented verbs (`impl_file != "<UserTalk script>"`) rather than just any implemented verbs
- Added documentation explaining the script-only processor exclusion

## Test plan

- [x] Verified `defined(webserver.init)` returns `true` after fix
- [x] Verified `string(123)` still works (regression test)
- [x] Ran string verb resolution integration tests - 40 passed, 0 failed
- [x] Regenerated `kernel_verbs_init.c` - webserver excluded from whitelist