### PR TITLE
test: Add comprehensive menu integration tests for headless mode

### DIFF
--- a/reports/integration_tests_menu_data_verbs.opml
+++ b/reports/integration_tests_menu_data_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Menu Data Verbs (menu_data_verbs)</title>
-    <dateCreated>Tue, 03 Feb 2026 03:30:11 GMT</dateCreated>
+    <dateCreated>Tue, 03 Feb 2026 05:54:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="menu.addMenuCommand - create new menu and add item - Add a command to a new menubar, creating the menu if it doesn't exist">
@@ -434,6 +434,505 @@
         <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item1&quot;, &quot;modifiedScript1()&quot;)"/>
         <outline text="delete(@workspace.testMenu)"/>
         <outline text="return true"/>
+      </outline>
+    </outline>
+    <outline text="menu.addSubMenu - add submenu to existing menu - Add a pre-existing menubar as a submenu within another menubar">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="# Create the parent menubar"/>
+        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.parentMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="# Create the submenu menubar"/>
+        <outline text="new(menubarType, @workspace.subMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;File1.txt&quot;, &quot;openRecent(1)&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;File2.txt&quot;, &quot;openRecent(2)&quot;)"/>
+        <outline text="# Add submenu to File menu"/>
+        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;File&quot;, @workspace.subMenu))"/>
+        <outline text="# Clean up"/>
+        <outline text="delete(@workspace.parentMenu)"/>
+        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="menu.addSubMenu - add as new top-level menu with empty menuName - Using empty string for menuName adds submenu as new top-level menu">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="# Create submenu"/>
+        <outline text="new(menubarType, @workspace.subMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Tools&quot;, &quot;Calculator&quot;, &quot;calc()&quot;)"/>
+        <outline text="# Add as top-level (empty menuName)"/>
+        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;&quot;, @workspace.subMenu))"/>
+        <outline text="delete(@workspace.parentMenu)"/>
+        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="menu.addSubMenu - creates menu if menuName doesn't exist - If menuName doesn't exist, it should be created">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="# parentMenu is empty - no &quot;Custom&quot; menu exists yet"/>
+        <outline text="new(menubarType, @workspace.subMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Sub&quot;, &quot;Item&quot;, &quot;doIt()&quot;)"/>
+        <outline text="# This should create &quot;Custom&quot; menu and add submenu to it"/>
+        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;Custom&quot;, @workspace.subMenu))"/>
+        <outline text="delete(@workspace.parentMenu)"/>
+        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="menu.addSubMenu - submenu address must exist - Adding a submenu from nonexistent address should fail">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: error_caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="# Try to add submenu from address that doesn't exist"/>
+        <outline text="try">
+          <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;File&quot;, @workspace.doesNotExist))"/>
+          <outline text="delete(@workspace.parentMenu)"/>
+          <outline text="return &quot;should_have_failed&quot;"/>
+        </outline>
+        <outline text="} else">
+          <outline text="delete(@workspace.parentMenu)"/>
+          <outline text="return &quot;error_caught&quot;"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="menu.deleteSubMenu - delete existing submenu - Delete a menu from the menubar by name">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="# Add some menus"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Help&quot;, &quot;About&quot;, &quot;helpAbout()&quot;)"/>
+        <outline text="# Delete the Edit menu"/>
+        <outline text="local(ok = menu.deleteSubMenu(@workspace.testMenu, &quot;Edit&quot;))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="menu.deleteSubMenu - delete nonexistent menu returns false - Attempting to delete a menu that doesn't exist returns false">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="# Try to delete menu that doesn't exist"/>
+        <outline text="local(ok = menu.deleteSubMenu(@workspace.testMenu, &quot;NoSuchMenu&quot;))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="menu.deleteSubMenu - can delete single item too - deleteSubMenu can delete a single item, not just a submenu">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;SingleItem&quot;, &quot;doIt()&quot;)"/>
+        <outline text="# deleteSubMenu on a single item should still work"/>
+        <outline text="local(ok = menu.deleteSubMenu(@workspace.testMenu, &quot;SingleItem&quot;))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="sizeOf - empty menubar - sizeOf on empty menubar returns 0">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: 0"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="local(size = sizeOf(@workspace.testMenu))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return size"/>
+      </outline>
+    </outline>
+    <outline text="sizeOf - counts all items - sizeOf counts menus and their items">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: 4"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="# Add File menu with 3 items (1 menu + 3 items = 4 headings)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;open()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;save()&quot;)"/>
+        <outline text="local(size = sizeOf(@workspace.testMenu))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return size"/>
+      </outline>
+    </outline>
+    <outline text="sizeOf - counts multiple menus - sizeOf counts all headings across multiple menus">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: 7"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="# File menu: 1 + 2 items = 3"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;open()&quot;)"/>
+        <outline text="# Edit menu: 1 + 3 items = 4"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;undo()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;cut()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;copy()&quot;)"/>
+        <outline text="# Total: 3 + 4 = 7"/>
+        <outline text="local(size = sizeOf(@workspace.testMenu))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return size"/>
+      </outline>
+    </outline>
+    <outline text="sizeOf - counts submenus and their contents - sizeOf includes submenu items in the count">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="new(menubarType, @workspace.subMenu)"/>
+        <outline text="# Parent has File with 1 item"/>
+        <outline text="menu.addMenuCommand(@workspace.parentMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
+        <outline text="# Submenu has 2 items"/>
+        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;Doc1&quot;, &quot;open1()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;Doc2&quot;, &quot;open2()&quot;)"/>
+        <outline text="# Add submenu to File"/>
+        <outline text="menu.addSubMenu(@workspace.parentMenu, &quot;File&quot;, @workspace.subMenu)"/>
+        <outline text="# Expected: File(1) + New(1) + Recent submenu structure"/>
+        <outline text="# The exact count depends on how submenus are represented"/>
+        <outline text="local(size = sizeOf(@workspace.parentMenu))"/>
+        <outline text="delete(@workspace.parentMenu)"/>
+        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="# Size should be &gt; 2 (at minimum File + New + submenu content)"/>
+        <outline text="return (size &gt; 2)"/>
+      </outline>
+    </outline>
+    <outline text="cursor navigation - navigate to item and getScript - Navigate to specific menu item using op verbs, then get its script">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="# Build menu: File &gt; New, Open, Save"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;fileSave()&quot;)"/>
+        <outline text="# Set target to menubar"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="# Navigate: firstSummit (File), expand, go right (into items), down 1 (to Open)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="op.go(down, 1)"/>
+        <outline text="# Get script from &quot;Open&quot; item"/>
+        <outline text="menu.getScript(@workspace.retrievedScript)"/>
+        <outline text="# Verify we got the right script"/>
+        <outline text="local(match = (workspace.retrievedScript == &quot;fileOpen()&quot;))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="try {delete(@workspace.retrievedScript)}"/>
+        <outline text="return match"/>
+      </outline>
+    </outline>
+    <outline text="cursor navigation - navigate and setScript - Navigate to item, change its script, verify change">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;originalScript()&quot;)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="# Navigate to File &gt; Test"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="# Create new script and set it"/>
+        <outline text="workspace.newScript = &quot;modifiedScript()&quot;"/>
+        <outline text="menu.setScript(@workspace.newScript)"/>
+        <outline text="# Get it back to verify"/>
+        <outline text="menu.getScript(@workspace.verifyScript)"/>
+        <outline text="local(match = (workspace.verifyScript == &quot;modifiedScript()&quot;))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@workspace.newScript)"/>
+        <outline text="try {delete(@workspace.verifyScript)}"/>
+        <outline text="return match"/>
+      </outline>
+    </outline>
+    <outline text="cursor navigation - navigate to third item - Navigate deeper into menu structure">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="# File menu with 4 items"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;script1()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;script2()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;script3()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Close&quot;, &quot;script4()&quot;)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="# Navigate to Save (3rd item)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="op.go(down, 2)"/>
+        <outline text="menu.getScript(@workspace.retrieved)"/>
+        <outline text="local(match = (workspace.retrieved == &quot;script3()&quot;))"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="try {delete(@workspace.retrieved)}"/>
+        <outline text="return match"/>
+      </outline>
+    </outline>
+    <outline text="menu.zoomScript - returns false in headless mode - zoomScript is a GUI operation, should return false headless">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;script()&quot;)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="# zoomScript opens editor window - noop in headless"/>
+        <outline text="local(result = menu.zoomScript())"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="persistence - save and reload menubar structure - Create menubar, save to file, reload, verify structure intact">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="# Create menubar with structure"/>
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
+        <outline text="# Remember size before save"/>
+        <outline text="local(sizeBefore = sizeOf(@workspace.testMenu))"/>
+        <outline text="# Save to a file"/>
+        <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/menu_persist_test.root7&quot;)"/>
+        <outline text="file.new(testPath, 'TABL')"/>
+        <outline text="local(fref = file.open(testPath, true))"/>
+        <outline text="db.save(@workspace.testMenu, fref)"/>
+        <outline text="file.close(fref)"/>
+        <outline text="# Delete from memory"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="# Reload"/>
+        <outline text="fref = file.open(testPath, false)"/>
+        <outline text="db.load(fref, @workspace.reloadedMenu)"/>
+        <outline text="file.close(fref)"/>
+        <outline text="# Verify size matches"/>
+        <outline text="local(sizeAfter = sizeOf(@workspace.reloadedMenu))"/>
+        <outline text="local(sizeMatch = (sizeBefore == sizeAfter))"/>
+        <outline text="# Clean up"/>
+        <outline text="delete(@workspace.reloadedMenu)"/>
+        <outline text="file.delete(testPath)"/>
+        <outline text="return sizeMatch"/>
+      </outline>
+    </outline>
+    <outline text="persistence - script content survives save/reload - Verify script text is preserved through save/reload cycle">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(testScript = &quot;dialog.alert(\&quot;Hello World!\&quot;)&quot;)"/>
+        <outline text="# Create menubar with script"/>
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Test&quot;, &quot;Item&quot;, testScript)"/>
+        <outline text="# Save"/>
+        <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/menu_script_persist.root7&quot;)"/>
+        <outline text="file.new(testPath, 'TABL')"/>
+        <outline text="local(fref = file.open(testPath, true))"/>
+        <outline text="db.save(@workspace.testMenu, fref)"/>
+        <outline text="file.close(fref)"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="# Reload"/>
+        <outline text="fref = file.open(testPath, false)"/>
+        <outline text="db.load(fref, @workspace.reloadedMenu)"/>
+        <outline text="file.close(fref)"/>
+        <outline text="# Navigate to item and get script"/>
+        <outline text="target.set(@workspace.reloadedMenu)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="menu.getScript(@workspace.retrievedScript)"/>
+        <outline text="# Compare"/>
+        <outline text="local(match = (workspace.retrievedScript == testScript))"/>
+        <outline text="# Clean up"/>
+        <outline text="delete(@workspace.reloadedMenu)"/>
+        <outline text="try {delete(@workspace.retrievedScript)}"/>
+        <outline text="file.delete(testPath)"/>
+        <outline text="return match"/>
+      </outline>
+    </outline>
+    <outline text="persistence - menu names survive save/reload - Verify menu and item names are preserved">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;CustomMenu&quot;, &quot;CustomItem&quot;, &quot;script()&quot;)"/>
+        <outline text="# Save"/>
+        <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/menu_names_persist.root7&quot;)"/>
+        <outline text="file.new(testPath, 'TABL')"/>
+        <outline text="local(fref = file.open(testPath, true))"/>
+        <outline text="db.save(@workspace.testMenu, fref)"/>
+        <outline text="file.close(fref)"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="# Reload"/>
+        <outline text="fref = file.open(testPath, false)"/>
+        <outline text="db.load(fref, @workspace.reloadedMenu)"/>
+        <outline text="file.close(fref)"/>
+        <outline text="# Navigate and get the headline text to verify name"/>
+        <outline text="target.set(@workspace.reloadedMenu)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="local(menuName = op.getLineText())"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="local(itemName = op.getLineText())"/>
+        <outline text="# Clean up"/>
+        <outline text="delete(@workspace.reloadedMenu)"/>
+        <outline text="file.delete(testPath)"/>
+        <outline text="return (menuName == &quot;CustomMenu&quot;) and (itemName == &quot;CustomItem&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="menu.buildMenuBar - returns false without error - buildMenuBar should return false in headless without throwing error">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;test()&quot;)"/>
+        <outline text="# Should return false, NOT throw an error"/>
+        <outline text="local(result = menu.buildMenuBar())"/>
+        <outline text="local(noError = true);  # If we got here, no error was thrown"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return (result == false) and noError"/>
+      </outline>
+    </outline>
+    <outline text="menu.install - returns false without error - install should return false in headless without throwing error">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Custom&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="local(result = menu.install())"/>
+        <outline text="local(noError = true)"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return (result == false) and noError"/>
+      </outline>
+    </outline>
+    <outline text="menu.isInstalled - returns false without error - isInstalled should return false in headless without throwing error">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="local(result = menu.isInstalled())"/>
+        <outline text="local(noError = true)"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return (result == false) and noError"/>
+      </outline>
+    </outline>
+    <outline text="menu.remove - returns false without error - remove should return false in headless without throwing error">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="local(result = menu.remove())"/>
+        <outline text="local(noError = true)"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return (result == false) and noError"/>
+      </outline>
+    </outline>
+    <outline text="menu.clearMenubar - returns true without error - clearMenubar affects OS menubar, but should not error in headless">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="# clearMenubar operates on OS menu bar, not a menubar object"/>
+        <outline text="# In headless, it should be a noop that returns true"/>
+        <outline text="local(result = menu.clearMenubar())"/>
+        <outline text="local(noError = true)"/>
+        <outline text="return noError"/>
+      </outline>
+    </outline>
+    <outline text="menu.toggle - returns false without error - toggle should return false in headless without throwing error">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: TDD: Menu verb implementations pending in headless_menu_verbs.c"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Toggle&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="local(result = menu.toggle())"/>
+        <outline text="local(noError = true)"/>
+        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="return (result == false) and noError"/>
       </outline>
     </outline>
   </body>

--- a/tests/integration/test_cases/menu_data_verbs.yaml
+++ b/tests/integration/test_cases/menu_data_verbs.yaml
@@ -32,7 +32,7 @@ tests:
   - name: "menu.addMenuCommand - create new menu and add item"
     description: "Add a command to a new menubar, creating the menu if it doesn't exist"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "New", "dialog.alert(\"New!\")"));
@@ -44,7 +44,7 @@ tests:
   - name: "menu.addMenuCommand - add multiple items to same menu"
     description: "Add multiple commands to the same menu"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "Edit", "Cut", "edit.cut()");
@@ -58,7 +58,7 @@ tests:
   - name: "menu.addMenuCommand - replace existing item script"
     description: "Adding an item that already exists should replace its script"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -76,7 +76,7 @@ tests:
   - name: "menu.addMenuCommand - create multiple menus"
     description: "Add items to different menus in the same menubar"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -96,7 +96,7 @@ tests:
   - name: "menu.deleteMenuCommand - delete existing item"
     description: "Delete a command that exists in the menu"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "ToDelete", "script()");
@@ -109,7 +109,7 @@ tests:
   - name: "menu.deleteMenuCommand - delete nonexistent item returns false"
     description: "Attempting to delete a nonexistent item should return false"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -124,7 +124,7 @@ tests:
   - name: "menu.deleteMenuCommand - delete from nonexistent menu returns false"
     description: "Deleting from a menu that doesn't exist should return false"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -139,7 +139,7 @@ tests:
   - name: "menu.deleteMenuCommand - verify item is actually removed"
     description: "After deletion, adding same item again should work"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -165,7 +165,7 @@ tests:
   - name: "menu.getScript - retrieve script from menu item"
     description: "Get the script attached to a menu item"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -193,7 +193,7 @@ tests:
   - name: "menu.setScript - change script on menu item"
     description: "Set a new script on a menu item using address"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -220,7 +220,7 @@ tests:
   - name: "menu.getScript and setScript - round-trip verification"
     description: "Set a script, get it back, verify they match"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -254,7 +254,7 @@ tests:
   - name: "menu.setCommandKey - set keyboard shortcut"
     description: "Set a command key (keyboard shortcut) on a menu item"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -275,7 +275,7 @@ tests:
   - name: "menu.getCommandKey - retrieve keyboard shortcut"
     description: "Get the command key from a menu item"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -298,7 +298,7 @@ tests:
   - name: "menu.setCommandKey - clear shortcut with empty string"
     description: "Setting empty string should clear the command key"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -322,7 +322,7 @@ tests:
   - name: "menu.getCommandKey and setCommandKey - round-trip"
     description: "Set a key, get it back, verify round-trip works"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -350,7 +350,7 @@ tests:
   - name: "menu.addMenuCommand - empty menu name creates unnamed menu"
     description: "Using empty string for menu name should still work"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -365,7 +365,7 @@ tests:
   - name: "menu.addMenuCommand - empty item name"
     description: "Using empty string for item name"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -380,7 +380,7 @@ tests:
   - name: "menu.addMenuCommand - special characters in item name"
     description: "Item names with special characters should work"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -395,7 +395,7 @@ tests:
   - name: "menu.addMenuCommand - separator item"
     description: "Using dash for item name may create separator"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -410,7 +410,7 @@ tests:
   - name: "menu.addMenuCommand - multiline script"
     description: "Script parameter can contain multiple lines"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -431,7 +431,7 @@ tests:
   - name: "menu.buildMenuBar - stubbed in headless mode"
     description: "Display verb should return false in headless mode"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "New", "test()");
@@ -447,7 +447,7 @@ tests:
   - name: "menu.install - stubbed in headless mode"
     description: "menu.install should return false without GUI"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "Custom", "Test", "test()");
@@ -464,7 +464,7 @@ tests:
   - name: "menu.isInstalled - stubbed in headless mode"
     description: "menu.isInstalled should return false without GUI"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -484,7 +484,7 @@ tests:
   - name: "menu verbs - build complete menu structure"
     description: "Create a realistic menu structure with multiple menus and items"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -515,7 +515,7 @@ tests:
   - name: "menu verbs - modify existing menu"
     description: "Add items, delete some, modify others"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -546,7 +546,7 @@ tests:
   - name: "menu.addSubMenu - add submenu to existing menu"
     description: "Add a pre-existing menubar as a submenu within another menubar"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       # Create the parent menubar
       new(menubarType, @workspace.parentMenu);
@@ -570,7 +570,7 @@ tests:
   - name: "menu.addSubMenu - add as new top-level menu with empty menuName"
     description: "Using empty string for menuName adds submenu as new top-level menu"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.parentMenu);
 
@@ -590,7 +590,7 @@ tests:
   - name: "menu.addSubMenu - creates menu if menuName doesn't exist"
     description: "If menuName doesn't exist, it should be created"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.parentMenu);
       # parentMenu is empty - no "Custom" menu exists yet
@@ -610,7 +610,7 @@ tests:
   - name: "menu.addSubMenu - submenu address must exist"
     description: "Adding a submenu from nonexistent address should fail"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.parentMenu);
 
@@ -629,7 +629,7 @@ tests:
   - name: "menu.deleteSubMenu - delete existing submenu"
     description: "Delete a menu from the menubar by name"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -649,7 +649,7 @@ tests:
   - name: "menu.deleteSubMenu - delete nonexistent menu returns false"
     description: "Attempting to delete a menu that doesn't exist returns false"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
@@ -665,7 +665,7 @@ tests:
   - name: "menu.deleteSubMenu - can delete single item too"
     description: "deleteSubMenu can delete a single item, not just a submenu"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "SingleItem", "doIt()");
@@ -686,7 +686,7 @@ tests:
   - name: "sizeOf - empty menubar"
     description: "sizeOf on empty menubar returns 0"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       local(size = sizeOf(@workspace.testMenu));
@@ -698,7 +698,7 @@ tests:
   - name: "sizeOf - counts all items"
     description: "sizeOf counts menus and their items"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -716,7 +716,7 @@ tests:
   - name: "sizeOf - counts multiple menus"
     description: "sizeOf counts all headings across multiple menus"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -739,7 +739,7 @@ tests:
   - name: "sizeOf - counts submenus and their contents"
     description: "sizeOf includes submenu items in the count"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.parentMenu);
       new(menubarType, @workspace.subMenu);
@@ -754,15 +754,16 @@ tests:
       # Add submenu to File
       menu.addSubMenu(@workspace.parentMenu, "File", @workspace.subMenu);
 
-      # Expected: File(1) + New(1) + Recent submenu structure
-      # The exact count depends on how submenus are represented
+      # Expected count: File(1) + New(1) + Recent(1) + Doc1(1) + Doc2(1) = 5 minimum
+      # May include additional structure nodes depending on representation
       local(size = sizeOf(@workspace.parentMenu));
 
       delete(@workspace.parentMenu);
       delete(@workspace.subMenu);
 
-      # Size should be > 2 (at minimum File + New + submenu content)
-      return (size > 2)
+      # Verify size is at least the expected minimum (5 headings)
+      local(expectedMinimum = 5);
+      return (size >= expectedMinimum)
     expected_success: true
     expected_result: "true"
 
@@ -774,7 +775,7 @@ tests:
   - name: "cursor navigation - navigate to item and getScript"
     description: "Navigate to specific menu item using op verbs, then get its script"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -807,7 +808,7 @@ tests:
   - name: "cursor navigation - navigate and setScript"
     description: "Navigate to item, change its script, verify change"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "Test", "originalScript()");
@@ -837,7 +838,7 @@ tests:
   - name: "cursor navigation - navigate to third item"
     description: "Navigate deeper into menu structure"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -872,7 +873,7 @@ tests:
   - name: "menu.zoomScript - returns false in headless mode"
     description: "zoomScript is a GUI operation, should return false headless"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "Test", "script()");
@@ -898,7 +899,7 @@ tests:
   - name: "persistence - save and reload menubar structure"
     description: "Create menubar, save to file, reload, verify structure intact"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       # Create menubar with structure
       new(menubarType, @workspace.testMenu);
@@ -939,7 +940,7 @@ tests:
   - name: "persistence - script content survives save/reload"
     description: "Verify script text is preserved through save/reload cycle"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       local(testScript = "dialog.alert(\"Hello World!\")");
 
@@ -983,7 +984,7 @@ tests:
   - name: "persistence - menu names survive save/reload"
     description: "Verify menu and item names are preserved"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "CustomMenu", "CustomItem", "script()");
@@ -1027,7 +1028,7 @@ tests:
   - name: "menu.buildMenuBar - returns false without error"
     description: "buildMenuBar should return false in headless without throwing error"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "New", "test()");
@@ -1044,7 +1045,7 @@ tests:
   - name: "menu.install - returns false without error"
     description: "install should return false in headless without throwing error"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "Custom", "Test", "test()");
@@ -1061,7 +1062,7 @@ tests:
   - name: "menu.isInstalled - returns false without error"
     description: "isInstalled should return false in headless without throwing error"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
 
@@ -1077,7 +1078,7 @@ tests:
   - name: "menu.remove - returns false without error"
     description: "remove should return false in headless without throwing error"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "Test", "test()");
@@ -1094,20 +1095,19 @@ tests:
   - name: "menu.clearMenubar - returns true without error"
     description: "clearMenubar affects OS menubar, but should not error in headless"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       # clearMenubar operates on OS menu bar, not a menubar object
       # In headless, it should be a noop that returns true
       local(result = menu.clearMenubar());
-      local(noError = true);
-      return noError
+      return (result == true)
     expected_success: true
     expected_result: "true"
 
   - name: "menu.toggle - returns false without error"
     description: "toggle should return false in headless without throwing error"
     skip: true
-    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    skip_reason: "TDD: Menu verb implementations pending (menuverbs.c headless support)"
     script: |
       new(menubarType, @workspace.testMenu);
       menu.addMenuCommand(@workspace.testMenu, "File", "Toggle", "test()");

--- a/tests/integration/test_cases/menu_data_verbs.yaml
+++ b/tests/integration/test_cases/menu_data_verbs.yaml
@@ -537,3 +537,586 @@ tests:
       return true
     expected_success: true
     expected_result: "true"
+
+  # ==========================================================================
+  # menu.addSubMenu() and menu.deleteSubMenu() Tests
+  # Submenus allow composing menubars from other menubar objects
+  # ==========================================================================
+
+  - name: "menu.addSubMenu - add submenu to existing menu"
+    description: "Add a pre-existing menubar as a submenu within another menubar"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      # Create the parent menubar
+      new(menubarType, @workspace.parentMenu);
+      menu.addMenuCommand(@workspace.parentMenu, "File", "New", "fileNew()");
+
+      # Create the submenu menubar
+      new(menubarType, @workspace.subMenu);
+      menu.addMenuCommand(@workspace.subMenu, "Recent", "File1.txt", "openRecent(1)");
+      menu.addMenuCommand(@workspace.subMenu, "Recent", "File2.txt", "openRecent(2)");
+
+      # Add submenu to File menu
+      local(ok = menu.addSubMenu(@workspace.parentMenu, "File", @workspace.subMenu));
+
+      # Clean up
+      delete(@workspace.parentMenu);
+      delete(@workspace.subMenu);
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.addSubMenu - add as new top-level menu with empty menuName"
+    description: "Using empty string for menuName adds submenu as new top-level menu"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.parentMenu);
+
+      # Create submenu
+      new(menubarType, @workspace.subMenu);
+      menu.addMenuCommand(@workspace.subMenu, "Tools", "Calculator", "calc()");
+
+      # Add as top-level (empty menuName)
+      local(ok = menu.addSubMenu(@workspace.parentMenu, "", @workspace.subMenu));
+
+      delete(@workspace.parentMenu);
+      delete(@workspace.subMenu);
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.addSubMenu - creates menu if menuName doesn't exist"
+    description: "If menuName doesn't exist, it should be created"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.parentMenu);
+      # parentMenu is empty - no "Custom" menu exists yet
+
+      new(menubarType, @workspace.subMenu);
+      menu.addMenuCommand(@workspace.subMenu, "Sub", "Item", "doIt()");
+
+      # This should create "Custom" menu and add submenu to it
+      local(ok = menu.addSubMenu(@workspace.parentMenu, "Custom", @workspace.subMenu));
+
+      delete(@workspace.parentMenu);
+      delete(@workspace.subMenu);
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.addSubMenu - submenu address must exist"
+    description: "Adding a submenu from nonexistent address should fail"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.parentMenu);
+
+      # Try to add submenu from address that doesn't exist
+      try {
+        local(ok = menu.addSubMenu(@workspace.parentMenu, "File", @workspace.doesNotExist));
+        delete(@workspace.parentMenu);
+        return "should_have_failed"
+      } else {
+        delete(@workspace.parentMenu);
+        return "error_caught"
+      }
+    expected_success: true
+    expected_result: "error_caught"
+
+  - name: "menu.deleteSubMenu - delete existing submenu"
+    description: "Delete a menu from the menubar by name"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+
+      # Add some menus
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "editUndo()");
+      menu.addMenuCommand(@workspace.testMenu, "Help", "About", "helpAbout()");
+
+      # Delete the Edit menu
+      local(ok = menu.deleteSubMenu(@workspace.testMenu, "Edit"));
+
+      delete(@workspace.testMenu);
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.deleteSubMenu - delete nonexistent menu returns false"
+    description: "Attempting to delete a menu that doesn't exist returns false"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
+
+      # Try to delete menu that doesn't exist
+      local(ok = menu.deleteSubMenu(@workspace.testMenu, "NoSuchMenu"));
+
+      delete(@workspace.testMenu);
+      return ok
+    expected_success: true
+    expected_result: "false"
+
+  - name: "menu.deleteSubMenu - can delete single item too"
+    description: "deleteSubMenu can delete a single item, not just a submenu"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "SingleItem", "doIt()");
+
+      # deleteSubMenu on a single item should still work
+      local(ok = menu.deleteSubMenu(@workspace.testMenu, "SingleItem"));
+
+      delete(@workspace.testMenu);
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # sizeOf() Tests for Menubar Objects
+  # sizeOf() returns total headings in menu outline regardless of expansion
+  # ==========================================================================
+
+  - name: "sizeOf - empty menubar"
+    description: "sizeOf on empty menubar returns 0"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      local(size = sizeOf(@workspace.testMenu));
+      delete(@workspace.testMenu);
+      return size
+    expected_success: true
+    expected_result: "0"
+
+  - name: "sizeOf - counts all items"
+    description: "sizeOf counts menus and their items"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+
+      # Add File menu with 3 items (1 menu + 3 items = 4 headings)
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "new()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "open()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "save()");
+
+      local(size = sizeOf(@workspace.testMenu));
+      delete(@workspace.testMenu);
+      return size
+    expected_success: true
+    expected_result: "4"
+
+  - name: "sizeOf - counts multiple menus"
+    description: "sizeOf counts all headings across multiple menus"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+
+      # File menu: 1 + 2 items = 3
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "new()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "open()");
+
+      # Edit menu: 1 + 3 items = 4
+      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "undo()");
+      menu.addMenuCommand(@workspace.testMenu, "Edit", "Cut", "cut()");
+      menu.addMenuCommand(@workspace.testMenu, "Edit", "Copy", "copy()");
+
+      # Total: 3 + 4 = 7
+      local(size = sizeOf(@workspace.testMenu));
+      delete(@workspace.testMenu);
+      return size
+    expected_success: true
+    expected_result: "7"
+
+  - name: "sizeOf - counts submenus and their contents"
+    description: "sizeOf includes submenu items in the count"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.parentMenu);
+      new(menubarType, @workspace.subMenu);
+
+      # Parent has File with 1 item
+      menu.addMenuCommand(@workspace.parentMenu, "File", "New", "new()");
+
+      # Submenu has 2 items
+      menu.addMenuCommand(@workspace.subMenu, "Recent", "Doc1", "open1()");
+      menu.addMenuCommand(@workspace.subMenu, "Recent", "Doc2", "open2()");
+
+      # Add submenu to File
+      menu.addSubMenu(@workspace.parentMenu, "File", @workspace.subMenu);
+
+      # Expected: File(1) + New(1) + Recent submenu structure
+      # The exact count depends on how submenus are represented
+      local(size = sizeOf(@workspace.parentMenu));
+
+      delete(@workspace.parentMenu);
+      delete(@workspace.subMenu);
+
+      # Size should be > 2 (at minimum File + New + submenu content)
+      return (size > 2)
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # Cursor Navigation Tests
+  # Using op verbs to navigate within menubar and access items
+  # ==========================================================================
+
+  - name: "cursor navigation - navigate to item and getScript"
+    description: "Navigate to specific menu item using op verbs, then get its script"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+
+      # Build menu: File > New, Open, Save
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "fileOpen()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "fileSave()");
+
+      # Set target to menubar
+      target.set(@workspace.testMenu);
+
+      # Navigate: firstSummit (File), expand, go right (into items), down 1 (to Open)
+      op.firstSummit();
+      op.expand();
+      op.go(right, 1);
+      op.go(down, 1);
+
+      # Get script from "Open" item
+      menu.getScript(@workspace.retrievedScript);
+
+      # Verify we got the right script
+      local(match = (workspace.retrievedScript == "fileOpen()"));
+
+      delete(@workspace.testMenu);
+      try {delete(@workspace.retrievedScript)};
+      return match
+    expected_success: true
+    expected_result: "true"
+
+  - name: "cursor navigation - navigate and setScript"
+    description: "Navigate to item, change its script, verify change"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "originalScript()");
+
+      target.set(@workspace.testMenu);
+
+      # Navigate to File > Test
+      op.firstSummit();
+      op.expand();
+      op.go(right, 1);
+
+      # Create new script and set it
+      workspace.newScript = "modifiedScript()";
+      menu.setScript(@workspace.newScript);
+
+      # Get it back to verify
+      menu.getScript(@workspace.verifyScript);
+      local(match = (workspace.verifyScript == "modifiedScript()"));
+
+      delete(@workspace.testMenu);
+      delete(@workspace.newScript);
+      try {delete(@workspace.verifyScript)};
+      return match
+    expected_success: true
+    expected_result: "true"
+
+  - name: "cursor navigation - navigate to third item"
+    description: "Navigate deeper into menu structure"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+
+      # File menu with 4 items
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "script1()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "script2()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "script3()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Close", "script4()");
+
+      target.set(@workspace.testMenu);
+
+      # Navigate to Save (3rd item)
+      op.firstSummit();
+      op.expand();
+      op.go(right, 1);
+      op.go(down, 2);
+
+      menu.getScript(@workspace.retrieved);
+      local(match = (workspace.retrieved == "script3()"));
+
+      delete(@workspace.testMenu);
+      try {delete(@workspace.retrieved)};
+      return match
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # menu.zoomScript() Tests
+  # In headless mode, zoomScript should be a noop returning false
+  # ==========================================================================
+
+  - name: "menu.zoomScript - returns false in headless mode"
+    description: "zoomScript is a GUI operation, should return false headless"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "script()");
+
+      target.set(@workspace.testMenu);
+      op.firstSummit();
+      op.expand();
+      op.go(right, 1);
+
+      # zoomScript opens editor window - noop in headless
+      local(result = menu.zoomScript());
+
+      delete(@workspace.testMenu);
+      return result
+    expected_success: true
+    expected_result: "false"
+
+  # ==========================================================================
+  # Persistence Tests
+  # Verify menubar structure survives save and reload
+  # ==========================================================================
+
+  - name: "persistence - save and reload menubar structure"
+    description: "Create menubar, save to file, reload, verify structure intact"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      # Create menubar with structure
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "fileOpen()");
+      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "editUndo()");
+
+      # Remember size before save
+      local(sizeBefore = sizeOf(@workspace.testMenu));
+
+      # Save to a file
+      local(testPath = "{FRONTIER_TEST_TMP_DIR}/menu_persist_test.root7");
+      file.new(testPath, 'TABL');
+      local(fref = file.open(testPath, true));
+      db.save(@workspace.testMenu, fref);
+      file.close(fref);
+
+      # Delete from memory
+      delete(@workspace.testMenu);
+
+      # Reload
+      fref = file.open(testPath, false);
+      db.load(fref, @workspace.reloadedMenu);
+      file.close(fref);
+
+      # Verify size matches
+      local(sizeAfter = sizeOf(@workspace.reloadedMenu));
+      local(sizeMatch = (sizeBefore == sizeAfter));
+
+      # Clean up
+      delete(@workspace.reloadedMenu);
+      file.delete(testPath);
+
+      return sizeMatch
+    expected_success: true
+    expected_result: "true"
+
+  - name: "persistence - script content survives save/reload"
+    description: "Verify script text is preserved through save/reload cycle"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      local(testScript = "dialog.alert(\"Hello World!\")");
+
+      # Create menubar with script
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "Test", "Item", testScript);
+
+      # Save
+      local(testPath = "{FRONTIER_TEST_TMP_DIR}/menu_script_persist.root7");
+      file.new(testPath, 'TABL');
+      local(fref = file.open(testPath, true));
+      db.save(@workspace.testMenu, fref);
+      file.close(fref);
+
+      delete(@workspace.testMenu);
+
+      # Reload
+      fref = file.open(testPath, false);
+      db.load(fref, @workspace.reloadedMenu);
+      file.close(fref);
+
+      # Navigate to item and get script
+      target.set(@workspace.reloadedMenu);
+      op.firstSummit();
+      op.expand();
+      op.go(right, 1);
+      menu.getScript(@workspace.retrievedScript);
+
+      # Compare
+      local(match = (workspace.retrievedScript == testScript));
+
+      # Clean up
+      delete(@workspace.reloadedMenu);
+      try {delete(@workspace.retrievedScript)};
+      file.delete(testPath);
+
+      return match
+    expected_success: true
+    expected_result: "true"
+
+  - name: "persistence - menu names survive save/reload"
+    description: "Verify menu and item names are preserved"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "CustomMenu", "CustomItem", "script()");
+
+      # Save
+      local(testPath = "{FRONTIER_TEST_TMP_DIR}/menu_names_persist.root7");
+      file.new(testPath, 'TABL');
+      local(fref = file.open(testPath, true));
+      db.save(@workspace.testMenu, fref);
+      file.close(fref);
+
+      delete(@workspace.testMenu);
+
+      # Reload
+      fref = file.open(testPath, false);
+      db.load(fref, @workspace.reloadedMenu);
+      file.close(fref);
+
+      # Navigate and get the headline text to verify name
+      target.set(@workspace.reloadedMenu);
+      op.firstSummit();
+      local(menuName = op.getLineText());
+
+      op.expand();
+      op.go(right, 1);
+      local(itemName = op.getLineText());
+
+      # Clean up
+      delete(@workspace.reloadedMenu);
+      file.delete(testPath);
+
+      return (menuName == "CustomMenu") and (itemName == "CustomItem")
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # Category B Tests - Verify No Errors (Updated)
+  # These GUI-only verbs should return false without causing UserTalk errors
+  # ==========================================================================
+
+  - name: "menu.buildMenuBar - returns false without error"
+    description: "buildMenuBar should return false in headless without throwing error"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "New", "test()");
+
+      # Should return false, NOT throw an error
+      local(result = menu.buildMenuBar());
+      local(noError = true);  # If we got here, no error was thrown
+
+      delete(@workspace.testMenu);
+      return (result == false) and noError
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.install - returns false without error"
+    description: "install should return false in headless without throwing error"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "Custom", "Test", "test()");
+
+      target.set(@workspace.testMenu);
+      local(result = menu.install());
+      local(noError = true);
+
+      delete(@workspace.testMenu);
+      return (result == false) and noError
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.isInstalled - returns false without error"
+    description: "isInstalled should return false in headless without throwing error"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+
+      target.set(@workspace.testMenu);
+      local(result = menu.isInstalled());
+      local(noError = true);
+
+      delete(@workspace.testMenu);
+      return (result == false) and noError
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.remove - returns false without error"
+    description: "remove should return false in headless without throwing error"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "test()");
+
+      target.set(@workspace.testMenu);
+      local(result = menu.remove());
+      local(noError = true);
+
+      delete(@workspace.testMenu);
+      return (result == false) and noError
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.clearMenubar - returns true without error"
+    description: "clearMenubar affects OS menubar, but should not error in headless"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      # clearMenubar operates on OS menu bar, not a menubar object
+      # In headless, it should be a noop that returns true
+      local(result = menu.clearMenubar());
+      local(noError = true);
+      return noError
+    expected_success: true
+    expected_result: "true"
+
+  - name: "menu.toggle - returns false without error"
+    description: "toggle should return false in headless without throwing error"
+    skip: true
+    skip_reason: "TDD: Menu verb implementations pending in headless_menu_verbs.c"
+    script: |
+      new(menubarType, @workspace.testMenu);
+      menu.addMenuCommand(@workspace.testMenu, "File", "Toggle", "test()");
+
+      target.set(@workspace.testMenu);
+      local(result = menu.toggle());
+      local(noError = true);
+
+      delete(@workspace.testMenu);
+      return (result == false) and noError
+    expected_success: true
+    expected_result: "true"


### PR DESCRIPTION
## Summary
- Add 24 new integration tests for menubarType operations in headless mode
- Tests cover submenu operations, sizeOf(), cursor navigation, persistence, and Category B verbs
- All tests marked `skip: true` pending verb implementation

## Test Categories Added

| Category | Tests | Coverage |
|----------|-------|----------|
| menu.addSubMenu | 4 | Add submenu, empty menuName, auto-create menu, error handling |
| menu.deleteSubMenu | 3 | Delete existing, nonexistent returns false, delete single item |
| sizeOf() | 4 | Empty menubar, all items count, multiple menus, submenus |
| Cursor navigation | 3 | Navigate to item, verify getScript, navigate to specific position |
| menu.zoomScript | 1 | Noop verification in headless mode |
| Persistence | 3 | Structure, script content, and menu names survive save/reload |
| Category B updates | 6 | Verify return false WITHOUT throwing UserTalk errors |

## Test plan
- [x] YAML validation passes (49 total tests)
- [x] OPML export regenerated automatically via git hook
- [ ] Tests will be enabled as verbs are implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)