### PR TITLE
fix: Materialize all external types during guest DB loading

### DIFF
--- a/Common/headers/langexternal.h
+++ b/Common/headers/langexternal.h
@@ -232,6 +232,8 @@ extern boolean langexternalunpack (Handle, hdlexternalhandle *);
 struct db_context; /* forward declaration */
 extern boolean langexternalpack_internal (const struct db_context *, hdlexternalhandle, Handle *, boolean *);
 
+extern boolean ensure_external_in_memory (const struct db_context *, hdlexternalvariable);
+
 /* Legacy (32-bit) pack/unpack shims used during migration. */
 extern boolean langexternalpack_legacy (hdlexternalhandle, Handle *, boolean *);
 extern boolean langexternalunpack_legacy (Handle, hdlexternalhandle *);

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -912,7 +912,7 @@ boolean langexternalsetdirty (hdlexternalhandle h, boolean fldirty) {
 	} /*langexternalsetdirty*/
 
 
-static boolean ensure_external_in_memory (const db_context *ctx, hdlexternalvariable hv) {
+boolean ensure_external_in_memory (const db_context *ctx, hdlexternalvariable hv) {
 
 	/*
 	2025-12-20: Type-specific external loading dispatcher with explicit context

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -407,9 +407,29 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 			langhash_materialize_current_path = prior_path;
 			return ok;
 		}
-		default:
+		default: {
+			/* Materialize all other external types (scripts, outlines, menus, pictures, etc.)
+			 * using the comprehensive loader from langexternal.c */
+			if (log_enabled(LOG_LEVEL_TRACE, LOG_COMP_HASH)) {
+				log_trace(LOG_COMP_HASH, "materialize external path=%s id=%d",
+						path ? path : "<nil>", (int)(**hv).id);
+			}
+			db_context ctx;
+			if (db_format_is_legacy_db((**hv).hdatabase)) {
+				db_context_init_legacy_read(&ctx, (**hv).hdatabase);
+			} else {
+				db_context_init(&ctx);
+				ctx.database = (**hv).hdatabase;
+			}
+			if (!ensure_external_in_memory(&ctx, hv)) {
+				log_error(LOG_COMP_HASH, "materialize external load failed path=%s id=%d",
+						path ? path : "<nil>", (int)(**hv).id);
+				langhash_materialize_current_path = prior_path;
+				return false;
+			}
 			langhash_materialize_current_path = prior_path;
 			return true;
+		}
 	}
 }
 

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -1144,7 +1144,6 @@ boolean meloadmenurecord_internal (const db_context *ctx, dbaddress adr,
 
 	if (!meloadoutline_internal (ctx, outline_adr, &houtline)) {
 #if defined(FRONTIER_HEADLESS)
-		/* Expected in headless mode - menus are intentionally deferred */
 		log_debug(LOG_COMP_OP, "meloadmenurecord_internal: meloadoutline_internal FAILED");
 #endif
 		return (false);

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -192,7 +192,6 @@ boolean menuverbinmemory_context (const db_context *ctx, hdlexternalvariable hva
 	fl = meloadmenurecord_internal(ctx, adr, &hmenurecord);
 
 	if (!fl) {
-		/* Expected in headless mode - menus are intentionally deferred */
 		log_debug(LOG_COMP_OP, "menuverbinmemory_context: meloadmenurecord_internal FAILED adr=0x%llx",
 		        (unsigned long long)adr);
 		return (false);

--- a/tests/headless_menu_stubs.c
+++ b/tests/headless_menu_stubs.c
@@ -353,9 +353,6 @@ boolean meloadoutline_internal (const db_context *ctx, dbaddress adr,
         log_debug(LOG_COMP_OP, "meloadoutline_internal: created new outline fl=%d", (int)fl);
     }
     else {
-        /* These are debug messages, not errors - menu loading in headless mode
-         * is expected to be deferred or skipped entirely. Failures here are
-         * normal and handled gracefully. */
         log_debug(LOG_COMP_OP, "meloadoutline_internal: reading adr=0x%llx ctx_db=%p global_db=%p",
                 (unsigned long long)adr, (void*)(ctx ? ctx->database : nil), (void*)databasedata);
 
@@ -366,8 +363,6 @@ boolean meloadoutline_internal (const db_context *ctx, dbaddress adr,
         }
 
         if (!fl) {
-            /* Database read failed - leave *houtline as nil. This is expected
-             * in headless mode where menus are intentionally deferred. */
             log_debug(LOG_COMP_OP, "meloadoutline_internal: dbrefhandle FAILED adr=0x%llx", (unsigned long long)adr);
             oppopoutline ();
             return (false);


### PR DESCRIPTION
## Summary

- Fixed a bug where non-table/non-wp external types (scripts, outlines, menus, pictures) were silently skipped during database materialization, causing `opverbinmemory opunpack failed` errors at runtime
- Replaced the `default: return true` no-op in `langhash_materialize_external()` with a call to `ensure_external_in_memory()`, which already handles all external types correctly
- Exposed `ensure_external_in_memory()` from `langexternal.c` (removed `static`, added header declaration)

## Test plan

- [x] Unit tests: all passed
- [x] Integration tests: 1660/1866 passed, 174 skipped, 32 failed (all pre-existing, unrelated to this change)
- [ ] Verify guest database scripts/outlines/menus/pictures load without `opunpack` errors after materialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)