### PR TITLE
fix: Eliminate remaining 24 compiler warnings (Phase 2)

### DIFF
--- a/Common/source/iso8859.c
+++ b/Common/source/iso8859.c
@@ -387,7 +387,7 @@ unsigned char * iso8859table [256] = {
 
 	/*175*/ BIGSTRING ("&Oslash;"),
 
-	/*176*/ BIGSTRING ("°"),
+	/*176*/ BIGSTRING ("&infin;"),
 
 	/*177*/ BIGSTRING ("&#177;"),
 

--- a/Common/source/langerror.c
+++ b/Common/source/langerror.c
@@ -140,7 +140,7 @@ void parseerror (bigstring bs) {
 	/* 2025-12-09 Codex: bs is a C string from yacc/lex; copy to Pascal safely. */
 	bigstring bscopy; /* must work on a copy */
 
-	copyctopstring ((ptrstring) bs, bscopy);
+	copyctopstring ((const char *) bs, bscopy);
 	langparamerror (parsererror, bscopy);
 	} /*parseerror*/
 

--- a/Common/source/langhtml.c
+++ b/Common/source/langhtml.c
@@ -7096,15 +7096,15 @@ static boolean mrcalendargetdayaddress (tyaddress adrcalendar, unsigned long sec
 static boolean mrcalendargetdayaddressverb (hdltreenode hp1, tyvaluerecord *v) {
 	
 	short ctconsumed = 2, ctpositional = 2;
-	unsigned long secs;
+	int64_t secs;
 	tyvaluerecord val;
-	tyaddress adrcalendar, adr;	
+	tyaddress adrcalendar, adr;
 	boolean flcreate;
 	OSType idtype;
-	
+
 	if (!getaddressparam (hp1, 1, &val) || !getaddressvalue (val, &adrcalendar.ht, adrcalendar.bs))
 		return (false);
-	
+
 	if (!getdatevalue (hp1, 2, &secs))
 		return (false);
 		
@@ -8637,7 +8637,7 @@ static boolean htmlcalendardrawverb (hdltreenode hp1, tyvaluerecord *v) {
 	Handle hurlprefix = nil; /*exempt*/
 	Handle hbgcolor = nil; /*exempt*/
 	Handle hcssprefix = nil;
-	unsigned long curdate; /*date*/
+	int64_t curdate; /*date*/
 	long firstdayofweek; /*first day of the week, 1 == Sunday*/
 	tyvaluerecord vmonthlist, vdayofweeklist, vcssprefix;
 

--- a/Common/source/langhtml.c
+++ b/Common/source/langhtml.c
@@ -3849,7 +3849,7 @@ static boolean stripmarkup (handlestream *s) {
 	long ix;
 	boolean fldidspace = true; // so leading spaces are omitted
 	
-	p = *(*s).data;
+	p = (char *) *(*s).data;
 	
 	for ((*s).pos = 0; (*s).pos < (*s).eof; ++(*s).pos) {
 		

--- a/Common/source/langsystypes.c
+++ b/Common/source/langsystypes.c
@@ -727,7 +727,7 @@ boolean aliastofilespec ( AliasHandle halias, ptrfilespec fs ) {
 		FSAliasInfoBitmap whichAliasInfo = kFSAliasInfoNone;
 		tyfsname volumeName;
 		
-		status = FSCopyAliasInfo ( halias, NULL, &volumeName, NULL, &whichAliasInfo, NULL );
+		status = FSCopyAliasInfo ( halias, NULL, (HFSUniStr255 *) &volumeName, NULL, &whichAliasInfo, NULL );
 		
 		if ( status == noErr ) { // try to get vol info
 		
@@ -736,7 +736,7 @@ boolean aliastofilespec ( AliasHandle halias, ptrfilespec fs ) {
 			fileparsevolname ( bs, fs );
 			}
 		
-		status = FSCopyAliasInfo ( halias, &fs->name, NULL, NULL, &whichAliasInfo, NULL );
+		status = FSCopyAliasInfo ( halias, (HFSUniStr255 *) &fs->name, NULL, NULL, &whichAliasInfo, NULL );
 		
 		if ( status != noErr ) {
 		

--- a/Common/source/langxml.c
+++ b/Common/source/langxml.c
@@ -859,7 +859,7 @@ boolean xmlstructtofrontiervalue (tyaddress *adrstruct, tyvaluerecord *v) {
 		if (!copyvaluerecord (vstruct, &val) || !coercetostring (&val))
 			return (false);
 
-		if (!stringtonumber (val.data.stringvalue, &longval)) {
+		if (!stringtonumber (*val.data.stringvalue, &longval)) {
 			disposevaluerecord (val, false);
 			return (false);
 		}
@@ -874,7 +874,7 @@ boolean xmlstructtofrontiervalue (tyaddress *adrstruct, tyvaluerecord *v) {
 		if (!copyvaluerecord (vstruct, &val) || !coercetostring (&val))
 			return (false);
 
-		if (!stringtonumber (val.data.stringvalue, &longval)) {
+		if (!stringtonumber (*val.data.stringvalue, &longval)) {
 			disposevaluerecord (val, false);
 			return (false);
 		}

--- a/Common/source/odbengine.c
+++ b/Common/source/odbengine.c
@@ -641,7 +641,8 @@ pascal boolean odbOpenFile (hdlfilenum fnum, odbref *odb, boolean flreadonly) {
 			goto error;
 		}
 
-		(**hc).hrootvariable = rootvariable = (hdltablevariable)val.data.externalvalue;
+		rootvariable = (Handle) val.data.externalvalue;
+		(**hc).hrootvariable = rootvariable;
 		(**hc).hroottable = roottable = htable;
 		/* htablestack is already allocated by newcancoonrecord() */
 

--- a/Common/source/stringverbs.c
+++ b/Common/source/stringverbs.c
@@ -1871,7 +1871,7 @@ boolean stringfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord *vr
 			}
 		
 		case timestringfunc: {
-			unsigned long dt = timenow64 ();
+			int64_t dt = timenow64 ();
 			
 			/*
 			if (!langcheckparamcount (hp1, 0))
@@ -1892,7 +1892,7 @@ boolean stringfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord *vr
 			}
 		
 		case datestringfunc: {
-			unsigned long dt = timenow64 ();
+			int64_t dt = timenow64 ();
 			
 			/*
 			if (!langcheckparamcount (hp1, 0))

--- a/Common/source/sysshellcall.c
+++ b/Common/source/sysshellcall.c
@@ -228,7 +228,7 @@ boolean unixshellcall (Handle hcommand, Handle hreturn) {
 
 	lockhandle (hcommand);
 
-	f = popenfunc (*hcommand, "r"); /*popen*/
+	f = popenfunc ((const char *) *hcommand, "r"); /*popen*/
 
 	unlockhandle (hcommand);
 

--- a/Common/source/tableexternal.c
+++ b/Common/source/tableexternal.c
@@ -1191,7 +1191,7 @@ static boolean tablesymbolchangedwindowvisit (WindowPtr w, ptrsymbolchangedinfo 
 		
 		shellpushglobals (w);
 		
-		if (tableformatsdata == op_get_outlinedata()) { // && !opinternalchange ())
+		if ((Handle) tableformatsdata == (Handle) op_get_outlinedata()) { // && !opinternalchange ())
 	
 			opvisiteverything ((*symbolinfo).opvisitroutine, symbolinfo);
 			

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -673,7 +673,7 @@ boolean tcp_read_stream(long stream_id, long bytes_to_read, Handle *data_out) {
     }
 
     /* SECURITY: Verify allocated buffer size matches request (prevents undersized allocation) */
-    if (GetHandleSize(hdata) < bytes_to_read) {
+    if (GetHandleSize(hdata) < (size_t) bytes_to_read) {
         disposehandle(hdata);
         tcp_stream_release(stream);
         *data_out = nil;

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -682,7 +682,7 @@ boolean tcp_read_stream(long stream_id, long bytes_to_read, Handle *data_out) {
     }
 
     lockhandle(hdata);
-    buffer = *hdata;
+    buffer = (char *) *hdata;
 
     /* Set socket to non-blocking mode for this read */
     int flags = fcntl(sockfd, F_GETFL, 0);
@@ -783,7 +783,7 @@ boolean tcp_write_stream(long stream_id, Handle hdata) {
     }
 
     lockhandle(hdata);
-    buffer = *hdata;
+    buffer = (char *) *hdata;
 
     /* Write all data (loop until complete) */
     long total_written = 0;

--- a/frontier-cli/repl_variables.c
+++ b/frontier-cli/repl_variables.c
@@ -304,7 +304,7 @@ static boolean build_wrapped_script(const char *script, Handle *hresult) {
     }
 
     HLock(htext);
-    char *p = *htext;
+    char *p = (char *) *htext;
     memcpy(p, prefix, prefix_len);
     p += prefix_len;
     memcpy(p, script, script_len);

--- a/portable/fileverbs_portable.c
+++ b/portable/fileverbs_portable.c
@@ -1534,7 +1534,7 @@ boolean portable_filefunctionvalue(short token, hdltreenode hparam1,
 			unlockhandle(hdata);
 			fclose(fp);
 
-			if (bytesread != filesize) {
+			if (bytesread != (size_t) filesize) {
 				disposehandle(hdata);
 				copyctopstring("Read error", bserror);
 				return false;
@@ -1577,7 +1577,7 @@ boolean portable_filefunctionvalue(short token, hdltreenode hparam1,
 			if (datasize > 0) {
 				lockhandle(hdata);
 				buffer = (unsigned char *)*hdata;
-				if (fwrite(buffer, 1, datasize, fp) != datasize) {
+				if (fwrite(buffer, 1, datasize, fp) != (size_t) datasize) {
 					unlockhandle(hdata);
 					disposehandle(hdata);
 					fclose(fp);

--- a/portable/fileverbs_portable.c
+++ b/portable/fileverbs_portable.c
@@ -2123,7 +2123,7 @@ boolean portable_file_dialog_verb(short token, hdltreenode hparam1,
 		if (copyvaluerecord(val, &valcopy)) {
 			disablelangerror();
 			if (coercetofilespec(&valcopy)) {
-				filespec_to_cstring(&valcopy.data.filespecvalue, start_path, sizeof(start_path));
+				filespec_to_cstring(*valcopy.data.filespecvalue, start_path, sizeof(start_path));
 			}
 			enablelangerror();
 		}

--- a/tests/headless_op_verbs.c
+++ b/tests/headless_op_verbs.c
@@ -146,7 +146,7 @@ static boolean getoutlinefromtarget(hdloutlinerecord *ho, bigstring bserror) {
     }
 
     /* Get the outline record */
-    if ((**hv).variabledata == NULL) {
+    if ((**hv).variabledata == 0) {
         seterrorstring("target is not an outline", bserror);
         return false;
     }

--- a/tests/headless_script_verbs.c
+++ b/tests/headless_script_verbs.c
@@ -123,7 +123,7 @@ static boolean script_compile(hdltreenode hparam1, tyvaluerecord *vreturned) {
     }
 
     /* Link the compiled code to the script variable */
-    opverblinkcode(hv, hcode);
+    opverblinkcode(hv, (Handle) hcode);
 
     return setbooleanvalue(true, vreturned);
 }
@@ -387,7 +387,7 @@ static boolean script_setcode(hdltreenode hparam1, tyvaluerecord *vreturned) {
     }
 
     /* Link the code to the script */
-    opverblinkcode(hv, hcode);
+    opverblinkcode(hv, (Handle) hcode);
 
     return setbooleanvalue(true, vreturned);
 }


### PR DESCRIPTION
## Summary

Completes the warning cleanup effort by eliminating all 24 remaining compiler warnings deferred from PR #372. The build now compiles with **zero warnings**.

**Warning categories fixed:**

- **Pointer sign conversions (6 warnings)**: Cast between `char *` and `unsigned char *` (Ptr) types
- **Incompatible pointer types (12 warnings)**: Handle dereferences, struct pointer casts, date type mismatches
- **Sign comparisons (3 warnings)**: Cast `long` to `size_t` for fread/fwrite/GetHandleSize comparisons
- **Invalid source encoding (1 warning)**: Replace Mac Roman infinity symbol with `&infin;` HTML entity

**Files modified:**
- langerror.c, langhtml.c, sysshellcall.c, tcpverbs.c, repl_variables.c (pointer sign)
- langsystypes.c, langxml.c, stringverbs.c, odbengine.c, tableexternal.c, fileverbs_portable.c, headless_script_verbs.c, headless_op_verbs.c (incompatible pointers)
- tcpverbs.c, fileverbs_portable.c (sign comparison)
- iso8859.c (source encoding)

## Test plan

- [x] Build with zero warnings: `make -C frontier-cli`
- [x] Run integration tests: 1451 passed, 96 failed, 151 skipped (matches develop baseline)
- [x] Verify no regressions introduced by warning fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)