### PR TITLE
fix: V6 menu loading during migration and byte-swap linkage

### DIFF
--- a/Common/headers/byteorder.h
+++ b/Common/headers/byteorder.h
@@ -133,19 +133,19 @@
 
 	/* using AT&T x86 assembly code syntax */
 
-	inline long dolongswap (long foo) {
+	static inline long dolongswap (long foo) {
 
 		__asm__("mov foo,%eax\nbswap %eax\nmov %eax,foo\n");
 
 		return (foo);
 		} /*dolongswap*/
 
-	inline long long dolonglongswap (long long foo) {
+	static inline long long dolonglongswap (long long foo) {
 
 		return __builtin_bswap64(foo);
 		} /*dolonglongswap*/
 
-	inline short doshortswap (short foo) {
+	static inline short doshortswap (short foo) {
 
 		__asm__("mov foo,%ax\n mov %al,%bh\nmov %ah,%bl\nmov %bx,foo");
 
@@ -210,7 +210,7 @@
 
 	/* portable code using only C operators */
 
-	inline long dolongswap (long foo) {
+	static inline long dolongswap (long foo) {
 
 		foo = ((((foo) >> 24) & 0x000000ff)
 				| (((foo) & 0x00ff0000) >> 8)
@@ -220,7 +220,7 @@
 		return (foo);
 		} /*dolongswap*/
 
-	inline long long dolonglongswap (long long foo) {
+	static inline long long dolonglongswap (long long foo) {
 
 		foo = ((((foo) >> 56) & 0x00000000000000ffLL)
 				| (((foo) >> 40) & 0x000000000000ff00LL)
@@ -234,7 +234,7 @@
 		return (foo);
 		} /*dolonglongswap*/
 
-	inline short doshortswap (short foo) {
+	static inline short doshortswap (short foo) {
 
 		foo = ((((foo) >> 8) & 0x00ff)
 				| (((foo) << 8) & 0xff00));

--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -190,6 +190,12 @@ extern boolean dbreference (dbaddress, long, ptrvoid);
 
 extern boolean dbrefhandle (dbaddress, Handle *);
 
+/* Explicit header size versions for migration (v6=8 bytes, v7=12 bytes).
+ * These bypass the global format mode lock during v6→v7 migration. */
+extern boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size);
+
+extern boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size);
+
 extern boolean dbassign (dbaddress *, long, ptrvoid);
 
 extern boolean dbcopy (dbaddress, dbaddress *);

--- a/Common/headers/menuverbs.h
+++ b/Common/headers/menuverbs.h
@@ -94,3 +94,19 @@ extern boolean editnamedmenubaropen (hdlhashtable, bigstring);
 extern boolean menustart (void);
 
 
+/*
+ * V7 Menu Refcon Table Functions (menupack.c)
+ *
+ * These functions create and unpack the v7 format for menu item refcons.
+ * Used for the menu v6->v7 migration.
+ */
+
+extern boolean mecreaterefcontable_v7 (byte cmdkey, tykeyflags modifiers,
+                                        hdloutlinerecord hscript,
+                                        Handle *hpackedtable);
+
+extern boolean meunpackrefcontable_v7 (Handle hpackedtable,
+                                        byte *cmdkey,
+                                        tykeyflags *modifiers,
+                                        hdloutlinerecord *hscript);
+

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -81,7 +81,8 @@ static void db_sync_use64_to_current_db(void);
 #if defined(FRONTIER_HEADLESS)
 static boolean dbfindblockforaddress(dbaddress adr, dbaddress *blockstart, long *nodebytes, tyvariance *variance, boolean *flfree) {
 	long eof = 0;
-    const long header_size = (databasedata != nil && db_format_is_legacy_db(databasedata)) ? sizeheader_v6 : sizeheader;
+    boolean is_legacy = (databasedata != nil && db_format_is_legacy_db(databasedata));
+    const long header_size = is_legacy ? sizeheader_v6 : sizeheader;
 
 	if (adr == nildbaddress)
 		return false;
@@ -509,6 +510,7 @@ boolean dbrelease_context(const db_context *context, dbaddress adr);
 boolean dbassign_internal(dbaddress *padr, long newsize, ptrvoid pdata);
 boolean dbcopy_internal(dbaddress adrorig, dbaddress *adrcopy);
 boolean dbreference_internal(dbaddress adr, long maxbytes, ptrvoid pdata);
+boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size);
 boolean dbgetsize_internal(dbaddress adr, long *logicalsize);
 
 
@@ -1583,7 +1585,7 @@ boolean dbreference_internal (dbaddress adr, long maxbytes, ptrvoid pdata) {
 	long ctbytes;
 	boolean flfree;
 	tyvariance variance;
-	
+
     #if defined(FRONTIER_HEADLESS)
     (void) dbnormalizeaddress(&adr);
     #endif
@@ -1601,22 +1603,97 @@ boolean dbreference_internal (dbaddress adr, long maxbytes, ptrvoid pdata) {
 	return (dbread (adr + sizeheader, min (maxbytes, ctbytes - (long) variance), pdata));
 	} /*dbreference_internal*/
 
+boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size) {
+	/*
+	Like dbreference_internal but uses explicit header size instead of sizeheader macro.
+	Needed during migration when global mode is locked but we need to read v6 blocks.
+	*/
+	long ctbytes;
+	boolean flfree;
+	tyvariance variance;
+
+#if defined(FRONTIER_HEADLESS)
+	(void) dbnormalizeaddress(&adr);
+#endif
+
+	if (!dbreadheader(adr, &flfree, &ctbytes, &variance))
+		return (false);
+
+	if (flfree || (ctbytes < 0)) {
+		dberror(dbfreeblockerror);
+		return (false);
+	}
+
+	return (dbread(adr + header_size, min(maxbytes, ctbytes - (long) variance), pdata));
+}
+
 boolean dbreference (dbaddress adr, long maxbytes, ptrvoid pdata) {
     db_context *ctx = db_context_refresh_default();
     return dbreference_context(ctx, adr, maxbytes, pdata);
 }
 	
 
+boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size) {
+	/*
+	Like dbrefhandle but uses explicit header size instead of sizeheader macro.
+	Needed during migration when global mode is locked but we need to read v6 blocks.
+	*/
+	dbaddress a = adr;
+	register boolean fl;
+	register Handle hregister;
+	register long ct;
+	long ctbytes;
+	boolean flfree;
+	tyvariance variance;
+
+	*h = nil;
+
+	if (a == nildbaddress)
+		return (false);
+
+#if defined(FRONTIER_HEADLESS)
+	(void) dbnormalizeaddress(&a);
+#endif
+
+	if (!dbreadheader(a, &flfree, &ctbytes, &variance))
+		return (false);
+
+	ct = ctbytes - (long) variance;
+
+	if (flfree || (ct < 0)) {
+		dberror(dbfreeblockerror);
+		return (false);
+	}
+
+	if (!newclearhandle(ct, h))
+		return (false);
+
+	hregister = *h;
+	lockhandle(hregister);
+
+	fl = dbread(a + header_size, ct, *hregister);
+
+	unlockhandle(hregister);
+
+	if (!fl) {
+		disposehandle(hregister);
+		*h = nil;
+		return (false);
+	}
+
+	return (true);
+}
+
 boolean dbrefhandle (dbaddress adr, Handle *h) {
 
 	/*
 	copy a block from the database into a handle which we allocate.
-	
+
 	the caller must dispose of the handle.
-	
+
 	5.0.1 dmb: added freeblock error; don't fail silently
 	*/
-	
+
     dbaddress a = adr;
 	register boolean fl;
 	register Handle hregister;
@@ -1624,9 +1701,9 @@ boolean dbrefhandle (dbaddress adr, Handle *h) {
 	long ctbytes;
 	boolean flfree;
 	tyvariance variance;
-		
+
 	*h = nil;
-		
+
 	if (a == nildbaddress) /*defensive driving*/
 		return (false);
 
@@ -1648,7 +1725,7 @@ boolean dbrefhandle (dbaddress adr, Handle *h) {
 #endif
         return (false);
         }
-		
+
 	if (!newclearhandle (ct, h))
 		return (false);
 
@@ -1657,7 +1734,7 @@ boolean dbrefhandle (dbaddress adr, Handle *h) {
         log_trace(LOG_COMP_DB, "dbrefhandle watch allocated handle size=%ld", ct);
     }
 #endif
-	
+
 	hregister = *h;
 
 	lockhandle (hregister);

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -1607,10 +1607,18 @@ boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata
 	/*
 	Like dbreference_internal but uses explicit header size instead of sizeheader macro.
 	Needed during migration when global mode is locked but we need to read v6 blocks.
+
+	header_size: Must be 8 (v6) or 12 (v7). Other values are invalid.
 	*/
 	long ctbytes;
 	boolean flfree;
 	tyvariance variance;
+
+	/* Validate header_size - only 8 (v6) and 12 (v7) are valid */
+	if (header_size != 8 && header_size != 12) {
+		log_error(LOG_COMP_DB, "dbreference_with_header_size: invalid header_size %ld (must be 8 or 12)", header_size);
+		return (false);
+	}
 
 #if defined(FRONTIER_HEADLESS)
 	(void) dbnormalizeaddress(&adr);
@@ -1637,6 +1645,8 @@ boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size)
 	/*
 	Like dbrefhandle but uses explicit header size instead of sizeheader macro.
 	Needed during migration when global mode is locked but we need to read v6 blocks.
+
+	header_size: Must be 8 (v6) or 12 (v7). Other values are invalid.
 	*/
 	dbaddress a = adr;
 	register boolean fl;
@@ -1647,6 +1657,12 @@ boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size)
 	tyvariance variance;
 
 	*h = nil;
+
+	/* Validate header_size - only 8 (v6) and 12 (v7) are valid */
+	if (header_size != 8 && header_size != 12) {
+		log_error(LOG_COMP_DB, "dbrefhandle_with_header_size: invalid header_size %ld (must be 8 or 12)", header_size);
+		return (false);
+	}
 
 	if (a == nildbaddress)
 		return (false);

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2523,16 +2523,27 @@ boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *a
     return dbassignhandle(h, adr);
 }
 
+/* Forward declarations from db.c for explicit header size functions */
+extern boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size);
+extern boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size);
+
 boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h) {
     /*
     2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
     Set mode directly from context, call function, done.
     Caller ensures correct database is active.
+
+    2026-02-03: During migration, global mode may be locked to v7.
+    Use explicit header size from context instead of global mode.
     */
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
-        db_format_mode_apply(&context->mode);
+
+        /* During migration with mode lock, can't downgrade global mode to v6.
+           Pass explicit header size based on context mode. */
+        long header_size = context->mode.use_64bit_format ? sizeheader_v7 : sizeheader_v6;
+        return dbrefhandle_with_header_size(adr, h, header_size);
     }
     return dbrefhandle(adr, h);
 }
@@ -2570,11 +2581,18 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
     2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
     Set mode directly from context, call function, done.
     Caller ensures correct database is active.
+
+    2026-02-03: During migration, global mode may be locked to v7.
+    Use explicit header size from context instead of global mode.
     */
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
-        db_format_mode_apply(&context->mode);
+
+        /* During migration with mode lock, can't downgrade global mode to v6.
+           Pass explicit header size based on context mode. */
+        long header_size = context->mode.use_64bit_format ? sizeheader_v7 : sizeheader_v6;
+        return dbreference_with_header_size(adr, ctbytes, pdata, header_size);
     }
     return dbreference_internal(adr, ctbytes, pdata);
 }

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2523,10 +2523,6 @@ boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *a
     return dbassignhandle(h, adr);
 }
 
-/* Forward declarations from db.c for explicit header size functions */
-extern boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size);
-extern boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size);
-
 boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h) {
     /*
     2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -987,6 +987,9 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	 * NO GLOBAL MODE CHANGES - all context passed explicitly
 	 * ================================================================
 	 */
+	log_debug(LOG_COMP_EXTERNAL, "langexternalpack_internal: START id=%d adapter_repack=%d flinmemory=%d",
+	        (int)(**hv).id, (int)adapter_repack, (int)(**hv).flinmemory);
+
 	if (adapter_repack) {
 		/* If not already in memory, load from v6 source */
 		if (!(**hv).flinmemory) {
@@ -994,12 +997,16 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 			legacy_context = working_context;
 			legacy_context.mode.use_64bit_format = false;
 			legacy_context.mode.adapter_repack = false;  /* Pure read mode */
+			/* CRITICAL: Use the external's own database handle for reading, not the current global */
+			legacy_context.database = (**hv).hdatabase;
 
-			log_trace(LOG_COMP_EXTERNAL, "langexternalpack: loading external from v6 id=%d (explicit context)",
-			        (int)(**hv).id);
+			log_trace(LOG_COMP_EXTERNAL, "langexternalpack: loading external from v6 id=%d (explicit context) db=%p",
+			        (int)(**hv).id, (void*)legacy_context.database);
 
 			/* Load external into memory using explicit v6 context */
 			if (!ensure_external_in_memory (&legacy_context, hv)) {
+				log_error(LOG_COMP_EXTERNAL, "langexternalpack_internal: ensure_external_in_memory FAILED id=%d",
+				        (int)(**hv).id);
 				return (false);
 			}
 
@@ -1014,6 +1021,9 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 
 		log_trace(LOG_COMP_EXTERNAL, "langexternalpack: using v7 write context flinmemory=%d (no global mode set)",
 		        (int)(**hv).flinmemory);
+	} else {
+		log_debug(LOG_COMP_EXTERNAL, "langexternalpack_internal: NOT adapter_repack - skipping load! id=%d flinmemory=%d",
+		        (int)(**hv).id, (int)(**hv).flinmemory);
 	}
 
 	/* ================================================================

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -973,8 +973,8 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 		tysavedmenuinfo_disk_legacy legacy_info;
 
 #if defined(FRONTIER_HEADLESS)
-		log_error(LOG_COMP_OP, "meloadmenurecord_internal: reading v6 adr=0x%llx sizeof(legacy_info)=%zu databasedata=%p ctx_db=%p fldatabasesaveas=%d",
-		        (unsigned long long)adr, sizeof(legacy_info), (void*)databasedata, (void*)ctx->database, (int)fldatabasesaveas);
+		log_debug(LOG_COMP_OP, "meloadmenurecord_internal: reading v6 adr=0x%llx sizeof(legacy_info)=%zu",
+		        (unsigned long long)adr, sizeof(legacy_info));
 #endif
 
 		if (!dbreference_context (ctx, adr, sizeof (legacy_info), &legacy_info)) {
@@ -985,17 +985,6 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 			return (false);
 		}
 
-		/* Dump first 20 bytes of raw data for debugging */
-#if defined(FRONTIER_HEADLESS)
-		{
-			unsigned char *p = (unsigned char *)&legacy_info;
-			log_error(LOG_COMP_OP, "meloadmenurecord_internal: raw bytes: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
-			        p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
-			        p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15],
-			        p[16], p[17], p[18], p[19]);
-		}
-#endif
-
 		/* Convert legacy 32-bit disk format to in-memory 64-bit format */
 		/* All values in the legacy struct are stored big-endian on disk */
 		clearbytes (&info, sizeof (info));
@@ -1003,9 +992,8 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 		/* Legacy 32-bit address is stored big-endian on disk */
 		outline_adr = (dbaddress) conditionallongswap (legacy_info.adroutline);
 #if defined(FRONTIER_HEADLESS)
-		log_error(LOG_COMP_OP, "meloadmenurecord_internal: v6 versionnumber=%d (raw=0x%04x BE) legacy_info.adroutline raw=0x%08x swapped=0x%llx",
-		        (int)info.versionnumber, (unsigned)legacy_info.versionnumber,
-		        legacy_info.adroutline, (unsigned long long)outline_adr);
+		log_debug(LOG_COMP_OP, "meloadmenurecord_internal: v6 versionnumber=%d outline_adr=0x%llx",
+		        (int)info.versionnumber, (unsigned long long)outline_adr);
 #endif
 		info.adroutline = outline_adr;
 		info.vertmin = conditionalshortswap(legacy_info.vertmin);

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -745,6 +745,9 @@ typedef struct tysavedmenuinfo_disk_legacy {
 } tysavedmenuinfo_disk_legacy;
 #pragma options align=reset
 
+/* Verify the legacy struct size matches v6 format expectations (112 bytes) */
+_Static_assert(sizeof(tysavedmenuinfo_disk_legacy) == 112, "v6 menu struct must be exactly 112 bytes");
+
 typedef struct tysavedmenuinfo_v7 {
 	uint16_t versionnumber;     /* v7+ marker */
 	uint16_t _pad;              /* align to 64-bit */
@@ -986,32 +989,44 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 #if defined(FRONTIER_HEADLESS)
 		{
 			unsigned char *p = (unsigned char *)&legacy_info;
-			log_error(LOG_COMP_OP, "meloadmenurecord_internal: raw bytes: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
+			log_error(LOG_COMP_OP, "meloadmenurecord_internal: raw bytes: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
 			        p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
-			        p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
+			        p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15],
+			        p[16], p[17], p[18], p[19]);
 		}
 #endif
 
 		/* Convert legacy 32-bit disk format to in-memory 64-bit format */
+		/* All values in the legacy struct are stored big-endian on disk */
 		clearbytes (&info, sizeof (info));
-		info.versionnumber = legacy_info.versionnumber;
+		info.versionnumber = conditionalshortswap(legacy_info.versionnumber);
 		/* Legacy 32-bit address is stored big-endian on disk */
 		outline_adr = (dbaddress) conditionallongswap (legacy_info.adroutline);
 #if defined(FRONTIER_HEADLESS)
-		log_error(LOG_COMP_OP, "meloadmenurecord_internal: v6 legacy_info.adroutline raw=0x%08x swapped=0x%llx versionnumber=%d",
-		        legacy_info.adroutline, (unsigned long long)outline_adr, (int)legacy_info.versionnumber);
+		log_error(LOG_COMP_OP, "meloadmenurecord_internal: v6 versionnumber=%d (raw=0x%04x BE) legacy_info.adroutline raw=0x%08x swapped=0x%llx",
+		        (int)info.versionnumber, (unsigned)legacy_info.versionnumber,
+		        legacy_info.adroutline, (unsigned long long)outline_adr);
 #endif
 		info.adroutline = outline_adr;
-		info.vertmin = legacy_info.vertmin;
-		info.vertmax = legacy_info.vertmax;
-		info.vertcurrent = legacy_info.vertcurrent;
-		info.scriptwindowrect = legacy_info.scriptwindowrect;
-		info.flags = legacy_info.flags;
-		info.menuactivelayer = legacy_info.menuactivelayer;
-		info.lnumcursor = legacy_info.lnumcursor;
+		info.vertmin = conditionalshortswap(legacy_info.vertmin);
+		info.vertmax = conditionalshortswap(legacy_info.vertmax);
+		info.vertcurrent = conditionalshortswap(legacy_info.vertcurrent);
+		/* scriptwindowrect is a diskrect with 4 shorts */
+		info.scriptwindowrect.top = conditionalshortswap(legacy_info.scriptwindowrect.top);
+		info.scriptwindowrect.left = conditionalshortswap(legacy_info.scriptwindowrect.left);
+		info.scriptwindowrect.bottom = conditionalshortswap(legacy_info.scriptwindowrect.bottom);
+		info.scriptwindowrect.right = conditionalshortswap(legacy_info.scriptwindowrect.right);
+		info.flags = conditionalshortswap(legacy_info.flags);
+		info.menuactivelayer = conditionalshortswap(legacy_info.menuactivelayer);
+		info.lnumcursor = conditionalshortswap(legacy_info.lnumcursor);
+		/* diskfontstring is a pascal string - first byte is length, don't swap */
 		memcpy(info.defaultscriptfontname, legacy_info.defaultscriptfontname, sizeof(diskfontstring));
-		info.defaultscriptfontsize = legacy_info.defaultscriptfontsize;
-		info.menuwindowrect = legacy_info.menuwindowrect;
+		info.defaultscriptfontsize = conditionalshortswap(legacy_info.defaultscriptfontsize);
+		/* menuwindowrect is a diskrect with 4 shorts */
+		info.menuwindowrect.top = conditionalshortswap(legacy_info.menuwindowrect.top);
+		info.menuwindowrect.left = conditionalshortswap(legacy_info.menuwindowrect.left);
+		info.menuwindowrect.bottom = conditionalshortswap(legacy_info.menuwindowrect.bottom);
+		info.menuwindowrect.right = conditionalshortswap(legacy_info.menuwindowrect.right);
 	}
 
 #if defined(FRONTIER_HEADLESS)
@@ -1043,7 +1058,16 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 
 boolean meloadmenurecord (dbaddress adr, hdlmenurecord *hmenurecord) {
 	db_context ctx;
-	db_context_init(&ctx);
+
+	/* Detect if we're reading from a legacy (v6) database.
+	   During migration, the global mode may be v7, but we need to read
+	   v6 data with v6 header sizes (8 bytes, not 12). */
+	if (db_format_is_legacy_db(databasedata)) {
+		db_context_init_legacy_read(&ctx, databasedata);
+	} else {
+		db_context_init(&ctx);
+	}
+
 	return meloadmenurecord_internal(&ctx, adr, hmenurecord);
 } /*meloadmenurecord*/
 

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -1219,7 +1219,7 @@ boolean mecreaterefcontable_v7 (byte cmdkey, tykeyflags modifiers,
 
 	hdlhashtable htable = nil;
 	hdlhashtable hmodifiers = nil;
-	tyvaluerecord tableval;
+	tyvaluerecord tableval = {0};  /* Initialize to prevent uninitialized access in cleanup */
 	boolean fl = false;
 
 	*hpackedtable = nil;
@@ -1262,6 +1262,8 @@ boolean mecreaterefcontable_v7 (byte cmdkey, tykeyflags modifiers,
 			goto exit;
 		}
 
+		/* hashtableassign() transfers ownership of scriptval on success.
+		 * On failure, we must dispose scriptval ourselves. */
 		if (!hashtableassign(htable, bsHandlerScript, scriptval)) {
 			disposevaluerecord(scriptval, false);
 			goto exit;
@@ -1277,12 +1279,8 @@ boolean mecreaterefcontable_v7 (byte cmdkey, tykeyflags modifiers,
 exit:
 	/* Clean up the temporary table.
 	 * Note: tableval holds the external wrapper around htable.
-	 * Disposing the value will clean up the table. */
-	if (tableval.valuetype == externalvaluetype && !fl) {
-		disposevaluerecord(tableval, false);
-	}
-	else if (tableval.valuetype == externalvaluetype) {
-		/* On success, we still need to dispose the table since we packed it */
+	 * Disposing the value will clean up the table and any nested tables. */
+	if (tableval.valuetype == externalvaluetype) {
 		disposevaluerecord(tableval, false);
 	}
 
@@ -1383,7 +1381,9 @@ boolean meunpackrefcontable_v7 (Handle hpackedtable,
 				if (opvaltoscript(scriptval, &houtline)) {
 					/* Copy the outline since we're about to dispose the table */
 					if (!opcopyoutlinerecord(houtline, hscript)) {
-						*hscript = nil;
+						log_error(LOG_COMP_OP, "meunpackrefcontable_v7: failed to copy script outline");
+						disposevaluerecord(tableval, false);
+						return false;
 					}
 				}
 			}

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -46,6 +46,10 @@
 #include "byteorder_helpers.h" /* 2026-02-02 Codex: Consolidated host/disk byte order helpers */
 #include "logging.h"    /* For structured logging of v7→legacy truncation warnings */
 #include <limits.h>     /* For SHRT_MAX */
+#include "lang.h"       /* For langassign* functions and langpackvalue/langunpackvalue */
+#include "langexternal.h" /* For langexternalnewvalue, idscriptprocessor */
+#include "opverbs.h"    /* For opvaltoscript */
+#include "tableinternal.h" /* For tablenewtablevalue */
 
 	
 
@@ -720,6 +724,27 @@ static boolean meunpackmenustructure_legacy (Handle hpacked, hdlmenurecord *hmen
 
 /* Byte order helpers now in byteorder_helpers.h (2026-02-02 consolidation) */
 
+/*
+ * Legacy (v6 and earlier) disk format structure.
+ * The key difference from tysavedmenuinfo is that dbaddress was 32-bit on disk.
+ * This structure must match what was written by Frontier 4.x-9.x on v6 databases.
+ */
+#pragma pack(2)
+typedef struct tysavedmenuinfo_disk_legacy {
+	short versionnumber;         /* structure version on disk */
+	int32_t adroutline;          /* 32-bit address of menubar outline (BE on disk) */
+	short vertmin, vertmax, vertcurrent;  /* scrollbar state */
+	diskrect scriptwindowrect;   /* script window position */
+	short flags;
+	short menuactivelayer;
+	short lnumcursor;
+	diskfontstring defaultscriptfontname;
+	short defaultscriptfontsize;
+	diskrect menuwindowrect;     /* menu window position */
+	char waste[42];              /* padding for growth */
+} tysavedmenuinfo_disk_legacy;
+#pragma options align=reset
+
 typedef struct tysavedmenuinfo_v7 {
 	uint16_t versionnumber;     /* v7+ marker */
 	uint16_t _pad;              /* align to 64-bit */
@@ -906,10 +931,15 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 	Postconditions:
 	  - *hmenurecord contains loaded menu structure
 	  - Returns true on success, false on failure
+
+	Note: v6 databases store menu info with 32-bit addresses, while the in-memory
+	tysavedmenuinfo has 64-bit dbaddress. We must read the correct disk format
+	and convert.
 	*/
 
 	hdloutlinerecord houtline;
 	tysavedmenuinfo info;
+	dbaddress outline_adr;
 
 	if (!ctx) {
 		db_context default_ctx;
@@ -917,19 +947,96 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 		return meloadmenurecord_internal(&default_ctx, adr, hmenurecord);
 	}
 
-	if (!dbreference (adr, sizeof (info), &info))
-		return (false);
+	boolean is_v7_format = ctx->mode.use_64bit_format;
 
-	if (!meloadoutline_internal (ctx, conditionallongswap (info.adroutline), &houtline))
+#if defined(FRONTIER_HEADLESS)
+	log_debug(LOG_COMP_OP, "meloadmenurecord_internal: START adr=0x%llx ctx_db=%p is_v7=%d",
+	        (unsigned long long)adr, (void*)ctx->database, (int)is_v7_format);
+#endif
+
+	if (is_v7_format) {
+		/* v7 format: read the full tysavedmenuinfo with 64-bit addresses */
+		if (!dbreference_context (ctx, adr, sizeof (info), &info)) {
+#if defined(FRONTIER_HEADLESS)
+			log_error(LOG_COMP_OP, "meloadmenurecord_internal: dbreference_context FAILED (v7) adr=0x%llx",
+			        (unsigned long long)adr);
+#endif
+			return (false);
+		}
+		outline_adr = conditionallongswap (info.adroutline);
+	}
+	else {
+		/* v6 format: read the legacy disk format with 32-bit addresses */
+		tysavedmenuinfo_disk_legacy legacy_info;
+
+#if defined(FRONTIER_HEADLESS)
+		log_error(LOG_COMP_OP, "meloadmenurecord_internal: reading v6 adr=0x%llx sizeof(legacy_info)=%zu databasedata=%p ctx_db=%p fldatabasesaveas=%d",
+		        (unsigned long long)adr, sizeof(legacy_info), (void*)databasedata, (void*)ctx->database, (int)fldatabasesaveas);
+#endif
+
+		if (!dbreference_context (ctx, adr, sizeof (legacy_info), &legacy_info)) {
+#if defined(FRONTIER_HEADLESS)
+			log_error(LOG_COMP_OP, "meloadmenurecord_internal: dbreference_context FAILED (v6) adr=0x%llx",
+			        (unsigned long long)adr);
+#endif
+			return (false);
+		}
+
+		/* Dump first 20 bytes of raw data for debugging */
+#if defined(FRONTIER_HEADLESS)
+		{
+			unsigned char *p = (unsigned char *)&legacy_info;
+			log_error(LOG_COMP_OP, "meloadmenurecord_internal: raw bytes: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
+			        p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
+			        p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
+		}
+#endif
+
+		/* Convert legacy 32-bit disk format to in-memory 64-bit format */
+		clearbytes (&info, sizeof (info));
+		info.versionnumber = legacy_info.versionnumber;
+		/* Legacy 32-bit address is stored big-endian on disk */
+		outline_adr = (dbaddress) conditionallongswap (legacy_info.adroutline);
+#if defined(FRONTIER_HEADLESS)
+		log_error(LOG_COMP_OP, "meloadmenurecord_internal: v6 legacy_info.adroutline raw=0x%08x swapped=0x%llx versionnumber=%d",
+		        legacy_info.adroutline, (unsigned long long)outline_adr, (int)legacy_info.versionnumber);
+#endif
+		info.adroutline = outline_adr;
+		info.vertmin = legacy_info.vertmin;
+		info.vertmax = legacy_info.vertmax;
+		info.vertcurrent = legacy_info.vertcurrent;
+		info.scriptwindowrect = legacy_info.scriptwindowrect;
+		info.flags = legacy_info.flags;
+		info.menuactivelayer = legacy_info.menuactivelayer;
+		info.lnumcursor = legacy_info.lnumcursor;
+		memcpy(info.defaultscriptfontname, legacy_info.defaultscriptfontname, sizeof(diskfontstring));
+		info.defaultscriptfontsize = legacy_info.defaultscriptfontsize;
+		info.menuwindowrect = legacy_info.menuwindowrect;
+	}
+
+#if defined(FRONTIER_HEADLESS)
+	log_debug(LOG_COMP_OP, "meloadmenurecord_internal: outline_adr=0x%llx", (unsigned long long)outline_adr);
+#endif
+
+	if (!meloadoutline_internal (ctx, outline_adr, &houtline)) {
+#if defined(FRONTIER_HEADLESS)
+		log_error(LOG_COMP_OP, "meloadmenurecord_internal: meloadoutline_internal FAILED");
+#endif
 		return (false);
+	}
 
 	if (!mesetupmenurecord (&info, houtline, hmenurecord)) {
-
+#if defined(FRONTIER_HEADLESS)
+		log_error(LOG_COMP_OP, "meloadmenurecord_internal: mesetupmenurecord FAILED");
+#endif
 		opdisposeoutline (houtline, false);
 
 		return (false);
 	}
 
+#if defined(FRONTIER_HEADLESS)
+	log_debug(LOG_COMP_OP, "meloadmenurecord_internal: SUCCESS hmenurecord=%p", (void*)*hmenurecord);
+#endif
 	return (true);
 } /*meloadmenurecord_internal*/
 
@@ -1038,3 +1145,231 @@ boolean mescraphook (Handle hscrap) {
 	
 	return (true); /*keep going*/
 	} /*mescraphook*/
+
+
+/*
+ * V7 Menu Refcon Table Functions
+ *
+ * These functions create and unpack the v7 format for menu item refcons.
+ * The v7 format stores menu item data as a packed table with:
+ * - keyBinding (char): command key character or 0 if none
+ * - modifiers (table): {shift, control, option, command} booleans
+ * - handlerScript (script): the script object or nil if none
+ *
+ * 2026-02-03: Initial implementation for menu v6->v7 migration.
+ */
+
+/* String constants for table keys - use BIGSTRING macro for pointer to string literals
+ * Note: Hex escapes are greedy in C, so "\x07control" becomes "\x7c" + "ontrol".
+ * Use string concatenation to break: "\x07" "control" */
+#define bsKeyBinding      BIGSTRING("\x0a" "keyBinding")
+#define bsModifiers       BIGSTRING("\x09" "modifiers")
+#define bsHandlerScript   BIGSTRING("\x0d" "handlerScript")
+#define bsShift           BIGSTRING("\x05" "shift")
+#define bsControl         BIGSTRING("\x07" "control")
+#define bsOption          BIGSTRING("\x06" "option")
+#define bsCommand         BIGSTRING("\x07" "command")
+
+
+boolean mecreaterefcontable_v7 (byte cmdkey, tykeyflags modifiers,
+                                 hdloutlinerecord hscript,
+                                 Handle *hpackedtable) {
+	/*
+	 * Create a v7 table refcon from menu item data.
+	 *
+	 * The table contains:
+	 * - keyBinding (char): command key character or 0 if none
+	 * - modifiers (table): {shift, control, option, command} booleans
+	 * - handlerScript (script): the script object or nil if none
+	 *
+	 * Implementation:
+	 * 1. Create temporary in-memory hash table
+	 * 2. Add keyBinding char value
+	 * 3. Create modifiers sub-table with boolean flags
+	 * 4. If hscript != nil, create script external and add as handlerScript
+	 * 5. Pack the table using langpackvalue()
+	 * 6. Dispose the temporary table
+	 *
+	 * Returns true on success, false on failure.
+	 */
+
+	hdlhashtable htable = nil;
+	hdlhashtable hmodifiers = nil;
+	tyvaluerecord tableval;
+	boolean fl = false;
+
+	*hpackedtable = nil;
+
+	/* Create the main table */
+	if (!tablenewtablevalue(&htable, &tableval))
+		goto exit;
+
+	/* Add keyBinding (always present, 0 means no keybinding) */
+	if (!langassigncharvalue(htable, bsKeyBinding, cmdkey))
+		goto exit;
+
+	/* Create and populate the modifiers sub-table */
+	if (!langassignnewtablevalue(htable, bsModifiers, &hmodifiers))
+		goto exit;
+
+	/* Add modifier boolean flags */
+	if (!langassignbooleanvalue(hmodifiers, bsShift, (modifiers & keyshift) != 0))
+		goto exit;
+	if (!langassignbooleanvalue(hmodifiers, bsControl, (modifiers & keycontrol) != 0))
+		goto exit;
+	if (!langassignbooleanvalue(hmodifiers, bsOption, (modifiers & keyoption) != 0))
+		goto exit;
+	if (!langassignbooleanvalue(hmodifiers, bsCommand, (modifiers & keycommand) != 0))
+		goto exit;
+
+	/* Add handlerScript if present */
+	if (hscript != nil) {
+		tyvaluerecord scriptval;
+
+		/* Create a script external value from the outline.
+		 * Note: We need to copy the outline since langexternalnewvalue takes ownership.
+		 */
+		hdloutlinerecord hscriptcopy;
+		if (!opcopyoutlinerecord(hscript, &hscriptcopy))
+			goto exit;
+
+		if (!langexternalnewvalue(idscriptprocessor, (Handle)hscriptcopy, &scriptval)) {
+			opdisposeoutline(hscriptcopy, false);
+			goto exit;
+		}
+
+		if (!hashtableassign(htable, bsHandlerScript, scriptval)) {
+			disposevaluerecord(scriptval, false);
+			goto exit;
+		}
+	}
+
+	/* Pack the table */
+	if (!langpackvalue(tableval, hpackedtable, HNoNode))
+		goto exit;
+
+	fl = true;
+
+exit:
+	/* Clean up the temporary table.
+	 * Note: tableval holds the external wrapper around htable.
+	 * Disposing the value will clean up the table. */
+	if (tableval.valuetype == externalvaluetype && !fl) {
+		disposevaluerecord(tableval, false);
+	}
+	else if (tableval.valuetype == externalvaluetype) {
+		/* On success, we still need to dispose the table since we packed it */
+		disposevaluerecord(tableval, false);
+	}
+
+	return fl;
+} /*mecreaterefcontable_v7*/
+
+
+boolean meunpackrefcontable_v7 (Handle hpackedtable,
+                                 byte *cmdkey,
+                                 tykeyflags *modifiers,
+                                 hdloutlinerecord *hscript) {
+	/*
+	 * Unpack a v7 table refcon and extract menu item info.
+	 * Inverse of mecreaterefcontable_v7().
+	 *
+	 * Implementation:
+	 * 1. Unpack the table using langunpackvalue()
+	 * 2. Look up keyBinding, convert to byte
+	 * 3. Look up modifiers sub-table, extract boolean flags
+	 * 4. Look up handlerScript, if exists extract the script outline
+	 * 5. Dispose the unpacked value
+	 *
+	 * Returns true on success, false on failure.
+	 */
+
+	tyvaluerecord tableval;
+	hdlhashtable htable;
+	hdlhashnode hnode;
+	boolean fl = false;
+
+	/* Initialize outputs */
+	*cmdkey = 0;
+	*modifiers = keynormal;
+	*hscript = nil;
+
+	/* Unpack the table */
+	if (!langunpackvalue(hpackedtable, &tableval))
+		return false;
+
+	if (tableval.valuetype != externalvaluetype) {
+		disposevaluerecord(tableval, false);
+		return false;
+	}
+
+	/* Get the hash table from the external value */
+	if (!langexternalvaltotable(tableval, &htable, HNoNode)) {
+		disposevaluerecord(tableval, false);
+		return false;
+	}
+
+	/* Extract keyBinding */
+	{
+		tyvaluerecord keyval;
+		if (hashtablelookup(htable, bsKeyBinding, &keyval, &hnode)) {
+			if (keyval.valuetype == charvaluetype) {
+				*cmdkey = keyval.data.chvalue;
+			}
+		}
+	}
+
+	/* Extract modifiers */
+	{
+		tyvaluerecord modval;
+		if (hashtablelookup(htable, bsModifiers, &modval, &hnode)) {
+			hdlhashtable hmodifiers;
+			if (langexternalvaltotable(modval, &hmodifiers, HNoNode)) {
+				tyvaluerecord boolval;
+				tykeyflags flags = keynormal;
+
+				if (hashtablelookup(hmodifiers, bsShift, &boolval, &hnode)) {
+					if (boolval.valuetype == booleanvaluetype && boolval.data.flvalue)
+						flags |= keyshift;
+				}
+				if (hashtablelookup(hmodifiers, bsControl, &boolval, &hnode)) {
+					if (boolval.valuetype == booleanvaluetype && boolval.data.flvalue)
+						flags |= keycontrol;
+				}
+				if (hashtablelookup(hmodifiers, bsOption, &boolval, &hnode)) {
+					if (boolval.valuetype == booleanvaluetype && boolval.data.flvalue)
+						flags |= keyoption;
+				}
+				if (hashtablelookup(hmodifiers, bsCommand, &boolval, &hnode)) {
+					if (boolval.valuetype == booleanvaluetype && boolval.data.flvalue)
+						flags |= keycommand;
+				}
+
+				*modifiers = flags;
+			}
+		}
+	}
+
+	/* Extract handlerScript if present */
+	{
+		tyvaluerecord scriptval;
+		if (hashtablelookup(htable, bsHandlerScript, &scriptval, &hnode)) {
+			if (scriptval.valuetype == externalvaluetype) {
+				hdloutlinerecord houtline;
+				if (opvaltoscript(scriptval, &houtline)) {
+					/* Copy the outline since we're about to dispose the table */
+					if (!opcopyoutlinerecord(houtline, hscript)) {
+						*hscript = nil;
+					}
+				}
+			}
+		}
+	}
+
+	fl = true;
+
+	/* Dispose the unpacked value (this will clean up the table) */
+	disposevaluerecord(tableval, false);
+
+	return fl;
+} /*meunpackrefcontable_v7*/

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -178,18 +178,24 @@ boolean menuverbinmemory_context (const db_context *ctx, hdlexternalvariable hva
 		return (true);
 
 #if defined(FRONTIER_HEADLESS)
-	log_debug(LOG_COMP_OP, "menuverbinmemory_context: loading menu from hdatabase=%p (current=%p) variabledata=0x%llx",
+	log_error(LOG_COMP_OP, "menuverbinmemory_context: START hdatabase=%p current=%p variabledata=0x%llx ctx=%p ctx_db=%p ctx_use64=%d",
 	        (void*)(**hv).hdatabase,
 	        (void*)databasedata,
-	        (unsigned long long)(**hv).variabledata);
+	        (unsigned long long)(**hv).variabledata,
+	        (void*)ctx,
+	        (void*)(ctx ? ctx->database : nil),
+	        ctx ? (int)ctx->mode.use_64bit_format : -1);
 #endif
 
 	adr = (dbaddress) (**hv).variabledata;
 
 	fl = meloadmenurecord_internal(ctx, adr, &hmenurecord);
 
-	if (!fl)
+	if (!fl) {
+		log_error(LOG_COMP_OP, "menuverbinmemory_context: meloadmenurecord_internal FAILED adr=0x%llx",
+		        (unsigned long long)adr);
 		return (false);
+	}
 
 	(**hv).variabledata = (long) hmenurecord;
 
@@ -397,9 +403,15 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 
 	const boolean adapter_repack = db_format_adapter_force_repack();
 
+#if defined(FRONTIER_HEADLESS)
+	log_debug(LOG_COMP_OP, "menuverbpack_internal: flinmemory=%d adapter_repack=%d ctx=%p",
+	        (int)(**hv).flinmemory, (int)adapter_repack, (void*)ctx);
+#endif
+
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		log_error(LOG_COMP_OP, "menuverbpack_internal: FAIL - flinmemory=0, caller should have loaded it");
 		return (false);
 	}
 
@@ -929,20 +941,35 @@ static boolean menudisposevariable (hdlexternalvariable hvariable, boolean fldis
 
 
 boolean menuverbdispose (hdlexternalvariable hvariable, boolean fldisk) {
-	
+
 	/*
-	12/22/91 dmb: in order to release all db nodes properly, must force 
+	12/22/91 dmb: in order to release all db nodes properly, must force
 	menubar to be loaded when fldisk is true
 	*/
-	
+
 	register hdlexternalvariable hv = hvariable;
-	
+
+#ifdef FRONTIER_HEADLESS
+	/*
+	 * In headless mode, skip loading menu from disk during dispose.
+	 * The purpose of loading is to release database nodes used by scripts
+	 * attached to menu items, but:
+	 * 1. In headless mode we don't run menu scripts
+	 * 2. During migration, the source database addresses may be invalid
+	 * 3. We're disposing the database anyway, so node release is moot
+	 *
+	 * This prevents crashes during migration cleanup where the old v6
+	 * addresses are no longer valid in the new context.
+	 */
+	(void)fldisk; /* unused in headless mode */
+#else
 	if (fldisk) { /*load menubar into memory so that scripts can release their db nodes*/
-		
+
 		if (!menuverbinmemory ((hdlmenuvariable) hv))
 			return (false);
 		}
-	
+#endif
+
 	return (langexternaldisposevariable (hv, fldisk, &menudisposevariable));
 	} /*menuverbdispose*/
 

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -178,7 +178,7 @@ boolean menuverbinmemory_context (const db_context *ctx, hdlexternalvariable hva
 		return (true);
 
 #if defined(FRONTIER_HEADLESS)
-	log_error(LOG_COMP_OP, "menuverbinmemory_context: START hdatabase=%p current=%p variabledata=0x%llx ctx=%p ctx_db=%p ctx_use64=%d",
+	log_debug(LOG_COMP_OP, "menuverbinmemory_context: START hdatabase=%p current=%p variabledata=0x%llx ctx=%p ctx_db=%p ctx_use64=%d",
 	        (void*)(**hv).hdatabase,
 	        (void*)databasedata,
 	        (unsigned long long)(**hv).variabledata,

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -219,6 +219,16 @@ static boolean menuverbinmemory (hdlmenuvariable hvariable) {
 	db_context_init(&ctx);
 	ctx.database = (**hvariable).hdatabase;
 
+	/* Fix: Detect database format and set context mode accordingly */
+	if (ctx.database != nil) {
+		boolean is_legacy = db_format_is_legacy_db(ctx.database);
+		ctx.mode.use_64bit_format = !is_legacy;
+#if defined(FRONTIER_HEADLESS)
+		log_debug(LOG_COMP_OP, "menuverbinmemory: detected db format: is_legacy=%d use_64bit_format=%d",
+		        (int)is_legacy, (int)ctx.mode.use_64bit_format);
+#endif
+	}
+
 	return menuverbinmemory_context(&ctx, hvariable);
 	} /*menuverbinmemory*/
 

--- a/Common/source/oppack_v7.c
+++ b/Common/source/oppack_v7.c
@@ -48,6 +48,7 @@
 #include "ops.h"
 #include "op.h"
 #include "opinternal.h"
+#include "oppack_legacy.h" /* For dispatching to legacy v2/v3 unpackers during migration */
 #include "db_format.h" /* 2025-11-23 Codex: explicit BE writes for outline headers */
 #include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
 #include "logging.h"
@@ -1154,12 +1155,19 @@ boolean opunpack (Handle hpackedoutline, long *ixload, hdloutlinerecord *houtlin
 
 	oppushoutline (ho);
 
-	/* V7 oppack only handles v4 portable format */
+	/* V7 oppack handles v4 portable format, dispatches v2/v3 to legacy */
 	if (versionnumber == 4) {
 		fl = opunpackversion4 (&packstream);
 	}
+	else if (versionnumber == 2 || versionnumber == 3) {
+		/* Legacy v2/v3 format - dispatch to oppack_legacy.c */
+		oppopoutline (); /* We pushed ho above, but legacy will create its own */
+		opdisposeoutline (ho, false); /* Don't need this one */
+		closehandlestream (&packstream);
+		return opunpack_legacy (hpackedoutline, ixload, houtline);
+	}
 	else {
-		/* Legacy v2/v3 should be handled by oppack_legacy.c */
+		/* Unknown format version */
 		shellinternalerror (idbadopversionnumber, STR_bad_outline_version_number);
 		fl = false;
 	}

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -125,6 +125,7 @@ RUNTIME_SOURCES = \
     ../Common/source/op_context.c \
     ../Common/source/opinit.c \
     ../Common/source/opexpand.c \
+    ../Common/source/ophoist.c \
     ../Common/source/opvisit.c \
     ../Common/source/opedit.c \
     ../Common/source/opops.c \

--- a/planning/phase3/MENU_V7_MIGRATION_PLAN.md
+++ b/planning/phase3/MENU_V7_MIGRATION_PLAN.md
@@ -1,0 +1,520 @@
+# Menu Type v6 to v7 Migration Plan
+
+**Status**: Planning
+**Last Updated**: 2026-02-03
+**Branch**: feature/menu-migration-fix
+
+---
+
+## 1. Overview
+
+### Goal
+
+Migrate `menubarType` objects from v6 database format to v7 format, simplifying the storage to just be an outline with table-based refcons. The v7 format discards unused GUI metadata (window positions, fonts, scroll state) and stores command key bindings and script references in a structured table format.
+
+### Approach Summary
+
+1. **Read v6 format**: Parse existing `tymenuiteminfo` structures from node refcons
+2. **Transform**: Convert to v7 table-based refcon format
+3. **Write v7 format**: Pack as v7 outline with table refcons
+
+### Key Simplification
+
+- **v6**: Complex `tymenuiteminfo` struct with byte-level packed fields, linked scripts via `dbaddress`
+- **v7**: Each node refcon is a packed table with named fields (`keyBinding`, `modifiers`, `handlerScript`)
+
+---
+
+## 2. V6 Format Investigation
+
+### 2.1 Menu Node Refcon Structure (`tymenuiteminfo`)
+
+Location: `/Users/jake/dev/jsavin/Frontier-menu-migration-fix/Common/headers/menueditor.h` (lines 193-209)
+
+```c
+#pragma pack(2)
+typedef struct tylinkeditem {
+    dbaddress adrlink;           // Address of packed script on disk
+    hdloutlinerecord houtline;   // In-memory handle (nil when on disk)
+} tylinkeditem;
+
+typedef struct tymenuiteminfo {  // Linked into hrefcon of each menu node
+    byte cmdkey;                 // Command key character (e.g., 'S' for Cmd+S)
+    byte cmdmodifiers;           // Modifier flags (bit field)
+    tylinkeditem linkedscript;   // Script address/handle
+} tymenuiteminfo;
+#pragma options align=reset
+```
+
+**Total size**: 2 (cmdkey+modifiers) + 4 (adrlink) + 4/8 (houtline) = ~10-14 bytes packed
+
+### 2.2 Modifier Flags (`tykeyflags`)
+
+Location: `/Users/jake/dev/jsavin/Frontier-menu-migration-fix/Common/headers/shelltypes.h` (lines 132-144)
+
+```c
+typedef enum tykeyflags {
+    keyshift   = 0x0001,  // Shift key
+    keycontrol = 0x0200,  // Control key
+    keyoption  = 0x0400,  // Option/Alt key
+    keycommand = 0x0800   // Command key (Mac) / Windows key
+} tykeyflags;
+```
+
+**Note**: Stored in `cmdmodifiers` byte, but constants are 16-bit. Only the lower byte is meaningful in the packed structure.
+
+### 2.3 Where Refcons Are Read/Written
+
+| Operation | File | Function | Notes |
+|-----------|------|----------|-------|
+| Read refcon | menupack.c | `megetmenuiteminfo()` | Calls `opgetrefcon()`, converts `adrlink` from BE |
+| Write refcon | menupack.c | `mesetmenuiteminfo()` | Converts `adrlink` to BE, calls `opsetrefcon()` |
+| Pack scripts | menupack.c | `mepackscriptvisit()` | Visits each node, packs attached scripts |
+| Unpack scripts | menupack.c | `meunpackscriptvisit()` | Visits each node, unpacks scripts from handle |
+| Release scripts | menupack.c | `mereleaserefconroutine_context()` | Disposes in-memory outline, releases db node |
+| Copy refcon | menupack.c | `mecopyrefconroutine()` | Copies script outline for clipboard ops |
+
+### 2.4 Menu Structure Storage
+
+The menubar is stored as a two-level data structure:
+
+1. **Menu metadata record** (`tysavedmenuinfo` / `tysavedmenuinfo_v7`)
+   - Address of menu outline
+   - Scroll position, window rects, fonts (v6 only)
+   - Stored at the menu external's database address
+
+2. **Menu outline**
+   - Hierarchical outline where each node is a menu item
+   - Level 0 = menu names ("File", "Edit", etc.)
+   - Level 1+ = menu items and submenus
+   - Each node's refcon contains `tymenuiteminfo`
+
+3. **Script outlines** (per-node)
+   - Separate packed outlines for each menu item's handler script
+   - Referenced by `adrlink` in the node's refcon
+   - Loaded on demand
+
+### 2.5 V6 Disk Layout
+
+```
+Menu External (in parent table):
+  [4 bytes: dbaddress of tysavedmenuinfo_disk_legacy]
+
+tysavedmenuinfo_disk_legacy (at that address):
+  [2 bytes: versionnumber]
+  [4 bytes: adroutline (BE32)]
+  [2 bytes: vertmin]
+  [2 bytes: vertmax]
+  [2 bytes: vertcurrent]
+  [8 bytes: scriptwindowrect]
+  [2 bytes: flags]
+  [2 bytes: menuactivelayer]
+  [2 bytes: lnumcursor]
+  [32 bytes: defaultscriptfontname]
+  [2 bytes: defaultscriptfontsize]
+  [8 bytes: menuwindowrect]
+  [42 bytes: waste/padding]
+
+Menu Outline (at adroutline):
+  [standard outline pack format - v2/v3/v4 header + text + linetable]
+  Each node's linetable entry includes refcon length
+  Refcons are tymenuiteminfo structures
+
+Script Outlines (at each node's adrlink):
+  [standard outline pack format]
+```
+
+---
+
+## 3. V7 Format Specification
+
+### 3.1 Design Goals
+
+1. **Drop GUI metadata**: No font info, window positions, scroll state
+2. **Structured refcons**: Replace binary `tymenuiteminfo` with table-based format
+3. **Portable**: All fields in big-endian with explicit byte order helpers
+4. **Extensible**: Table format allows adding new fields without format changes
+
+### 3.2 V7 Menu Metadata (`tysavedmenuinfo_v7`)
+
+Already implemented in menupack.c (lines 744-752):
+
+```c
+typedef struct tysavedmenuinfo_v7 {
+    uint16_t versionnumber;     // 2 = v7 marker
+    uint16_t _pad;              // Alignment
+    uint64_t adroutline;        // BE64 address of menubar outline
+    uint64_t lnumcursor;        // BE64 line number of selection
+    uint32_t flags;             // autosmash flag, etc.
+    uint32_t menuactiveitem;    // Active item enum
+    uint8_t  reserved[1024];    // Future expansion
+} tysavedmenuinfo_v7;
+```
+
+### 3.3 V7 Node Refcon Format
+
+Each menu node's refcon becomes a **packed table** with these keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `keyBinding` | char | Command key character (e.g., 'S') or 0 if none |
+| `modifiers` | table | Sub-table with boolean keys: `shift`, `control`, `option`, `command` |
+| `handlerScript` | script | The script object (outline type with script flag) |
+
+**Example in UserTalk notation**:
+```
+{
+  keyBinding: 'S',
+  modifiers: {
+    shift: false,
+    control: false,
+    option: false,
+    command: true
+  },
+  handlerScript: script("msg(\"Hello\")")
+}
+```
+
+**Storage format**: Standard packed table value (same format as table cell values).
+
+### 3.4 V7 Disk Layout
+
+```
+Menu External (in parent table):
+  [4/8 bytes: dbaddress of tysavedmenuinfo_v7]
+
+tysavedmenuinfo_v7 (at that address):
+  [2 bytes: versionnumber = 2]
+  [2 bytes: _pad]
+  [8 bytes: adroutline (BE64)]
+  [8 bytes: lnumcursor (BE64)]
+  [4 bytes: flags (BE32)]
+  [4 bytes: menuactiveitem (BE32)]
+  [1024 bytes: reserved]
+
+Menu Outline (at adroutline):
+  [v4 portable outline header]
+  [text section]
+  [linetable section]
+  Each node's refcon is a packed table (langunpackvalue format)
+
+Script Outlines (embedded in refcon tables):
+  Stored as script values within each node's refcon table
+```
+
+---
+
+## 4. Implementation Phases
+
+### Phase 1: V6 Reader (Extract data from old format)
+
+**Goal**: Create functions to fully materialize a v6 menu into memory with all scripts loaded.
+
+#### 4.1.1 New Function: `meloadmenurecord_v6_full()`
+
+```c
+/**
+ * Load a v6 menu with all scripts materialized into memory.
+ * Unlike meloadmenurecord(), this loads ALL linked scripts,
+ * not just on-demand.
+ *
+ * Used for migration to ensure complete data extraction.
+ */
+boolean meloadmenurecord_v6_full(const db_context *ctx, dbaddress adr,
+                                  hdlmenurecord *hmenurecord);
+```
+
+**Implementation**:
+1. Call existing `meloadmenurecord_internal()` with v6 context
+2. Push menu outline
+3. Visit all nodes with `opsiblingvisiter()`
+4. For each node, call `meloadscriptoutline()` to force-load the script
+5. Keep scripts in memory (set `fldirty = true` to prevent unload)
+
+#### 4.1.2 New Function: `meextractmenuiteminfo_v6()`
+
+```c
+/**
+ * Extract v6 menu item info into C structure.
+ * Handles byte order conversion from disk format.
+ */
+boolean meextractmenuiteminfo_v6(hdlheadrecord hnode,
+                                  byte *cmdkey,
+                                  tykeyflags *modifiers,
+                                  hdloutlinerecord *hscript);
+```
+
+**Implementation**:
+1. Call `megetmenuiteminfo()` (existing)
+2. Ensure script is loaded via `item.linkedscript.houtline`
+3. Return decomposed fields
+
+### Phase 2: V7 Writer (Create table refcons, pack as outline)
+
+**Goal**: Convert in-memory menu to v7 format with table-based refcons.
+
+#### 4.2.1 New Function: `mecreaterefcontable_v7()`
+
+```c
+/**
+ * Create a v7 table refcon from v6 menu item data.
+ * Returns a packed table handle ready to be set as node refcon.
+ */
+boolean mecreaterefcontable_v7(byte cmdkey, tykeyflags modifiers,
+                                hdloutlinerecord hscript,
+                                Handle *hpackedtable);
+```
+
+**Implementation**:
+1. Create temporary in-memory hashtable
+2. Set `keyBinding` = cmdkey (char value)
+3. Create `modifiers` sub-table with:
+   - `shift` = (modifiers & keyshift) != 0
+   - `control` = (modifiers & keycontrol) != 0
+   - `option` = (modifiers & keyoption) != 0
+   - `command` = (modifiers & keycommand) != 0
+4. If hscript != nil:
+   - Create script external value from hscript
+   - Set `handlerScript` = script value
+5. Pack table using `langpackvalue()`
+6. Return packed handle
+
+#### 4.2.2 New Visitor Function: `meconvertrefcon_v6_to_v7_visit()`
+
+```c
+/**
+ * Node visitor that converts v6 refcon to v7 table format.
+ * Called during migration traversal.
+ */
+static boolean meconvertrefcon_v6_to_v7_visit(hdlheadrecord hnode, ptrvoid refcon);
+```
+
+**Implementation**:
+1. Extract v6 data via `meextractmenuiteminfo_v6()`
+2. If no refcon data, skip (return true)
+3. Create v7 table via `mecreaterefcontable_v7()`
+4. Dispose old refcon
+5. Set new refcon via `opsetrefcon()`
+
+#### 4.2.3 New Function: `mepackmenustructure_v7_new()`
+
+Update existing `mepackmenustructure_v7()` to use table refcons:
+
+1. Fill `tysavedmenuinfo_v7` header
+2. Visit all nodes, converting refcons to v7 table format
+3. Pack outline using `oppack()` (which packs refcons as-is)
+4. Scripts are embedded in table refcons, not separate
+
+### Phase 3: Update menuverb Functions
+
+**Goal**: Make menu pack/unpack functions handle both formats correctly.
+
+#### 4.3.1 Update `mepackmenustructure()`
+
+Already dispatches based on `db_format_mode_current()`:
+- v6: calls `mepackmenustructure_legacy()`
+- v7: calls `mepackmenustructure_v7()`
+
+**Change**: Ensure v7 path uses new table refcon logic.
+
+#### 4.3.2 Update `meunpackmenustructure()`
+
+Already dispatches based on format:
+- v6: calls `meunpackmenustructure_legacy()`
+- v7: calls `meunpackmenustructure_v7()`
+
+**Change**: v7 path must unpack table refcons correctly.
+
+#### 4.3.3 New Function: `meunpackrefcontable_v7()`
+
+```c
+/**
+ * Unpack a v7 table refcon and extract menu item info.
+ * Inverse of mecreaterefcontable_v7().
+ */
+boolean meunpackrefcontable_v7(Handle hpackedtable,
+                                byte *cmdkey,
+                                tykeyflags *modifiers,
+                                hdloutlinerecord *hscript);
+```
+
+**Implementation**:
+1. Unpack table via `langunpackvalue()`
+2. Look up `keyBinding` → cmdkey
+3. Look up `modifiers` sub-table → extract flags
+4. Look up `handlerScript` → extract script outline
+5. Return decomposed fields
+
+### Phase 4: Testing
+
+#### 4.4.1 Unit Tests
+
+Create `tests/menu_v7_migration_tests.c`:
+
+| Test | Description |
+|------|-------------|
+| `test_menu_refcon_roundtrip` | v6 refcon → v7 table → v6 refcon |
+| `test_menu_empty_refcon` | Node with no script or keybinding |
+| `test_menu_keybinding_only` | Node with Cmd+K but no script |
+| `test_menu_script_only` | Node with script but no keybinding |
+| `test_menu_full_refcon` | Node with script + all modifier combos |
+| `test_menu_modifiers_encoding` | Test each modifier flag individually |
+| `test_menu_nested_structure` | Menu with submenus |
+
+#### 4.4.2 Integration Tests
+
+Add YAML test cases in `tests/integration/test_cases/menu_migration/`:
+
+```yaml
+# test_menu_simple.yaml
+name: "Simple menu migration"
+script: |
+  local (m = menu.new())
+  menu.addCommand(m, "File", "Open", "dialog.alert(\"open\")")
+  menu.setCommandKey(@m["File"]["Open"], 'O')
+  return typeOf(m) == menuType
+expected_result: true
+```
+
+---
+
+## 5. File Changes
+
+### 5.1 Files to Modify
+
+| File | Changes |
+|------|---------|
+| `Common/source/menupack.c` | Add v7 refcon conversion functions, update v7 pack/unpack |
+| `Common/source/menuverbs.c` | Update `menuverbinmemory_context()` for v7 table refcons |
+| `Common/headers/menueditor.h` | Add function declarations for new v7 helpers |
+| `tests/headless_menu_stubs.c` | Update stubs for v7 format |
+
+### 5.2 New Files
+
+| File | Purpose |
+|------|---------|
+| `tests/menu_v7_migration_tests.c` | Unit tests for refcon conversion |
+| `tests/integration/test_cases/menu_migration/*.yaml` | Integration tests |
+
+### 5.3 Detailed Changes to menupack.c
+
+#### Add after line ~750 (after tysavedmenuinfo_v7 typedef):
+
+```c
+/**
+ * V7 Table Refcon Format
+ *
+ * Each menu node's refcon is a packed table with these fields:
+ * - keyBinding (char): Command key character or 0
+ * - modifiers (table): {shift, control, option, command} booleans
+ * - handlerScript (script): The attached script or nil
+ */
+
+boolean mecreaterefcontable_v7(byte cmdkey, tykeyflags modifiers,
+                                hdloutlinerecord hscript,
+                                Handle *hpackedtable);
+
+boolean meunpackrefcontable_v7(Handle hpackedtable,
+                                byte *cmdkey,
+                                tykeyflags *modifiers,
+                                hdloutlinerecord *hscript);
+
+static boolean meconvertrefcon_v6_to_v7_visit(hdlheadrecord hnode, ptrvoid refcon);
+```
+
+#### Update mepackmenustructure_v7():
+
+Replace the direct refcon packing with conversion visitor call before packing.
+
+---
+
+## 6. Test Cases
+
+### 6.1 Data Migration Tests
+
+| # | Test Case | Input | Expected |
+|---|-----------|-------|----------|
+| 1 | Empty menu | Menu with no items | Packs to v7 with empty outline |
+| 2 | Single item, no script | One menu item, no keybinding | Table refcon with nil handlerScript |
+| 3 | Single item with Cmd+K | Item with command key | keyBinding='K', modifiers.command=true |
+| 4 | Item with Shift+Cmd+K | Complex modifier combo | All modifier flags set correctly |
+| 5 | Item with script | Simple script attached | handlerScript contains script outline |
+| 6 | Nested menu | File > Recent > item1, item2 | Correct outline hierarchy preserved |
+| 7 | Round-trip v6→v7→v6 | Full menu structure | Data integrity preserved |
+
+### 6.2 Edge Cases
+
+| # | Edge Case | Test Strategy |
+|---|-----------|---------------|
+| 1 | Corrupt refcon | Handle gracefully, don't crash |
+| 2 | Script load failure | Log error, continue with nil script |
+| 3 | Very large script | Memory handling |
+| 4 | Unicode menu item names | Preserved through migration |
+| 5 | Maximum nesting depth | Stress test with deep submenus |
+
+### 6.3 Regression Tests
+
+- Ensure existing v6 databases still load correctly
+- Ensure GUI builds can still edit menus (when applicable)
+- Ensure script execution works from migrated menus
+
+---
+
+## 7. Implementation Notes
+
+### 7.1 Memory Management
+
+- Scripts loaded for migration must be disposed after packing
+- Use `fldirty = true` to prevent premature unload during traversal
+- Track and release all temporary tables created for refcons
+
+### 7.2 Byte Order
+
+- All v7 fields use explicit BE helpers (`db_format_write_be64`, etc.)
+- Table packing uses standard `langpackvalue()` which handles byte order
+- Refcon data stored as packed table bytes (platform-independent)
+
+### 7.3 Backward Compatibility
+
+- v7 reader must handle v6 databases (detect via versionnumber)
+- v6 reader (in legacy Frontier) won't understand v7 format
+- Migration is one-way (v6 → v7)
+
+### 7.4 Error Handling
+
+- Log all conversion errors with context
+- Don't abort migration on single node failure
+- Track and report error count at end
+
+---
+
+## 8. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Script data loss | Medium | High | Comprehensive testing, backup v6 before migration |
+| Keybinding corruption | Low | Medium | Unit tests for all modifier combos |
+| Memory exhaustion on large menus | Low | High | Incremental processing, release after each node |
+| Table packing incompatibility | Low | Medium | Use existing langpackvalue(), well-tested |
+
+---
+
+## 9. Success Criteria
+
+- [ ] All v6 menu features preserved in v7 format
+- [ ] Unit tests pass for refcon conversion
+- [ ] Integration tests pass for menu verbs
+- [ ] Real-world menu data migrates correctly (Frontier.root menus)
+- [ ] No memory leaks in conversion code
+- [ ] GUI builds still work (when applicable)
+
+---
+
+## 10. References
+
+- V6 to V7 Migration Gaps: `planning/phase3/v6_to_v7_migration_gaps.md`
+- Outline Pack Format: `Common/source/oppack_v7.c`
+- Refcon Handling: `Common/source/oprefcon.c`
+- Menu Editor Header: `Common/headers/menueditor.h`
+- Menu Pack Implementation: `Common/source/menupack.c`
+- Headless Menu Stubs: `tests/headless_menu_stubs.c`

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -111,6 +111,7 @@ MIGRATION_SOURCES = \
     headless_shell.c \
     components/test_migration_portable.c
 
+# Note: ophoist.c is required because opverbnew() calls oppopallhoists() defined there.
 LANG_RUNTIME_SOURCES = \
     ../Common/source/logging.c \
     ../Common/source/lang.c \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -163,6 +163,7 @@ LANG_RUNTIME_SOURCES = \
     ../Common/source/legacy/oppack_legacy.c \
     ../Common/source/opverbs.c \
     ../Common/source/legacy/opverbs_legacy.c \
+    ../Common/source/ophoist.c \
     ../Common/source/opxml.c \
     ../Common/source/langxml.c \
     $(HEADLESS_VERBS_SOURCES) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -232,7 +232,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #219 tracks verb runtime fixes)
@@ -322,6 +322,11 @@ test_callback_infrastructure: test_callback_infrastructure.c $(LANG_RUNTIME_SOUR
 tcp_phase1a_unit_tests: tcp_phase1a_unit_tests.c ../Common/source/tcpverbs.c $(LANG_RUNTIME_SOURCES) headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -I../Common/headers -I../Common/SystemHeaders -I../portable \
 		tcp_phase1a_unit_tests.c ../Common/source/tcpverbs.c $(LANG_RUNTIME_SOURCES) headless_shell.c -o $@ $(LINK_LIBS)
+
+# Menu v7 refcon table format tests - validates mecreaterefcontable_v7/meunpackrefcontable_v7
+menu_v7_refcon_tests: menu_v7_refcon_tests.c $(LANG_RUNTIME_SOURCES) ../Common/source/menupack.c headless_shell.c
+	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -I../Common/headers -I../Common/SystemHeaders -I../portable \
+		menu_v7_refcon_tests.c $(LANG_RUNTIME_SOURCES) ../Common/source/menupack.c headless_shell.c -o $@ $(LINK_LIBS)
 
 runtime_tests: runtime_tests.c $(LANG_RUNTIME_SOURCES) headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -I../Common/headers -I../Common/SystemHeaders -I../portable runtime_tests.c $(LANG_RUNTIME_SOURCES) headless_shell.c -o $@ $(LINK_LIBS)

--- a/tests/headless_mac_compat.c
+++ b/tests/headless_mac_compat.c
@@ -356,7 +356,7 @@ boolean opbeginprint (void) { return false; }
 boolean opbuttonstatus (void) { return false; }
 boolean opbutton (void) { return false; }
 boolean oppostfontchange (void) { return true; }
-void oprestorehoists (void) { }
+/* oprestorehoists provided by ophoist.c in headless build */
 boolean oprestorescrollposition (void) { return false; }
 void opsetdisplaydefaults (hdloutlinerecord ho) { (void)ho; }
 
@@ -426,9 +426,7 @@ boolean opscroll (tydirection dir, boolean f, long n) { (void)dir; (void)f; (voi
 boolean opscrollto (long a, long b) { (void)a; (void)b; return false; }
 boolean opsetprintinfo (void) { return false; }
 boolean oprmousedown (Point pt, tyclickflags flags) { (void)pt; (void)flags; return false; }
-boolean oppushhoist (hdlheadrecord h) { (void)h; return false; }
-boolean oppophoist (void) { return false; }
-boolean oppopallhoists (void) { return false; }
+/* oppushhoist, oppophoist, oppopallhoists provided by ophoist.c in headless build */
 // traversal functions provided by opvisit.c in headless build
 void opscrollrect (Rect r, long dh, long dv) { (void)r; (void)dh; (void)dv; }
 

--- a/tests/headless_menu_stubs.c
+++ b/tests/headless_menu_stubs.c
@@ -21,11 +21,13 @@
 #include "standard.h"
 
 #include "menuverbs.h"  /* includes menueditor.h which includes menubar.h */
+#include "menuinternal.h" /* megetmenuiteminfo, mesetmenuiteminfo */
 #include "op.h"
 #include "opinternal.h"
 #include "memory.h"
 #include "db.h"
 #include "db_format.h"
+#include "logging.h"  /* For meloadscriptoutline diagnostics */
 
 #ifdef FRONTIER_HEADLESS
 
@@ -276,9 +278,8 @@ boolean meresetwindowrects (hdlwindowinfo hw) {
     return (false);
 }
 
-boolean meresize (void) {
-    /* GUI-only operation - return false */
-    return (false);
+void meresize (void) {
+    /* GUI-only operation - no-op */
 }
 
 void meinit (void) {
@@ -341,14 +342,20 @@ boolean meloadoutline_internal (const db_context *ctx, dbaddress adr,
 
     *houtline = nil;
 
+    log_debug(LOG_COMP_OP, "meloadoutline_internal: START adr=0x%llx ctx_db=%p",
+            (unsigned long long)adr, (void*)(ctx ? ctx->database : nil));
+
     oppushoutline (nil);
 
     if (adr == nildbaddress) {
-        /* New empty outline */
-        Rect r = {0, 0, 100, 100};
-        fl = opnewrecord (r, houtline);
+        /* New empty outline - use newoutlinerecord which doesn't require window info */
+        fl = newoutlinerecord (houtline);
+        log_debug(LOG_COMP_OP, "meloadoutline_internal: created new outline fl=%d", (int)fl);
     }
     else {
+        log_error(LOG_COMP_OP, "meloadoutline_internal: reading adr=0x%llx ctx_db=%p global_db=%p",
+                (unsigned long long)adr, (void*)(ctx ? ctx->database : nil), (void*)databasedata);
+
         if (ctx != nil) {
             fl = dbrefhandle_context (ctx, adr, &hpackedoutline);
         } else {
@@ -357,11 +364,24 @@ boolean meloadoutline_internal (const db_context *ctx, dbaddress adr,
 
         if (!fl) {
             /* Database read failed - leave *houtline as nil */
+            log_error(LOG_COMP_OP, "meloadoutline_internal: dbrefhandle FAILED adr=0x%llx", (unsigned long long)adr);
             oppopoutline ();
             return (false);
         }
 
+        {
+            long hsize = gethandlesize(hpackedoutline);
+            unsigned char *p = (unsigned char *) *hpackedoutline;
+            log_error(LOG_COMP_OP, "meloadoutline_internal: dbrefhandle OK, unpacking size=%ld first_bytes=%02x%02x%02x%02x",
+                    hsize, hsize > 0 ? p[0] : 0, hsize > 1 ? p[1] : 0, hsize > 2 ? p[2] : 0, hsize > 3 ? p[3] : 0);
+        }
+
         fl = opunpack (hpackedoutline, &ixload, houtline);
+
+        if (!fl) {
+            log_error(LOG_COMP_OP, "meloadoutline_internal: opunpack FAILED");
+        }
+
         disposehandle (hpackedoutline);
     }
 
@@ -373,6 +393,7 @@ boolean meloadoutline_internal (const db_context *ctx, dbaddress adr,
     if (*houtline != nil)
         opvalidate (*houtline);
 
+    log_debug(LOG_COMP_OP, "meloadoutline_internal: SUCCESS");
     return (true);
 }
 
@@ -399,13 +420,65 @@ boolean mesaveoutline (hdloutlinerecord ho, dbaddress *adr) {
 boolean meloadscriptoutline (hdlmenurecord hm, hdlheadrecord hnode,
                              hdloutlinerecord *houtline, boolean *fljustloaded) {
     /*
-     * Load script outline attached to a menu item. Simplified for headless.
+     * Load script outline attached to a menu item.
+     *
+     * This function is called during menu packing when fldatabasesaveas and
+     * flconvertingolddatabase are true (i.e., during migration). It needs to
+     * load attached scripts so they can be re-saved to the destination database.
+     *
+     * Returns true if successful (even if no script is attached - *houtline=nil).
+     * Returns false only on actual errors (e.g., database read failure).
      */
-    (void) hm;
-    (void) hnode;
+    tymenuiteminfo item;
+    dbaddress adr;
+    Handle hpackedoutline;
+    long ixload = 0;
+    boolean fl;
+
+    (void) hm; /* Menu record not needed - script address is in node refcon */
+
     *houtline = nil;
     if (fljustloaded) *fljustloaded = false;
-    return (false); /* Scripts not loaded in headless mode */
+
+    /* Get the script info from the node's refcon */
+    if (!megetmenuiteminfo (hnode, &item)) {
+        /* No refcon data - no script attached, this is OK */
+        log_trace(LOG_COMP_OP, "meloadscriptoutline: no refcon data, returning OK");
+        return (true);
+    }
+
+    adr = item.linkedscript.adrlink;
+
+    if (adr == nildbaddress) {
+        /* No linked script - this is OK */
+        log_trace(LOG_COMP_OP, "meloadscriptoutline: no linked script (adr=nil), returning OK");
+        return (true);
+    }
+
+    log_trace(LOG_COMP_OP, "meloadscriptoutline: loading script from adr=0x%llx", (unsigned long long)adr);
+
+    /* Load the packed script outline from database */
+    fl = dbrefhandle (adr, &hpackedoutline);
+    if (!fl) {
+        /* Database read error */
+        log_error(LOG_COMP_OP, "meloadscriptoutline: dbrefhandle failed for adr=0x%llx", (unsigned long long)adr);
+        return (false);
+    }
+
+    /* Unpack into outline record */
+    fl = opunpack (hpackedoutline, &ixload, houtline);
+
+    if (!fl) {
+        log_error(LOG_COMP_OP, "meloadscriptoutline: opunpack failed for adr=0x%llx", (unsigned long long)adr);
+    }
+
+    disposehandle (hpackedoutline);
+
+    if (fl && fljustloaded) {
+        *fljustloaded = true;
+    }
+
+    return (fl);
 }
 
 /*

--- a/tests/menu_v7_refcon_tests.c
+++ b/tests/menu_v7_refcon_tests.c
@@ -1,0 +1,470 @@
+/*
+ * menu_v7_refcon_tests.c - Unit tests for v7 menu refcon table format
+ *
+ * Tests the mecreaterefcontable_v7() and meunpackrefcontable_v7() functions
+ * that convert menu item data to/from the new v7 packed table format.
+ *
+ * V7 menu refcon format stores each node's refcon as a packed table with:
+ * - keyBinding (char) - command key character or 0
+ * - modifiers (table) - {shift, control, option, command} booleans
+ * - handlerScript (script) - the script object or nil
+ *
+ * Part of the menu v6->v7 migration validation test suite.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "frontier.h"
+#include "standard.h"
+#include "shelltypes.h"
+#include "op.h"
+#include "opinternal.h"
+#include "memory.h"
+#include "lang.h"
+#include "tablestructure.h"
+#include "logging.h"
+#include "../portable/wptext_portable.h"
+
+/*
+ * Forward declarations for functions being tested.
+ * These will be implemented in menuverbs.c or a new menu_v7.c file.
+ */
+extern boolean mecreaterefcontable_v7(byte cmdkey, tykeyflags modifiers,
+                                       hdloutlinerecord hscript,
+                                       Handle *hpackedtable);
+
+extern boolean meunpackrefcontable_v7(Handle hpackedtable,
+                                       byte *cmdkey,
+                                       tykeyflags *modifiers,
+                                       hdloutlinerecord *hscript);
+
+/*
+ * Helper: Create a simple test script outline with one line.
+ * Used to verify script roundtripping.
+ */
+static hdloutlinerecord create_test_script(const char *line) {
+    hdloutlinerecord ho = nil;
+    if (!newoutlinerecord(&ho))
+        return nil;
+
+    /* Set the root headline text */
+    bigstring bs;
+    copyctopstring(line, bs);
+    if (!opsetheadstring((**ho).hsummit, bs)) {
+        opdisposeoutline(ho, false);
+        return nil;
+    }
+
+    return ho;
+}
+
+/*
+ * Helper: Get the root headline text from an outline.
+ */
+static boolean get_script_text(hdloutlinerecord ho, char *out, size_t outsize) {
+    if (ho == nil || out == nil || outsize == 0)
+        return false;
+
+    bigstring bs;
+    opgetheadstring((**ho).hsummit, bs);
+    copyptocstring(bs, out);
+    return true;
+}
+
+/*
+ * Test 1: Empty refcon - no keybinding (cmdkey=0) and no script (hscript=nil)
+ *
+ * Verify roundtrip: create with no keybinding and no script,
+ * unpack and verify both are nil/0.
+ */
+static void test_menu_refcon_empty(void) {
+    printf("[menu_v7] Test 1: Empty refcon (no keybinding, no script)... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 0;
+    tykeyflags modifiers_in = keynormal;
+    hdloutlinerecord hscript_in = nil;
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, hscript_in, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0xFF;  /* Initialize to non-zero to detect changes */
+    tykeyflags modifiers_out = (tykeyflags)0xFFFF;
+    hdloutlinerecord hscript_out = (hdloutlinerecord)0x1;  /* Non-nil sentinel */
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 0);
+    assert(modifiers_out == keynormal);
+    assert(hscript_out == nil);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 2: Keybinding only - 'K' key with command modifier, no script
+ *
+ * Common case: menu item has Cmd-K shortcut but no attached script.
+ */
+static void test_menu_refcon_keybinding_only(void) {
+    printf("[menu_v7] Test 2: Keybinding only (Cmd-K, no script)... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'K';
+    tykeyflags modifiers_in = keycommand;
+    hdloutlinerecord hscript_in = nil;
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, hscript_in, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = (hdloutlinerecord)0x1;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    if (cmdkey_out != 'K' || modifiers_out != keycommand) {
+        printf("\nFAILED: cmdkey=%d (expected 'K'=%d), modifiers=0x%04x (expected 0x%04x)\n",
+               (int)cmdkey_out, (int)'K', (unsigned)modifiers_out, (unsigned)keycommand);
+        fflush(stdout);
+    }
+    assert(cmdkey_out == 'K');
+    assert(modifiers_out == keycommand);
+    assert(hscript_out == nil);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 3: Script only - no keybinding but has attached script
+ *
+ * Some menu items have scripts but no keyboard shortcut.
+ */
+static void test_menu_refcon_script_only(void) {
+    printf("[menu_v7] Test 3: Script only (no keybinding)... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 0;
+    tykeyflags modifiers_in = keynormal;
+    hdloutlinerecord hscript_in = create_test_script("dialog.alert(\"Hello\")");
+    assert(hscript_in != nil);
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, hscript_in, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0xFF;
+    tykeyflags modifiers_out = (tykeyflags)0xFFFF;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 0);
+    assert(modifiers_out == keynormal);
+    assert(hscript_out != nil);
+
+    /* Verify script content */
+    char script_text[256];
+    assert(get_script_text(hscript_out, script_text, sizeof(script_text)));
+    assert(strcmp(script_text, "dialog.alert(\"Hello\")") == 0);
+
+    /* Cleanup */
+    opdisposeoutline(hscript_in, false);
+    opdisposeoutline(hscript_out, false);
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 4: Full refcon - keybinding with all modifiers + script
+ *
+ * Test complete menu item data: Shift+Cmd+Option+Ctrl-X with script.
+ */
+static void test_menu_refcon_full(void) {
+    printf("[menu_v7] Test 4: Full refcon (all modifiers + script)... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'X';
+    tykeyflags modifiers_in = (tykeyflags)(keyshift | keycontrol | keyoption | keycommand);
+    hdloutlinerecord hscript_in = create_test_script("sys.beep()");
+    assert(hscript_in != nil);
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, hscript_in, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 'X');
+    assert((modifiers_out & keyshift) != 0);
+    assert((modifiers_out & keycontrol) != 0);
+    assert((modifiers_out & keyoption) != 0);
+    assert((modifiers_out & keycommand) != 0);
+    assert(hscript_out != nil);
+
+    /* Verify script content */
+    char script_text[256];
+    assert(get_script_text(hscript_out, script_text, sizeof(script_text)));
+    assert(strcmp(script_text, "sys.beep()") == 0);
+
+    /* Cleanup */
+    opdisposeoutline(hscript_in, false);
+    opdisposeoutline(hscript_out, false);
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 5: Shift modifier only
+ *
+ * Verify that the shift modifier flag (0x0001) is correctly encoded/decoded.
+ */
+static void test_menu_refcon_shift_modifier(void) {
+    printf("[menu_v7] Test 5: Shift modifier only... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'S';
+    tykeyflags modifiers_in = keyshift;
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, nil, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 'S');
+    assert((modifiers_out & keyshift) != 0);
+    assert((modifiers_out & keycontrol) == 0);
+    assert((modifiers_out & keyoption) == 0);
+    assert((modifiers_out & keycommand) == 0);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 6: Control modifier only
+ *
+ * Verify that the control modifier flag (0x0200) is correctly encoded/decoded.
+ */
+static void test_menu_refcon_control_modifier(void) {
+    printf("[menu_v7] Test 6: Control modifier only... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'C';
+    tykeyflags modifiers_in = keycontrol;
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, nil, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 'C');
+    assert((modifiers_out & keyshift) == 0);
+    assert((modifiers_out & keycontrol) != 0);
+    assert((modifiers_out & keyoption) == 0);
+    assert((modifiers_out & keycommand) == 0);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 7: Option modifier only
+ *
+ * Verify that the option modifier flag (0x0400) is correctly encoded/decoded.
+ */
+static void test_menu_refcon_option_modifier(void) {
+    printf("[menu_v7] Test 7: Option modifier only... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'O';
+    tykeyflags modifiers_in = keyoption;
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, nil, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 'O');
+    assert((modifiers_out & keyshift) == 0);
+    assert((modifiers_out & keycontrol) == 0);
+    assert((modifiers_out & keyoption) != 0);
+    assert((modifiers_out & keycommand) == 0);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 8: Command modifier only
+ *
+ * Verify that the command modifier flag (0x0800) is correctly encoded/decoded.
+ */
+static void test_menu_refcon_command_modifier(void) {
+    printf("[menu_v7] Test 8: Command modifier only... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'M';
+    tykeyflags modifiers_in = keycommand;
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, nil, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 'M');
+    assert((modifiers_out & keyshift) == 0);
+    assert((modifiers_out & keycontrol) == 0);
+    assert((modifiers_out & keyoption) == 0);
+    assert((modifiers_out & keycommand) != 0);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Test 9: Combined modifiers - Shift+Cmd+Option
+ *
+ * Test a realistic combination: Shift+Cmd+Option modifier combination.
+ * This is a common pattern for "alternate" menu commands.
+ */
+static void test_menu_refcon_combined_modifiers(void) {
+    printf("[menu_v7] Test 9: Combined modifiers (Shift+Cmd+Option)... ");
+    fflush(stdout);
+
+    Handle hpacked = nil;
+    byte cmdkey_in = 'A';
+    tykeyflags modifiers_in = (tykeyflags)(keyshift | keycommand | keyoption);
+
+    /* Create packed refcon */
+    assert(mecreaterefcontable_v7(cmdkey_in, modifiers_in, nil, &hpacked));
+    assert(hpacked != nil);
+
+    /* Unpack and verify */
+    byte cmdkey_out = 0;
+    tykeyflags modifiers_out = keynormal;
+    hdloutlinerecord hscript_out = nil;
+
+    assert(meunpackrefcontable_v7(hpacked, &cmdkey_out, &modifiers_out, &hscript_out));
+
+    assert(cmdkey_out == 'A');
+    assert((modifiers_out & keyshift) != 0);
+    assert((modifiers_out & keycontrol) == 0);  /* Control should NOT be set */
+    assert((modifiers_out & keyoption) != 0);
+    assert((modifiers_out & keycommand) != 0);
+
+    disposehandle(hpacked);
+
+    printf("PASS\n");
+    fflush(stdout);
+}
+
+/*
+ * Main test runner
+ */
+int main(void) {
+    printf("\n=== Menu V7 Refcon Table Format Tests ===\n");
+    printf("[menu_v7] Initializing runtime...\n");
+    fflush(stdout);
+
+    /* Initialize logging system */
+    log_init();
+
+    /* Initialize runtime subsystems - order matters! */
+    assert(initmemory());
+    initstrings();  /* Must be called before initlang - initializes lowercasetable for hash functions */
+    assert(initlang());
+    assert(inittablestructure());
+    assert(langinitverbs());
+    assert(wp_portable_init());
+
+    printf("[menu_v7] Testing v7 menu refcon table pack/unpack\n");
+    fflush(stdout);
+
+    test_menu_refcon_empty();
+    test_menu_refcon_keybinding_only();
+    /* Skip script tests until outline initialization is resolved */
+    printf("[menu_v7] Test 3: Script only (no keybinding)... SKIPPED (outline init)\n");
+    printf("[menu_v7] Test 4: Full refcon (all modifiers + script)... SKIPPED (outline init)\n");
+    // test_menu_refcon_script_only();
+    // test_menu_refcon_full();
+    test_menu_refcon_shift_modifier();
+    test_menu_refcon_control_modifier();
+    test_menu_refcon_option_modifier();
+    test_menu_refcon_command_modifier();
+    test_menu_refcon_combined_modifiers();
+
+    printf("\n========================================\n");
+    printf("[menu_v7] ALL TESTS PASSED\n");
+    printf("========================================\n");
+    fflush(stdout);
+
+    wp_portable_shutdown();
+    return 0;
+}

--- a/tests/menu_v7_refcon_tests.c
+++ b/tests/menu_v7_refcon_tests.c
@@ -53,13 +53,20 @@ static hdloutlinerecord create_test_script(const char *line) {
     if (!newoutlinerecord(&ho))
         return nil;
 
+    /* Push outline to make it current - required before modifying */
+    oppushoutline(ho);
+
     /* Set the root headline text */
     bigstring bs;
     copyctopstring(line, bs);
     if (!opsetheadstring((**ho).hsummit, bs)) {
+        oppopoutline();
         opdisposeoutline(ho, false);
         return nil;
     }
+
+    /* Pop outline but keep it allocated */
+    oppopoutline();
 
     return ho;
 }
@@ -71,9 +78,14 @@ static boolean get_script_text(hdloutlinerecord ho, char *out, size_t outsize) {
     if (ho == nil || out == nil || outsize == 0)
         return false;
 
+    /* Push outline to make it current - required for opgetheadstring */
+    oppushoutline(ho);
+
     bigstring bs;
     opgetheadstring((**ho).hsummit, bs);
     copyptocstring(bs, out);
+
+    oppopoutline();
     return true;
 }
 
@@ -441,6 +453,7 @@ int main(void) {
     initstrings();  /* Must be called before initlang - initializes lowercasetable for hash functions */
     assert(initlang());
     assert(inittablestructure());
+    assert(langinitresources_headless());  /* Initialize constants, keywords, builtins - required for outline ops */
     assert(langinitverbs());
     assert(wp_portable_init());
 
@@ -449,11 +462,8 @@ int main(void) {
 
     test_menu_refcon_empty();
     test_menu_refcon_keybinding_only();
-    /* Skip script tests until outline initialization is resolved */
-    printf("[menu_v7] Test 3: Script only (no keybinding)... SKIPPED (outline init)\n");
-    printf("[menu_v7] Test 4: Full refcon (all modifiers + script)... SKIPPED (outline init)\n");
-    // test_menu_refcon_script_only();
-    // test_menu_refcon_full();
+    test_menu_refcon_script_only();
+    test_menu_refcon_full();
     test_menu_refcon_shift_modifier();
     test_menu_refcon_control_modifier();
     test_menu_refcon_option_modifier();

--- a/tests/table_operations/table_operations_integration.c
+++ b/tests/table_operations/table_operations_integration.c
@@ -159,13 +159,17 @@ static void eval_cli(const char *script, char *output, size_t output_size) {
 		}
 
 		/* If result contains warning/error patterns, fall through to line-by-line parsing */
+		/* New structured logging format uses [component-LEVEL] like [startup-WARN] */
 		if (strstr(result_token, "system=") != NULL ||
-		    strstr(result_token, "[WARN]") != NULL ||
-		    strstr(result_token, "[ERROR]") != NULL ||
+		    strstr(result_token, "-WARN]") != NULL ||   /* New format: [xxx-WARN] */
+		    strstr(result_token, "-ERROR]") != NULL ||  /* New format: [xxx-ERROR] */
+		    strstr(result_token, "[WARN]") != NULL ||   /* Old format */
+		    strstr(result_token, "[ERROR]") != NULL ||  /* Old format */
 		    strstr(result_token, "ix=") != NULL ||  /* Memory error messages */
 		    strstr(result_token, "caller=") != NULL ||
 		    strstr(result_token, "Cant ") != NULL ||  /* UserTalk error messages */
-		    strstr(result_token, "hasnt ") != NULL) {
+		    strstr(result_token, "hasnt ") != NULL ||
+		    strstr(result_token, "completed with errors") != NULL) {  /* Startup warnings */
 			result_token[0] = '\0';  /* Clear and fall through */
 		}
 	}
@@ -189,15 +193,20 @@ static void eval_cli(const char *script, char *output, size_t output_size) {
 			current_line[line_len] = '\0';
 
 			/* Skip log lines, warnings, errors, and memory messages */
+			/* New structured logging format uses [component-LEVEL] like [startup-WARN] */
 			if (strstr(current_line, "[headless]") == NULL &&
-			    strstr(current_line, "[WARN]") == NULL &&
-			    strstr(current_line, "[ERROR]") == NULL &&
+			    strstr(current_line, "-WARN]") == NULL &&   /* New format: [xxx-WARN] */
+			    strstr(current_line, "-ERROR]") == NULL &&  /* New format: [xxx-ERROR] */
+			    strstr(current_line, "[WARN]") == NULL &&   /* Old format */
+			    strstr(current_line, "[ERROR]") == NULL &&  /* Old format */
 			    strstr(current_line, "[2025") == NULL &&
+			    strstr(current_line, "[2026") == NULL &&
 			    strstr(current_line, "system=") == NULL &&
 			    strstr(current_line, "ix=") == NULL &&  /* Memory error messages */
 			    strstr(current_line, "caller=") == NULL &&
 			    strstr(current_line, "Cant ") == NULL &&  /* UserTalk error messages */
 			    strstr(current_line, "hasnt ") == NULL &&
+			    strstr(current_line, "completed with errors") == NULL &&  /* Startup warnings */
 			    strlen(current_line) > 0) {
 				strncpy(result_token, current_line, sizeof(result_token) - 1);
 				result_token[sizeof(result_token) - 1] = '\0';


### PR DESCRIPTION
## Summary

This PR fixes issues with v6 menu loading during database migration and resolves a crash caused by unresolved inline function symbols.

### Changes

**fix: Correct v6 menu loading during migration with explicit header size**
- Added `dbreference_with_header_size()` and `dbrefhandle_with_header_size()` to bypass the global format mode lock during migration
- During migration, the global mode is locked to v7 to prevent downgrades, but we need to read source v6 blocks using the correct 8-byte header size (v7 uses 12-byte headers)
- This was causing a 4-byte offset error when reading v6 menu data

**fix: Make byte-swap inline functions static**
- Changed `inline` to `static inline` for `dolongswap`, `dolonglongswap`, and `doshortswap` in `byteorder.h`
- Without `static`, the inline functions have external linkage and become unresolved symbols on ARM64, causing crashes when calling byte-swap functions

**fix: Enable and fix menu script tests**
- Added `ophoist.c` to test Makefile (provides `oppopallhoists()` needed by `opverbnew()`)
- Added `langinitresources_headless()` initialization
- Wrapped outline operations with `oppushoutline/oppopoutline` as required by the API

**fix: Update test log filters for structured logging**
- Updated `table_operations_integration.c` to handle new logging format (`[component-LEVEL]` instead of `[LEVEL]`)

## Test plan

- [x] All 9 menu refcon tests pass (including script attachment tests 3 and 4)
- [x] CLI basic evaluation works: `3 + 4` returns `7`
- [x] Migration creates valid v7 database file
- [ ] Run full unit test suite (note: `test_callback_infrastructure` has a pre-existing failure unrelated to this PR)

---

Generated with [Claude Code](https://claude.com/claude-code)