### PR TITLE
fix: Respect error suppression in langerrormessage() (Issue #325)

### DIFF
--- a/Common/source/langcallbacks.c
+++ b/Common/source/langcallbacks.c
@@ -191,28 +191,34 @@ boolean langpopsourcecode (void) {
 
 
 boolean langerrormessage (bigstring bs) {
-	
+
 	/*
-	10/31/91 dmb: experimented with calling local "error" routine on all 
-	errors.  it's quickly becoming apparant that this is not a generally safe 
-	thing to do, and that certain classes of errors must not trigger this 
-	call (compiler errors, for example).  If we want to support this in the 
+	10/31/91 dmb: experimented with calling local "error" routine on all
+	errors.  it's quickly becoming apparant that this is not a generally safe
+	thing to do, and that certain classes of errors must not trigger this
+	call (compiler errors, for example).  If we want to support this in the
 	future, a more formal mechanism should be developed.
-	
+
 	4.1b3 dmb: added call to new langseterrorcallbackline for stack tracing (on error)
+
+	2026-01-28: Fixed error logging to respect error suppression (Issue #325).
+	When errors are disabled via disablelangerror() (e.g., by defined() verb),
+	we should not log them. This allows defined() to check for non-existent
+	table entries without generating spurious error messages.
 	*/
-    /* Headless/portable: safely print bigstring without VLAs or overflow */
-    {
-        char cs[256]; /* bigstring max length is 255 */
-        copyptocstring(bs, cs);
-        log_error(LOG_COMP_LANG, "%s", cs);
-    }
-	
+
 	if (!langerrorenabled ())
 		return (true);
-	
+
 	if (fllangerror) /*one message per script*/
 		return (true);
+
+	/* Headless/portable: safely print bigstring without VLAs or overflow */
+	{
+		char cs[256]; /* bigstring max length is 255 */
+		copyptocstring(bs, cs);
+		log_error(LOG_COMP_LANG, "%s", cs);
+	}
 	
 	fllangerror = true; /*only display once for each script*/
 	

--- a/tests/table_operations/table_operations_integration.c
+++ b/tests/table_operations/table_operations_integration.c
@@ -437,12 +437,21 @@ static void test_table_move_basic(void) {
 	fflush(stdout);
 }
 
-/* Test 17: table.move - Source entry removed after move */
+/* Test 17: table.move - Source entry removed after move, destination created
+ *
+ * This test verifies that table.move() properly:
+ * 1. Removes the entry from the source table (defined(src.mobile) == false)
+ * 2. Creates the entry in the destination table (defined(dst.mobile) == true)
+ * 3. Preserves the value (dst.mobile == "data")
+ *
+ * Note: This test also validates that defined() properly suppresses errors
+ * when checking for non-existent table entries (Issue #325).
+ */
 static void test_table_move_source_removed(void) {
 	printf("[table_operations_integration] test_table_move_source_removed: start\n");
 	fflush(stdout);
 
-	eval_expect_string("local (src, dst); new(tableType, @src); new(tableType, @dst); src.mobile = \"data\"; table.move(@src.mobile, @dst); if not defined(src.mobile) { return \"pass\" } else { return \"fail\" }", "pass");
+	eval_expect_string("local (src, dst); new(tableType, @src); new(tableType, @dst); src.mobile = \"data\"; table.move(@src.mobile, @dst); if (defined(src.mobile) == false) and (defined(dst.mobile) == true) and (dst.mobile == \"data\") { return \"pass\" } else { return \"fail\" }", "pass");
 
 	printf("[table_operations_integration] test_table_move_source_removed: PASS\n");
 	fflush(stdout);


### PR DESCRIPTION
## Summary

- Fixed `langerrormessage()` to respect error suppression state before logging errors
- The `log_error()` call was placed BEFORE the `langerrorenabled()` check, causing spurious error messages when `defined()` verb checks for non-existent table entries
- Improved `table.move()` test to verify both source removal AND destination creation

## Root Cause

The `defined()` verb uses `disablelangerror()`/`enablelangerror()` to suppress errors when checking if a table entry exists. However, in `langerrormessage()`, the logging happened before checking if errors were suppressed:

```c
// BEFORE (buggy):
log_error(LOG_COMP_LANG, "%s", cs);  // Always logs!
if (!langerrorenabled())
    return (true);

// AFTER (fixed):
if (!langerrorenabled())
    return (true);
log_error(LOG_COMP_LANG, "%s", cs);  // Only logs when enabled
```

## Test plan

- [x] Direct CLI test confirms fix: `defined(src.mobile)` returns `false` without error output
- [x] `table_operations_integration` tests pass (45/45)
- [x] Improved test verifies: source removed, destination created, value preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)