### PR TITLE
docs: centralize shared AI workflow guidance

### DIFF
--- a/.claude/agents/frontier-sdet.md
+++ b/.claude/agents/frontier-sdet.md
@@ -25,6 +25,8 @@ color: cyan
 
 You are a senior Software Development Engineer in Test (SDET) with 10 years of experience specializing in the Frontier runtime and UserTalk scripting language. Your expertise encompasses both deep technical knowledge of the Frontier codebase and comprehensive understanding of how users interact with the system.
 
+Cross-agent baseline policy (worktree/branch discipline, required test policy, logging rules, UserTalk parser constraints, issue hygiene) lives in `docs/AI_SHARED_GUIDELINES.md` and applies here.
+
 ## Your Core Responsibilities
 
 You design, implement, and maintain automated test frameworks and test suites that validate expected behavior, test boundary cases, and uncover edge cases. Your tests harden the application against unexpected behaviors and failures. You have a special talent for thinking like both a developer and a user, allowing you to identify scenarios that others might miss.
@@ -91,28 +93,10 @@ void test_replaceAll_empty_replacement() {
 
 ### UserTalk Integration Test Constraints (CRITICAL)
 
-When writing integration tests in UserTalk (YAML test cases):
-
-1. **NO Inline Comments Inside Code Blocks**
-   - ❌ WRONG: `if true { // comment inside block`
-   - ❌ WRONG: `on handler() { // comment`
-   - ✅ CORRECT: Place all // comments OUTSIDE blocks (before `if`, `on`, `try`, etc.)
-   - **Why**: The UserTalk parser does not support inline // comments inside `{ }` blocks
-   - **Pattern**: Use compact formatting without comments inside blocks
-
-2. **Blank Lines Must Match Indentation Level**
-   - ❌ WRONG: Blank line with zero indentation inside an indented block
-   - ✅ CORRECT: Blank lines must have same indentation as surrounding code
-   - ✅ SIMPLEST: Avoid blank lines inside blocks entirely (use compact formatting)
-   - **Why**: The parser expects consistent indentation even for blank lines
-   - **Best Practice**: UserTalk code is typically compact without blank lines for visual separation
-
-3. **Test Data Isolation - Use system.temp, NEVER system table**
-   - ❌ WRONG: `system.verbs.tcp.test.foo = "bar"` (modifies system table!)
-   - ✅ CORRECT: `new(tableType, @system.temp.tcpTest); system.temp.tcpTest.foo = "bar"`
-   - **Cleanup**: Always `delete(@system.temp.tcpTest)` at end of test
-   - **Why**: The system table is OFF LIMITS for modification by test/application code
-   - **Pattern**: Create temporary tables in system.temp.* namespace, clean up when done
+Follow the canonical constraints in `docs/AI_SHARED_GUIDELINES.md`:
+- no inline comments inside UserTalk code blocks,
+- consistent indentation behavior in blocks,
+- isolation under `system.temp.*` with explicit cleanup.
 
 **Example of Correct UserTalk Test Structure:**
 ```yaml
@@ -184,7 +168,7 @@ All error messages in tests should follow Frontier conventions:
 
 ## Logging in Tests
 
-Follow logging standards from CLAUDE.md:
+Follow logging standards from `docs/AI_SHARED_GUIDELINES.md` and implementation details in `docs/LOGGING_STANDARDS.md`:
 - Use structured logging macros (log_error, log_warn, log_debug, log_trace)
 - Never use fprintf(stderr) - always use appropriate log_* macro
 - Choose correct component (LOG_COMP_DB, LOG_COMP_HASH, LOG_COMP_TABLE, etc.)

--- a/.claude/agents/issue-writer.md
+++ b/.claude/agents/issue-writer.md
@@ -55,6 +55,8 @@ Architectural improvements need careful documentation with rationale, scope, and
 
 You are an expert GitHub issue writer specializing in creating clear, actionable, and well-structured issues that follow established project standards. Your role is to transform bug reports, feature requests, technical debt, and improvement suggestions into comprehensive GitHub issues that provide everything a developer needs to understand and address the problem.
 
+Cross-agent baseline policy (including PII sanitization and shared priority semantics) is defined in `docs/AI_SHARED_GUIDELINES.md` and applies here.
+
 ## Core Responsibilities
 
 1. **Create Structured Issues**: Every issue you create must include:
@@ -66,7 +68,7 @@ You are an expert GitHub issue writer specializing in creating clear, actionable
    - Proper labeling following the project's labeling strategy
 
 2. **Apply Proper Labels**: You must label issues according to `planning/labeling-strategy-proposal.md`:
-   - **Priority labels** (priority/p0 through priority/p3): Assess urgency and impact
+   - **Priority labels** (`P0`, `P1`, `P2`): Assess urgency and impact using the shared ladder in `docs/AI_SHARED_GUIDELINES.md`
    - **Workstream labels**: Identify the area of work (e.g., workstream/database, workstream/usertalk-runtime)
    - **Type labels**: Classify the issue (bug, enhancement, tech-debt, documentation, etc.)
    - **Scope labels**: Define the breadth of work (scope/small, scope/medium, scope/large)
@@ -91,16 +93,7 @@ You are an expert GitHub issue writer specializing in creating clear, actionable
    - For tech debt: "Refactoring is done when [specific metric] is achieved"
    - Make criteria objective and verifiable
 
-6. **PII Sanitization**: Before creating any GitHub issue, remove or sanitize all Personally Identifiable Information (PII):
-   - **Local directory paths**: Replace absolute paths with project-relative paths or generic placeholders
-     - ❌ BAD: `/Users/jake/dev/jsavin/Frontier/Common/source/db.c`
-     - ✅ GOOD: `Common/source/db.c`
-     - ✅ GOOD: `$PROJECT_ROOT/Common/source/db.c`
-   - **Usernames**: Remove or replace with generic identifiers when not relevant
-   - **Machine names**: Sanitize hostnames, computer names, or network identifiers
-   - **Email addresses**: Remove unless explicitly relevant to the issue
-   - **API keys/tokens**: Never include any credentials or secrets
-   - Apply this sanitization to error messages, stack traces, and code snippets
+6. **PII Sanitization**: Before creating any GitHub issue, apply the sanitization rules in `docs/AI_SHARED_GUIDELINES.md` and remove all sensitive identifiers from paths, logs, stack traces, and snippets.
 
 ## Issue Template Structure
 
@@ -133,10 +126,9 @@ Use this structure for all issues:
 ## Label Selection Guidelines
 
 **Priority Assessment**:
-- **p0**: Blocks release, data corruption, security issues
-- **p1**: Major functionality broken, significant user impact
-- **p2**: Important but not blocking, workarounds exist
-- **p3**: Nice to have, minor improvements
+- **P0**: Must-do-first / launch-blocking (data corruption, security, release blockers)
+- **P1**: Pre-production critical with significant user/runtime impact
+- **P2**: Future or nice-to-have improvements where workarounds exist
 
 **Workstream Selection**:
 - Align with existing workstreams when possible

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 # Repository Guidelines
 
+<!-- 2026-02-10 Codex: Split shared cross-agent policy into docs/AI_SHARED_GUIDELINES.md and trimmed Codex-specific guidance. -->
 <!-- 2025-11-08 Codex: Clarified planning backlog workflow (ADRs/issues) and priority usage. -->
 
 This document is a concise contributor guide for Frontier’s C/C toolchain and test harness. Use it to navigate the repo, build locally, and submit focused changes that keep tests green.
+
+## Shared Guidelines (Cross-Agent Source of Truth)
+- Read and follow `docs/AI_SHARED_GUIDELINES.md` before starting work.
+- `docs/AI_SHARED_GUIDELINES.md` is authoritative for policies shared across Codex/Claude and related automation.
+- If this file conflicts with `docs/AI_SHARED_GUIDELINES.md` on a cross-agent rule, follow `docs/AI_SHARED_GUIDELINES.md`.
 
 ## TBD Decisions (to revisit later)
 - Windows/Linux build paths and toolchains (MSVC/CMake/GNU) — TBD.
@@ -78,10 +84,8 @@ This document is a concise contributor guide for Frontier’s C/C toolchain and 
 - Do not reformat unrelated files; avoid editing generated `build_*` outputs.
 - When adding files, mirror existing naming and include patterns.
 - Always use built-in shell-based tools for debugging on-disk files and formats instead of writing your own code to parse the file. Only write code for this purpose if built-in shell-based utilities are unavailable, and only after asking the user first to install the tool(s) you need.
-- Frontier logging is reliable in headless builds now—exhaust the existing `[headless]`/`[wp-plain]` instrumentation or add lightweight stderr logs before reaching for LLDB. Keep the tmux/LLDB workflow as a fallback, not the default.
 - When new technical details surface (format quirks, runtime behavior, etc.), document them immediately in the most relevant markdown reference (e.g., `docs/database_architecture.md`) so future sessions can pick up the thread quickly.
 - Before writing any dated comments or doc updates, double-check the system clock to avoid stale timestamps.
-- During v6→v7 migrations only three external types may be copied verbatim: `binaryType`, `PICT`, and (when encountered) `CARD`. Every other non-scalar (menus, outlines, scripts, WPTexts, tables, etc.) must be fully decoded and reserialized so bugs are not masked by opaque blobs.
 - Treat the kernel↔UserTalk bridge doc (`planning/phase3/carbon_migration/kernel_userTalk_bridge.md`) as canonical for token/search-path behavior; consult/update it whenever you learn new details about runtime dispatch or table hydration.
 - Before archiving or mass-moving documents, verify each file’s status block. Only move docs whose `State` is `Completed`, `Done`, or `Deprecated`; if the status indicates ongoing work, leave it in place (or restore it) so in-flight plans stay editable.
 - When touching the database migrator, remember the current implementation only updates the header; ensure follow-up work reserializes tables so migrated roots become fully 64-bit.
@@ -93,12 +97,9 @@ This document is a concise contributor guide for Frontier’s C/C toolchain and 
 - When starting a new session, ask the user if you should try to pick up from where the previous session ended. If the user says so, you can either do what the user asks, or propose the following: 1) check the `README.md`, planning docs (in the planning directory), 2) review recent commits to understand where we're at in the project, 3) read `planning/_CURRENT_STATUS.md` to pick up context from the most recent sessions.
 - If the user or Codex PR Bot says follow-up fixes are already being handled, stop and confirm before making new changes—avoid duplicating or racing their work.
 - In general, avoid creating or maintaining shims that potentially mask underlying issues unless specifically asked to do so by the user.
-- Always run tests before pushing PRs to origin. If you encounter new or unexpected test failures, stop and ask the user what to do.
 - Whenever making changes to code, make sure to summarize the change with a dated comment near the top of the file, attributed to Codex.
 - Frontier’s database allocator (headers/trailers, variance fields, avail list merging) follows the Boundary Tag Method from Knuth’s *The Art of Computer Programming* (per Dave Winer); keep that lineage in mind when debugging allocation logic or documenting format quirks.
 - Track all future ADR-style decisions and upcoming issues inside `planning/TODO_future_improvements.md`; do not recreate `planning/adr` or `planning/issues`.
-- Use the shared priority ladder defined there: `P0` (must / do first), `P1` (pre-prod critical), `P2` (future/nice-to-have). Mirror those labels when filing GitHub issues or internal notes so urgency stays consistent across tools.
-- After every turn, update `planning/_CURRENT_STATUS.md` with the latest status summary and explicit next steps so the next session can resume immediately.
 - When migrating or saving non-scalar data (outlines, WPTexts, menus, scripts, tables, etc.) in v7+, strip cursor/window/font/UI metadata entirely; zero those fields and plan to store per-user preferences elsewhere so headless builds stay multi-user safe.
 - Prefer evidence over inference when interpreting identifiers or historical formats. If a name looks familiar (e.g., “WS” or “Word”), confirm its meaning via code/docs/logs before pursuing a theory to avoid chasing unrelated artifacts.
 - For modern BE64 paths, avoid format forks inside shared functions: fork legacy vs modern logic into separate functions/files so the modern code stays branch-free and clean; keep legacy-only code isolated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Frontier Development Guide
 
+## Shared Guidelines (Cross-Agent Source of Truth)
+
+- Read and follow `docs/AI_SHARED_GUIDELINES.md` before starting work.
+- `docs/AI_SHARED_GUIDELINES.md` is authoritative for cross-agent policy (branch/worktree discipline, test requirements, logging policy, UserTalk test constraints, issue hygiene, and shared priority usage).
+- If this file conflicts with `docs/AI_SHARED_GUIDELINES.md` on a cross-agent rule, follow `docs/AI_SHARED_GUIDELINES.md`.
+
 ## Technical Decision-Making Principles
 
 **Default to proper, maintainable, long-term solutions.** Quick fixes accumulate as technical debt that becomes costly to unwind. Unless the user explicitly requests a quick fix for time constraints, recommend the approach that solves the problem correctly rather than suppressing symptoms.
@@ -79,26 +85,10 @@ Use `$(./tools/get_test_temp_path.sh)` for manual testing paths.
 
 ---
 
-## ⚠️ MANDATORY: Pre-Work Location Verification
+## Pre-Work Verification
 
-**STOP AND VERIFY** before starting any work:
-
-```bash
-pwd && git branch --show-current
-```
-
-**Quick Decision**:
-- ✅ **Trivial work** (typo, single-line fix, quick doc update) → OK on develop
-- ❌ **Non-trivial work** (feature, bug fix, multi-file change) → MUST create worktree
-
-**If non-trivial AND on develop**:
-```bash
-cd /Users/jake/dev/jsavin/Frontier
-git worktree add ../Frontier-<feature-name> -b feature/<feature-name>
-cd ../Frontier-<feature-name>
-```
-
-**If committing**: Verify branch is `feature/*` in worktree, never `git push origin develop` directly.
+Cross-agent pre-work checks and branch/worktree policy now live in `docs/AI_SHARED_GUIDELINES.md`.
+Follow that file before starting non-trivial work.
 
 ---
 
@@ -200,34 +190,17 @@ Agents must verify fixes work end-to-end, not just fix one piece. Test the compl
 
 ---
 
-## UserTalk Critical Facts ⚠️
+## UserTalk Critical Facts
 
-**The Big Three Gotchas:**
-
-1. **Double quotes for strings** - `"hello"` not `'hello'` (opposite of JS/Python)
-2. **typeof() returns OSType codes** - `'TEXT'` not `"string"` - **NEVER CHANGE THIS**
-3. **Absolute paths required** - No cwd awareness, all file/db verbs need full paths
-
-**When writing UserTalk code:**
-- Syntax reference → `docs/usertalk/SYNTAX.md`
-- File/DB operations → `docs/usertalk/FILE_AND_DB.md`
-- Test patterns → `docs/TESTING_GUIDE.md`
-
-**Historical landmine:** typeof() was almost changed to return strings in Jan 2026 - would have broken all production code. Full history in `docs/usertalk/TYPEOF.md`.
+Cross-agent UserTalk invariants and integration-test parser constraints now live in `docs/AI_SHARED_GUIDELINES.md`.
+Use those rules as mandatory baseline guidance.
 
 ---
 
-## Critical Testing Constraints ⚠️
+## Critical Testing Constraints
 
-### Verb Testing Requirements
-
-PRs implementing new verbs or modifying verb functionality **MUST include integration tests**.
-
-- Tests in `tests/integration/test_cases/` (YAML format)
-- Cover happy path, edge cases, and error conditions
-- Tests must PASS before merge
-
-**Full details:** See `docs/TESTING_GUIDE.md`
+Cross-agent test requirements (including integration test expectations for verb changes) now live in `docs/AI_SHARED_GUIDELINES.md`.
+For Frontier-specific test patterns and command details, also see `docs/TESTING_GUIDE.md`.
 
 ---
 
@@ -266,15 +239,10 @@ PRs implementing new verbs or modifying verb functionality **MUST include integr
 
 ---
 
-## Logging Standards ⚠️
+## Logging Standards
 
-All debug and diagnostic output must use structured logging macros - **never use `fprintf(stderr, ...)`**.
-
-- ❌ NEVER: `fprintf(stderr, "message\n")`
-- ✅ ALWAYS: `log_trace(LOG_COMP_DB, "message")` or `log_error()`, `log_debug()`, etc.
-- ✅ EXCEPTION: `fputs()` for user-facing terminal output (not diagnostic logging)
-
-**Full details:** See `docs/LOGGING_STANDARDS.md`
+Cross-agent logging policy is defined in `docs/AI_SHARED_GUIDELINES.md`.
+Implementation-level logging details remain in `docs/LOGGING_STANDARDS.md`.
 
 ---
 

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -26,7 +26,8 @@ pwd && git branch --show-current && git status --short
 Recommended setup:
 
 ```bash
-cd /Users/jake/dev/jsavin/Frontier
+# Example (adjust to your local clone root):
+cd "${PROJECT_ROOT:-/path/to/Frontier}"
 git worktree add ../Frontier-<feature-name> -b feature/<feature-name>
 cd ../Frontier-<feature-name>
 ```

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -1,0 +1,93 @@
+# AI Shared Guidelines (Cross-Agent)
+
+Last Updated: 2026-02-10
+
+This file is the source of truth for cross-agent workflow and engineering policy shared by Codex, Claude Code, and related automation agents in this repository.
+
+## Scope and Priority
+
+- Use this document for repository-level engineering rules that apply regardless of agent tooling.
+- Keep agent-runtime specifics in `AGENTS.md` (Codex) and `CLAUDE.md` (Claude Code).
+- If a cross-agent policy in another file conflicts with this one, this file wins.
+
+## Pre-Work Verification and Branch Discipline
+
+Before non-trivial work:
+
+```bash
+pwd && git branch --show-current && git status --short
+```
+
+- Trivial work (single-line typo/docs fix) may proceed on `develop`.
+- Non-trivial work (feature, bug fix, multi-file edits) must use a dedicated branch and worktree.
+- Never push directly to `origin/develop`.
+- If your runtime requires a branch naming prefix, apply it while preserving a feature/fix semantic name.
+
+Recommended setup:
+
+```bash
+cd /Users/jake/dev/jsavin/Frontier
+git worktree add ../Frontier-<feature-name> -b feature/<feature-name>
+cd ../Frontier-<feature-name>
+```
+
+## Required Test and Validation Policy
+
+Run relevant tests before opening or updating a PR. For runtime/verb/database work, prefer full validation:
+
+```bash
+./tools/run_headless_tests.sh
+cd tests && make test-integration
+cd tests && make test-all
+SANITIZE=1 make -C tests
+```
+
+Minimum expectations:
+
+- New or modified behavior is covered by tests.
+- Verb behavior changes include integration tests in `tests/integration/test_cases/`.
+- Tests should be deterministic and avoid unnecessary filesystem/network side effects.
+
+## Logging and Diagnostics Policy
+
+- Use Frontier structured logging for diagnostics (`log_trace`, `log_debug`, `log_info`, `log_warn`, `log_error`).
+- Do not use ad hoc `fprintf(stderr, ...)` for diagnostic logging.
+- User-facing terminal output may use `fputs` when appropriate.
+
+## UserTalk and Integration Test Constraints
+
+### UserTalk runtime facts
+
+1. Strings use double quotes (`"text"`).
+2. `typeof()` returns OSType codes (for example `'TEXT'`) and must not be changed to return descriptive strings.
+3. File/database verb operations require absolute paths.
+
+### UserTalk integration YAML constraints
+
+- Do not place inline `//` comments inside UserTalk `{ ... }` blocks.
+- Keep indentation consistent inside blocks; avoid stray blank lines with mismatched indentation.
+- Isolate test state under `system.temp.*`, never by mutating `system.*` tables directly.
+- Always clean up temporary test objects (for example `delete(@system.temp.someTestTable)`).
+
+## Migration and Data-Safety Invariants
+
+- During v6 -> v7 migrations, only `binaryType`, `PICT`, and `CARD` may be copied verbatim.
+- All other non-scalars must be decoded and reserialized.
+- For v7+ non-scalar saves/migrations (outlines, WPText, menus, scripts, tables, etc.), strip UI metadata (cursor/window/font/UI fields).
+
+## Issue/PR Hygiene and Priority
+
+- Sanitize PII before creating issues/PR descriptions: absolute local paths, usernames, hostnames, emails, tokens, secrets.
+- Prefer repository-relative or `$PROJECT_ROOT/...` paths in public issue text.
+- Use shared priority labels consistently:
+  - `P0`: must do first / launch-blocking
+  - `P1`: pre-production critical
+  - `P2`: future / nice-to-have
+
+## Knowledge Capture and Status Updates
+
+When technical behavior or format details become clearer:
+
+- Update the most relevant long-lived reference docs (for example `docs/database_architecture.md`, phase planning docs, or ADRs).
+- Track future ADR-style decisions and upcoming issues in `planning/TODO_future_improvements.md`.
+- Update `planning/_CURRENT_STATUS.md` with latest status and explicit next steps so future sessions can resume quickly.

--- a/planning/_CURRENT_STATUS.md
+++ b/planning/_CURRENT_STATUS.md
@@ -16,6 +16,10 @@ Last Updated: 2026-02-10
 2. Audit remaining `.claude/agents/*.md` files and replace any duplicated global policy blocks with shared-file references.
 3. Keep branch/worktree, testing, logging, UserTalk constraints, and issue-hygiene updates centralized in `docs/AI_SHARED_GUIDELINES.md`.
 
+### Follow-up (2026-02-10, bot review response)
+- Generalized the shared guideline worktree example to avoid hardcoded local absolute paths.
+- Made `tools/check_ai_guidelines_refs.sh` portable by falling back to `grep` when `rg` is unavailable.
+
 **Status**: Guest database lifecycle (fileMenu verbs) fully operational in headless mode. Four database corruption bugs fixed. Startup scripts working. Menu system stabilized. GUI application planning complete. Compiler warnings eliminated.
 
 **Latest Release**: **v1.0.0-alpha.4** (January 31, 2026)

--- a/planning/_CURRENT_STATUS.md
+++ b/planning/_CURRENT_STATUS.md
@@ -1,8 +1,20 @@
 # Current Status
 
-Last Updated: 2026-02-07
+Last Updated: 2026-02-10
 
 ## Current Focus: Guest Database Lifecycle, Menu System & GUI Planning
+
+## Session Update (2026-02-10)
+
+- Created `docs/AI_SHARED_GUIDELINES.md` as the shared policy baseline for Codex/Claude and automation.
+- Updated `AGENTS.md` and `CLAUDE.md` to reference the shared file as cross-agent source of truth.
+- Trimmed duplicated cross-agent policy in `.claude/agents/frontier-sdet.md` and `.claude/agents/issue-writer.md`.
+- Added `tools/check_ai_guidelines_refs.sh` to verify both top-level agent files reference shared guidelines.
+
+### Explicit Next Steps
+1. Run `tools/check_ai_guidelines_refs.sh` in CI or pre-PR validation to prevent drift.
+2. Audit remaining `.claude/agents/*.md` files and replace any duplicated global policy blocks with shared-file references.
+3. Keep branch/worktree, testing, logging, UserTalk constraints, and issue-hygiene updates centralized in `docs/AI_SHARED_GUIDELINES.md`.
 
 **Status**: Guest database lifecycle (fileMenu verbs) fully operational in headless mode. Four database corruption bugs fixed. Startup scripts working. Menu system stabilized. GUI application planning complete. Compiler warnings eliminated.
 

--- a/tools/check_ai_guidelines_refs.sh
+++ b/tools/check_ai_guidelines_refs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# 2026-02-10 Codex: Added guard to keep CLAUDE.md and AGENTS.md linked to shared AI guidelines.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SHARED_REF="docs/AI_SHARED_GUIDELINES.md"
+
+missing=0
+for file in "${ROOT_DIR}/AGENTS.md" "${ROOT_DIR}/CLAUDE.md"; do
+    if ! rg -q "${SHARED_REF}" "${file}"; then
+        echo "missing shared-guidelines reference: ${file}" >&2
+        missing=1
+    fi
+done
+
+if [ "${missing}" -ne 0 ]; then
+    echo "check failed: both AGENTS.md and CLAUDE.md must reference ${SHARED_REF}" >&2
+    exit 1
+fi
+
+echo "ok: AGENTS.md and CLAUDE.md both reference ${SHARED_REF}"

--- a/tools/check_ai_guidelines_refs.sh
+++ b/tools/check_ai_guidelines_refs.sh
@@ -6,9 +6,19 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SHARED_REF="docs/AI_SHARED_GUIDELINES.md"
 
+has_ref() {
+    local pattern="$1"
+    local file="$2"
+    if command -v rg >/dev/null 2>&1; then
+        rg -q "${pattern}" "${file}"
+    else
+        grep -qF "${pattern}" "${file}"
+    fi
+}
+
 missing=0
 for file in "${ROOT_DIR}/AGENTS.md" "${ROOT_DIR}/CLAUDE.md"; do
-    if ! rg -q "${SHARED_REF}" "${file}"; then
+    if ! has_ref "${SHARED_REF}" "${file}"; then
         echo "missing shared-guidelines reference: ${file}" >&2
         missing=1
     fi


### PR DESCRIPTION
## Summary of changes
- Added `docs/AI_SHARED_GUIDELINES.md` as the cross-agent source of truth for shared policy (worktree/branch discipline, test expectations, logging policy, UserTalk integration constraints, migration invariants, issue hygiene, and priority usage).
- Updated `AGENTS.md` and `CLAUDE.md` to reference the shared guidelines and trimmed duplicate cross-agent policy text.
- Updated `.claude/agents/frontier-sdet.md` and `.claude/agents/issue-writer.md` to defer shared policy details to the shared guidelines file.
- Added `tools/check_ai_guidelines_refs.sh` to enforce that both top-level agent docs keep referencing the shared source.
- Updated `planning/_CURRENT_STATUS.md` with a session summary and explicit next steps.

## So what
- Reduces drift between Codex and Claude policy docs while preserving agent-specific instructions.
- Makes shared behavior maintainable in one place instead of duplicated sections across multiple files.
- Adds a lightweight guardrail to prevent accidental desynchronization of top-level guidance docs.

## Next steps
- Optionally wire `tools/check_ai_guidelines_refs.sh` into CI or pre-PR validation.
- Continue auditing remaining `.claude/agents/*.md` files for duplicated global policy blocks and replace with shared-doc references where appropriate.

## Validation
- Ran: `tools/check_ai_guidelines_refs.sh`
- Ran: `bash -n tools/check_ai_guidelines_refs.sh`
