### PR TITLE
fix: Raise script errors for realpath failures in window.isOpen

### DIFF
--- a/tests/headless_window_verbs.c
+++ b/tests/headless_window_verbs.c
@@ -24,6 +24,7 @@
 #include "frontier.h"
 #include "standard.h"
 
+#include <errno.h>
 #include <limits.h>
 #include <string.h>
 #include "memory.h"
@@ -146,10 +147,19 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
                 char inputpath[PATH_MAX];
                 pstrtocstr(bspath, inputpath, sizeof(inputpath));
 
-                /* Resolve to absolute path for reliable comparison */
+                /* Resolve to absolute path for reliable comparison.
+                 * If the path doesn't exist or is inaccessible, raise a
+                 * script-level error rather than silently returning false. */
                 char resolvedinput[PATH_MAX];
-                if (realpath(inputpath, resolvedinput) == NULL)
-                    return setbooleanvalue(false, vreturned);
+                if (realpath(inputpath, resolvedinput) == NULL) {
+                    if (errno == ENOENT)
+                        langerrormessage(BIGSTRING("\x27" "Can't check window: file does not exist"));
+                    else if (errno == EACCES)
+                        langerrormessage(BIGSTRING("\x25" "Can't check window: permission denied"));
+                    else
+                        langerrormessage(BIGSTRING("\x25" "Can't check window: invalid file path"));
+                    return false;
+                }
 
                 /* Check system root database file path */
                 if (databasedata != nil) {

--- a/tests/headless_window_verbs.c
+++ b/tests/headless_window_verbs.c
@@ -33,6 +33,7 @@
 #include "langinternal.h"
 #include "tablestructure.h"
 #include "odbinternal.h"
+#include "logging.h"
 
 /* From file_portable.c — declared locally because #include "file.h"
  * pulls in definitions that cause startup crashes in headless mode.
@@ -152,12 +153,32 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
                  * script-level error rather than silently returning false. */
                 char resolvedinput[PATH_MAX];
                 if (realpath(inputpath, resolvedinput) == NULL) {
-                    if (errno == ENOENT)
-                        langerrormessage(BIGSTRING("\x27" "Can't check window: file does not exist"));
-                    else if (errno == EACCES)
-                        langerrormessage(BIGSTRING("\x25" "Can't check window: permission denied"));
-                    else
-                        langerrormessage(BIGSTRING("\x25" "Can't check window: invalid file path"));
+                    int saved_errno = errno;
+
+                    log_debug(LOG_COMP_LANG, "window.isOpen: realpath failed for \"%s\": %s",
+                              inputpath, strerror(saved_errno));
+
+                    bigstring bserrmsg;
+                    bigstring bsinputpath;
+                    copyctopstring(inputpath, bsinputpath);
+
+                    if (saved_errno == ENOENT) {
+                        copystring(BIGSTRING("\x14" "Can't check window \""), bserrmsg);
+                        pushstring(bsinputpath, bserrmsg);
+                        pushstring(BIGSTRING("\x16" "\": file does not exist"), bserrmsg);
+                    }
+                    else if (saved_errno == EACCES) {
+                        copystring(BIGSTRING("\x14" "Can't check window \""), bserrmsg);
+                        pushstring(bsinputpath, bserrmsg);
+                        pushstring(BIGSTRING("\x14" "\": permission denied"), bserrmsg);
+                    }
+                    else {
+                        copystring(BIGSTRING("\x14" "Can't check window \""), bserrmsg);
+                        pushstring(bsinputpath, bserrmsg);
+                        pushstring(BIGSTRING("\x19" "\": path resolution failed"), bserrmsg);
+                    }
+
+                    langerrormessage(bserrmsg);
                     return false;
                 }
 

--- a/tests/integration/test_cases/window_verbs.yaml
+++ b/tests/integration/test_cases/window_verbs.yaml
@@ -43,12 +43,20 @@ tests:
     expected_success: true
     expected_result: "true"
 
-  - name: "window.isOpen - non-existent path returns false"
-    description: "A path to a file that doesn't exist returns false"
+  - name: "window.isOpen - non-existent path raises error"
+    description: "A path to a file that doesn't exist triggers a script error"
     script: |
       return window.isOpen("/tmp/nonexistent_database_12345.root")
+    expected_success: false
+
+  - name: "window.isOpen - non-existent path caught by try"
+    description: "The error from a non-existent path can be caught with try"
+    script: |
+      try {
+        window.isOpen("/tmp/nonexistent_database_12345.root")};
+      return "caught"
     expected_success: true
-    expected_result: "false"
+    expected_result: "caught"
 
   - name: "window.isOpen - opened guest database returns true"
     description: "After opening a guest DB, its path should return true"

--- a/tests/integration/test_cases/window_verbs.yaml
+++ b/tests/integration/test_cases/window_verbs.yaml
@@ -50,13 +50,17 @@ tests:
     expected_success: false
 
   - name: "window.isOpen - non-existent path caught by try"
-    description: "The error from a non-existent path can be caught with try"
+    description: "The error from a non-existent path can be caught with try and includes the path"
     script: |
       try {
-        window.isOpen("/tmp/nonexistent_database_12345.root")};
-      return "caught"
+        window.isOpen("/tmp/nonexistent_database_12345.root")
+      } else {
+        if tryError contains "/tmp/nonexistent_database_12345.root" {
+          return "caught with path"};
+        return tryError};
+      return "no error"
     expected_success: true
-    expected_result: "caught"
+    expected_result: "caught with path"
 
   - name: "window.isOpen - opened guest database returns true"
     description: "After opening a guest DB, its path should return true"


### PR DESCRIPTION
## Summary

- When window.isOpen() receives a string file path that cannot be resolved by realpath(), raise a script-level error instead of silently returning false
- Distinguishes three error cases: file not found (ENOENT), permission denied (EACCES), and other path errors
- Errors are catchable with try/catch in UserTalk, so callers can handle them gracefully

## Motivation

Follow-up to #398. The bot review suggested that realpath() failures should produce meaningful errors rather than silently returning false, which could mask bugs where a caller passes a mistyped path and gets false (interpreted as not open) instead of an error.

## Test plan

- [x] Existing window.isOpen tests still pass (10/10)
- [x] New test: non-existent path now raises a script error
- [x] New test: error is catchable with try
- [x] Unit tests show no regressions

Generated with [Claude Code](https://claude.com/claude-code)