### PR TITLE
fix: Use int32_t for disk struct fields to ensure 4-byte size on 64-bit

### DIFF
--- a/Common/source/langtree.c
+++ b/Common/source/langtree.c
@@ -43,7 +43,6 @@
 #include "db_format.h" /* 2025-11-23 Codex: BE helpers for tree packing */
 #include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
 #include "logging.h"
-#include <stdint.h>  /* 2026-02-03: for fixed-width int32_t in disk structs */
 
 #pragma pack(2)
 typedef struct tydisktreenode {

--- a/Common/source/langtree.c
+++ b/Common/source/langtree.c
@@ -43,6 +43,7 @@
 #include "db_format.h" /* 2025-11-23 Codex: BE helpers for tree packing */
 #include "byteorder.h"	/* 2006-04-08 aradke: endianness conversion macros */
 #include "logging.h"
+#include <stdint.h>  /* 2026-02-03: for fixed-width int32_t in disk structs */
 
 #pragma pack(2)
 typedef struct tydisktreenode {
@@ -53,7 +54,7 @@ typedef struct tydisktreenode {
 	tytreetype nodetype; /*add, subtract, if, etc.*/
 #endif
 
-	long nodevalsize;
+	int32_t nodevalsize;  /* Must be 4 bytes on all platforms for disk format */
 	
 	short lnum; /*which line number in the source was this node generated from?*/
 	
@@ -100,15 +101,15 @@ typedef enum tydisktreenodeparaminfo {
 
 #pragma pack(2)
 typedef struct tydisktreerec {
-	
+
 	short version;
-	
-	long ctnodes;
-	
-	long flags; /*currently unused*/
-	
+
+	int32_t ctnodes;  /* Must be 4 bytes on all platforms for disk format */
+
+	int32_t flags; /*currently unused - must be 4 bytes for disk format*/
+
 	byte waste [8];
-	
+
 	tydisktreenode nodes [];
 	} tydisktreerec, *ptrdisktreerec, **hdldisktreerec;
 
@@ -122,7 +123,7 @@ typedef struct tyOLD42disktreenode {
 	short nodetype;
 	#endif
 
-	long nodevalsize;
+	int32_t nodevalsize;  /* Must be 4 bytes on all platforms for disk format */
 	
 	short lnum; /*which line number in the source was this node generated from?*/
 	


### PR DESCRIPTION
## Summary

- Fix tydisktreenode, tydisktreerec, and tyOLD42disktreenode struct field types to use `int32_t` instead of `long`
- On 64-bit platforms (LP64), `long` is 8 bytes, but disk format expects 4-byte fields
- This was causing assertion failures in `langunpacktree()`:
  - `assert(sizeof(tydisktreenode) == 12)` failed (was 16-18 bytes)
  - `assert(sizeof(tydisktreerec) == 18)` failed

## Test plan

- [x] Verified struct sizes are correct (12 bytes and 18 bytes respectively)
- [x] Unit tests pass (20/20 core tests)
- [x] Migration completes successfully
- [x] test_callback_infrastructure no longer fails at struct size assertions

## Technical Details

Changed the following fields from `long` to `int32_t`:
- `tydisktreenode.nodevalsize`
- `tydisktreerec.ctnodes`
- `tydisktreerec.flags`
- `tyOLD42disktreenode.nodevalsize`

Added `#include <stdint.h>` for `int32_t` type.

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)