### PR TITLE
fix: Remove explicit EFP table search to fix introspection bugs

### DIFF
--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -297,66 +297,31 @@ boolean langexternalgettable (bigstring bs, hdlhashtable *htable) {
 		log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: info hit %s -> %p", PSTR(bs), (void *)*htable);
         return true;
     }
-	log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: getinfo miss %s, trying efptable fallback", PSTR(bs));
+	log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: getinfo miss %s, trying fallbacks", PSTR(bs));
 #if defined(FRONTIER_HEADLESS)
-    /* Headless fallback: look up external function processor under efptable.
-       2026-01-12 Codex: Use headless-created efptable if available, not database efptable.
-       When database is loaded, global efptable gets overwritten with tokenvaluetype entries.
-       We need to use the original headless-created table with working valueroutines. */
-    extern hdlhashtable get_headless_efptable(void);
-    hdlhashtable efp_to_search = get_headless_efptable();
-    if (efp_to_search == nil) {
-        efp_to_search = efptable;  /* Fallback if not saved yet */
-    }
-
-    {
-        hdlhashnode hnode = nil;
-        tyvaluerecord val;
-        pushhashtable(efp_to_search);
-		log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: searching efptable=%p (headless=%p db=%p) for %s (len=%d)",
-                  (void *)efp_to_search, (void*)get_headless_efptable(), (void *)efptable, PSTR(bs), (int)bs[0]);
-        if (hashtablelookupnode(efp_to_search, bs, &hnode)) {
-			log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: found %s in efptable hnode=%p", PSTR(bs), (void *)hnode);
-            val = (**hnode).val;
-			log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: val.valuetype=%d", (int)val.valuetype);
-
-            /* 2026-01-12 Codex: Skip tokenvaluetype entries in efptable.
-               When database is loaded, efptable gets populated with tokenvaluetype entries
-               from the database. These are stale references that don't have valueroutines.
-               The actual working processor tables were created by headless runtime init
-               and are accessible through other lookup paths (roottable fallback, etc.).
-               Skip tokens here and let the code fall through to those working tables. */
-            if (val.valuetype == tokenvaluetype) {
-                /* Token types appear in efptable after database load (serialization artifact).
-                   These are not functional processors, so fall through to other lookups. */
-                log_debug(LOG_COMP_EXTERNAL, "langexternalgettable: tokenvaluetype skipped, falling through to other lookups");
-                /* Don't return - let it fall through to roottable/systemtable fallbacks */
-            }
-            else if (tablevaltotable (val, htable, hnode)) {
-				log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: tablevaltotable SUCCESS htable=%p", (void *)*htable);
-                pophashtable();
-                return true;
-            }
-            else {
-			    log_trace(LOG_COMP_EXTERNAL, "langexternalgettable: tablevaltotable FAILED");
-            }
-
-            /* Direct headless coercion: extract table pointer from external
-			   Only attempt this if value is externalvaluetype to avoid
-			   segfault when casting non-external values */
-            if (val.valuetype == externalvaluetype) {
-                hdlexternalvariable hv3 = (hdlexternalvariable) val.data.externalvalue;
-                if (hv3 && (**hv3).id == idtableprocessor) {
-                    *htable = (hdlhashtable) (**hv3).variabledata;
-                    if (*htable != nil) {
-                        pophashtable();
-                        return true;
-                    }
-                }
-            }
-        }
-        pophashtable();
-    }
+    /* 2026-01-26 Issue #352: REMOVED explicit EFP table search
+     *
+     * The explicit efptable search was causing EFP processor tables (string, file,
+     * clock, etc.) to be found BEFORE database tables via system.paths. This broke
+     * introspection operations like parentOf() and typeOf().
+     *
+     * Example bugs this caused:
+     * - parentOf(string.mid) returned @system.compiler.["kernel"].string
+     *   instead of @system.verbs.builtins.string
+     * - typeOf(op.outlineToXml) returned 'tokn' instead of 'scpt'
+     *
+     * WHY REMOVING THIS IS SAFE:
+     * Verb dispatch (calling string.mid(), file.exists(), etc.) still works because
+     * langhandlercall() has its own search order that explicitly checks efptable
+     * AFTER system.paths. See langhandlercall() at line ~8756 in langvalue.c:
+     *   1. langgethandlercode(currenthashtable, ...) - local context
+     *   2. langsearchpathvisit(&langgethandlervisit, ...) - system.paths
+     *   3. langgethandlercode(efptable, ...) - EFP tables LAST
+     *
+     * With the explicit EFP search removed from here:
+     * - Introspection (parentOf, typeOf) finds database tables correctly
+     * - Verb dispatch still works via langhandlercall's explicit efptable search
+     */
 
     /* Direct lookup in root/system tables as headless-specific fallback.
        In headless mode, system tables (system, system.verbs, builtins, agents, root) are

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -4047,28 +4047,27 @@ boolean langgetdotparams (hdltreenode htree, hdlhashtable *htable, bigstring bsn
 		if (langgetspecialtable (bsname, htable)) /*translate "root" to roottable, etc.*/
 			goto L1;
 
-		/* 2026-01-26: RESTORED legacy search order (EFP first, then paths)
+		/* 2026-01-26: Search order matches legacy Frontier
 		 *
 		 * Search order:
 		 * 1. Special tables (root, etc.) - handled above
-		 * 2. EFP/current context (langexternalgettable) - kernel verb tables
+		 * 2. Current context via langexternalgettable
 		 * 3. system.paths search (if not blocked by recursion guard)
+		 * 4. Last-ditch effort for local paths
 		 *
-		 * This order is critical for verb dispatch:
-		 * - EFP tables have valueroutine callbacks for kernel verb dispatch
-		 * - Database tables don't have valueroutine
-		 * - string(123) MUST find EFP string table, not database builtins.string
+		 * IMPORTANT: The fix for Issue #352 (EFP introspection bugs) is in
+		 * langexternalgettable(), NOT here. The headless code was explicitly
+		 * searching efptable in langexternalgettable(), which caused EFP
+		 * tables to be found before database tables.
 		 *
-		 * For defined(webserver.init) to work:
-		 * - webserver EFP stub registration is SKIPPED (see kernel_verbs_init.c)
-		 * - So EFP lookup fails, falls through to path search
-		 * - Path search finds builtins.webserver with full content
-		 *
-		 * Note: Processors with all-script implementations should NOT register
-		 * as EFPs. See tools/kernelverbs_parser/script_implemented_verbs.py
+		 * After that fix, this search order works correctly:
+		 * - langexternalgettable only searches local scope + legacy paths
+		 * - langsearchpathvisit finds database tables via system.paths
+		 * - Verb dispatch still works because langhandlercall() has its own
+		 *   search that explicitly checks efptable AFTER paths
 		 */
 
-		/* 2. Check current context / EFP (kernel verb tables) */
+		/* 2. Check current context (local scope, NOT efptable) */
         if (langexternalgettable (bsname, htable)) {
 			goto L1;
 		}

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Test Categories</title>
-    <dateCreated>Mon, 26 Jan 2026 10:17:33 GMT</dateCreated>
+    <dateCreated>Tue, 27 Jan 2026 05:12:53 GMT</dateCreated>
   </head>
   <body>
     <outline text="Builtins Priority (builtins_priority)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_builtins_priority.opml"/>
@@ -11,6 +11,7 @@
     <outline text="Db Migration (db_migration)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_db_migration.opml"/>
     <outline text="Db Verbs (db_verbs)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_db_verbs.opml"/>
     <outline text="Dialog Verbs (dialog_verbs)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_dialog_verbs.opml"/>
+    <outline text="Efp Introspection (efp_introspection)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_efp_introspection.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_file_dialog_verbs.opml"/>
     <outline text="File Verbs (file_verbs)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_file_verbs.opml"/>
     <outline text="Html Core Tests (html_core_tests)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests_html_core_tests.opml"/>

--- a/reports/integration_tests_efp_introspection.opml
+++ b/reports/integration_tests_efp_introspection.opml
@@ -1,0 +1,121 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Efp Introspection (efp_introspection)</title>
+    <dateCreated>Tue, 27 Jan 2026 05:12:53 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="parentOf(string.mid) - returns database path - CRITICAL TEST: parentOf(string.mid) should return the database path&#10;@system.verbs.builtins.string, not the EFP internal path&#10;@system.compiler.[&quot;kernel&quot;].string.&#10;&#10;Bug behavior: Returns @system.compiler.[&quot;kernel&quot;].string&#10;Fixed behavior: Returns @system.verbs.builtins.string&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: system.verbs.builtins.string"/>
+      </outline>
+      <outline text="Script">
+        <outline text="parentOf(string.mid)"/>
+      </outline>
+    </outline>
+    <outline text="parentOf(file.exists) - returns database path - Verify parentOf() returns database path for file processor verbs.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: system.verbs.builtins.file"/>
+      </outline>
+      <outline text="Script">
+        <outline text="parentOf(file.exists)"/>
+      </outline>
+    </outline>
+    <outline text="parentOf(clock.now) - returns database path - Verify parentOf() returns database path for clock processor verbs.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: system.verbs.builtins.clock"/>
+      </outline>
+      <outline text="Script">
+        <outline text="parentOf(clock.now)"/>
+      </outline>
+    </outline>
+    <outline text="parentOf(date.get) - returns database path - Verify parentOf() returns database path for date processor verbs.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: system.verbs.builtins.date"/>
+      </outline>
+      <outline text="Script">
+        <outline text="parentOf(date.get)"/>
+      </outline>
+    </outline>
+    <outline text="typeOf(op.outlineToXml) - returns script type - typeOf() for a script-implemented verb should return 'scpt' (script type),&#10;not 'tokn' (token type from EFP stub).&#10;&#10;Bug behavior: Returns 'tokn' (sees EFP token entry)&#10;Fixed behavior: Returns 'scpt' (sees database script)&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: scpt"/>
+      </outline>
+      <outline text="Script">
+        <outline text="typeOf(op.outlineToXml)"/>
+      </outline>
+    </outline>
+    <outline text="string.mid - verb dispatch works - REGRESSION TEST: string.mid() must still work for verb dispatch.&#10;The fix should not break kernel verb calling.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: ell"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.mid(&quot;hello&quot;, 2, 3)"/>
+      </outline>
+    </outline>
+    <outline text="string.length - verb dispatch works - REGRESSION TEST: string.length() must still work.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.length(&quot;hello&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string(123) - coercion verb works - REGRESSION TEST: string() coercion must still work.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: 123"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string(123)"/>
+      </outline>
+    </outline>
+    <outline text="file.exists - file verb dispatch works - REGRESSION TEST: file.exists() must still work.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="file.exists(&quot;/nonexistent/path/that/does/not/exist&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="clock.now - clock verb dispatch works - REGRESSION TEST: clock.now() must still return a date value.&#10;We just verify it returns something (a date), not a specific value.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: date"/>
+      </outline>
+      <outline text="Script">
+        <outline text="typeOf(clock.now())"/>
+      </outline>
+    </outline>
+    <outline text="clock.now - clock verb returns date - REGRESSION TEST: clock.now() must return a date value that we can use.&#10;We check by calling clock.now() directly (not wrapped in typeOf).&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(clock.now())"/>
+      </outline>
+    </outline>
+    <outline text="defined(string) - EFP processor is defined - defined(string) should return true - the string processor exists.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(string)"/>
+      </outline>
+    </outline>
+    <outline text="defined(string.mid) - EFP verb is defined - defined(string.mid) should return true - the mid verb exists.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(string.mid)"/>
+      </outline>
+    </outline>
+    <outline text="defined(string.nonexistent) - nonexistent verb is not defined - defined(string.nonexistent) should return false.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(string.nonexistent)"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests_string_verb_resolution_fix.opml
+++ b/reports/integration_tests_string_verb_resolution_fix.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>String Verb Resolution Fix (string_verb_resolution_fix)</title>
-    <dateCreated>Mon, 26 Jan 2026 10:17:33 GMT</dateCreated>
+    <dateCreated>Tue, 27 Jan 2026 05:12:53 GMT</dateCreated>
   </head>
   <body>
     <outline text="CRITICAL - string(123) coerces integer to string - BUG: string(123) currently fails because:&#10;1. langsearchpathvisit() checks path01 (system.verbs.globals) first&#10;2. Finds &quot;string&quot; SCRIPT → langdirecttablelookup() calls tablevaltotable()&#10;3. tablevaltotable() rejects SCRIPT type → returns false&#10;4. Continues to path03 (system.verbs.builtins), finds &quot;string&quot; TABLE&#10;5. Tries to CALL a table (not a script) → error!&#10;&#10;EXPECTED: Resolve to system.verbs.globals.string SCRIPT, execute coercion.&#10;">
@@ -239,11 +239,9 @@
         <outline text="system.verbs.builtins.string(123)"/>
       </outline>
     </outline>
-    <outline text="Regression - webserver.init still works - Regression test from PR #337 and PR #342.&#10;Ensure webserver.init (external script) still resolves correctly.&#10;NOTE: webserver.init may not exist in v7 database.&#10;">
+    <outline text="Regression - webserver.init still works - Regression test from PR #337, PR #342, and PR #351.&#10;Ensure webserver.init (external script) still resolves correctly.&#10;Fixed in PR #351: webserver processor excluded from EFP whitelist,&#10;allowing builtins.webserver table (with init script) to be found.&#10;">
       <outline text="Metadata">
         <outline text="expected_result: true"/>
-        <outline text="skip: True"/>
-        <outline text="reason: webserver.init may not exist in migrated database - separate from verb resolution fix"/>
       </outline>
       <outline text="Script">
         <outline text="defined(webserver.init)"/>

--- a/tests/integration/test_cases/efp_introspection.yaml
+++ b/tests/integration/test_cases/efp_introspection.yaml
@@ -1,0 +1,159 @@
+# Integration tests for EFP table isolation in introspection operations
+#
+# BUG CONTEXT:
+# The headless-specific code in langexternalgettable() explicitly searches
+# efptable for processor tables BEFORE langsearchpathvisit() gets a chance
+# to find the database tables. This causes introspection operations like
+# parentOf(), typeOf() to return EFP-internal paths instead of database paths.
+#
+# Example of the bug:
+#   parentOf(string.mid) → Returns "system.compiler.["kernel"].string" (WRONG)
+#                        → Should return "system.verbs.builtins.string" (CORRECT)
+#
+# The fix removes the explicit EFP table search from langexternalgettable(),
+# allowing langsearchpathvisit() to find database tables first.
+#
+# IMPORTANT: Verb dispatch (calling string.mid("123",2,1)) must still work!
+# The EFP table lookup is preserved as a fallback for cases where the database
+# path doesn't exist.
+#
+# REFERENCE: Common/source/langexternal.c, langexternalgettable() function
+#
+# Test Structure:
+# - parentOf() introspection (the primary bug)
+# - typeOf() introspection (related issue)
+# - Verb dispatch regression (must still work)
+# - Nested parentOf() calls (crash fix)
+
+tests:
+  # ====================================================================
+  # SECTION 1: parentOf() Introspection
+  # ====================================================================
+  # These tests validate that parentOf() returns database paths, not EFP paths.
+
+  - name: "parentOf(string.mid) - returns database path"
+    description: |
+      CRITICAL TEST: parentOf(string.mid) should return the database path
+      @system.verbs.builtins.string, not the EFP internal path
+      @system.compiler.["kernel"].string.
+
+      Bug behavior: Returns @system.compiler.["kernel"].string
+      Fixed behavior: Returns @system.verbs.builtins.string
+    script: 'parentOf(string.mid)'
+    expected_success: true
+    expected_result: "system.verbs.builtins.string"
+
+  - name: "parentOf(file.exists) - returns database path"
+    description: |
+      Verify parentOf() returns database path for file processor verbs.
+    script: 'parentOf(file.exists)'
+    expected_success: true
+    expected_result: "system.verbs.builtins.file"
+
+  - name: "parentOf(clock.now) - returns database path"
+    description: |
+      Verify parentOf() returns database path for clock processor verbs.
+    script: 'parentOf(clock.now)'
+    expected_success: true
+    expected_result: "system.verbs.builtins.clock"
+
+  - name: "parentOf(date.get) - returns database path"
+    description: |
+      Verify parentOf() returns database path for date processor verbs.
+    script: 'parentOf(date.get)'
+    expected_success: true
+    expected_result: "system.verbs.builtins.date"
+
+  # ====================================================================
+  # SECTION 2: typeOf() Introspection
+  # ====================================================================
+  # typeOf() should return the type of the database object, not the EFP token.
+
+  - name: "typeOf(op.outlineToXml) - returns script type"
+    description: |
+      typeOf() for a script-implemented verb should return 'scpt' (script type),
+      not 'tokn' (token type from EFP stub).
+
+      Bug behavior: Returns 'tokn' (sees EFP token entry)
+      Fixed behavior: Returns 'scpt' (sees database script)
+    script: "typeOf(op.outlineToXml)"
+    expected_success: true
+    expected_result: "scpt"
+
+  # ====================================================================
+  # SECTION 3: Verb Dispatch Regression Tests
+  # ====================================================================
+  # These tests verify that verb dispatch (actually calling verbs) still works
+  # after the search order change. The EFP table must still be consulted for
+  # verb dispatch to get the valueroutine callback.
+
+  - name: "string.mid - verb dispatch works"
+    description: |
+      REGRESSION TEST: string.mid() must still work for verb dispatch.
+      The fix should not break kernel verb calling.
+    script: 'string.mid("hello", 2, 3)'
+    expected_success: true
+    expected_result: "ell"
+
+  - name: "string.length - verb dispatch works"
+    description: |
+      REGRESSION TEST: string.length() must still work.
+    script: 'string.length("hello")'
+    expected_success: true
+    expected_result: "5"
+
+  - name: "string(123) - coercion verb works"
+    description: |
+      REGRESSION TEST: string() coercion must still work.
+    script: 'string(123)'
+    expected_success: true
+    expected_result: "123"
+
+  - name: "file.exists - file verb dispatch works"
+    description: |
+      REGRESSION TEST: file.exists() must still work.
+    script: 'file.exists("/nonexistent/path/that/does/not/exist")'
+    expected_success: true
+    expected_result: "false"
+
+  - name: "clock.now - clock verb dispatch works"
+    description: |
+      REGRESSION TEST: clock.now() must still return a date value.
+      We just verify it returns something (a date), not a specific value.
+    script: 'typeOf(clock.now())'
+    expected_success: true
+    expected_result: "date"
+
+  - name: "clock.now - clock verb returns date"
+    description: |
+      REGRESSION TEST: clock.now() must return a date value that we can use.
+      We check by calling clock.now() directly (not wrapped in typeOf).
+    script: 'defined(clock.now())'
+    expected_success: true
+    expected_result: "true"
+
+  # ====================================================================
+  # SECTION 4: defined() for EFP Processors
+  # ====================================================================
+  # These tests verify that defined() works correctly for EFP processor tables.
+
+  - name: "defined(string) - EFP processor is defined"
+    description: |
+      defined(string) should return true - the string processor exists.
+    script: 'defined(string)'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "defined(string.mid) - EFP verb is defined"
+    description: |
+      defined(string.mid) should return true - the mid verb exists.
+    script: 'defined(string.mid)'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "defined(string.nonexistent) - nonexistent verb is not defined"
+    description: |
+      defined(string.nonexistent) should return false.
+    script: 'defined(string.nonexistent)'
+    expected_success: true
+    expected_result: "false"


### PR DESCRIPTION
## Summary
- Fixes #352 and #349
- Removes explicit EFP table search from `langexternalgettable()` that was causing introspection operations to return wrong results
- `parentOf(string.mid)` now correctly returns `system.verbs.builtins.string` (was returning `system.compiler.["kernel"].string`)
- `typeOf(op.outlineToXml)` now correctly returns `scpt` (was returning `tokn`)

## Root Cause
The headless-specific code in `langexternalgettable()` was explicitly searching `efptable` for processor tables BEFORE `langsearchpathvisit()` could find database tables. This caused introspection operations like `parentOf()` and `typeOf()` to see EFP internal paths instead of database paths.

## Why Removing the EFP Search is Safe
Verb dispatch (`string.mid()`, `file.exists()`, etc.) still works because `langhandlercall()` has its own search order that explicitly checks `efptable` AFTER `system.paths`. This is the correct place for EFP lookup - during verb dispatch, not during name resolution.

## Test plan
- [x] New tests in `efp_introspection.yaml` validate:
  - `parentOf()` returns database paths for string, file, clock, date processors
  - `typeOf(op.outlineToXml)` returns `scpt` (script type)
  - Verb dispatch regression tests (string.mid, string.length, string(), file.exists, clock.now)
  - `defined()` tests for EFP processors
- [x] All 14 new tests pass
- [x] Manually verified fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)