### PR TITLE
fix: Add menubar (mbar) value copying for headless mode

### DIFF
--- a/Common/headers/menuverbs.h
+++ b/Common/headers/menuverbs.h
@@ -83,6 +83,8 @@ extern boolean menuverbdispose (hdlexternalvariable, boolean);
 
 extern boolean menuverbnew (Handle, hdlexternalvariable *);
 
+extern boolean menuverbcopyvalue (hdlexternalvariable, hdlexternalvariable *);
+
 extern boolean menunewmenubar (hdlhashtable, bigstring, hdlmenurecord *);
 
 extern boolean menugetmenubar (hdlhashtable, bigstring, boolean, hdlmenurecord *);

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1314,16 +1314,24 @@ boolean langexternalcopyvalue (const tyvaluerecord *v1, tyvaluerecord *v2) {
 	boolean fl;
 	
 	switch ((**h).id) {
-		
-		case idoutlineprocessor: 
+
+		case idoutlineprocessor:
 		case idscriptprocessor:
 			if (!opverbcopyvalue (h, &h))
 				return (false);
-			
+
 			setexternalvalue ((Handle) h, v2);
-			
+
 			return (true);
-			
+
+		case idmenuprocessor:
+			if (!menuverbcopyvalue (h, &h))
+				return (false);
+
+			setexternalvalue ((Handle) h, v2);
+
+			return (true);
+
 		default:
 			if (!langpackvalue (*v1, &x, HNoNode))
 				return (false);

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -1049,6 +1049,40 @@ boolean menuverbnew (Handle hdata, hdlexternalvariable *hvariable) {
 	} /*menuverbnew*/
 
 
+boolean menuverbcopyvalue (hdlexternalvariable hsource, hdlexternalvariable *hcopy) {
+
+	/*
+	2026-02-05: new routine, so we don't have to pack/unpack for menu copies.
+
+	Always loads the menu into memory first (if not already loaded), then copies
+	from the in-memory outline representation. This avoids format mismatch issues
+	that can occur when the database stores legacy (v6) format data but the global
+	format mode is set to v7.
+
+	The load-then-copy approach follows the same pattern as opverbcopyvalue but
+	uses menuverbinmemory() which has proper format detection via
+	db_format_is_legacy_db().
+	*/
+
+	register hdlmenuvariable hv = (hdlmenuvariable) hsource;
+	hdlmenurecord hm;
+	boolean fl;
+
+	/* Ensure the menu is loaded into memory with correct format detection */
+	if (!menuverbinmemory (hv))
+		return (false);
+
+	hm = (hdlmenurecord) (**hv).variabledata;
+
+	fl = menuverbnew ((Handle) (**hm).menuoutline, hcopy);
+
+	if (fl)
+		(***hcopy).id = (**hv).id;
+
+	return (fl);
+	} /*menuverbcopyvalue*/
+
+
 static boolean menubuildverb (void) {
 	
 	/*

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1794 tests: 1643 pass (91%) 151 skip (8%)</title>
-    <dateCreated>Thu, 05 Feb 2026 07:07:01 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1802 tests: 1650 pass (91%) 152 skip (8%)</title>
+    <dateCreated>Fri, 06 Feb 2026 06:03:28 GMT</dateCreated>
   </head>
   <body>
     <outline text="Builtins Priority (builtins_priority) - 25 tests: 25 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
@@ -21,9 +21,10 @@
     <outline text="Html Text Processing Phase2 Tests (html_text_processing_phase2_tests) - 30 tests: 24 pass (80%) 6 skip (20%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_text_processing_phase2_tests.opml"/>
     <outline text="Lang Verbs (lang_verbs) - 156 tests: 141 pass (90%) 15 skip (9%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/lang_verbs.opml"/>
     <outline text="Menu Data Verbs (menu_data_verbs) - 49 tests: 49 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/menu_data_verbs.opml"/>
+    <outline text="Menu Value Copy (menu_value_copy) - 5 tests: 4 pass (80%) 1 skip (20%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/menu_value_copy.opml"/>
     <outline text="Migration Externals (migration_externals) - 19 tests: 16 pass (84%) 3 skip (15%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/migration_externals.opml"/>
     <outline text="Nested Parentof (nested_parentof) - 18 tests: 13 pass (72%) 5 skip (27%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/nested_parentof.opml"/>
-    <outline text="Op Outlinetoxml Headless (op_outlinetoxml_headless) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_outlinetoxml_headless.opml"/>
+    <outline text="Op Outlinetoxml Headless (op_outlinetoxml_headless) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_outlinetoxml_headless.opml"/>
     <outline text="Op Verbs (op_verbs) - 265 tests: 253 pass (95%) 12 skip (4%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_verbs.opml"/>
     <outline text="Opattributes Verbs (opattributes_verbs) - 7 tests: 0 pass (0%) 7 skip (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/opattributes_verbs.opml"/>
     <outline text="Path Resolution (path_resolution) - 39 tests: 39 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/path_resolution.opml"/>

--- a/reports/integration_tests/menu_value_copy.opml
+++ b/reports/integration_tests/menu_value_copy.opml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Menu Value Copy (menu_value_copy) - 5 tests: 4 pass (80%) 1 skip (20%)</title>
+    <dateCreated>Fri, 06 Feb 2026 06:03:28 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="mbar copy - copy menubar value to new location - Create a menubar at workspace.src, copy to workspace.dst, verify typeof is mbar">
+      <outline text="Metadata">
+        <outline text="skip: False"/>
+        <outline text="skip_reason: "/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.src)"/>
+        <outline text="workspace.dst = workspace.src"/>
+        <outline text="local (result = typeof(workspace.dst) == 'mbar')"/>
+        <outline text="delete(@workspace.src)"/>
+        <outline text="delete(@workspace.dst)"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="mbar copy - defined() works after copy - Create menubar, copy it, verify defined() returns true on the copy">
+      <outline text="Metadata">
+        <outline text="skip: False"/>
+        <outline text="skip_reason: "/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.src)"/>
+        <outline text="workspace.dst = workspace.src"/>
+        <outline text="local (result = defined(@workspace.dst))"/>
+        <outline text="delete(@workspace.src)"/>
+        <outline text="delete(@workspace.dst)"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="mbar copy - copy menubar with items preserves content - Create menubar with items, copy it, verify the copy has the items via getScript">
+      <outline text="Metadata">
+        <outline text="skip: True"/>
+        <outline text="skip_reason: menu.addMenuCommand and related menu editing verbs not implemented in headless"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(menubarType, @workspace.src)"/>
+        <outline text="menu.addMenuCommand(@workspace.src, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="workspace.dst = workspace.src"/>
+        <outline text="target.set(@workspace.dst)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="op.expand()"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="menu.getScript(@workspace.retrieved)"/>
+        <outline text="local (result = (workspace.retrieved == &quot;fileOpen()&quot;))"/>
+        <outline text="delete(@workspace.src)"/>
+        <outline text="delete(@workspace.dst)"/>
+        <outline text="try {delete(@workspace.retrieved)}"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="mbar read - typeof userland.virginBookmarkMenu is mbar - Verify we can access userland.virginBookmarkMenu and its type is mbar">
+      <outline text="Metadata">
+        <outline text="skip: False"/>
+        <outline text="skip_reason: "/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return typeof(userland.virginBookmarkMenu) == 'mbar'"/>
+      </outline>
+    </outline>
+    <outline text="mbar copy - copy userland.virginBookmarkMenu to workspace - Copy userland.virginBookmarkMenu to workspace location - this is the exact operation that was failing">
+      <outline text="Metadata">
+        <outline text="skip: False"/>
+        <outline text="skip_reason: "/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="workspace.testCopy = userland.virginBookmarkMenu"/>
+        <outline text="local (result = typeof(workspace.testCopy) == 'mbar')"/>
+        <outline text="delete(@workspace.testCopy)"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/op_outlinetoxml_headless.opml
+++ b/reports/integration_tests/op_outlinetoxml_headless.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Op Outlinetoxml Headless (op_outlinetoxml_headless) - 12 tests: 12 pass (100%)</title>
-    <dateCreated>Thu, 05 Feb 2026 07:07:01 GMT</dateCreated>
+    <title>Op Outlinetoxml Headless (op_outlinetoxml_headless) - 15 tests: 15 pass (100%)</title>
+    <dateCreated>Fri, 06 Feb 2026 06:03:28 GMT</dateCreated>
   </head>
   <body>
     <outline text="op.outlineToXml - empty outline returns valid OPML - Convert empty outline to OPML (previously caused stack overflow)">
@@ -153,6 +153,60 @@
         <outline text="op.setLineText(&quot;Test&quot;)"/>
         <outline text="local(xml = op.outlineToXml(@workspace.outline, &quot;User&quot;, &quot;user@example.com&quot;))"/>
         <outline text="return string.mid(xml, 1, 5) == &quot;&lt;?xml&quot;"/>
+      </outline>
+    </outline>
+    <outline text="round-trip - single line preserves content - Converting outline to XML and back preserves line text">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new(outlineType, @workspace.rtSrc)"/>
+        <outline text="target.set(@workspace.rtSrc)"/>
+        <outline text="op.setLineText(&quot;RoundTripTest&quot;)"/>
+        <outline text="local(xml = op.outlineToXml(@workspace.rtSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @workspace.rtDst)"/>
+        <outline text="op.xmlToOutline(xml, @workspace.rtDst)"/>
+        <outline text="target.set(@workspace.rtDst)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="return op.getLineText() == &quot;RoundTripTest&quot;"/>
+      </outline>
+    </outline>
+    <outline text="round-trip - multiple lines preserved - Converting multi-line outline to XML and back preserves first and second lines">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new(outlineType, @workspace.rtMultiSrc)"/>
+        <outline text="target.set(@workspace.rtMultiSrc)"/>
+        <outline text="op.setLineText(&quot;First&quot;)"/>
+        <outline text="op.insert(&quot;Second&quot;, down)"/>
+        <outline text="local(xml = op.outlineToXml(@workspace.rtMultiSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @workspace.rtMultiDst)"/>
+        <outline text="op.xmlToOutline(xml, @workspace.rtMultiDst)"/>
+        <outline text="target.set(@workspace.rtMultiDst)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="local(hasFirst = op.getLineText() == &quot;First&quot;)"/>
+        <outline text="op.go(right, 1)"/>
+        <outline text="local(hasSecond = op.getLineText() == &quot;Second&quot;)"/>
+        <outline text="return hasFirst and hasSecond"/>
+      </outline>
+    </outline>
+    <outline text="round-trip - nested hierarchy preserved - Converting nested outline to XML and back preserves structure">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new(outlineType, @workspace.rtNestedSrc)"/>
+        <outline text="target.set(@workspace.rtNestedSrc)"/>
+        <outline text="op.setLineText(&quot;Parent&quot;)"/>
+        <outline text="op.insert(&quot;Child&quot;, right)"/>
+        <outline text="local(xml = op.outlineToXml(@workspace.rtNestedSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @workspace.rtNestedDst)"/>
+        <outline text="op.xmlToOutline(xml, @workspace.rtNestedDst)"/>
+        <outline text="target.set(@workspace.rtNestedDst)"/>
+        <outline text="op.firstSummit()"/>
+        <outline text="local(hasChild = op.go(right, 1))"/>
+        <outline text="return hasChild"/>
       </outline>
     </outline>
   </body>

--- a/tests/headless_menu_stubs.c
+++ b/tests/headless_menu_stubs.c
@@ -591,6 +591,10 @@ boolean menuverbnew (Handle hdata, hdlexternalvariable *hv) {
     (void) hdata; (void) hv; return false;
 }
 
+boolean menuverbcopyvalue (hdlexternalvariable hsource, hdlexternalvariable *hcopy) {
+    (void) hsource; (void) hcopy; return false;
+}
+
 boolean menuverbinmemory_context (const db_context *ctx, hdlexternalvariable hvariable) {
     /*
      * Menu externals are not materialized during headless migration.

--- a/tests/integration/test_cases/menu_value_copy.yaml
+++ b/tests/integration/test_cases/menu_value_copy.yaml
@@ -1,0 +1,104 @@
+# Integration tests for copying/assigning menubar (mbar) type values
+#
+# These tests verify that menubar values can be copied and assigned between
+# ODB locations, which was previously broken in headless mode. The core issue
+# was that assigning an mbar value from one location to another would fail,
+# preventing operations like:
+#   workspace.copy = userland.virginBookmarkMenu
+#
+# Test Strategy:
+#   - Test basic copy of empty menubar
+#   - Verify typeof() and defined() work on copied values
+#   - Test reading userland.virginBookmarkMenu (real ODB value)
+#   - Test copying userland.virginBookmarkMenu (the exact failing operation)
+
+tests:
+  # ==========================================================================
+  # Basic Menubar Value Copy Tests
+  # ==========================================================================
+
+  - name: "mbar copy - copy menubar value to new location"
+    description: "Create a menubar at workspace.src, copy to workspace.dst, verify typeof is mbar"
+    skip: false
+    skip_reason: ""
+    script: |
+      new(menubarType, @workspace.src);
+      workspace.dst = workspace.src;
+      local (result = typeof(workspace.dst) == 'mbar');
+      delete(@workspace.src);
+      delete(@workspace.dst);
+      return result
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # defined() After Copy
+  # ==========================================================================
+
+  - name: "mbar copy - defined() works after copy"
+    description: "Create menubar, copy it, verify defined() returns true on the copy"
+    skip: false
+    skip_reason: ""
+    script: |
+      new(menubarType, @workspace.src);
+      workspace.dst = workspace.src;
+      local (result = defined(@workspace.dst));
+      delete(@workspace.src);
+      delete(@workspace.dst);
+      return result
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # Copy Menubar With Menu Items (requires menu.addMenuCommand, not yet implemented)
+  # ==========================================================================
+
+  - name: "mbar copy - copy menubar with items preserves content"
+    description: "Create menubar with items, copy it, verify the copy has the items via getScript"
+    skip: true
+    skip_reason: "menu.addMenuCommand and related menu editing verbs not implemented in headless"
+    script: |
+      new(menubarType, @workspace.src);
+      menu.addMenuCommand(@workspace.src, "File", "Open", "fileOpen()");
+      workspace.dst = workspace.src;
+      target.set(@workspace.dst);
+      op.firstSummit();
+      op.expand();
+      op.go(right, 1);
+      menu.getScript(@workspace.retrieved);
+      local (result = (workspace.retrieved == "fileOpen()"));
+      delete(@workspace.src);
+      delete(@workspace.dst);
+      try {delete(@workspace.retrieved)};
+      return result
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # Read userland.virginBookmarkMenu
+  # ==========================================================================
+
+  - name: "mbar read - typeof userland.virginBookmarkMenu is mbar"
+    description: "Verify we can access userland.virginBookmarkMenu and its type is mbar"
+    skip: false
+    skip_reason: ""
+    script: |
+      return typeof(userland.virginBookmarkMenu) == 'mbar'
+    expected_success: true
+    expected_result: "true"
+
+  # ==========================================================================
+  # Copy userland.virginBookmarkMenu - The Exact Failing Operation
+  # ==========================================================================
+
+  - name: "mbar copy - copy userland.virginBookmarkMenu to workspace"
+    description: "Copy userland.virginBookmarkMenu to workspace location - this is the exact operation that was failing"
+    skip: false
+    skip_reason: ""
+    script: |
+      workspace.testCopy = userland.virginBookmarkMenu;
+      local (result = typeof(workspace.testCopy) == 'mbar');
+      delete(@workspace.testCopy);
+      return result
+    expected_success: true
+    expected_result: "true"


### PR DESCRIPTION
## Summary

- Add `menuverbcopyvalue()` to handle mbar value copying in headless mode, following the `opverbcopyvalue()` pattern
- Add `idmenuprocessor` case to `langexternalcopyvalue()` switch to use the dedicated copy function instead of falling through to the generic pack/unpack path
- The implementation loads the menu into memory first via `menuverbinmemory()` for proper v6/v7 format detection, then copies from the in-memory outline representation

## Problem

`langexternalcopyvalue()` had no case for `idmenuprocessor`, so mbar copies fell through to the default path which called `langpackvalue()` → failed silently in headless mode without setting a script error message. This caused three operations in `userland.firstRootRun()` to fail:
- `user.menus.bookmarkMenu = userland.virginBookmarkMenu`
- `user.menus.customMenu = userland.virginCustomMenu`
- `webEdit.init()` (internally copies `webEdit.virginServerMenu`)

The failure was uncatchable by `try{}` since it occurred at the C level.

## Test plan

- [x] New integration tests in `menu_value_copy.yaml` (4 pass, 1 skip)
- [x] Manual verification: `workspace.x = userland.virginBookmarkMenu` succeeds
- [x] Manual verification: `workspace.x = userland.virginCustomMenu` succeeds
- [x] Unit tests pass (pre-existing `test_callback_infrastructure` segfault unrelated)
- [x] Stub added to `headless_menu_stubs.c` for `save_migration_tests` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)