### PR TITLE
fix: Suppress v6→v7 migration log spew during REPL startup

### DIFF
--- a/Common/headers/logging.h
+++ b/Common/headers/logging.h
@@ -48,6 +48,7 @@ typedef enum {
     LOG_COMP_EXTERNAL,        // External objects (langexternal.c)
     LOG_COMP_STARTUP,         // Startup/initialization (langstartup.c)
     LOG_COMP_THREAD,          // Thread registry (threadregistry.c)
+    LOG_COMP_MIGRATION,       // Database v6→v7 migration diagnostics (disabled by default)
     LOG_COMP_GENERAL,         // General/uncategorized
     LOG_COMP_COUNT            // Number of components (internal use)
 } log_component_t;

--- a/Common/source/logging.c
+++ b/Common/source/logging.c
@@ -46,6 +46,7 @@ static const char *component_names[] = {
     [LOG_COMP_EXTERNAL]     = "external",
     [LOG_COMP_STARTUP]      = "startup",
     [LOG_COMP_THREAD]       = "thread",
+    [LOG_COMP_MIGRATION]    = "migration",
     [LOG_COMP_GENERAL]      = "general"
 };
 
@@ -112,17 +113,18 @@ static int parse_component(const char *str) {
  */
 static void parse_components(const char *str) {
     if (!str) {
-        // Default: enable all components
+        // Default: enable all components EXCEPT migration (disabled by default)
         for (int i = 0; i < LOG_COMP_COUNT; i++) {
-            g_component_enabled[i] = true;
+            g_component_enabled[i] = (i != LOG_COMP_MIGRATION);
         }
         return;
     }
 
     // Check for "all" or "*"
     if (strcasecmp(str, "all") == 0 || strcmp(str, "*") == 0) {
+        // Enable all components EXCEPT migration (disabled by default)
         for (int i = 0; i < LOG_COMP_COUNT; i++) {
-            g_component_enabled[i] = true;
+            g_component_enabled[i] = (i != LOG_COMP_MIGRATION);
         }
         return;
     }

--- a/Common/source/memory.c
+++ b/Common/source/memory.c
@@ -1671,7 +1671,7 @@ boolean loadlongfromdiskhandle (Handle hload, long *ixload, long *x) {
 				return (false);
 			dbaddress full_adr = db_format_read_be64(adrbytes);
 			*x = (long) full_adr;
-			log_error(LOG_COMP_DB, "loadlongfromdiskhandle: Read 64-bit adr=0x%llx, TRUNCATED to long=0x%lx (sizeof(long)=%d)",
+			log_trace(LOG_COMP_MIGRATION, "loadlongfromdiskhandle: Read 64-bit adr=0x%llx, TRUNCATED to long=0x%lx (sizeof(long)=%d)",
 			          (unsigned long long)full_adr, (unsigned long)*x, (int)sizeof(long));
 			return (true);
 		} else if (remaining == (long)sizeof(int32_t)) {

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -947,7 +947,7 @@ boolean opverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariab
 	if (!loadlongfromdiskhandle (hpacked, ixload, &rawadr))
 		return (false);
 
-	log_error(LOG_COMP_DB, "opverbunpack: rawadr=0x%lx (32-bit long), casting to dbaddress", (unsigned long)rawadr);
+	log_trace(LOG_COMP_MIGRATION, "opverbunpack: rawadr=0x%lx (32-bit long), casting to dbaddress", (unsigned long)rawadr);
 
 	return (newoutlinevariable (false, (dbaddress) rawadr, (hdloutlinevariable *) hvariable));
 	} /*opverbunpack*/


### PR DESCRIPTION
## Summary

- Add LOG_COMP_MIGRATION component (disabled by default)
- Move verbose migration diagnostics from ERROR to TRACE level
- Clean REPL startup with no log spew

## Problem

Opening the REPL displayed hundreds of `[db-ERROR]` messages during v6→v7 database migration:
```
[db-ERROR] memory.c:1675: loadlongfromdiskhandle...
[db-ERROR] opverbs.c:950: opverbunpack...
```

These are diagnostic messages, not actual errors.

## Solution

1. **New LOG_COMP_MIGRATION component**: Disabled by default, can be enabled with `FRONTIER_LOG_COMPONENT=migration`
2. **Changed log level**: ERROR → TRACE for migration diagnostics in memory.c and opverbs.c
3. **Explicit exclusion**: LOG_COMP_MIGRATION excluded from "all components" initialization

## Testing

```bash
# Default: no migration log spew
./frontier-cli/frontier-cli -e "1 + 1"

# Enable migration diagnostics when needed:
FRONTIER_LOG_LEVEL=trace FRONTIER_LOG_COMPONENT=migration ./frontier-cli/frontier-cli -e "1 + 1"
```

## Files Changed

- `Common/headers/logging.h` - Added LOG_COMP_MIGRATION enum
- `Common/source/logging.c` - Added "migration" component name, excluded from default initialization
- `Common/source/memory.c:1675` - Changed log_error(LOG_COMP_DB) to log_trace(LOG_COMP_MIGRATION)
- `Common/source/opverbs.c:950` - Changed log_error(LOG_COMP_DB) to log_trace(LOG_COMP_MIGRATION)

🤖 Generated with [Claude Code](https://claude.com/claude-code)