### PR TITLE
fix: Pass explicit db_context to *verbinmemory functions (Issue #347)

### DIFF
--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1661,8 +1661,8 @@ static boolean fullpathsearch (hdlhashtable intable, hdlhashtable fortable, bigs
 				return (false);
 			}
 
-		fltempload = true;
-			}
+			fltempload = true;
+		}
 		
 /////////			assert (tablesetdebugglobals (ht, x)); /*set debug globals*/
 		

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1653,10 +1653,15 @@ static boolean fullpathsearch (hdlhashtable intable, hdlhashtable fortable, bigs
 			if (flonlyinmemory)	/*can't find it if it isn't in memory*/
 				goto nextx;
 			
-			if (!tableverbinmemory (NULL, hv, x))
+			{
+			db_context ctx;
+			db_context_init(&ctx);
+
+			if (!tableverbinmemory (&ctx, hv, x))
 				return (false);
-				
-			fltempload = true;
+			}
+
+		fltempload = true;
 			}
 		
 /////////			assert (tablesetdebugglobals (ht, x)); /*set debug globals*/

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -369,11 +369,16 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 				log_trace(LOG_COMP_HASH, "materialize external path=%s id=table",
 				        path ? path : "<nil>");
 			}
-			if (!tableverbinmemory(NULL, hv, HNoNode)) {
+			{
+			db_context ctx;
+			db_context_init(&ctx);
+
+			if (!tableverbinmemory(&ctx, hv, HNoNode)) {
 				log_error(LOG_COMP_HASH, "materialize external table load failed path=%s",
 				        path ? path : "<nil>");
 				langhash_materialize_current_path = prior_path;
 				return false;
+				}
 			}
 			hdlhashtable child = (hdlhashtable)(**hv).variabledata;
 			/* During adapter_repack (migration), mark materialized tables as dirty to force save */

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -378,9 +378,9 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 				        path ? path : "<nil>");
 				langhash_materialize_current_path = prior_path;
 				return false;
-				}
 			}
-			hdlhashtable child = (hdlhashtable)(**hv).variabledata;
+		}
+		hdlhashtable child = (hdlhashtable)(**hv).variabledata;
 			/* During adapter_repack (migration), mark materialized tables as dirty to force save */
 			if (db_format_mode_current().adapter_repack && child != nil) {
 				(**child).fldirty = true;

--- a/Common/source/langipc.c
+++ b/Common/source/langipc.c
@@ -2693,8 +2693,8 @@ static boolean apptablevisit (bigstring bsname, hdlhashnode hnode, tyvaluerecord
 		return (false);
 	}
 
-ht = (hdlhashtable) (**hv).variabledata; 
-	
+	ht = (hdlhashtable) (**hv).variabledata;
+
 	if (appinfovisit (ht, bsname, appvisitinfo)) {
 		
 		(*appvisitinfo).apptablefound = ht;

--- a/Common/source/langipc.c
+++ b/Common/source/langipc.c
@@ -47,6 +47,7 @@
 #include "tableinternal.h" /*for error string numbers -- see langipctablemessage*/
 #include "tablestructure.h"
 #include "tableverbs.h"
+#include "db_format.h"
 #include "op.h"
 #include "meprograms.h"
 #include "process.h"
@@ -2684,10 +2685,15 @@ static boolean apptablevisit (bigstring bsname, hdlhashnode hnode, tyvaluerecord
 	
 	fltempload = !(**hv).flinmemory;
 	
-	if (!tableverbinmemory (NULL, (hdlexternalvariable) hv, hnode))
+	{
+	db_context ctx;
+	db_context_init(&ctx);
+
+	if (!tableverbinmemory (&ctx, (hdlexternalvariable) hv, hnode))
 		return (false);
-	
-	ht = (hdlhashtable) (**hv).variabledata; 
+	}
+
+ht = (hdlhashtable) (**hv).variabledata; 
 	
 	if (appinfovisit (ht, bsname, appvisitinfo)) {
 		

--- a/Common/source/legacy/tablepack_legacy.c
+++ b/Common/source/legacy/tablepack_legacy.c
@@ -217,14 +217,17 @@ boolean tableverbmemorypack_legacy (hdlexternalvariable h, Handle *hpacked, hdlh
 	register boolean fl;
 	boolean fltempload;
 	boolean fldummy;
-	db_context ctx;
 
 	fltempload = !(**hv).flinmemory;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, hnode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, hnode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata; 
 	
 	tablecheckwindowrect (ht); 
@@ -530,12 +533,15 @@ boolean tableverbpack_legacytotext (hdlexternalvariable h, Handle htext) {
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload = !(**hv).flinmemory;
-	db_context ctx;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, HNoNode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, HNoNode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata;
 	
 	//htextscrap = htext; /*set for visit routine*/
@@ -555,12 +561,15 @@ boolean tableverbgettimes_legacy (hdlexternalvariable h, long *timecreated, long
 
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	db_context ctx;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, hnode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, hnode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata;
 	
 	*timecreated = (**ht).timecreated;
@@ -575,12 +584,15 @@ boolean tableverbsettimes_legacy (hdlexternalvariable h, long timecreated, long 
 
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	db_context ctx;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, hnode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, hnode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata;
 	
 	(**ht).timecreated = timecreated;
@@ -629,14 +641,17 @@ boolean tableverbfindusedblocks_legacy (hdlexternalvariable h, bigstring bspath)
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload;
-	db_context ctx;
 
 	fltempload = !(**hv).flinmemory;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, HNoNode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, HNoNode))
+			return (false);
+	}
+
 	if (!statsblockinuse ((**hv).oldaddress, bspath))
 		return (false);
 	

--- a/Common/source/legacy/tablepack_legacy.c
+++ b/Common/source/legacy/tablepack_legacy.c
@@ -210,17 +210,19 @@ boolean tableunpacktable_legacy (Handle hpacked, boolean flmemory, hdlhashtable 
 
 
 boolean tableverbmemorypack_legacy (hdlexternalvariable h, Handle *hpacked, hdlhashnode hnode) {
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
 	Handle hpush;
 	register boolean fl;
 	boolean fltempload;
 	boolean fldummy;
-	
+	db_context ctx;
+
 	fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, hv, hnode))
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, hnode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata; 
@@ -302,29 +304,32 @@ boolean tableverbpack_legacy (hdlexternalvariable h, Handle *hpacked, boolean *f
 	boolean flmustsave = false;
 	hdlwindowinfo hinfo;
 	const boolean adapter_repack = db_format_adapter_force_repack();
-    db_format_mode legacy_mode = {false, adapter_repack, false};
-    db_format_mode_push(&legacy_mode);
+	db_format_mode legacy_mode = {false, adapter_repack, false};
+	db_context ctx;
+	db_format_mode_push(&legacy_mode);
 
 #if defined(FRONTIER_HEADLESS)
 	log_debug(LOG_COMP_TABLE, "tableverbpack_legacy start");
 #endif
-	
+
+	db_context_init(&ctx);
+
 	if (fldatabasesaveas) {
-		
+
 		fltempload = !(**hv).flinmemory;
-		
-		if (!tableverbinmemory (NULL, hv, HNoNode))
+
+		if (!tableverbinmemory (&ctx, hv, HNoNode))
 			return (false);
-		
+
 		*flnewdbaddress = true; /*it's in another database even*/
 		}
 
 	if (adapter_repack && !(**hv).flinmemory) {
 		fltempload = true;
-		if (!tableverbinmemory(NULL, hv, HNoNode)) {
-            db_format_mode_pop();
+		if (!tableverbinmemory(&ctx, hv, HNoNode)) {
+			db_format_mode_pop();
 			return (false);
-        }
+		}
 	}
 
 	if (!(**hv).flinmemory && !adapter_repack) { /*not in memory, just push the old db address*/
@@ -510,23 +515,25 @@ static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvalu
 
 
 boolean tableverbpack_legacytotext (hdlexternalvariable h, Handle htext) {
-	
+
 	/*
 	12/23/92 dmb: hashinversesearch now takes table as param; don't push/pop
-	
+
 	12/31/92 dmb: use hashsortedinversesearch so text is in correct order
-	
+
 	5.0.2b20 dmb: unload if just loaded
-	
+
 	5.1.5 dmb: use tablesortedinversesearch for guest databases
 	*/
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, hv, HNoNode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, HNoNode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -545,11 +552,13 @@ boolean tableverbpack_legacytotext (hdlexternalvariable h, Handle htext) {
 
 
 boolean tableverbgettimes_legacy (hdlexternalvariable h, long *timecreated, long *timemodified, hdlhashnode hnode) {
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	
-	if (!tableverbinmemory (NULL, hv, hnode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, hnode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -563,11 +572,13 @@ boolean tableverbgettimes_legacy (hdlexternalvariable h, long *timecreated, long
 
 
 boolean tableverbsettimes_legacy (hdlexternalvariable h, long timecreated, long timemodified, hdlhashnode hnode) {
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	
-	if (!tableverbinmemory (NULL, hv, hnode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, hnode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -613,15 +624,17 @@ static boolean findusedblocksvisit (hdlhashnode hnode, ptrvoid refcon) {
 
 
 boolean tableverbfindusedblocks_legacy (hdlexternalvariable h, bigstring bspath) {
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload;
-	
+	db_context ctx;
+
 	fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, hv, HNoNode))
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, HNoNode))
 		return (false);
 	
 	if (!statsblockinuse ((**hv).oldaddress, bspath))

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -990,10 +990,12 @@ boolean opverbgetlangtext (hdlexternalvariable hvariable, boolean flpretty, Hand
 	register hdloutlinerecord ho;
 	register boolean fltempload;
 	boolean fl;
-	
+	db_context ctx;
+
 	fltempload = !(**hv).flinmemory;
-	
-	if (!opverbinmemory (NULL, hv))
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -1022,12 +1024,14 @@ boolean opverbgetlangtext (hdlexternalvariable hvariable, boolean flpretty, Hand
 
 
 boolean opverbgetsize (hdlexternalvariable hvariable, long *size) {
-	
+
 	register hdloutlinevariable hv = (hdloutlinevariable) hvariable;
 	register hdloutlinerecord ho;
 	register long ctheads;
-	
-	if (!opverbinmemory (NULL, hv))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -1091,15 +1095,17 @@ boolean opverbisdirty (hdlexternalvariable hvariable) {
 
 
 boolean opverbsetdirty (hdlexternalvariable hvariable, boolean fldirty) {
-	
+
 	/*
 	4/15/92 dmb: see comments in langexternalsetdirty
 	*/
-	
+
 	register hdloutlinevariable hv = (hdloutlinevariable) hvariable;
 	register hdloutlinerecord ho;
-	
-	if (!opverbinmemory (NULL, hv))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -1111,21 +1117,23 @@ boolean opverbsetdirty (hdlexternalvariable hvariable, boolean fldirty) {
 
 
 boolean opverbpacktotext (hdlexternalvariable h, Handle htext) {
-	
+
 	/*
-	12/13/91 dmb: now that opgetlangtext can make it pretty, use it 
+	12/13/91 dmb: now that opgetlangtext can make it pretty, use it
 	when exporting scripts
-	
+
 	5.0.2b20 dmb: unload if just loaded
 	*/
-	
+
 	register hdloutlinevariable hv = (hdloutlinevariable) h;
 	register hdloutlinerecord ho;
 	register boolean fl;
 	Handle hprogram;
 	boolean fltempload = !(**hv).flinmemory;
-	
-	if (!opverbinmemory (NULL, hv))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -1152,11 +1160,13 @@ boolean opverbpacktotext (hdlexternalvariable h, Handle htext) {
 
 
 boolean opverbgettimes (hdlexternalvariable h, int64_t *timecreated, int64_t *timemodified) {
-	
+
 	register hdloutlinevariable hv = (hdloutlinevariable) h;
 	register hdloutlinerecord ho;
-	
-	if (!opverbinmemory (NULL, hv))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -1170,11 +1180,13 @@ boolean opverbgettimes (hdlexternalvariable h, int64_t *timecreated, int64_t *ti
 
 
 boolean opverbsettimes (hdlexternalvariable h, int64_t timecreated, int64_t timemodified) {
-	
+
 	register hdloutlinevariable hv = (hdloutlinevariable) h;
 	register hdloutlinerecord ho;
-	
-	if (!opverbinmemory (NULL, hv))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -1382,26 +1394,28 @@ static boolean getscriptparam (hdltreenode hfirst, short pnum, hdloutlinevariabl
 
 
 boolean getoutlinevalue (hdltreenode hfirst, short pnum, hdloutlinerecord *houtline) {
-	
+
 	/*
 	5.0.2b15 dmb: public routline - get an outline or script parameter, passed by reference
 	*/
-	
+
 	hdloutlinevariable hv;
 	bigstring bserror;
 	short id;
-	
+	db_context ctx;
+
 	if (!langexternalgetexternalparam (hfirst, pnum, &id, (hdlexternalvariable *) &hv) ||
 		 ((id != idoutlineprocessor) && (id != idscriptprocessor))) {
-		
+
 		getstringlist (operrorlist, namenotoutlineerror, bserror);
-		
+
 		langerrormessage (bserror);
-		
+
 		return (false);
 		}
-	
-	if (!opverbinmemory (NULL, hv))
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	*houtline = (hdloutlinerecord) (**hv).variabledata;
@@ -1412,13 +1426,15 @@ boolean getoutlinevalue (hdltreenode hfirst, short pnum, hdloutlinerecord *houtl
 
 
 boolean opverbarrayreference (hdlexternalvariable hvariable, long ix, hdlheadrecord *hnode) {
-	
+
 	register hdloutlinevariable hv = (hdloutlinevariable) hvariable;
 	register boolean fl;
-	
+	db_context ctx;
+
 	*hnode = nil;
-	
-	if (!opverbinmemory (NULL, hv)) /*couldn't swap into memory*/
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv)) /*couldn't swap into memory*/
 		return (false);
 		
 	oppushoutline ((hdloutlinerecord) (**hv).variabledata); /*assume it's in memory*/
@@ -1464,8 +1480,10 @@ boolean opedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfilespe
 	WindowPtr w;
 	hdlwindowinfo hi;
 	short id;
+	db_context ctx;
 
-	if (!opverbinmemory (NULL, hv)) // couldn't swap it into memory
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv)) // couldn't swap it into memory
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata; // assume it's in memory
@@ -1593,23 +1611,25 @@ boolean opedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfilespe
 	
 	
 boolean opvaltoscript (tyvaluerecord val, hdloutlinerecord *houtline) {
-	
+
 	/*
 	called externally -- you give us a value that holds a script that's
 	a tableprocessor variable, we'll return you a handle to the outline.
 	*/
-	
+
 	register hdloutlinevariable hv;
-	
+	db_context ctx;
+
 	if (val.valuetype != externalvaluetype)
 		return (false);
-	
+
 	hv = (hdloutlinevariable) val.data.externalvalue;
-	
+
 	if ((**hv).id != idscriptprocessor)
 		return (false);
-	
-	if (!opverbinmemory (NULL, hv))
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	*houtline = (hdloutlinerecord) (**hv).variabledata;
@@ -2061,30 +2081,32 @@ static boolean opgettypeverb (hdltreenode hparam1, tyvaluerecord *v) {
 
 
 static boolean opsettypeverb (hdltreenode hparam1, tyvaluerecord *v) {
-	
+
 	/*
 	2.1b12 dmb: new verb
 	*/
-	
+
 	register hdltreenode hp1 = hparam1;
 	bigstring bsname;
 	hdloutlinevariable hv;
 	hdloutlinerecord ho;
 	long signature;
 	hdlwindowinfo hinfo;
-	
+	db_context ctx;
+
 	if (!getscriptparam (hp1, 1, &hv))
 		return (false);
-	
+
 	flnextparamislast = true;
-	
+
 	if (!getstringvalue (hp1, 2, bsname))
 		return (false);
-	
+
 	if (!scriptgetnametype (bsname, &signature)) /*unknown, let verb return false*/
 		return (true);
-	
-	if (!opverbinmemory (NULL, hv))
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;
@@ -3959,7 +3981,7 @@ static boolean opfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord 
 			}
 		
 		case insertoutlinefunc: {
-			
+
 			/*
 			7.0b13 PBS: menus can be inserted into menus now.
 			*/
@@ -3968,6 +3990,7 @@ static boolean opfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord 
 			short id;
 			tydirection dir;
 			boolean floutline = true;
+			db_context ctx;
 
 			if (!langexternalgetexternalparam (hparam1, 1, &id, (hdlexternalvariable *) &hv))
 				floutline = false;
@@ -3979,7 +4002,7 @@ static boolean opfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord 
 					case idoutlineprocessor:
 					case idmenuprocessor:
 					case idscriptprocessor:
-					
+
 						floutline = true;
 
 						break;
@@ -3989,20 +4012,21 @@ static boolean opfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord 
 						floutline = false;
 					} /*switch*/
 				} /*if*/
-			
+
 			//if (!langexternalgetexternalparam (hparam1, 1, &id, (hdlexternalvariable *) &hv) || (id != idoutlineprocessor)) {
 			if (!floutline) {
-					
+
 				bigstring lbserror;
-				
+
 				getstringlist (operrorlist, namenotoutlineerror, lbserror);
-				
+
 				langerrormessage (lbserror);
-				
+
 				return (false);
 				}
-			
-			if (!opverbinmemory (NULL, hv))
+
+			db_context_init(&ctx);
+			if (!opverbinmemory (&ctx, hv))
 				return (false);
 			
 			flnextparamislast = true;
@@ -4336,10 +4360,12 @@ boolean opverbfind (hdlexternalvariable hvariable, boolean *flzoom) {
 	boolean flwindowopen;
 	hdlwindowinfo hinfo;
 	boolean fldisplaywasenabled = true;
-	
+	db_context ctx;
+
 	fltempload = !(**hv).flinmemory;
-	
-	if (!opverbinmemory (NULL, hv))
+
+	db_context_init(&ctx);
+	if (!opverbinmemory (&ctx, hv))
 		return (false);
 	
 	ho = (hdloutlinerecord) (**hv).variabledata;

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -594,11 +594,9 @@ boolean opverbinmemory (const db_context *ctx, hdlexternalvariable hvariable) {
 	Handle hpackedoutline;
 	long ix = 0;
 
-	/* Issue #347: Warn if caller passes NULL context (should use db_context_init) */
+	/* Issue #347: Assert context is not NULL - all callers should use db_context_init() */
 #if defined(FRONTIER_HEADLESS) && !defined(NDEBUG)
-	if (ctx == NULL) {
-		log_warn(LOG_COMP_OP, "opverbinmemory: NULL context passed - caller should use db_context_init()");
-	}
+	assert(ctx != NULL && "Issue #347: NULL context passed to opverbinmemory - use db_context_init()");
 #endif
 
 	if ((**hv).flinmemory) /*nothing to do, it's already in memory*/

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -594,6 +594,13 @@ boolean opverbinmemory (const db_context *ctx, hdlexternalvariable hvariable) {
 	Handle hpackedoutline;
 	long ix = 0;
 
+	/* Issue #347: Warn if caller passes NULL context (should use db_context_init) */
+#if defined(FRONTIER_HEADLESS) && !defined(NDEBUG)
+	if (ctx == NULL) {
+		log_warn(LOG_COMP_OP, "opverbinmemory: NULL context passed - caller should use db_context_init()");
+	}
+#endif
+
 	if ((**hv).flinmemory) /*nothing to do, it's already in memory*/
 		return (true);
 

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -47,6 +47,7 @@
 #include "pictverbs.h"
 #include "kernelverbdefs.h"
 #include "logging.h"
+#include "db_format.h"
 
 
 
@@ -503,11 +504,13 @@ boolean pictverbpacktotext (hdlexternalvariable h, Handle htext) {
 
 
 boolean pictverbgetsize (hdlexternalvariable hvariable, long *size) {
-	
+
 	register hdlpictvariable hv = (hdlpictvariable) hvariable;
 	register PicHandle macpicture;
+	db_context ctx;
 
-	if (!pictverbinmemory (NULL, hvariable))
+	db_context_init(&ctx);
+	if (!pictverbinmemory (&ctx, hvariable))
 		return (false);
 
 	macpicture = (**(hdlpictrecord) (**hv).variabledata).macpicture;
@@ -563,14 +566,16 @@ boolean pictverbisdirty (hdlexternalvariable hvariable) {
 
 
 boolean pictverbsetdirty (hdlexternalvariable hvariable, boolean fldirty) {
-	
+
 	/*
 	4/15/92 dmb: see comments in langexternalsetdirty
 	*/
-	
-	register hdlpictvariable hv = (hdlpictvariable) hvariable;
 
-	if (!pictverbinmemory (NULL, hvariable))
+	register hdlpictvariable hv = (hdlpictvariable) hvariable;
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!pictverbinmemory (&ctx, hvariable))
 		return (false);
 
 	(**(hdlpictrecord) (**hv).variabledata).fldirty = fldirty;
@@ -583,8 +588,10 @@ boolean pictverbgettimes (hdlexternalvariable h, int64_t *timecreated, int64_t *
 
 	register hdlpictvariable hv = (hdlpictvariable) h;
 	register hdlpictrecord hp;
+	db_context ctx;
 
-	if (!pictverbinmemory (NULL, h)) /*couldn't swap it into memory*/
+	db_context_init(&ctx);
+	if (!pictverbinmemory (&ctx, h)) /*couldn't swap it into memory*/
 		return (false);
 	
 	hp = (hdlpictrecord) (**hv).variabledata; /*assume it's in memory*/
@@ -601,8 +608,10 @@ boolean pictverbsettimes (hdlexternalvariable h, int64_t timecreated, int64_t ti
 
 	register hdlpictvariable hv = (hdlpictvariable) h;
 	register hdlpictrecord hp;
+	db_context ctx;
 
-	if (!pictverbinmemory (NULL, h)) /*couldn't swap it into memory*/
+	db_context_init(&ctx);
+	if (!pictverbinmemory (&ctx, h)) /*couldn't swap it into memory*/
 		return (false);
 	
 	hp = (hdlpictrecord) (**hv).variabledata; /*assume it's in memory*/
@@ -632,7 +641,7 @@ boolean pictwindowopen (hdlexternalvariable hvariable, hdlwindowinfo *hinfo) {
 
 
 boolean pictedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfilespec fs, bigstring bstitle, rectparam rzoom) {
-	
+
 	/*
 	5.0.2b6 dmb: added flwindowopen loop to handle Windows async overlap
 	*/
@@ -642,8 +651,10 @@ boolean pictedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfiles
 	Rect rwindow;
 	WindowPtr w;
 	hdlwindowinfo hi;
+	db_context ctx;
 
-	if (!pictverbinmemory (NULL, hvariable)) /*couldn't swap it into memory*/
+	db_context_init(&ctx);
+	if (!pictverbinmemory (&ctx, hvariable)) /*couldn't swap it into memory*/
 		return (false);
 	
 	hp = (hdlpictrecord) (**hv).variabledata; /*assume it's in memory*/

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -213,6 +213,13 @@ boolean pictverbinmemory (const db_context *ctx, hdlexternalvariable hv) {
 	long ix = 0;
 	hdlpictrecord hpict;
 
+	/* Issue #347: Warn if caller passes NULL context (should use db_context_init) */
+#if defined(FRONTIER_HEADLESS) && !defined(NDEBUG)
+	if (ctx == NULL) {
+		log_warn(LOG_COMP_OP, "pictverbinmemory: NULL context passed - caller should use db_context_init()");
+	}
+#endif
+
 #if defined(FRONTIER_HEADLESS)
 	log_debug(LOG_COMP_OP, "pictverbinmemory: ENTER hv=%p", (void*)hv);
 #endif

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -214,11 +214,9 @@ boolean pictverbinmemory (const db_context *ctx, hdlexternalvariable hv) {
 	long ix = 0;
 	hdlpictrecord hpict;
 
-	/* Issue #347: Warn if caller passes NULL context (should use db_context_init) */
+	/* Issue #347: Assert context is not NULL - all callers should use db_context_init() */
 #if defined(FRONTIER_HEADLESS) && !defined(NDEBUG)
-	if (ctx == NULL) {
-		log_warn(LOG_COMP_OP, "pictverbinmemory: NULL context passed - caller should use db_context_init()");
-	}
+	assert(ctx != NULL && "Issue #347: NULL context passed to pictverbinmemory - use db_context_init()");
 #endif
 
 #if defined(FRONTIER_HEADLESS)

--- a/Common/source/tableexternal.c
+++ b/Common/source/tableexternal.c
@@ -51,20 +51,22 @@
 #include "claycallbacks.h"
 #include "cancoon.h"
 #include "logging.h"
+#include "db_format.h"
 
 /* 2025-12-01 Codex: Add headless diagnostics for tablevaltotable to trace migration lookups. */
 
 
 
 boolean tablevaltotable (tyvaluerecord val, hdlhashtable *htable, hdlhashnode hnode) {
-	
+
 	/*
 	called externally -- you give us a value that holds an external value that's
 	a tableprocessor variable, we'll return you a handle to the hashtable.
 	*/
-	
+
 	hdltablevariable hvariable;
 	short errorcode;
+	db_context ctx;
 
 	log_debug(LOG_COMP_TABLE, "tablevaltotable enter valtype=%d external=0x%llx hnode=%p",
 	          (int) val.valuetype,
@@ -75,9 +77,10 @@ boolean tablevaltotable (tyvaluerecord val, hdlhashtable *htable, hdlhashnode hn
 		log_debug(LOG_COMP_TABLE, "tablevaltotable gettablevariable failed err=%d valtype=%d",
 		          (int) errorcode, (int) val.valuetype);
 		return (false);
-    }
+	}
 
-	if (!tableverbinmemory (NULL, (hdlexternalvariable) hvariable, hnode)) {
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, (hdlexternalvariable) hvariable, hnode)) {
 		log_debug(LOG_COMP_TABLE, "tablevaltotable tableverbinmemory failed valtype=%d oldaddr=%llx hnode=%p",
 		          (int) val.valuetype,
 		          (unsigned long long) (**hvariable).oldaddress,
@@ -177,22 +180,24 @@ static boolean tabledisposevariable (hdlexternalvariable hvariable, boolean fldi
 
 
 boolean tableverbdispose (hdlexternalvariable hvariable, boolean fldisk) {
-	
+
 	/*
-	1/25/91 dmb: special-case local tables; they're the only kind of 
-	system table that can be thrown out.  we might be able to get rid 
+	1/25/91 dmb: special-case local tables; they're the only kind of
+	system table that can be thrown out.  we might be able to get rid
 	of this dirtyness after we support locked tables
-	
-	12/22/91 dmb: in order to release all db nodes properly, must force 
+
+	12/22/91 dmb: in order to release all db nodes properly, must force
 	table to be loaded into memory when fldisk is true
 	*/
-	
+
 	register hdltablevariable hv = (hdltablevariable) hvariable;
 	register hdlhashtable ht;
-	
+	db_context ctx;
+
 	if (fldisk) { /*load table into memory so that all items can release their db nodes*/
-		
-		if (!tableverbinmemory (NULL, (hdlexternalvariable) hv, HNoNode))
+
+		db_context_init(&ctx);
+		if (!tableverbinmemory (&ctx, (hdlexternalvariable) hv, HNoNode))
 			return (false);
 		}
 	
@@ -235,11 +240,13 @@ boolean tableverbinmemory (const db_context *ctx, hdlexternalvariable hvariable,
 	
 
 boolean tableverbgetsize (hdlexternalvariable hvariable, long *size) {
-	
+
 	register hdlexternalvariable hv = hvariable;
 	long ctitems;
-	
-	if (!tableverbinmemory (NULL, hv, HNoNode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, HNoNode))
 		return (false);
 		
 	hashcountitems ((hdlhashtable) (**hv).variabledata, &ctitems);
@@ -271,15 +278,17 @@ boolean tableverbisdirty (hdlexternalvariable hvariable) {
 
 
 boolean tableverbsetdirty (hdlexternalvariable hvariable, boolean fldirty) {
-	
+
 	/*
-	4/15/92 dmb: see comments in langexternalsetdirty.  also note that when the table 
+	4/15/92 dmb: see comments in langexternalsetdirty.  also note that when the table
 	is being set as clean, its may still be dirty.
 	*/
-	
+
 	register hdltablevariable hv = (hdltablevariable) hvariable;
-	
-	if (!tableverbinmemory (NULL, (hdlexternalvariable) hv, HNoNode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, (hdlexternalvariable) hv, HNoNode))
 		return (false);
 	
 	(**(hdlhashtable) (**hv).variabledata).fldirty = fldirty;
@@ -374,14 +383,14 @@ boolean tableverbsetupdisplay (hdlhashtable htable, hdlwindowinfo hinfo) {
 
 
 boolean tableedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfilespec fs, bigstring bs, rectparam rzoom) {
-	
+
 	//
 	// 2006-09-16 creedon: on Mac, only set the window proxy icon when the file exists
 	//
 	// 1993--3-30 dmb:	don't resort the table before zooming. not sure why this was ever necessary, but it sure is slow
 	//				for large tables
 	//
-	
+
 	register hdltablevariable hv = (hdltablevariable) hvariable;
 	register hdlhashtable ht;
 	register hdltableformats hf;
@@ -390,10 +399,12 @@ boolean tableedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfile
 	bigstring bsname;
 	WindowPtr w;
 	hdlwindowinfo hi;
+	db_context ctx;
 
-    (void) fs;
-	
-	if (!tableverbinmemory (NULL, (hdlexternalvariable) hv, HNoNode)) // couldn't swap it into memory
+	(void) fs;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, (hdlexternalvariable) hv, HNoNode)) // couldn't swap it into memory
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -315,11 +315,9 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     bigstring bspath, bsunpackerror;
     boolean fl;
 
-    /* Issue #347: Warn if caller passes NULL context (should use db_context_init) */
+    /* Issue #347: Assert context is not NULL - all callers should use db_context_init() */
 #if !defined(NDEBUG)
-    if (ctx == NULL) {
-        log_warn(LOG_COMP_TABLE, "tableverbinmemory_common: NULL context passed - caller should use db_context_init()");
-    }
+    assert(ctx != NULL && "Issue #347: NULL context passed to tableverbinmemory_common - use db_context_init()");
 #endif
 
     log_trace(LOG_COMP_TABLE, "tableverbinmemory enter hvariable=%p hnode=%p flinmemory=%d",

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -315,6 +315,13 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     bigstring bspath, bsunpackerror;
     boolean fl;
 
+    /* Issue #347: Warn if caller passes NULL context (should use db_context_init) */
+#if !defined(NDEBUG)
+    if (ctx == NULL) {
+        log_warn(LOG_COMP_TABLE, "tableverbinmemory_common: NULL context passed - caller should use db_context_init()");
+    }
+#endif
+
     log_trace(LOG_COMP_TABLE, "tableverbinmemory enter hvariable=%p hnode=%p flinmemory=%d",
             (void *) hvariable,
             (void *) hnode,

--- a/Common/source/tablefind.c
+++ b/Common/source/tablefind.c
@@ -38,6 +38,7 @@
 #include "tablestructure.h"
 #include "tableinternal.h"
 #include "tableverbs.h"
+#include "db_format.h"
 
 
 
@@ -343,9 +344,14 @@ boolean tableverbfind (hdlexternalvariable hvariable, boolean *flzoom) {
 	boolean fltempload;
 	
 	fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, (hdlexternalvariable) hv, HNoNode))
-		return (false);
+
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, (hdlexternalvariable) hv, HNoNode))
+			return (false);
+		}
 	
 	ht = (hdlhashtable) (**hv).variabledata; 
 	

--- a/Common/source/tableops.c
+++ b/Common/source/tableops.c
@@ -43,6 +43,7 @@
 #include "tableinternal.h"
 #include "tableverbs.h"
 #include "claybrowser.h"
+#include "db_format.h"
 
 /* 2025-12-01 Codex: Clamp headless table lookup logs to string length to keep debug output readable. */
 
@@ -443,45 +444,48 @@ boolean findvariablesearch (hdlhashtable intable, hdlexternalvariable forvariabl
 	register short i;
 	tyvaluerecord val;
 	register hdlexternalvariable hv = nil;
-	
+	db_context ctx;
+
+	db_context_init(&ctx);
+
 	for (i = 0; i < ctbuckets; i++) {
-		
+
 		x = (**ht).hashbucket [i];
-		
+
 		while (x != nil) { /*chain through the hash list*/
-			
+
 			register boolean fltempload = false;
-			
+
 			val = (**x).val;
-			
-			if (val.valuetype != externalvaluetype) 
+
+			if (val.valuetype != externalvaluetype)
 				goto nextx;
-				
+
 			hv = (hdlexternalvariable) val.data.externalvalue;
-			
+
 			if (hv == forvariable) { /*bravo!  we found it...*/
-				
+
 				*foundintable = ht;
-				
+
 				gethashkey (x, foundname);
-				
+
 				if (ancestorcallback != nil)
 					(*ancestorcallback) (ht, x);
-				
+
 				return (true);
 				}
-			
+
 			if (!istablevariable (hv))
 				goto nextx;
-			
+
 			if (!(**hv).flinmemory) {
-				
+
 				if (flonlyinmemory)
 					goto nextx;
-					
-				if (!tableverbinmemory (NULL, hv, x))
+
+				if (!tableverbinmemory (&ctx, hv, x))
 					return (false);
-					
+
 				fltempload = true;
 				}
 			
@@ -699,64 +703,67 @@ static boolean findtablevisit (hdlhashnode hnode, ptrvoid refcon) {
 
 
 static boolean parentsearch (hdlhashtable intable, hdlhashtable fortable, boolean flonlyinmemory, hdlhashtable *hparent, bigstring bsname) {
-	
+
 	/*
 	4/29/96 4.0b8 dmb: we need to convert fortable to a parenttable/name address pair
-	
+
 	root is a special case.
-	
-	we have no direct way of making a table-to-parent connection independent of 
-	windows. someday, we should make the parenttable field always valid, but that 
+
+	we have no direct way of making a table-to-parent connection independent of
+	windows. someday, we should make the parenttable field always valid, but that
 	will require relatively extensive (minor but widely distributed) code change.
-	
+
 	5.0.2b13 dmb: moved this in from langvalue.c
 	*/
-	
+
 	register hdlhashtable ht = intable;
 	register hdlhashnode x;
 	register short i;
 	tyvaluerecord val;
 	register hdlexternalvariable hv = nil;
-	
+	db_context ctx;
+
+	db_context_init(&ctx);
+
 	if (intable == fortable) {	/*special case for root*/
-	
+
 		*hparent = nil;
-		
+
 		if ((**intable).fllocaltable)
 			setemptystring (bsname);
 		else
 			copystring (nameroottable, bsname);
-		
+
 		return (true);
 		}
-	
+
 	for (i = 0; i < ctbuckets; i++) {
-		
+
 		x = (**ht).hashbucket [i];
-		
+
 		while (x != nil) { /*chain through the hash list*/
-			
+
 			register boolean fltempload = false;
 			hdlhashtable htable;
-			
+
 			val = (**x).val;
-			
-			if (val.valuetype != externalvaluetype) 
+
+			if (val.valuetype != externalvaluetype)
 				goto nextx;
-				
+
 			hv = (hdlexternalvariable) val.data.externalvalue;
-	
+
 			if ((**hv).id != idtableprocessor)
 				goto nextx;
-			
+
 			if (!(**hv).flinmemory) {
-			
+
 				if (flonlyinmemory)	/*can't find it if it isn't in memory*/
 					goto nextx;
-				
-				if (!tableverbinmemory (NULL, hv, x))
+
+				if (!tableverbinmemory (&ctx, hv, x))
 					return (false);
-					
+
 				fltempload = true;
 				}
 			

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -246,14 +246,17 @@ boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode
 	register boolean fl;
 	boolean fltempload;
 	boolean fldummy;
-	db_context ctx;
 
 	fltempload = !(**hv).flinmemory;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, hnode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, hnode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata; 
 	
 	tablecheckwindowrect (ht); 
@@ -598,23 +601,26 @@ boolean tableverbpacktotext (hdlexternalvariable h, Handle htext) {
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload = !(**hv).flinmemory;
-	db_context ctx;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, HNoNode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, HNoNode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata;
-	
+
 	//htextscrap = htext; /*set for visit routine*/
-	
+
 	//fl = !hashinversesearch (ht, &tablepacktotextvisit, bsname); /*false means complete traversal%/
-	
+
 	fl = !tablesortedinversesearch (ht, &tablepacktotextvisit, htext);
-	
+
 	if (fltempload)
 		tableverbunload (hv);
-	
+
 	return (fl);
 	} /*tableverbpacktotext*/
 
@@ -623,12 +629,15 @@ boolean tableverbgettimes (hdlexternalvariable h, int64_t *timecreated, int64_t 
 
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	db_context ctx;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, hnode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, hnode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata;
 	
 	*timecreated = (**ht).timecreated;
@@ -643,12 +652,15 @@ boolean tableverbsettimes (hdlexternalvariable h, int64_t timecreated, int64_t t
 
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	db_context ctx;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, hnode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, hnode))
+			return (false);
+	}
+
 	ht = (hdlhashtable) (**hv).variabledata;
 	
 	(**ht).timecreated = timecreated;
@@ -697,14 +709,17 @@ boolean tableverbfindusedblocks (hdlexternalvariable h, bigstring bspath) {
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload;
-	db_context ctx;
 
 	fltempload = !(**hv).flinmemory;
 
-	db_context_init(&ctx);
-	if (!tableverbinmemory (&ctx, hv, HNoNode))
-		return (false);
-	
+	{
+		db_context ctx;
+		db_context_init(&ctx);
+
+		if (!tableverbinmemory (&ctx, hv, HNoNode))
+			return (false);
+	}
+
 	if (!statsblockinuse ((**hv).oldaddress, bspath))
 		return (false);
 	

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -239,17 +239,19 @@ boolean tableunpacktable (Handle hpacked, boolean flmemory, hdlhashtable *htable
 
 
 boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode hnode) {
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
 	Handle hpush;
 	register boolean fl;
 	boolean fltempload;
 	boolean fldummy;
-	
+	db_context ctx;
+
 	fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, hv, hnode))
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, hnode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata; 
@@ -581,23 +583,25 @@ static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvalu
 
 
 boolean tableverbpacktotext (hdlexternalvariable h, Handle htext) {
-	
+
 	/*
 	12/23/92 dmb: hashinversesearch now takes table as param; don't push/pop
-	
+
 	12/31/92 dmb: use hashsortedinversesearch so text is in correct order
-	
+
 	5.0.2b20 dmb: unload if just loaded
-	
+
 	5.1.5 dmb: use tablesortedinversesearch for guest databases
 	*/
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, hv, HNoNode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, HNoNode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -619,8 +623,10 @@ boolean tableverbgettimes (hdlexternalvariable h, int64_t *timecreated, int64_t 
 
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	
-	if (!tableverbinmemory (NULL, hv, hnode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, hnode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -637,8 +643,10 @@ boolean tableverbsettimes (hdlexternalvariable h, int64_t timecreated, int64_t t
 
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
-	
-	if (!tableverbinmemory (NULL, hv, hnode))
+	db_context ctx;
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, hnode))
 		return (false);
 	
 	ht = (hdlhashtable) (**hv).variabledata;
@@ -684,15 +692,17 @@ static boolean findusedblocksvisit (hdlhashnode hnode, ptrvoid refcon) {
 
 
 boolean tableverbfindusedblocks (hdlexternalvariable h, bigstring bspath) {
-	
+
 	register hdlexternalvariable hv = h;
 	register hdlhashtable ht;
 	register boolean fl;
 	boolean fltempload;
-	
+	db_context ctx;
+
 	fltempload = !(**hv).flinmemory;
-	
-	if (!tableverbinmemory (NULL, hv, HNoNode))
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, hv, HNoNode))
 		return (false);
 	
 	if (!statsblockinuse ((**hv).oldaddress, bspath))

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -552,7 +552,9 @@ boolean headless_init_system_paths (hdlhashtable hroot) {
 				if (val_check.valuetype == externalvaluetype) {
 					// Force hydration by calling tableverbinmemory
 					hdlexternalvariable hv = (hdlexternalvariable)val_check.data.externalvalue;
-					if (tableverbinmemory(NULL, hv, hnode_check)) {
+					db_context ctx;
+					db_context_init(&ctx);
+					if (tableverbinmemory(&ctx, hv, hnode_check)) {
 						log_trace(LOG_COMP_LANG, "Hydrated external table %s before findnamedtable", cname);
 					} else {
 						log_warn(LOG_COMP_LANG, "Failed to hydrate external table %s", cname);
@@ -933,39 +935,41 @@ boolean tableloadsystemtable (dbaddress adr, Handle *hvariable, hdlhashtable *ht
 	register hdlexternalvariable hv;
 	register hdlhashtable ht;
 	hdlhashtable hsubtable;
+	db_context ctx;
 
 	log_debug(LOG_COMP_TABLE, "tableloadsystemtable adr=0x%llx flcreate=%d",
 	          (unsigned long long) adr, (int) flcreate);
 
 	assert (sizeof (tyexternalvariable) == sizeof (tytablevariable));
-	
+
 	if (adr == nildbaddress) { /*start an empty table*/
-		
+
 		if (!tablenewtable ((hdltablevariable *) hvariable, htable)) /*this will be the root table*/
 			return (false);
-		
+
 		hv = (hdlexternalvariable) *hvariable;
-		
+
 		if (flcreate && !tablenewsubtable (*htable, namesystembranch, &hsubtable)) {
-			
+
 			tableverbdispose (hv, true);
-			
+
 			return (false);
 			}
 		}
 	else {
-		
+
 		if (!newtablevariable (false, adr, (hdltablevariable *) hvariable, false))
 			return (false);
-		
+
 		hv = (hdlexternalvariable) *hvariable;
-		
-	if (!tableverbinmemory (NULL, hv, HNoNode)) {
-		
-		disposehandle ((Handle) hv);
-		
-		return (false);
-		}
+
+		db_context_init(&ctx);
+		if (!tableverbinmemory (&ctx, hv, HNoNode)) {
+
+			disposehandle ((Handle) hv);
+
+			return (false);
+			}
 		}
 	
 	ht = (hdlhashtable) (**hv).variabledata;

--- a/Common/source/tablevalidate.c
+++ b/Common/source/tablevalidate.c
@@ -36,6 +36,7 @@
 #include "tableinternal.h"
 #include "tablestructure.h"
 #include "tableverbs.h"
+#include "db_format.h"
 
 
 
@@ -133,7 +134,11 @@ static boolean validate (hdlhashtable htable, boolean flalert) {
 				if (flonlyinmemory)
 					goto nextx;
 					
-				if (!tableverbinmemory (NULL, (hdlexternalvariable) hvariable, x)) {
+				{
+				db_context ctx;
+				db_context_init(&ctx);
+
+				if (!tableverbinmemory (&ctx, (hdlexternalvariable) hvariable, x)) {
 					
 					if (flalert)
 						shellinternalerror (iderrorloadingtable, BIGSTRING ("\x13" "error loading table"));
@@ -141,7 +146,8 @@ static boolean validate (hdlhashtable htable, boolean flalert) {
 					return (false);
 					}
 				}
-			
+			}
+
 			assert (tablesetdebugglobals (ht, x));
 			
 			if (!validate ((hdlhashtable) (**hvariable).variabledata, flalert)) /*recurse*/

--- a/Common/source/tableverbs.c
+++ b/Common/source/tableverbs.c
@@ -133,15 +133,17 @@ static boolean gettableparam (hdltreenode hfirst, short pnum, hdlhashtable *htab
 
 
 boolean gettablevalue (hdltreenode hfirst, short pnum, hdlhashtable *htable) {
-	
+
 	hdltablevariable hv;
 	bigstring bsname;
 	hdlhashnode hnode;
-	
+	db_context ctx;
+
 	if (!gettableparam (hfirst, pnum, htable, bsname, &hv, &hnode))
 		return (false);
-	
-	if (!tableverbinmemory (NULL, (hdlexternalvariable) hv, hnode)) /*couldn't swap it into memory*/
+
+	db_context_init(&ctx);
+	if (!tableverbinmemory (&ctx, (hdlexternalvariable) hv, hnode)) /*couldn't swap it into memory*/
 		return (false);
 	
 	*htable = (hdlhashtable) (**hv).variabledata;

--- a/tests/headless_op_verbs.c
+++ b/tests/headless_op_verbs.c
@@ -47,6 +47,7 @@
 #include "frontier.h"
 #include "standard.h"
 
+#include "db_format.h"
 #include "memory.h"
 #include "strings.h"
 #include "lang.h"
@@ -134,9 +135,14 @@ static boolean getoutlinefromtarget(hdloutlinerecord *ho, bigstring bserror) {
     }
 
     /* Ensure outline is in memory */
-    if (!opverbinmemory(NULL, hv)) {
-        seterrorstring("could not load outline", bserror);
-        return false;
+    {
+        db_context ctx;
+        db_context_init(&ctx);
+
+        if (!opverbinmemory(&ctx, hv)) {
+            seterrorstring("could not load outline", bserror);
+            return false;
+        }
     }
 
     /* Get the outline record */
@@ -1486,8 +1492,13 @@ static boolean op_valueproc(short token, hdltreenode hparam1,
             }
 
             /* Ensure outline is in memory */
-            if (!opverbinmemory(NULL, hv))
-                return false;
+            {
+                db_context ctx;
+                db_context_init(&ctx);
+
+                if (!opverbinmemory(&ctx, hv))
+                    return false;
+            }
 
             /* Get direction parameter */
             flnextparamislast = true;

--- a/tests/headless_script_verbs.c
+++ b/tests/headless_script_verbs.c
@@ -33,6 +33,7 @@
 #include "frontier.h"
 #include "standard.h"
 
+#include "db_format.h"
 #include "memory.h"
 #include "strings.h"
 #include "lang.h"
@@ -227,9 +228,14 @@ static boolean script_setsource(hdltreenode hparam1, tyvaluerecord *vreturned) {
         return false;
 
     /* Ensure script is in memory */
-    if (!opverbinmemory(NULL, hv)) {
-        disposehandle(hsourcetext);
-        return false;
+    {
+        db_context ctx;
+        db_context_init(&ctx);
+
+        if (!opverbinmemory(&ctx, hv)) {
+            disposehandle(hsourcetext);
+            return false;
+        }
     }
 
     /* Validate hv before dereferencing */

--- a/tests/headless_thread_registry_tests.c
+++ b/tests/headless_thread_registry_tests.c
@@ -69,9 +69,17 @@ TEST(init_and_cleanup) {
 TEST(id_allocation_unique) {
     init_thread_registry();
 
-    long id1 = allocate_thread_id();
-    long id2 = allocate_thread_id();
-    long id3 = allocate_thread_id();
+    frontier_pthread_record *rec1 = allocate_thread_record();
+    frontier_pthread_record *rec2 = allocate_thread_record();
+    frontier_pthread_record *rec3 = allocate_thread_record();
+
+    ASSERT_NOT_NULL(rec1);
+    ASSERT_NOT_NULL(rec2);
+    ASSERT_NOT_NULL(rec3);
+
+    long id1 = rec1->user_thread_id;
+    long id2 = rec2->user_thread_id;
+    long id3 = rec3->user_thread_id;
 
     /* IDs must be positive */
     ASSERT(id1 > 0);
@@ -86,6 +94,11 @@ TEST(id_allocation_unique) {
     /* IDs must be monotonically increasing */
     ASSERT(id2 > id1);
     ASSERT(id3 > id2);
+
+    /* Clean up records */
+    free_thread_record(rec1);
+    free_thread_record(rec2);
+    free_thread_record(rec3);
 
     cleanup_thread_registry();
 }


### PR DESCRIPTION
## Summary

Fixes Issue #347 - Replace all NULL context calls to `*verbinmemory()` functions with explicit `db_context` structs.

- **51 call sites fixed** across 17 files (48 production + 3 test)
- **Hard assertions added** to catch future NULL context calls in debug builds
- **Bonus fix**: Thread registry test was calling non-existent function

### Changes by Phase

| Phase | Files | Calls Fixed |
|-------|-------|-------------|
| 1 | 3 files | Add NULL context warnings |
| 2 | opverbs.c, tablepack.c, tablepack_legacy.c | 25 calls |
| 3 | pictverbs.c, tableexternal.c, tableops.c, tablestructure.c | 14 calls |
| 4 | tableverbs.c, tablevalidate.c, langexternal.c, langipc.c, langhash.c, tablefind.c | 6 calls |
| 5 | headless_op_verbs.c, headless_script_verbs.c + upgrade assertions | 3 calls |

### The Fix Pattern

```c
// BEFORE (wrong - relies on global state fallback)
opverbinmemory(NULL, hv);

// AFTER (correct - explicit context passing)
{
    db_context ctx;
    db_context_init(&ctx);  // Snapshot current thread-local state
    opverbinmemory(&ctx, hv);
}
```

### Not Fixed (Intentional)

- `langsystem7.c:231` and `langsystypes.c:234` - inside `/* */` comment blocks

## Test plan

- [x] Build passes (universal binary)
- [x] Thread registry unit tests: 15/15 passed
- [x] Integration tests: 1264/1631 passed (same as develop - pre-existing failures)
- [x] CLI smoke test: `sizeOf(system.verbs.builtins)` returns 60
- [x] Verify `grep -r "verbinmemory(NULL" Common/source/` returns only commented code

🤖 Generated with [Claude Code](https://claude.ai/code)