### PR TITLE
feat: REPL navigation and table listing commands

### DIFF
--- a/frontier-cli/completion.c
+++ b/frontier-cli/completion.c
@@ -19,6 +19,7 @@
 #include "../Common/headers/strings.h"
 #include "../Common/headers/tablestructure.h"
 #include "../Common/headers/langexternal.h"
+#include "../Common/headers/langinternal.h"  /* hashresolvevalue */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -328,10 +329,236 @@ void completion_add_table_entries(completion_matches_t *matches,
 }
 
 /* ============================================================================
+ * Phase 2.5: system.paths Support
+ * ============================================================================
+ * system.paths contains address values pointing to tables that are in global
+ * scope. This allows verbs like fileMenu, new(), defined() to work without
+ * fully-qualified paths. We iterate through pathstable to:
+ * 1. Find names for tab completion (completion_add_path_entries)
+ * 2. Resolve single-component paths via path search (completion_search_paths)
+ */
+
+/* Searches system.paths for a name and returns the table, optionally with full path.
+ * Used as a fallback when direct roottable lookup fails.
+ *
+ * For example, searching for "fileMenu":
+ * - Iterates through pathstable entries
+ * - For each entry (e.g., @system.verbs.builtins), resolves to table
+ * - Looks up "fileMenu" in that table
+ * - If found and it's a table, returns it
+ * - If resolved_path is provided, fills it with "system.verbs.builtins.fileMenu"
+ *
+ * Parameters:
+ *   name - The name to search for (e.g., "fileMenu")
+ *   resolved_path - If non-NULL, filled with the full path (e.g., "system.verbs.builtins.fileMenu")
+ *   path_bufsize - Size of the resolved_path buffer
+ *
+ * Returns the target table, or nil if not found.
+ */
+hdlhashtable completion_search_paths_ex(const char *name, char *resolved_path, size_t path_bufsize) {
+    if (name == NULL || name[0] == '\0' || pathstable == nil) {
+        return nil;
+    }
+
+    bigstring bsname;
+    copyctopstring(name, bsname);
+
+    hdlhashnode nomad = (**pathstable).hfirstsort;
+
+    while (nomad != nil) {
+        /* Skip non-address entries */
+        if ((**nomad).val.valuetype != addressvaluetype) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        /* Resolve unresolved addresses */
+        if ((**nomad).flunresolvedaddress) {
+            if (!hashresolvevalue(pathstable, nomad)) {
+                nomad = (**nomad).sortedlink;
+                continue;
+            }
+        }
+
+        /* Get the table that this path entry points to */
+        bigstring bs_local;
+        hdlhashtable hparent;
+        if (!getaddressvalue((**nomad).val, &hparent, bs_local)) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        if (hparent == nil) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        /* Resolve bs_local in hparent to get the actual target table */
+        tyvaluerecord pathval;
+        hdlhashnode pathnode;
+
+        if (!hashtablelookup(hparent, bs_local, &pathval, &pathnode)) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        hdlhashtable hsearch;
+        if (!langexternalvaltotable(pathval, &hsearch, pathnode) || hsearch == nil) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        /* Now look up the requested name in this path table */
+        tyvaluerecord val;
+        hdlhashnode node;
+        if (hashtablelookup(hsearch, bsname, &val, &node)) {
+            /* Found it - check if it's a navigable table */
+            hdlhashtable result;
+            if (langexternalvaltotable(val, &result, node) && result != nil) {
+                /* Build the full resolved path if requested */
+                if (resolved_path != NULL && path_bufsize > 0) {
+                    /* Get the path from the address value (e.g., "system.verbs.builtins") */
+                    bigstring bspath;
+                    if (getaddresspath((**nomad).val, bspath)) {
+                        /* Skip leading @ if present */
+                        const char *pathstart = (const char *)stringbaseaddress(bspath);
+                        size_t pathlen = stringlength(bspath);
+                        if (pathlen > 0 && pathstart[0] == '@') {
+                            pathstart++;
+                            pathlen--;
+                        }
+                        /* Build "path.name" */
+                        size_t namelen = strlen(name);
+                        if (pathlen + 1 + namelen < path_bufsize) {
+                            memcpy(resolved_path, pathstart, pathlen);
+                            resolved_path[pathlen] = '.';
+                            memcpy(resolved_path + pathlen + 1, name, namelen);
+                            resolved_path[pathlen + 1 + namelen] = '\0';
+                        } else {
+                            /* Buffer too small - just use the name */
+                            strncpy(resolved_path, name, path_bufsize - 1);
+                            resolved_path[path_bufsize - 1] = '\0';
+                        }
+                    } else {
+                        /* Couldn't get path - just use the name */
+                        strncpy(resolved_path, name, path_bufsize - 1);
+                        resolved_path[path_bufsize - 1] = '\0';
+                    }
+                }
+                return result;  /* Return the target table */
+            }
+        }
+
+        nomad = (**nomad).sortedlink;
+    }
+
+    return nil;  /* Not found in any path table */
+}
+
+/* Simple wrapper for completion_search_paths_ex without path output */
+hdlhashtable completion_search_paths(const char *name) {
+    return completion_search_paths_ex(name, NULL, 0);
+}
+
+/* Adds matching entries from all system.paths tables to completion results.
+ * This makes path-accessible names (like fileMenu, new, etc.) available
+ * for top-level tab completion without requiring the full path.
+ */
+void completion_add_path_entries(completion_matches_t *matches, const char *prefix) {
+    if (pathstable == nil) {
+        return;
+    }
+
+    size_t prefix_len = strlen(prefix);
+    hdlhashnode nomad = (**pathstable).hfirstsort;
+
+    while (nomad != nil && matches->count < COMPLETION_MAX_MATCHES) {
+        /* Skip non-address entries */
+        if ((**nomad).val.valuetype != addressvaluetype) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        /* Resolve unresolved addresses */
+        if ((**nomad).flunresolvedaddress) {
+            if (!hashresolvevalue(pathstable, nomad)) {
+                nomad = (**nomad).sortedlink;
+                continue;
+            }
+        }
+
+        /* Get the table that this path entry points to */
+        bigstring bs_local;
+        hdlhashtable hparent;
+        if (!getaddressvalue((**nomad).val, &hparent, bs_local)) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        if (hparent == nil) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        /* Resolve bs_local in hparent to get the actual target table */
+        tyvaluerecord pathval;
+        hdlhashnode pathnode;
+
+        if (!hashtablelookup(hparent, bs_local, &pathval, &pathnode)) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        hdlhashtable hsearch;
+        if (!langexternalvaltotable(pathval, &hsearch, pathnode) || hsearch == nil) {
+            nomad = (**nomad).sortedlink;
+            continue;
+        }
+
+        /* Add matching entries from this path table */
+        hdlhashnode entry = (**hsearch).hfirstsort;
+
+        while (entry != nil && matches->count < COMPLETION_MAX_MATCHES) {
+            bigstring bs;
+            gethashkey(entry, bs);
+
+            /* Convert to C string */
+            char name[COMPLETION_MAX_NAME_LEN];
+            size_t len = stringlength(bs);
+            if (len >= COMPLETION_MAX_NAME_LEN) {
+                len = COMPLETION_MAX_NAME_LEN - 1;
+            }
+            memcpy(name, stringbaseaddress(bs), len);
+            name[len] = '\0';
+
+            /* Check prefix match (case-insensitive) */
+            if (prefix_len == 0 || strncasecmp(name, prefix, prefix_len) == 0) {
+                tyvaluetype type = (**entry).val.valuetype;
+                bool is_table = (type == externalvaluetype);
+
+                if (is_table) {
+                    tyexternalid exttype = langexternalgettype((**entry).val);
+                    is_table = (exttype == idtableprocessor);
+                }
+
+                completion_matches_add(matches, name, type, is_table);
+            }
+
+            entry = (**entry).sortedlink;
+        }
+
+        nomad = (**nomad).sortedlink;
+    }
+}
+
+/* ============================================================================
  * Phase 3: Dotted Path Navigation
  * ============================================================================ */
 
-/* Navigates a dotted path (e.g., "system.verbs") and returns the target table. */
+/* Navigates a dotted path (e.g., "system.verbs") and returns the target table.
+ * For single-component paths, also searches system.paths as a fallback.
+ * This allows /jump fileMenu to navigate to system.verbs.builtins.fileMenu.
+ */
 hdlhashtable completion_navigate_path(const char *path) {
     if (path == NULL || path[0] == '\0') {
         return roottable;
@@ -344,6 +571,7 @@ hdlhashtable completion_navigate_path(const char *path) {
 
     hdlhashtable current = roottable;
     int depth = 0;
+    boolean first_component = true;
 
     char *saveptr = NULL;
     char *component = strtok_r(path_copy, ".", &saveptr);
@@ -357,6 +585,20 @@ hdlhashtable completion_navigate_path(const char *path) {
         tyvaluerecord val;
         hdlhashnode node;
         if (!hashtablelookup(current, bs, &val, &node)) {
+            /* Not found in current table.
+             * For the first component, try system.paths as fallback.
+             * This allows single names like "fileMenu" to resolve via paths.
+             */
+            if (first_component) {
+                hdlhashtable path_result = completion_search_paths(component);
+                if (path_result != nil) {
+                    current = path_result;
+                    component = strtok_r(NULL, ".", &saveptr);
+                    depth++;
+                    first_component = false;
+                    continue;
+                }
+            }
             return nil;  /* Path component not found */
         }
 
@@ -377,6 +619,7 @@ hdlhashtable completion_navigate_path(const char *path) {
 
         component = strtok_r(NULL, ".", &saveptr);
         depth++;
+        first_component = false;
     }
 
     return current;

--- a/frontier-cli/completion.h
+++ b/frontier-cli/completion.h
@@ -135,8 +135,29 @@ void completion_add_table_entries(completion_matches_t *matches,
                                   const char *prefix);
 
 /*
+ * Phase 2.5: Search system.paths for a name.
+ * Returns the table if found via system.paths, nil otherwise.
+ * Used as fallback when direct roottable lookup fails.
+ */
+hdlhashtable completion_search_paths(const char *name);
+
+/*
+ * Phase 2.5: Search system.paths for a name, returning full resolved path.
+ * Like completion_search_paths but also fills resolved_path with the full
+ * path (e.g., "system.verbs.builtins.fileMenu" for name "fileMenu").
+ */
+hdlhashtable completion_search_paths_ex(const char *name, char *resolved_path, size_t path_bufsize);
+
+/*
+ * Phase 2.5: Add matching entries from all system.paths tables.
+ * Makes path-accessible names available for top-level completion.
+ */
+void completion_add_path_entries(completion_matches_t *matches, const char *prefix);
+
+/*
  * Phase 3: Navigate to a table by dotted path.
  * Returns nil if path is invalid or not a table.
+ * For single-component paths, also searches system.paths as fallback.
  */
 hdlhashtable completion_navigate_path(const char *path);
 

--- a/frontier-cli/headless_scripts_loader.c
+++ b/frontier-cli/headless_scripts_loader.c
@@ -36,7 +36,8 @@ static boolean headless_msgverb(hdltreenode hparam1, tyvaluerecord *vreturned) {
 	/* Convert Pascal string to C string */
 	copyptocstring(bsmsg, msg);
 
-	/* Output to stdout (user-facing output, not diagnostic logging) */
+	/* Output to stdout with "msg: " prefix to distinguish from return values */
+	fputs("msg: ", stdout);
 	fputs(msg, stdout);
 	fputs("\n", stdout);
 	fflush(stdout);

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -331,6 +331,7 @@ static const char *repl_slash_commands[] = {
     "exit",
     "help",
     "keycodes",
+    "list",
     NULL
 };
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -46,12 +46,73 @@
 // Event loop configuration
 #define POLL_TIMEOUT_MS 10  // 10ms = responsive while allowing ~100Hz callback processing
 
-// REPL prompt
-#define REPL_PROMPT "[root]> "
+// REPL prompt settings
+#define g_repl_prompt_MAX_LEN 256
+#define REPL_PATH_MAX_LEN 512
+
+// REPL navigation state - tracks current table like CWD in a shell
+static hdlhashtable g_repl_current_table = nil;
+static char g_repl_current_path[REPL_PATH_MAX_LEN] = "";
+static char g_repl_prompt[g_repl_prompt_MAX_LEN] = "[root]> ";
 
 // Session command tracking for merge-before-save
 static char *session_commands[MAX_SESSION_COMMANDS];
 static size_t session_command_count = 0;
+
+/* Updates the prompt string based on current path */
+static void update_prompt(void) {
+    if (g_repl_current_path[0] == '\0') {
+        snprintf(g_repl_prompt, g_repl_prompt_MAX_LEN, "[root]> ");
+    } else {
+        snprintf(g_repl_prompt, g_repl_prompt_MAX_LEN, "[%s]> ", g_repl_current_path);
+    }
+}
+
+/* Get the current REPL table (like CWD) */
+hdlhashtable repl_get_current_table(void) {
+    if (g_repl_current_table == nil) {
+        return roottable;
+    }
+    return g_repl_current_table;
+}
+
+/* Get the current REPL path */
+const char *repl_get_current_path(void) {
+    return g_repl_current_path;
+}
+
+/* Set the current REPL table by navigating to a path.
+ * Returns true on success, false if path is invalid.
+ */
+boolean repl_goto_path(const char *path) {
+    /* Handle empty path or "@" - go to root */
+    if (path == NULL || path[0] == '\0' ||
+        (path[0] == '@' && path[1] == '\0')) {
+        g_repl_current_table = roottable;
+        g_repl_current_path[0] = '\0';
+        update_prompt();
+        return true;
+    }
+
+    /* Skip leading @ if present */
+    const char *clean_path = path;
+    if (path[0] == '@') {
+        clean_path = path + 1;
+    }
+
+    /* Navigate to the path */
+    hdlhashtable target = completion_navigate_path(clean_path);
+    if (target == nil) {
+        return false;
+    }
+
+    /* Update state */
+    g_repl_current_table = target;
+    strncpy(g_repl_current_path, clean_path, REPL_PATH_MAX_LEN - 1);
+    g_repl_current_path[REPL_PATH_MAX_LEN - 1] = '\0';
+    update_prompt();
+    return true;
+}
 
 // Global interrupt flag (signal-safe)
 // Declared as non-static so lang.c can check it for script interruption
@@ -135,7 +196,7 @@ static void handle_interrupt(struct linenoiseState *ls, char *buf, size_t buflen
         // Restart with fresh prompt using caller's buffer (not ls->buf which
         // may be invalid after linenoiseEditStop)
         if (linenoiseEditStart(ls, STDIN_FILENO, STDOUT_FILENO,
-                              buf, buflen, REPL_PROMPT) == -1) {
+                              buf, buflen, g_repl_prompt) == -1) {
             // Failed to restart - log error and set flag for main loop to exit
             log_error(LOG_COMP_GENERAL, "Failed to restart linenoise after interrupt");
             // Note: Main loop will exit on next iteration since ls is invalid
@@ -329,6 +390,7 @@ static void cleanup_linenoise(void) {
 /* List of REPL slash commands for tab completion */
 static const char *repl_slash_commands[] = {
     "exit",
+    "goto",
     "help",
     "keycodes",
     "list",
@@ -341,6 +403,60 @@ static void linenoise_completion_callback(const char *buf, linenoiseCompletions 
 
     // Handle slash command completion
     if (buf_len > 0 && buf[0] == '/') {
+        // Check if this is "/goto <path>" - complete the path argument
+        if (strncasecmp(buf, "/goto ", 6) == 0) {
+            // Extract the path being typed
+            const char *path_start = buf + 6;
+
+            // Skip leading @ if present
+            if (*path_start == '@') {
+                path_start++;
+            }
+
+            // Parse as a dotted path for completion
+            completion_context_t ctx;
+            completion_parse_context(path_start, (int)strlen(path_start), &ctx);
+
+            // Collect matches from roottable (paths are always absolute)
+            completion_matches_t matches;
+            completion_matches_init(&matches);
+
+            if (ctx.has_dot) {
+                hdlhashtable target = completion_navigate_path(ctx.table_path);
+                if (target != nil) {
+                    completion_add_table_entries(&matches, target, ctx.leaf_prefix);
+                }
+            } else {
+                completion_add_table_entries(&matches, roottable, ctx.leaf_prefix);
+            }
+
+            // Add matches - only include tables (navigable items)
+            for (size_t i = 0; i < matches.count; i++) {
+                if (matches.items[i].is_table) {
+                    char completion[1024];
+                    size_t leaf_len = strlen(ctx.leaf_prefix);
+                    size_t prefix_len = buf_len - leaf_len;
+
+                    // Copy everything before the leaf
+                    if (prefix_len > sizeof(completion) - 1) {
+                        prefix_len = sizeof(completion) - 1;
+                    }
+                    memcpy(completion, buf, prefix_len);
+                    completion[prefix_len] = '\0';
+
+                    // Append the match with trailing dot
+                    size_t remaining = sizeof(completion) - prefix_len - 1;
+                    strncat(completion, matches.items[i].name, remaining);
+                    remaining = sizeof(completion) - strlen(completion) - 1;
+                    strncat(completion, ".", remaining);
+
+                    linenoiseAddCompletion(lc, completion);
+                }
+            }
+            return;
+        }
+
+        // Regular slash command completion
         const char *cmd_prefix = buf + 1;  // Skip the '/'
         size_t prefix_len = buf_len - 1;
 
@@ -496,7 +612,7 @@ static int repl_main_blocking(void) {
 
     while (running) {
         // Read line with blocking linenoise
-        char *line = linenoise(REPL_PROMPT);
+        char *line = linenoise(g_repl_prompt);
 
         if (line == NULL) {
             // EOF (Ctrl-D) or error
@@ -552,7 +668,7 @@ int repl_main(cli_options_t *options) {
 
     // 5. Start non-blocking line editing (only for TTY)
     if (linenoiseEditStart(&ls, STDIN_FILENO, STDOUT_FILENO,
-                           line_buf, sizeof(line_buf), REPL_PROMPT) == -1) {
+                           line_buf, sizeof(line_buf), g_repl_prompt) == -1) {
         log_error(LOG_COMP_GENERAL, "Failed to start linenoise editing");
         cleanup_linenoise();
         return 1;
@@ -585,7 +701,7 @@ int repl_main(cli_options_t *options) {
                 if (running) {
                     // Restart line editing for next command
                     if (linenoiseEditStart(&ls, STDIN_FILENO, STDOUT_FILENO,
-                                           line_buf, sizeof(line_buf), REPL_PROMPT) == -1) {
+                                           line_buf, sizeof(line_buf), g_repl_prompt) == -1) {
                         log_error(LOG_COMP_GENERAL, "Failed to restart linenoise editing");
                         running = false;
                         break;  // Exit immediately - linenoise state is invalid

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -314,6 +314,119 @@ boolean repl_jump_path(const char *path) {
     return true;
 }
 
+/* Resolve a path to a table without changing the current REPL table.
+ * Supports the same path formats as repl_jump_path():
+ *   - Dot-paths like "system.verbs"
+ *   - Single names resolved via system.paths (e.g., "fileMenu")
+ *   - Script expressions like "parentOf(@user.inetd)"
+ *   - Addresses with leading @ like "@user.prefs"
+ * Returns the resolved table, or nil if path is invalid.
+ */
+hdlhashtable repl_resolve_path(const char *path) {
+    /* Handle empty path - return current table */
+    if (path == NULL || path[0] == '\0') {
+        return repl_get_current_table();
+    }
+
+    /* Check if this looks like a script expression */
+    if (path_is_script_expression(path)) {
+        /* Evaluate script and extract table from result */
+        size_t script_len = strlen(path);
+        Handle htext = nil;
+
+        if (!newemptyhandle(&htext)) {
+            return nil;
+        }
+        if (!sethandlesize(htext, (long)script_len)) {
+            disposehandle(htext);
+            return nil;
+        }
+        HLock(htext);
+        memcpy(*htext, path, script_len);
+        HUnlock(htext);
+
+        tyvaluerecord val;
+        boolean flpushpop = !flscriptrunning;
+
+        if (flpushpop)
+            flpushpop = pushprocess(nil);
+
+        boolean fl = langrun(htext, &val);
+
+        if (flpushpop)
+            popprocess();
+
+        if (!fl) {
+            return nil;
+        }
+
+        /* Extract table from result */
+        hdlhashtable result = nil;
+
+        if (val.valuetype == addressvaluetype) {
+            hdlhashtable htable = nil;
+            bigstring bsname;
+
+            if (getaddressvalue(val, &htable, bsname)) {
+                tyvaluerecord targetval;
+                hdlhashnode hnode;
+
+                if (hashtablelookup(htable, bsname, &targetval, &hnode)) {
+                    langexternalvaltotable(targetval, &result, hnode);
+                }
+            }
+        } else if (val.valuetype == externalvaluetype) {
+            langexternalvaltotable(val, &result, nil);
+        }
+
+        return result;
+    }
+
+    /* Skip leading @ if present */
+    const char *clean_path = path;
+    if (path[0] == '@') {
+        clean_path = path + 1;
+    }
+
+    /* Make a mutable copy */
+    char path_buf[REPL_PATH_MAX_LEN];
+    strncpy(path_buf, clean_path, REPL_PATH_MAX_LEN - 1);
+    path_buf[REPL_PATH_MAX_LEN - 1] = '\0';
+
+    /* Strip trailing dot (from tab completion) */
+    size_t len = strlen(path_buf);
+    if (len > 0 && path_buf[len - 1] == '.') {
+        path_buf[len - 1] = '\0';
+    }
+
+    /* Check if this is a single-component path (no dots) */
+    boolean is_single_component = (strchr(path_buf, '.') == NULL);
+
+    hdlhashtable target = nil;
+
+    if (is_single_component) {
+        /* Single component - try roottable first, then system.paths */
+        bigstring bs;
+        copyctopstring(path_buf, bs);
+        tyvaluerecord val;
+        hdlhashnode node;
+
+        if (roottable != nil && hashtablelookup(roottable, bs, &val, &node)) {
+            langexternalvaltotable(val, &target, node);
+        }
+
+        if (target == nil) {
+            /* Try system.paths */
+            target = completion_search_paths(path_buf);
+        }
+    } else {
+        /* Multi-component path - use standard navigation */
+        target = completion_navigate_path(path_buf);
+    }
+
+    return target;
+}
+
 // Global interrupt flag (signal-safe)
 // Declared as non-static so lang.c can check it for script interruption
 volatile sig_atomic_t g_repl_interrupt_requested = 0;

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -34,8 +34,10 @@
 #include "../Common/headers/lang.h"
 #include "../Common/headers/strings.h"
 #include "../Common/headers/tablestructure.h"
-#include "../Common/headers/tcpverbs.h"  /* tcp_process_callbacks */
-#include "../Common/headers/process.h"   /* agentsenabled, agentscheduler_tick */
+#include "../Common/headers/langexternal.h" /* langexternalvaltotable */
+#include "../Common/headers/memory.h"       /* newemptyhandle, sethandlesize */
+#include "../Common/headers/tcpverbs.h"     /* tcp_process_callbacks */
+#include "../Common/headers/process.h"      /* agentsenabled, agentscheduler_tick */
 
 // History configuration
 #define HISTORY_FILE ".frontier_history"
@@ -81,12 +83,124 @@ const char *repl_get_current_path(void) {
     return g_repl_current_path;
 }
 
+/* Check if path looks like a script expression (contains ( ) or +) */
+static boolean path_is_script_expression(const char *path) {
+    if (path == NULL) return false;
+    while (*path) {
+        if (*path == '(' || *path == ')' || *path == '+') {
+            return true;
+        }
+        path++;
+    }
+    return false;
+}
+
+/* Evaluate a script and jump to the resulting address.
+ * Returns true if script evaluated to a valid table address.
+ */
+static boolean repl_jump_script(const char *script) {
+    /* Create handle for script text */
+    size_t script_len = strlen(script);
+    Handle htext = nil;
+
+    if (!newemptyhandle(&htext)) {
+        return false;
+    }
+    if (!sethandlesize(htext, (long)script_len)) {
+        disposehandle(htext);
+        return false;
+    }
+    HLock(htext);
+    memcpy(*htext, script, script_len);
+    HUnlock(htext);
+
+    /* Evaluate the script */
+    tyvaluerecord val;
+    boolean flpushpop = !flscriptrunning;
+
+    if (flpushpop)
+        flpushpop = pushprocess(nil);
+
+    boolean fl = langrun(htext, &val);  /* langrun consumes htext */
+
+    if (flpushpop)
+        popprocess();
+
+    if (!fl) {
+        return false;
+    }
+
+    /* Check if result is an address */
+    if (val.valuetype != addressvaluetype) {
+        /* Not an address - try to interpret as external table value */
+        if (val.valuetype == externalvaluetype) {
+            hdlhashtable target = nil;
+            if (langexternalvaltotable(val, &target, nil) && target != nil) {
+                g_repl_current_table = target;
+                /* For script results, show the expression in prompt */
+                strncpy(g_repl_current_path, script, REPL_PATH_MAX_LEN - 1);
+                g_repl_current_path[REPL_PATH_MAX_LEN - 1] = '\0';
+                update_prompt();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* Extract table and name from address */
+    hdlhashtable htable = nil;
+    bigstring bsname;
+
+    if (!getaddressvalue(val, &htable, bsname)) {
+        return false;
+    }
+
+    /* Look up the final name in the table to get the target table */
+    tyvaluerecord targetval;
+    hdlhashnode hnode;
+
+    if (!hashtablelookup(htable, bsname, &targetval, &hnode)) {
+        return false;
+    }
+
+    /* The target must be a table */
+    hdlhashtable target = nil;
+    if (!langexternalvaltotable(targetval, &target, hnode) || target == nil) {
+        return false;
+    }
+
+    /* Build the path string from the address */
+    bigstring bspath;
+    if (!getaddresspath(val, bspath)) {
+        /* Fallback: use the script as the path display */
+        strncpy(g_repl_current_path, script, REPL_PATH_MAX_LEN - 1);
+    } else {
+        /* Convert bigstring to C string, skip leading @ */
+        size_t pathlen = stringlength(bspath);
+        const char *pathstart = (const char *)stringbaseaddress(bspath);
+        if (pathlen > 0 && pathstart[0] == '@') {
+            pathstart++;
+            pathlen--;
+        }
+        if (pathlen >= REPL_PATH_MAX_LEN) {
+            pathlen = REPL_PATH_MAX_LEN - 1;
+        }
+        memcpy(g_repl_current_path, pathstart, pathlen);
+        g_repl_current_path[pathlen] = '\0';
+    }
+
+    g_repl_current_table = target;
+    update_prompt();
+    return true;
+}
+
 /* Set the current REPL table by navigating to a path.
  * Returns true on success, false if path is invalid.
  * Supports:
  *   - Empty path or "@" to go to root
  *   - ".." to go to parent
  *   - Dot-paths like "system.verbs"
+ *   - Script expressions like "parentOf(@user.inetd)" if path contains ( ) or +
  *   - Trailing dots are stripped (from tab completion)
  */
 boolean repl_jump_path(const char *path) {
@@ -97,6 +211,11 @@ boolean repl_jump_path(const char *path) {
         g_repl_current_path[0] = '\0';
         update_prompt();
         return true;
+    }
+
+    /* Check if this looks like a script expression */
+    if (path_is_script_expression(path)) {
+        return repl_jump_script(path);
     }
 
     /* Skip leading @ if present */

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -83,8 +83,13 @@ const char *repl_get_current_path(void) {
 
 /* Set the current REPL table by navigating to a path.
  * Returns true on success, false if path is invalid.
+ * Supports:
+ *   - Empty path or "@" to go to root
+ *   - ".." to go to parent
+ *   - Dot-paths like "system.verbs"
+ *   - Trailing dots are stripped (from tab completion)
  */
-boolean repl_goto_path(const char *path) {
+boolean repl_jump_path(const char *path) {
     /* Handle empty path or "@" - go to root */
     if (path == NULL || path[0] == '\0' ||
         (path[0] == '@' && path[1] == '\0')) {
@@ -100,15 +105,56 @@ boolean repl_goto_path(const char *path) {
         clean_path = path + 1;
     }
 
+    /* Make a mutable copy */
+    char path_buf[REPL_PATH_MAX_LEN];
+    strncpy(path_buf, clean_path, REPL_PATH_MAX_LEN - 1);
+    path_buf[REPL_PATH_MAX_LEN - 1] = '\0';
+
+    /* Handle ".." - go to parent (before stripping trailing dot) */
+    if (strcmp(path_buf, "..") == 0) {
+        if (g_repl_current_path[0] == '\0') {
+            /* Already at root, stay at root */
+            return true;
+        }
+
+        /* Find last dot in current path */
+        char *last_dot = strrchr(g_repl_current_path, '.');
+        if (last_dot == NULL) {
+            /* No dot means we're one level deep - go to root */
+            g_repl_current_table = roottable;
+            g_repl_current_path[0] = '\0';
+        } else {
+            /* Truncate at the last dot to get parent path */
+            *last_dot = '\0';
+            /* Navigate to the parent path */
+            hdlhashtable parent = completion_navigate_path(g_repl_current_path);
+            if (parent == nil) {
+                /* Shouldn't happen, but handle gracefully */
+                g_repl_current_table = roottable;
+                g_repl_current_path[0] = '\0';
+            } else {
+                g_repl_current_table = parent;
+            }
+        }
+        update_prompt();
+        return true;
+    }
+
+    /* Strip trailing dot (from tab completion) for regular paths */
+    size_t len = strlen(path_buf);
+    if (len > 0 && path_buf[len - 1] == '.') {
+        path_buf[len - 1] = '\0';
+    }
+
     /* Navigate to the path */
-    hdlhashtable target = completion_navigate_path(clean_path);
+    hdlhashtable target = completion_navigate_path(path_buf);
     if (target == nil) {
         return false;
     }
 
     /* Update state */
     g_repl_current_table = target;
-    strncpy(g_repl_current_path, clean_path, REPL_PATH_MAX_LEN - 1);
+    strncpy(g_repl_current_path, path_buf, REPL_PATH_MAX_LEN - 1);
     g_repl_current_path[REPL_PATH_MAX_LEN - 1] = '\0';
     update_prompt();
     return true;
@@ -390,7 +436,7 @@ static void cleanup_linenoise(void) {
 /* List of REPL slash commands for tab completion */
 static const char *repl_slash_commands[] = {
     "exit",
-    "goto",
+    "jump",
     "help",
     "keycodes",
     "list",
@@ -403,8 +449,8 @@ static void linenoise_completion_callback(const char *buf, linenoiseCompletions 
 
     // Handle slash command completion
     if (buf_len > 0 && buf[0] == '/') {
-        // Check if this is "/goto <path>" - complete the path argument
-        if (strncasecmp(buf, "/goto ", 6) == 0) {
+        // Check if this is "/jump <path>" - complete the path argument
+        if (strncasecmp(buf, "/jump ", 6) == 0) {
             // Extract the path being typed
             const char *path_start = buf + 6;
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -175,12 +175,17 @@ static boolean repl_jump_script(const char *script) {
         /* Fallback: use the script as the path display */
         strncpy(g_repl_current_path, script, REPL_PATH_MAX_LEN - 1);
     } else {
-        /* Convert bigstring to C string, skip leading @ */
+        /* Convert bigstring to C string, skip leading @ and "root." prefix */
         size_t pathlen = stringlength(bspath);
         const char *pathstart = (const char *)stringbaseaddress(bspath);
         if (pathlen > 0 && pathstart[0] == '@') {
             pathstart++;
             pathlen--;
+        }
+        /* Skip "root." prefix if present */
+        if (pathlen > 5 && strncmp(pathstart, "root.", 5) == 0) {
+            pathstart += 5;
+            pathlen -= 5;
         }
         if (pathlen >= REPL_PATH_MAX_LEN) {
             pathlen = REPL_PATH_MAX_LEN - 1;
@@ -981,10 +986,18 @@ static boolean process_line(const char *line, boolean *running) {
  */
 static int repl_main_blocking(void) {
     boolean running = true;
+    boolean force_interactive = (getenv("FRONTIER_FORCE_INTERACTIVE") != NULL);
 
     while (running) {
+        // In force-interactive mode (testing), manually output the prompt
+        // since linenoise may suppress it when stdin isn't a real TTY
+        if (force_interactive) {
+            fputs(g_repl_prompt, stderr);
+            fflush(stderr);
+        }
+
         // Read line with blocking linenoise
-        char *line = linenoise(g_repl_prompt);
+        char *line = linenoise(force_interactive ? "" : g_repl_prompt);
 
         if (line == NULL) {
             // EOF (Ctrl-D) or error

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -320,11 +320,24 @@ boolean repl_jump_path(const char *path) {
  *   - Single names resolved via system.paths (e.g., "fileMenu")
  *   - Script expressions like "parentOf(@user.inetd)"
  *   - Addresses with leading @ like "@user.prefs"
+ *
+ * If resolved_path is non-NULL, fills it with the actual resolved path
+ * (e.g., "system.verbs.builtins" for "parentOf(fileMenu)").
+ *
  * Returns the resolved table, or nil if path is invalid.
  */
-hdlhashtable repl_resolve_path(const char *path) {
+hdlhashtable repl_resolve_path(const char *path, char *resolved_path, size_t path_bufsize) {
     /* Handle empty path - return current table */
     if (path == NULL || path[0] == '\0') {
+        if (resolved_path != NULL && path_bufsize > 0) {
+            const char *current = repl_get_current_path();
+            if (current != NULL && current[0] != '\0') {
+                strncpy(resolved_path, current, path_bufsize - 1);
+                resolved_path[path_bufsize - 1] = '\0';
+            } else {
+                resolved_path[0] = '\0';
+            }
+        }
         return repl_get_current_table();
     }
 
@@ -374,9 +387,42 @@ hdlhashtable repl_resolve_path(const char *path) {
                 if (hashtablelookup(htable, bsname, &targetval, &hnode)) {
                     langexternalvaltotable(targetval, &result, hnode);
                 }
+
+                /* Get the resolved path from the address */
+                if (resolved_path != NULL && path_bufsize > 0) {
+                    bigstring bspath;
+                    if (getaddresspath(val, bspath)) {
+                        const char *pathstart = (const char *)stringbaseaddress(bspath);
+                        size_t pathlen = stringlength(bspath);
+                        /* Skip leading @ if present */
+                        if (pathlen > 0 && pathstart[0] == '@') {
+                            pathstart++;
+                            pathlen--;
+                        }
+                        /* Skip "root." prefix if present */
+                        if (pathlen > 5 && strncmp(pathstart, "root.", 5) == 0) {
+                            pathstart += 5;
+                            pathlen -= 5;
+                        }
+                        if (pathlen >= path_bufsize) {
+                            pathlen = path_bufsize - 1;
+                        }
+                        memcpy(resolved_path, pathstart, pathlen);
+                        resolved_path[pathlen] = '\0';
+                    } else {
+                        /* Fallback to input path */
+                        strncpy(resolved_path, path, path_bufsize - 1);
+                        resolved_path[path_bufsize - 1] = '\0';
+                    }
+                }
             }
         } else if (val.valuetype == externalvaluetype) {
             langexternalvaltotable(val, &result, nil);
+            /* For direct external values, we can't easily get the path */
+            if (resolved_path != NULL && path_bufsize > 0) {
+                strncpy(resolved_path, path, path_bufsize - 1);
+                resolved_path[path_bufsize - 1] = '\0';
+            }
         }
 
         return result;
@@ -413,15 +459,23 @@ hdlhashtable repl_resolve_path(const char *path) {
 
         if (roottable != nil && hashtablelookup(roottable, bs, &val, &node)) {
             langexternalvaltotable(val, &target, node);
+            if (target != nil && resolved_path != NULL && path_bufsize > 0) {
+                strncpy(resolved_path, path_buf, path_bufsize - 1);
+                resolved_path[path_bufsize - 1] = '\0';
+            }
         }
 
         if (target == nil) {
-            /* Try system.paths */
-            target = completion_search_paths(path_buf);
+            /* Try system.paths - this gives us the resolved path */
+            target = completion_search_paths_ex(path_buf, resolved_path, path_bufsize);
         }
     } else {
         /* Multi-component path - use standard navigation */
         target = completion_navigate_path(path_buf);
+        if (target != nil && resolved_path != NULL && path_bufsize > 0) {
+            strncpy(resolved_path, path_buf, path_bufsize - 1);
+            resolved_path[path_bufsize - 1] = '\0';
+        }
     }
 
     return target;

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -265,15 +265,50 @@ boolean repl_jump_path(const char *path) {
         path_buf[len - 1] = '\0';
     }
 
-    /* Navigate to the path */
-    hdlhashtable target = completion_navigate_path(path_buf);
+    /* Check if this is a single-component path (no dots) */
+    boolean is_single_component = (strchr(path_buf, '.') == NULL);
+
+    hdlhashtable target = nil;
+    char resolved_path[REPL_PATH_MAX_LEN] = "";
+
+    if (is_single_component) {
+        /* Single component - try roottable first, then system.paths */
+        bigstring bs;
+        copyctopstring(path_buf, bs);
+        tyvaluerecord val;
+        hdlhashnode node;
+
+        if (roottable != nil && hashtablelookup(roottable, bs, &val, &node)) {
+            /* Found in roottable - use direct navigation */
+            if (!langexternalvaltotable(val, &target, node)) {
+                target = nil;
+            } else {
+                /* Path is just the name since it's at root level */
+                strncpy(resolved_path, path_buf, REPL_PATH_MAX_LEN - 1);
+                resolved_path[REPL_PATH_MAX_LEN - 1] = '\0';
+            }
+        }
+
+        if (target == nil) {
+            /* Try system.paths - this gives us both table and resolved path */
+            target = completion_search_paths_ex(path_buf, resolved_path, sizeof(resolved_path));
+        }
+    } else {
+        /* Multi-component path - use standard navigation */
+        target = completion_navigate_path(path_buf);
+        if (target != nil) {
+            strncpy(resolved_path, path_buf, REPL_PATH_MAX_LEN - 1);
+            resolved_path[REPL_PATH_MAX_LEN - 1] = '\0';
+        }
+    }
+
     if (target == nil) {
         return false;
     }
 
-    /* Update state */
+    /* Update state with the resolved path */
     g_repl_current_table = target;
-    strncpy(g_repl_current_path, path_buf, REPL_PATH_MAX_LEN - 1);
+    strncpy(g_repl_current_path, resolved_path, REPL_PATH_MAX_LEN - 1);
     g_repl_current_path[REPL_PATH_MAX_LEN - 1] = '\0';
     update_prompt();
     return true;
@@ -592,7 +627,9 @@ static void linenoise_completion_callback(const char *buf, linenoiseCompletions 
                     completion_add_table_entries(&matches, target, ctx.leaf_prefix);
                 }
             } else {
+                // For single-component paths, include both roottable and path entries
                 completion_add_table_entries(&matches, roottable, ctx.leaf_prefix);
+                completion_add_path_entries(&matches, ctx.leaf_prefix);
             }
 
             // Add matches - only include tables (navigable items)
@@ -676,6 +713,9 @@ static void linenoise_completion_callback(const char *buf, linenoiseCompletions 
         if (systemtable != nil) {
             completion_add_table_entries(&matches, systemtable, ctx.token);
         }
+
+        // Phase 2.5: Add path-accessible names (fileMenu, new, etc.)
+        completion_add_path_entries(&matches, ctx.token);
     }
 
     // Add matches to linenoise

--- a/frontier-cli/repl.h
+++ b/frontier-cli/repl.h
@@ -37,8 +37,10 @@ boolean repl_jump_path(const char *path);
 
 /* Resolve a path to a table without changing current table.
  * Accepts dot-paths, addresses, system.paths names, or script expressions.
+ * If resolved_path is non-NULL, fills it with the actual resolved path
+ * (e.g., "system.verbs.builtins" for "parentOf(fileMenu)").
  * Returns the resolved table, or nil if path is invalid.
  */
-hdlhashtable repl_resolve_path(const char *path);
+hdlhashtable repl_resolve_path(const char *path, char *resolved_path, size_t path_bufsize);
 
 #endif // REPL_H

--- a/frontier-cli/repl.h
+++ b/frontier-cli/repl.h
@@ -33,6 +33,6 @@ const char *repl_get_current_path(void);
 /* Navigate to a path. Accepts dot-paths with or without leading @.
  * Returns true on success, false if path doesn't exist or isn't a table.
  */
-boolean repl_goto_path(const char *path);
+boolean repl_jump_path(const char *path);
 
 #endif // REPL_H

--- a/frontier-cli/repl.h
+++ b/frontier-cli/repl.h
@@ -35,4 +35,10 @@ const char *repl_get_current_path(void);
  */
 boolean repl_jump_path(const char *path);
 
+/* Resolve a path to a table without changing current table.
+ * Accepts dot-paths, addresses, system.paths names, or script expressions.
+ * Returns the resolved table, or nil if path is invalid.
+ */
+hdlhashtable repl_resolve_path(const char *path);
+
 #endif // REPL_H

--- a/frontier-cli/repl.h
+++ b/frontier-cli/repl.h
@@ -15,9 +15,24 @@
 #define REPL_H
 
 #include "cli_parser.h"
+#include "../Common/headers/frontier.h"
+#include "../Common/headers/lang.h"  /* For hdlhashtable */
 
 // Main REPL entry point
 // Returns: exit code (0 for success, 1 for error)
 int repl_main(cli_options_t *options);
+
+/* REPL Navigation - similar to CWD in a shell */
+
+/* Get the current REPL table (like CWD). Returns roottable if at root. */
+hdlhashtable repl_get_current_table(void);
+
+/* Get the current REPL path as a string. Empty string means root. */
+const char *repl_get_current_path(void);
+
+/* Navigate to a path. Accepts dot-paths with or without leading @.
+ * Returns true on success, false if path doesn't exist or isn't a table.
+ */
+boolean repl_goto_path(const char *path);
 
 #endif // REPL_H

--- a/frontier-cli/repl_commands.c
+++ b/frontier-cli/repl_commands.c
@@ -120,6 +120,14 @@ repl_command_result repl_process_command(const char *input) {
     }
 
     /* ======================================================================
+     * /list - List contents of current table
+     * ====================================================================== */
+    if (strcmp(cmd_buf, "list") == 0) {
+        repl_output_list();
+        return REPL_CMD_CONTINUE;
+    }
+
+    /* ======================================================================
      * Unknown command
      * ====================================================================== */
     printf("Unknown command: /%s\n", cmd_buf);

--- a/frontier-cli/repl_commands.c
+++ b/frontier-cli/repl_commands.c
@@ -134,7 +134,7 @@ repl_command_result repl_process_command(const char *input) {
 
         /* Empty path means list current table */
         if (*path == '\0') {
-            repl_output_list(nil);
+            repl_output_list(nil, NULL);
             return REPL_CMD_CONTINUE;
         }
 
@@ -145,7 +145,7 @@ repl_command_result repl_process_command(const char *input) {
             return REPL_CMD_CONTINUE;
         }
 
-        repl_output_list(target);
+        repl_output_list(target, path);
         return REPL_CMD_CONTINUE;
     }
 

--- a/frontier-cli/repl_commands.c
+++ b/frontier-cli/repl_commands.c
@@ -138,14 +138,15 @@ repl_command_result repl_process_command(const char *input) {
             return REPL_CMD_CONTINUE;
         }
 
-        /* Resolve the path to a table */
-        hdlhashtable target = repl_resolve_path(path);
+        /* Resolve the path to a table, getting the actual resolved path */
+        char resolved_path[512];
+        hdlhashtable target = repl_resolve_path(path, resolved_path, sizeof(resolved_path));
         if (target == nil) {
             printf("Error: '%s' is not a valid table path\n", path);
             return REPL_CMD_CONTINUE;
         }
 
-        repl_output_list(target, path);
+        repl_output_list(target, resolved_path);
         return REPL_CMD_CONTINUE;
     }
 

--- a/frontier-cli/repl_commands.c
+++ b/frontier-cli/repl_commands.c
@@ -7,7 +7,7 @@
  */
 
 #include "repl_commands.h"
-#include "repl.h"         /* For repl_goto_path(), repl_get_current_path() */
+#include "repl.h"         /* For repl_jump_path(), repl_get_current_path() */
 #include "repl_output.h"  /* For repl_output_help(), repl_output_vars() */
 #include "../third_party/linenoise/linenoise.h"  /* For linenoisePrintKeyCodes() */
 #include <stdio.h>
@@ -130,26 +130,26 @@ repl_command_result repl_process_command(const char *input) {
     }
 
     /* ======================================================================
-     * /goto <path> - Navigate to a table (like cd in a shell)
+     * /jump <path> - Navigate to a table (like cd in a shell)
      * ====================================================================== */
-    if (strncmp(cmd_buf, "goto", 4) == 0) {
+    if (strncmp(cmd_buf, "jump", 4) == 0) {
         const char *path = cmd_buf + 4;
 
-        /* Skip whitespace after "goto" */
+        /* Skip whitespace after "jump" */
         while (*path && isspace((unsigned char)*path)) {
             path++;
         }
 
         /* Empty path means go to root */
         if (*path == '\0') {
-            if (!repl_goto_path("")) {
+            if (!repl_jump_path("")) {
                 printf("Error: Cannot navigate to root\n");
             }
             return REPL_CMD_CONTINUE;
         }
 
         /* Try to navigate to the path */
-        if (!repl_goto_path(path)) {
+        if (!repl_jump_path(path)) {
             printf("Error: '%s' is not a valid table path\n", path);
         }
         return REPL_CMD_CONTINUE;

--- a/frontier-cli/repl_commands.c
+++ b/frontier-cli/repl_commands.c
@@ -122,10 +122,30 @@ repl_command_result repl_process_command(const char *input) {
     }
 
     /* ======================================================================
-     * /list - List contents of current table
+     * /list [path] - List contents of a table (current table if no path)
      * ====================================================================== */
-    if (strcmp(cmd_buf, "list") == 0) {
-        repl_output_list();
+    if (strncmp(cmd_buf, "list", 4) == 0) {
+        const char *path = cmd_buf + 4;
+
+        /* Skip whitespace after "list" */
+        while (*path && isspace((unsigned char)*path)) {
+            path++;
+        }
+
+        /* Empty path means list current table */
+        if (*path == '\0') {
+            repl_output_list(nil);
+            return REPL_CMD_CONTINUE;
+        }
+
+        /* Resolve the path to a table */
+        hdlhashtable target = repl_resolve_path(path);
+        if (target == nil) {
+            printf("Error: '%s' is not a valid table path\n", path);
+            return REPL_CMD_CONTINUE;
+        }
+
+        repl_output_list(target);
         return REPL_CMD_CONTINUE;
     }
 

--- a/frontier-cli/repl_commands.c
+++ b/frontier-cli/repl_commands.c
@@ -7,8 +7,10 @@
  */
 
 #include "repl_commands.h"
+#include "repl.h"         /* For repl_goto_path(), repl_get_current_path() */
 #include "repl_output.h"  /* For repl_output_help(), repl_output_vars() */
 #include "../third_party/linenoise/linenoise.h"  /* For linenoisePrintKeyCodes() */
+#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 
@@ -124,6 +126,32 @@ repl_command_result repl_process_command(const char *input) {
      * ====================================================================== */
     if (strcmp(cmd_buf, "list") == 0) {
         repl_output_list();
+        return REPL_CMD_CONTINUE;
+    }
+
+    /* ======================================================================
+     * /goto <path> - Navigate to a table (like cd in a shell)
+     * ====================================================================== */
+    if (strncmp(cmd_buf, "goto", 4) == 0) {
+        const char *path = cmd_buf + 4;
+
+        /* Skip whitespace after "goto" */
+        while (*path && isspace((unsigned char)*path)) {
+            path++;
+        }
+
+        /* Empty path means go to root */
+        if (*path == '\0') {
+            if (!repl_goto_path("")) {
+                printf("Error: Cannot navigate to root\n");
+            }
+            return REPL_CMD_CONTINUE;
+        }
+
+        /* Try to navigate to the path */
+        if (!repl_goto_path(path)) {
+            printf("Error: '%s' is not a valid table path\n", path);
+        }
         return REPL_CMD_CONTINUE;
     }
 

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -16,6 +16,7 @@
 #include "../Common/headers/lang.h"
 #include "../Common/headers/langexternal.h"
 #include "../Common/headers/strings.h"
+#include "../Common/headers/tablestructure.h"  /* For currenthashtable */
 #include "../Common/headers/logging.h"
 #include <stdio.h>
 #include <string.h>
@@ -175,6 +176,7 @@ void repl_output_help(void) {
 	fputs("  /exit          Exit the REPL\n", stdout);
 	fputs("  /help          Show this help message\n", stdout);
 	fputs("  /keycodes      Debug terminal key sequences\n", stdout);
+	fputs("  /list          List contents of current table\n", stdout);
 	fputs("\n", stdout);
 	fputs("QuickScript Model - Variable Persistence:\n", stdout);
 	fputs("  Local variables (x = 5) don't persist between evaluations\n", stdout);
@@ -280,6 +282,105 @@ void repl_output_vars(hdlhashtable workspace) {
 		printf("  %.*s = %s\n",
 			(int)stringlength(name), stringbaseaddress(name),
 			value_buf);
+
+		nomad = (**nomad).sortedlink;
+	}
+
+	fflush(stdout);
+}
+
+/* --- /list Command Support --- */
+
+/* Display contents of current table (for /list command) */
+void repl_output_list(void) {
+	hdlhashtable htable = currenthashtable;
+	hdlhashnode nomad;
+	long count;
+
+	/* Check if we have a current table */
+	if (htable == nil) {
+		fputs("(no current table)\n", stdout);
+		fflush(stdout);
+		return;
+	}
+
+	count = count_hashtable_items(htable);
+
+	if (count == 0) {
+		fputs("(empty table)\n", stdout);
+		fflush(stdout);
+		return;
+	}
+
+	/* First pass: calculate column widths for alignment */
+	size_t max_name_len = 0;
+	size_t max_type_len = 0;
+
+	nomad = (**htable).hfirstsort;
+
+	while (nomad != nil) {
+		bigstring name;
+		gethashkey(nomad, name);
+		size_t name_len = stringlength(name);
+		if (name_len > max_name_len) {
+			max_name_len = name_len;
+		}
+
+		/* Get type string */
+		bigstring type_str;
+		tyvaluerecord val = (**nomad).val;
+
+		if (val.valuetype == externalvaluetype) {
+			langexternaltypestring((hdlexternalvariable)val.data.externalvalue, type_str);
+		} else {
+			langgettypestring(val.valuetype, type_str);
+		}
+
+		size_t type_len = stringlength(type_str);
+		if (type_len > max_type_len) {
+			max_type_len = type_len;
+		}
+
+		nomad = (**nomad).sortedlink;
+	}
+
+	/* Second pass: print entries with alignment */
+	nomad = (**htable).hfirstsort;
+
+	while (nomad != nil) {
+		bigstring name;
+		gethashkey(nomad, name);
+
+		/* Get type string */
+		bigstring type_str;
+		tyvaluerecord val = (**nomad).val;
+
+		if (val.valuetype == externalvaluetype) {
+			langexternaltypestring((hdlexternalvariable)val.data.externalvalue, type_str);
+		} else {
+			langgettypestring(val.valuetype, type_str);
+		}
+
+		/* Get display string (N items or "on disk") */
+		bigstring display_str;
+		setemptystring(display_str);
+
+		if (val.valuetype == externalvaluetype) {
+			langexternalgetdisplaystring((hdlexternalvariable)val.data.externalvalue, display_str);
+		}
+
+		/* Print: name : type : display */
+		printf("  %-*.*s : %-*.*s",
+			(int)max_name_len,
+			(int)stringlength(name), stringbaseaddress(name),
+			(int)max_type_len,
+			(int)stringlength(type_str), stringbaseaddress(type_str));
+
+		if (stringlength(display_str) > 0) {
+			printf(" : %.*s", (int)stringlength(display_str), stringbaseaddress(display_str));
+		}
+
+		printf("\n");
 
 		nomad = (**nomad).sortedlink;
 	}

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -181,9 +181,11 @@ void repl_output_help(void) {
 	fputs("  /list          List contents of current table\n", stdout);
 	fputs("\n", stdout);
 	fputs("Navigation:\n", stdout);
-	fputs("  /jump system        Navigate to system table\n", stdout);
-	fputs("  /jump user.inetd    Navigate to nested table\n", stdout);
-	fputs("  /jump               Return to root\n", stdout);
+	fputs("  /jump system              Navigate to system table\n", stdout);
+	fputs("  /jump user.inetd          Navigate to nested table\n", stdout);
+	fputs("  /jump ..                  Go to parent table\n", stdout);
+	fputs("  /jump                     Return to root\n", stdout);
+	fputs("  /jump parentOf(@user)     Evaluate script for address\n", stdout);
 	fputs("\n", stdout);
 	fputs("QuickScript Model - Variable Persistence:\n", stdout);
 	fputs("  Local variables (x = 5) don't persist between evaluations\n", stdout);

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -175,15 +175,15 @@ void repl_output_error(const char *error_msg) {
 void repl_output_help(void) {
 	fputs("Available commands:\n", stdout);
 	fputs("  /exit          Exit the REPL\n", stdout);
-	fputs("  /goto <path>   Navigate to a table (like cd)\n", stdout);
+	fputs("  /jump <path>   Navigate to a table (like cd)\n", stdout);
 	fputs("  /help          Show this help message\n", stdout);
 	fputs("  /keycodes      Debug terminal key sequences\n", stdout);
 	fputs("  /list          List contents of current table\n", stdout);
 	fputs("\n", stdout);
 	fputs("Navigation:\n", stdout);
-	fputs("  /goto system        Navigate to system table\n", stdout);
-	fputs("  /goto user.inetd    Navigate to nested table\n", stdout);
-	fputs("  /goto               Return to root\n", stdout);
+	fputs("  /jump system        Navigate to system table\n", stdout);
+	fputs("  /jump user.inetd    Navigate to nested table\n", stdout);
+	fputs("  /jump               Return to root\n", stdout);
 	fputs("\n", stdout);
 	fputs("QuickScript Model - Variable Persistence:\n", stdout);
 	fputs("  Local variables (x = 5) don't persist between evaluations\n", stdout);

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -343,8 +343,9 @@ void repl_output_vars(hdlhashtable workspace) {
 
 /* Display contents of a table (for /list command).
  * If htable is nil, displays the current REPL table.
+ * path_label is displayed as a header (e.g., "user.prefs:"). Can be NULL.
  */
-void repl_output_list(hdlhashtable htable) {
+void repl_output_list(hdlhashtable htable, const char *path_label) {
 	if (htable == nil) {
 		htable = repl_get_current_table();
 	}
@@ -356,6 +357,19 @@ void repl_output_list(hdlhashtable htable) {
 		fputs("(no current table)\n", stdout);
 		fflush(stdout);
 		return;
+	}
+
+	/* Display path header */
+	if (path_label != NULL && path_label[0] != '\0') {
+		printf("%s:\n", path_label);
+	} else {
+		/* Use current path if no label provided */
+		const char *current_path = repl_get_current_path();
+		if (current_path != NULL && current_path[0] != '\0') {
+			printf("%s:\n", current_path);
+		} else {
+			printf("root:\n");
+		}
 	}
 
 	count = count_hashtable_items(htable);

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -213,14 +213,20 @@ void repl_output_help(void) {
 	fputs("  /jump <path>   Navigate to a table (like cd)\n", stdout);
 	fputs("  /help          Show this help message\n", stdout);
 	fputs("  /keycodes      Debug terminal key sequences\n", stdout);
-	fputs("  /list          List contents of current table\n", stdout);
+	fputs("  /list [path]   List contents of table (current if no path)\n", stdout);
 	fputs("\n", stdout);
 	fputs("Navigation:\n", stdout);
 	fputs("  /jump system              Navigate to system table\n", stdout);
 	fputs("  /jump user.inetd          Navigate to nested table\n", stdout);
 	fputs("  /jump ..                  Go to parent table\n", stdout);
 	fputs("  /jump                     Return to root\n", stdout);
+	fputs("  /jump fileMenu            Navigate via system.paths\n", stdout);
 	fputs("  /jump parentOf(@user)     Evaluate script for address\n", stdout);
+	fputs("\n", stdout);
+	fputs("Listing:\n", stdout);
+	fputs("  /list                     List current table\n", stdout);
+	fputs("  /list system.verbs        List specific table\n", stdout);
+	fputs("  /list fileMenu            List via system.paths\n", stdout);
 	fputs("\n", stdout);
 	fputs("QuickScript Model - Variable Persistence:\n", stdout);
 	fputs("  Local variables (x = 5) don't persist between evaluations\n", stdout);
@@ -335,9 +341,13 @@ void repl_output_vars(hdlhashtable workspace) {
 
 /* --- /list Command Support --- */
 
-/* Display contents of current table (for /list command) */
-void repl_output_list(void) {
-	hdlhashtable htable = repl_get_current_table();
+/* Display contents of a table (for /list command).
+ * If htable is nil, displays the current REPL table.
+ */
+void repl_output_list(hdlhashtable htable) {
+	if (htable == nil) {
+		htable = repl_get_current_table();
+	}
 	hdlhashnode nomad;
 	long count;
 

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -21,6 +21,8 @@
 #include "../Common/headers/logging.h"
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
 
 /* Global linenoise state for async output (set by event loop) */
 static struct linenoiseState *g_linenoisestate = NULL;
@@ -37,6 +39,39 @@ static void fputs_cr_to_lf(const char *str, size_t len, FILE *stream) {
 		} else {
 			putc(str[i], stream);
 		}
+	}
+}
+
+/* Get terminal width, defaulting to 80 columns if unavailable. */
+static int get_terminal_width(void) {
+	struct winsize ws;
+	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0) {
+		return ws.ws_col;
+	}
+	return 80;
+}
+
+/* Returns true if the value type is a scalar that can be displayed inline. */
+static boolean is_scalar_valuetype(tyvaluetype vtype) {
+	switch (vtype) {
+		case charvaluetype:
+		case intvaluetype:
+		case longvaluetype:
+		case booleanvaluetype:
+		case stringvaluetype:
+		case addressvaluetype:
+		case doublevaluetype:
+		case singlevaluetype:
+		case fixedvaluetype:
+		case datevaluetype:
+		case ostypevaluetype:
+		case directionvaluetype:
+		case pointvaluetype:
+		case rectvaluetype:
+		case rgbvaluetype:
+			return true;
+		default:
+			return false;
 	}
 }
 
@@ -353,6 +388,9 @@ void repl_output_list(void) {
 		nomad = (**nomad).sortedlink;
 	}
 
+	/* Get terminal width for value truncation */
+	int term_width = get_terminal_width();
+
 	/* Second pass: print entries with alignment */
 	nomad = (**htable).hfirstsort;
 
@@ -370,23 +408,39 @@ void repl_output_list(void) {
 			langgettypestring(val.valuetype, type_str);
 		}
 
-		/* Get display string (N items or "on disk") */
-		bigstring display_str;
-		setemptystring(display_str);
-
-		if (val.valuetype == externalvaluetype) {
-			langexternalgetdisplaystring((hdlexternalvariable)val.data.externalvalue, display_str);
-		}
-
-		/* Print: name : type : display */
-		printf("  %-*.*s : %-*.*s",
+		/* Print: name : type */
+		int prefix_len = printf("  %-*.*s : %-*.*s",
 			(int)max_name_len,
 			(int)stringlength(name), stringbaseaddress(name),
 			(int)max_type_len,
 			(int)stringlength(type_str), stringbaseaddress(type_str));
 
-		if (stringlength(display_str) > 0) {
-			printf(" : %.*s", (int)stringlength(display_str), stringbaseaddress(display_str));
+		/* Get display string - either external info or scalar value */
+		if (val.valuetype == externalvaluetype) {
+			/* External types: show "N items" or "on disk" */
+			bigstring display_str;
+			setemptystring(display_str);
+			langexternalgetdisplaystring((hdlexternalvariable)val.data.externalvalue, display_str);
+
+			if (stringlength(display_str) > 0) {
+				printf(" : %.*s", (int)stringlength(display_str), stringbaseaddress(display_str));
+			}
+		} else if (is_scalar_valuetype(val.valuetype)) {
+			/* Scalar types: show value inline, truncated to fit terminal */
+			char value_buf[512];
+			format_value_summary(&val, value_buf, sizeof(value_buf));
+
+			/* Calculate available space: terminal - prefix - " : " - "..." margin */
+			int available = term_width - prefix_len - 3 - 3;
+			if (available < 10) available = 10;  /* Minimum display width */
+
+			size_t value_len = strlen(value_buf);
+			if ((int)value_len <= available) {
+				printf(" : %s", value_buf);
+			} else {
+				/* Truncate with ellipsis */
+				printf(" : %.*s...", available, value_buf);
+			}
 		}
 
 		printf("\n");

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -209,24 +209,25 @@ void repl_output_error(const char *error_msg) {
 /* Displays the /help command output with available commands and persistence info. */
 void repl_output_help(void) {
 	fputs("Available commands:\n", stdout);
-	fputs("  /exit          Exit the REPL\n", stdout);
-	fputs("  /jump <path>   Navigate to a table (like cd)\n", stdout);
-	fputs("  /help          Show this help message\n", stdout);
-	fputs("  /keycodes      Debug terminal key sequences\n", stdout);
-	fputs("  /list [path]   List contents of table (current if no path)\n", stdout);
+	fputs("  /exit              Exit the REPL\n", stdout);
+	fputs("  /help              Show this help message\n", stdout);
+	fputs("  /jump [path]       Navigate to a table (like cd)\n", stdout);
+	fputs("  /keycodes          Debug terminal key sequences\n", stdout);
+	fputs("  /list [path]       List contents of a table\n", stdout);
 	fputs("\n", stdout);
-	fputs("Navigation:\n", stdout);
+	fputs("/jump - Navigate to a table (like cd in a shell):\n", stdout);
+	fputs("  /jump                     Return to root\n", stdout);
 	fputs("  /jump system              Navigate to system table\n", stdout);
 	fputs("  /jump user.inetd          Navigate to nested table\n", stdout);
 	fputs("  /jump ..                  Go to parent table\n", stdout);
-	fputs("  /jump                     Return to root\n", stdout);
 	fputs("  /jump fileMenu            Navigate via system.paths\n", stdout);
-	fputs("  /jump parentOf(@user)     Evaluate script for address\n", stdout);
+	fputs("  /jump parentOf(@user)     Evaluate expression for address\n", stdout);
 	fputs("\n", stdout);
-	fputs("Listing:\n", stdout);
+	fputs("/list - List contents of a table:\n", stdout);
 	fputs("  /list                     List current table\n", stdout);
-	fputs("  /list system.verbs        List specific table\n", stdout);
+	fputs("  /list system.verbs        List specific table by path\n", stdout);
 	fputs("  /list fileMenu            List via system.paths\n", stdout);
+	fputs("  /list parentOf(fileMenu)  Evaluate expression for table\n", stdout);
 	fputs("\n", stdout);
 	fputs("QuickScript Model - Variable Persistence:\n", stdout);
 	fputs("  Local variables (x = 5) don't persist between evaluations\n", stdout);

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -12,11 +12,12 @@
  */
 
 #include "repl_output.h"
+#include "repl.h"       /* For repl_get_current_table() */
 #include "linenoise.h"  /* For linenoiseHide/Show */
 #include "../Common/headers/lang.h"
 #include "../Common/headers/langexternal.h"
 #include "../Common/headers/strings.h"
-#include "../Common/headers/tablestructure.h"  /* For currenthashtable */
+#include "../Common/headers/tablestructure.h"  /* For roottable */
 #include "../Common/headers/logging.h"
 #include <stdio.h>
 #include <string.h>
@@ -174,9 +175,15 @@ void repl_output_error(const char *error_msg) {
 void repl_output_help(void) {
 	fputs("Available commands:\n", stdout);
 	fputs("  /exit          Exit the REPL\n", stdout);
+	fputs("  /goto <path>   Navigate to a table (like cd)\n", stdout);
 	fputs("  /help          Show this help message\n", stdout);
 	fputs("  /keycodes      Debug terminal key sequences\n", stdout);
 	fputs("  /list          List contents of current table\n", stdout);
+	fputs("\n", stdout);
+	fputs("Navigation:\n", stdout);
+	fputs("  /goto system        Navigate to system table\n", stdout);
+	fputs("  /goto user.inetd    Navigate to nested table\n", stdout);
+	fputs("  /goto               Return to root\n", stdout);
 	fputs("\n", stdout);
 	fputs("QuickScript Model - Variable Persistence:\n", stdout);
 	fputs("  Local variables (x = 5) don't persist between evaluations\n", stdout);
@@ -293,7 +300,7 @@ void repl_output_vars(hdlhashtable workspace) {
 
 /* Display contents of current table (for /list command) */
 void repl_output_list(void) {
-	hdlhashtable htable = currenthashtable;
+	hdlhashtable htable = repl_get_current_table();
 	hdlhashnode nomad;
 	long count;
 

--- a/frontier-cli/repl_output.h
+++ b/frontier-cli/repl_output.h
@@ -54,8 +54,9 @@ void repl_output_vars(hdlhashtable workspace);
  * Shows name, type, and display string (N items or "on disk") for each entry.
  * Output is formatted in aligned columns.
  * If htable is nil, displays the current REPL table.
+ * path_label is displayed as a header (e.g., "user.prefs:"). If NULL, uses current path.
  */
-void repl_output_list(hdlhashtable htable);
+void repl_output_list(hdlhashtable htable, const char *path_label);
 
 /* --- Event Loop Support (Phase 4) --- */
 

--- a/frontier-cli/repl_output.h
+++ b/frontier-cli/repl_output.h
@@ -50,6 +50,12 @@ void repl_output_help(void);
  */
 void repl_output_vars(hdlhashtable workspace);
 
+/* Display contents of current table (for /list command)
+ * Shows name, type, and display string (N items or "on disk") for each entry.
+ * Output is formatted in aligned columns.
+ */
+void repl_output_list(void);
+
 /* --- Event Loop Support (Phase 4) --- */
 
 /* Set the active linenoise state for async output.

--- a/frontier-cli/repl_output.h
+++ b/frontier-cli/repl_output.h
@@ -50,11 +50,12 @@ void repl_output_help(void);
  */
 void repl_output_vars(hdlhashtable workspace);
 
-/* Display contents of current table (for /list command)
+/* Display contents of a table (for /list command)
  * Shows name, type, and display string (N items or "on disk") for each entry.
  * Output is formatted in aligned columns.
+ * If htable is nil, displays the current REPL table.
  */
-void repl_output_list(void);
+void repl_output_list(hdlhashtable htable);
 
 /* --- Event Loop Support (Phase 4) --- */
 

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -185,6 +185,8 @@ class FrontierCLI:
 
         # Merge environment variables with current environment
         process_env = os.environ.copy()
+        # Force interactive mode for testing (ensures prompts are shown)
+        process_env['FRONTIER_FORCE_INTERACTIVE'] = '1'
         if env:
             process_env.update(env)
 
@@ -375,11 +377,9 @@ class TestRunner:
     def run_test(self, test: TestCase) -> TestResult:
         """Run a single test case."""
         # Check if test should be skipped
-        if test.skip or test.repl_mode:
+        if test.skip:
             # Determine skip reason
-            if test.repl_mode:
-                reason = "REPL interactive mode not supported in automated testing"
-            elif isinstance(test.skip, str):
+            if isinstance(test.skip, str):
                 reason = test.skip  # skip field contains the reason
             else:
                 reason = test.skip_reason  # Use skip_reason field

--- a/tests/integration/test_cases/repl_commands.yaml
+++ b/tests/integration/test_cases/repl_commands.yaml
@@ -22,14 +22,26 @@ tests:
   # =========================================================================
 
   - name: "REPL /help - displays available commands"
-    description: "/help should list available commands (QuickScript model)"
+    description: "/help should list all available commands"
     repl_mode: true
     stdin_input: "/help\n/exit\n"
     expected_output_contains:
       - "/exit"
       - "/help"
+      - "/jump"
+      - "/list"
+      - "/keycodes"
       - "Available commands"
-      - "QuickScript"  # Help text explains QuickScript model
+    expected_success: true
+
+  - name: "REPL /help - shows QuickScript model"
+    description: "/help should explain QuickScript variable persistence"
+    repl_mode: true
+    stdin_input: "/help\n/exit\n"
+    expected_output_contains:
+      - "QuickScript"
+      - "workspace"
+      - "system.temp"
     expected_success: true
 
   - name: "REPL /help - shows multi-line usage"
@@ -39,15 +51,6 @@ tests:
     expected_output_contains:
       - "Multi-line"
       - "Phase 2"
-    expected_success: true
-
-  - name: "REPL /help - shows examples"
-    description: "/help should provide usage examples"
-    repl_mode: true
-    stdin_input: "/help\n/exit\n"
-    expected_output_contains:
-      - "Examples"
-      - "workspace"
     expected_success: true
 
   # =========================================================================
@@ -225,6 +228,216 @@ tests:
     stdin_input: "/exit\nx = 42\n"
     expected_output_not_contains:
       - "42"  # Should exit before evaluating second line
+    expected_success: true
+
+  # =========================================================================
+  # /list Command
+  # =========================================================================
+
+  - name: "REPL /list - lists current table (root)"
+    description: "/list with no argument lists the current table"
+    repl_mode: true
+    stdin_input: "/list\n/exit\n"
+    expected_output_contains:
+      - "root:"
+      - "system"
+      - "user"
+    expected_success: true
+
+  - name: "REPL /list - shows table type"
+    description: "/list should show 'table' type for sub-tables"
+    repl_mode: true
+    stdin_input: "/list\n/exit\n"
+    expected_output_contains:
+      - "table"
+    expected_success: true
+
+  - name: "REPL /list - with dot-path argument"
+    description: "/list should accept dot-path to list specific table"
+    repl_mode: true
+    stdin_input: "/list system\n/exit\n"
+    expected_output_contains:
+      - "system:"
+      - "verbs"
+    expected_success: true
+
+  - name: "REPL /list - with nested dot-path"
+    description: "/list should accept nested dot-paths"
+    repl_mode: true
+    stdin_input: "/list system.verbs\n/exit\n"
+    expected_output_contains:
+      - "system.verbs:"
+      - "builtins"
+    expected_success: true
+
+  - name: "REPL /list - with system.paths name"
+    description: "/list should resolve names via system.paths"
+    repl_mode: true
+    stdin_input: "/list fileMenu\n/exit\n"
+    expected_output_contains:
+      - "system.verbs.builtins.fileMenu:"
+    expected_success: true
+
+  - name: "REPL /list - with script expression"
+    description: "/list should evaluate script expressions like parentOf()"
+    repl_mode: true
+    stdin_input: "/list parentOf(fileMenu)\n/exit\n"
+    expected_output_contains:
+      - "system.verbs.builtins:"
+    expected_success: true
+
+  - name: "REPL /list - with address expression"
+    description: "/list should work with @ address expressions"
+    repl_mode: true
+    stdin_input: "/list parentOf(@user.inetd)\n/exit\n"
+    expected_output_contains:
+      - "user:"
+    expected_success: true
+
+  - name: "REPL /list - shows scalar values inline"
+    description: "/list should display scalar values (numbers, strings) inline"
+    repl_mode: true
+    stdin_input: "/list user.prefs\n/exit\n"
+    expected_output_contains:
+      - "user.prefs:"
+    expected_success: true
+
+  - name: "REPL /list - invalid path shows error"
+    description: "/list with invalid path should show error message"
+    repl_mode: true
+    stdin_input: "/list nonexistent.path\n/exit\n"
+    expected_output_contains:
+      - "Error"
+      - "not a valid table path"
+    expected_success: true
+
+  - name: "REPL /list - empty path argument lists current"
+    description: "/list with just whitespace lists current table"
+    repl_mode: true
+    stdin_input: "/list   \n/exit\n"
+    expected_output_contains:
+      - "root:"
+    expected_success: true
+
+  # =========================================================================
+  # /jump Command
+  # =========================================================================
+
+  - name: "REPL /jump - to root (no argument)"
+    description: "/jump with no argument returns to root"
+    repl_mode: true
+    stdin_input: "/jump system\n/jump\n/exit\n"
+    expected_output_contains:
+      - "[root]>"
+    expected_success: true
+
+  - name: "REPL /jump - changes prompt"
+    description: "/jump should change the prompt to show current location"
+    repl_mode: true
+    stdin_input: "/jump system\n/exit\n"
+    expected_output_contains:
+      - "[system]>"
+    expected_success: true
+
+  - name: "REPL /jump - to nested table"
+    description: "/jump should navigate to nested tables"
+    repl_mode: true
+    stdin_input: "/jump system.verbs\n/exit\n"
+    expected_output_contains:
+      - "[system.verbs]>"
+    expected_success: true
+
+  - name: "REPL /jump - parent with .."
+    description: "/jump .. should go to parent table"
+    repl_mode: true
+    stdin_input: "/jump system.verbs\n/jump ..\n/exit\n"
+    expected_output_contains:
+      - "[system]>"
+    expected_success: true
+
+  - name: "REPL /jump - via system.paths"
+    description: "/jump should resolve names via system.paths"
+    repl_mode: true
+    stdin_input: "/jump fileMenu\n/exit\n"
+    expected_output_contains:
+      - "[system.verbs.builtins.fileMenu]>"
+    expected_success: true
+
+  - name: "REPL /jump - with script expression"
+    description: "/jump should evaluate script expressions"
+    repl_mode: true
+    stdin_input: "/jump parentOf(fileMenu)\n/exit\n"
+    expected_output_contains:
+      - "[system.verbs.builtins]>"
+    expected_success: true
+
+  - name: "REPL /jump - with address expression"
+    description: "/jump should work with @ address expressions"
+    repl_mode: true
+    stdin_input: "/jump parentOf(@user.inetd)\n/exit\n"
+    expected_output_contains:
+      - "[user]>"
+    expected_success: true
+
+  - name: "REPL /jump - invalid path shows error"
+    description: "/jump with invalid path should show error"
+    repl_mode: true
+    stdin_input: "/jump nonexistent.path\n/exit\n"
+    expected_output_contains:
+      - "Error"
+      - "not a valid table path"
+    expected_success: true
+
+  - name: "REPL /jump - doesn't change on error"
+    description: "/jump to invalid path shouldn't change current table"
+    repl_mode: true
+    stdin_input: "/jump system\n/jump nonexistent\n/exit\n"
+    expected_output_contains:
+      - "[system]>"
+      - "Error"
+    expected_success: true
+
+  - name: "REPL /jump - then /list shows jumped table"
+    description: "/list after /jump should show the jumped-to table"
+    repl_mode: true
+    stdin_input: "/jump system\n/list\n/exit\n"
+    expected_output_contains:
+      - "system:"
+      - "verbs"
+    expected_success: true
+
+  # =========================================================================
+  # /help Command - Documents All Commands
+  # =========================================================================
+
+  - name: "REPL /help - documents /jump command"
+    description: "/help should explain /jump command with examples"
+    repl_mode: true
+    stdin_input: "/help\n/exit\n"
+    expected_output_contains:
+      - "/jump"
+      - "Navigate"
+      - "system.paths"
+      - "parentOf"
+    expected_success: true
+
+  - name: "REPL /help - documents /list command"
+    description: "/help should explain /list command with examples"
+    repl_mode: true
+    stdin_input: "/help\n/exit\n"
+    expected_output_contains:
+      - "/list"
+      - "List"
+      - "system.paths"
+      - "parentOf"
+    expected_success: true
+
+  - name: "REPL /help - documents /keycodes command"
+    description: "/help should explain /keycodes command"
+    repl_mode: true
+    stdin_input: "/help\n/exit\n"
+    expected_output_contains:
+      - "/keycodes"
     expected_success: true
 
   # =========================================================================


### PR DESCRIPTION
## Summary

Adds shell-like navigation and listing commands to the Frontier REPL, making it easier to explore the object database interactively.

### New Commands

- **`/list [path]`** - List contents of a table (like `ls` in a shell)
  - Shows table entries with name, type, and item count
  - Displays scalar values inline (numbers, strings, booleans)
  - Shows path header (e.g., `system.verbs:`)

- **`/jump [path]`** - Navigate to a table (like `cd` in a shell)
  - Updates prompt to show current location (e.g., `[system.verbs]>`)
  - Supports `..` to go to parent table

### Path Resolution Features

Both commands support flexible path formats:
- **Dot-paths**: `/jump system.verbs.builtins`
- **system.paths names**: `/jump fileMenu` → navigates to `system.verbs.builtins.fileMenu`
- **Script expressions**: `/list parentOf(fileMenu)` → lists `system.verbs.builtins`
- **Address expressions**: `/jump parentOf(@user.inetd)` → navigates to `user`

### Other Improvements

- Updated `/help` to document all commands with usage examples
- Tab completion now searches system.paths for single-component names
- Enabled REPL mode integration tests (previously skipped)

## Test Plan

- [x] All 41 REPL command tests pass
- [x] `/list` tests: basic, dot-paths, system.paths, expressions, errors
- [x] `/jump` tests: navigation, prompt updates, parent (..), errors
- [x] `/help` documents all commands with examples
- [x] Manual testing of tab completion with system.paths

```
[root]> /jump fileMenu
[system.verbs.builtins.fileMenu]> /list
system.verbs.builtins.fileMenu:
  Name                 Type       Items
  ────────────────────────────────────────
  addToFrontierMenu    script     
  buildMenu            script     
  ...
[system.verbs.builtins.fileMenu]> /jump ..
[system.verbs.builtins]> /list parentOf(@user.inetd)
user:
  Name     Type    Items
  ────────────────────────
  inetd    table   3 items
  prefs    table   5 items
```

🤖 Generated with [Claude Code](https://claude.ai/code)