### PR TITLE
feat: Per-component log levels via FRONTIER_LOG and --log

### DIFF
--- a/Common/headers/logging.h
+++ b/Common/headers/logging.h
@@ -8,15 +8,21 @@
 /*
  * Logging Infrastructure
  *
- * Provides runtime-controlled logging with per-component filtering.
- * Configure via environment variables:
- *   FRONTIER_LOG_LEVEL=error|warn|info|debug|trace (default: warn)
- *   FRONTIER_LOG_COMPONENT=db,hash,table,... (default: all)
- *   FRONTIER_LOG_FORMAT=text|json (default: text)
+ * Provides runtime-controlled logging with per-component filtering and levels.
  *
- * Example:
+ * Configuration (highest to lowest precedence):
+ *   1. FRONTIER_LOG=comp:level,comp:level,...  (unified, per-component levels)
+ *   2. --log CLI argument                      (same syntax, merged with env)
+ *   3. FRONTIER_LOG_LEVEL + FRONTIER_LOG_COMPONENT (legacy, still works)
+ *
+ * FRONTIER_LOG examples:
+ *   FRONTIER_LOG=db:trace,lang:warn ./frontier-cli -e "..."
+ *   FRONTIER_LOG=debug ./frontier-cli -e "..."        # global level shorthand
+ *   FRONTIER_LOG=db,hash:trace ./frontier-cli -e "..."  # db=global default, hash=trace
+ *
+ * Legacy (used when FRONTIER_LOG is not set):
  *   FRONTIER_LOG_LEVEL=debug FRONTIER_LOG_COMPONENT=db ./frontier-cli -e "..."
- *   FRONTIER_LOG_FORMAT=json FRONTIER_LOG_LEVEL=debug ./frontier-cli -e "..."
+ *   FRONTIER_LOG_FORMAT=text|json (default: text)
  */
 
 // ============================================================================
@@ -84,8 +90,22 @@ void log_set_suppressed(bool suppressed);
 void log_set_component_enabled(log_component_t component, bool enabled);
 
 /**
+ * Set the log level for a specific component.
+ * When set, overrides the global log level for that component.
+ */
+void log_set_component_level(log_component_t component, log_level_t level);
+
+/**
+ * Parse a unified log spec string.
+ * Format: "comp:level,comp:level,..." or just "level" for global.
+ * Component without level uses the current global default.
+ * Example: "db:trace,lang:warn,hash" or "debug"
+ */
+void log_parse_spec(const char *spec);
+
+/**
  * Check if a specific level/component is enabled.
- * Used internally by macros; can also be used for conditional expensive operations.
+ * Uses per-component level if set, otherwise global level.
  */
 bool log_is_enabled(log_level_t level, log_component_t component);
 

--- a/Common/source/logging.c
+++ b/Common/source/logging.c
@@ -28,6 +28,8 @@ typedef enum {
 
 static log_level_t g_log_level = LOG_LEVEL_WARN;  // Default: warnings and errors
 static bool g_component_enabled[LOG_COMP_COUNT];  // Per-component enable flags
+static log_level_t g_component_level[LOG_COMP_COUNT];  // Per-component level override
+static bool g_component_level_set[LOG_COMP_COUNT];      // Whether per-component level was explicitly set
 static bool g_initialized = false;
 static log_format_t g_log_format = LOG_FORMAT_TEXT;  // Default: plain text
 static bool g_log_suppressed = false;  // Suppress all output (for JSON mode)
@@ -170,29 +172,134 @@ static void parse_components(const char *str) {
 // Public API Implementation
 // ============================================================================
 
+/**
+ * Check if a string looks like a bare level name (no colons, matches a level).
+ * Returns true if str is a recognized level name.
+ */
+static bool is_bare_level(const char *str) {
+    if (!str) return false;
+    return (strcasecmp(str, "error") == 0 ||
+            strcasecmp(str, "warn") == 0 ||
+            strcasecmp(str, "info") == 0 ||
+            strcasecmp(str, "debug") == 0 ||
+            strcasecmp(str, "trace") == 0);
+}
+
+void log_parse_spec(const char *spec) {
+    if (!spec || !spec[0]) return;
+    if (!g_initialized) log_init();
+
+    char *str_copy = strdup(spec);
+    if (!str_copy) return;
+
+    // Check if this is a bare global level (no commas, no colons)
+    if (!strchr(str_copy, ',') && !strchr(str_copy, ':') && is_bare_level(str_copy)) {
+        g_log_level = parse_log_level(str_copy);
+        // Enable all components (except migration) since user set a global level
+        for (int i = 0; i < LOG_COMP_COUNT; i++) {
+            g_component_enabled[i] = (i != LOG_COMP_MIGRATION);
+        }
+        free(str_copy);
+        return;
+    }
+
+    // Per-component spec: start with all disabled, then enable mentioned components
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        g_component_enabled[i] = false;
+        g_component_level_set[i] = false;
+    }
+
+    char *saveptr = NULL;
+    char *token = strtok_r(str_copy, ",", &saveptr);
+    while (token) {
+        // Trim whitespace
+        while (*token == ' ' || *token == '\t') token++;
+        char *end = token + strlen(token) - 1;
+        while (end > token && (*end == ' ' || *end == '\t')) {
+            *end = '\0';
+            end--;
+        }
+
+        // Split on colon
+        char *colon = strchr(token, ':');
+        if (colon) {
+            *colon = '\0';
+            const char *comp_name = token;
+            const char *level_name_str = colon + 1;
+
+            int comp = parse_component(comp_name);
+            if (comp >= 0) {
+                g_component_enabled[comp] = true;
+                g_component_level[comp] = parse_log_level(level_name_str);
+                g_component_level_set[comp] = true;
+            } else {
+                fprintf(stderr, "[LOG] Warning: Unknown component '%s' in log spec, ignoring\n", comp_name);
+            }
+        } else {
+            // Component without level — enable at global default
+            int comp = parse_component(token);
+            if (comp >= 0) {
+                g_component_enabled[comp] = true;
+            } else {
+                fprintf(stderr, "[LOG] Warning: Unknown component '%s' in log spec, ignoring\n", token);
+            }
+        }
+
+        token = strtok_r(NULL, ",", &saveptr);
+    }
+
+    free(str_copy);
+}
+
 void log_init(void) {
     if (g_initialized) return;
 
-    // Parse FRONTIER_LOG_LEVEL
-    const char *level_str = getenv("FRONTIER_LOG_LEVEL");
-    g_log_level = parse_log_level(level_str);
+    // Initialize per-component level arrays
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        g_component_level_set[i] = false;
+        g_component_level[i] = LOG_LEVEL_WARN;
+    }
 
-    // Parse FRONTIER_LOG_COMPONENT
-    const char *comp_str = getenv("FRONTIER_LOG_COMPONENT");
-    parse_components(comp_str);
+    // Check for unified FRONTIER_LOG first (takes precedence over legacy vars)
+    const char *log_spec = getenv("FRONTIER_LOG");
+    const char *comp_str = NULL;
 
-    // Parse FRONTIER_LOG_FORMAT
+    if (log_spec && log_spec[0]) {
+        // FRONTIER_LOG is set — use it, ignore legacy vars
+        // Set defaults first, then parse_spec will override
+        g_log_level = LOG_LEVEL_WARN;
+        for (int i = 0; i < LOG_COMP_COUNT; i++) {
+            g_component_enabled[i] = (i != LOG_COMP_MIGRATION);
+        }
+        g_initialized = true;  // Set before parse_spec since it calls log_init()
+        log_parse_spec(log_spec);
+    } else {
+        // Legacy path: FRONTIER_LOG_LEVEL + FRONTIER_LOG_COMPONENT
+        const char *level_str = getenv("FRONTIER_LOG_LEVEL");
+        g_log_level = parse_log_level(level_str);
+
+        comp_str = getenv("FRONTIER_LOG_COMPONENT");
+        parse_components(comp_str);
+
+        g_initialized = true;
+    }
+
+    // Parse FRONTIER_LOG_FORMAT (always respected)
     const char *format_str = getenv("FRONTIER_LOG_FORMAT");
     g_log_format = parse_log_format(format_str);
 
-    g_initialized = true;
-
     // Optional: log initialization message (only if INFO or above)
     if (g_log_level >= LOG_LEVEL_INFO && g_component_enabled[LOG_COMP_STARTUP]) {
-        fprintf(stderr, "[STARTUP-INFO] Logging initialized: level=%s components=%s format=%s\n",
-                level_names[g_log_level],
-                comp_str ? comp_str : "all",
-                g_log_format == LOG_FORMAT_JSON ? "json" : "text");
+        if (log_spec && log_spec[0]) {
+            fprintf(stderr, "[STARTUP-INFO] Logging initialized: spec=%s format=%s\n",
+                    log_spec,
+                    g_log_format == LOG_FORMAT_JSON ? "json" : "text");
+        } else {
+            fprintf(stderr, "[STARTUP-INFO] Logging initialized: level=%s components=%s format=%s\n",
+                    level_names[g_log_level],
+                    comp_str ? comp_str : "all",
+                    g_log_format == LOG_FORMAT_JSON ? "json" : "text");
+        }
     }
 }
 
@@ -213,18 +320,31 @@ void log_set_component_enabled(log_component_t component, bool enabled) {
     }
 }
 
+void log_set_component_level(log_component_t component, log_level_t level) {
+    if (!g_initialized) log_init();
+    if (component >= 0 && component < LOG_COMP_COUNT) {
+        g_component_level[component] = level;
+        g_component_level_set[component] = true;
+        g_component_enabled[component] = true;
+    }
+}
+
 bool log_is_enabled(log_level_t level, log_component_t component) {
     if (!g_initialized) log_init();
 
     // Errors are always enabled
     if (level == LOG_LEVEL_ERROR) return true;
 
-    // Check level
-    if (level > g_log_level) return false;
-
-    // Check component
+    // Check component is enabled
     if (component >= 0 && component < LOG_COMP_COUNT) {
-        return g_component_enabled[component];
+        if (!g_component_enabled[component]) return false;
+
+        // Use per-component level if set, otherwise global level
+        log_level_t effective = g_component_level_set[component]
+            ? g_component_level[component]
+            : g_log_level;
+
+        return (level <= effective);
     }
 
     return false;

--- a/Common/source/logging.c
+++ b/Common/source/logging.c
@@ -148,8 +148,13 @@ static void parse_components(const char *str) {
 
     char *token = strtok(str_copy, ",");
     while (token) {
-        // Trim whitespace
+        // Trim leading whitespace
         while (*token == ' ' || *token == '\t') token++;
+        if (*token == '\0') {
+            token = strtok(NULL, ",");
+            continue;
+        }
+        // Trim trailing whitespace
         char *end = token + strlen(token) - 1;
         while (end > token && (*end == ' ' || *end == '\t')) {
             *end = '\0';
@@ -195,9 +200,10 @@ void log_parse_spec(const char *spec) {
     // Check if this is a bare global level (no commas, no colons)
     if (!strchr(str_copy, ',') && !strchr(str_copy, ':') && is_bare_level(str_copy)) {
         g_log_level = parse_log_level(str_copy);
-        // Enable all components (except migration) since user set a global level
+        // Enable all components (except migration) and clear per-component overrides
         for (int i = 0; i < LOG_COMP_COUNT; i++) {
             g_component_enabled[i] = (i != LOG_COMP_MIGRATION);
+            g_component_level_set[i] = false;
         }
         free(str_copy);
         return;
@@ -212,8 +218,13 @@ void log_parse_spec(const char *spec) {
     char *saveptr = NULL;
     char *token = strtok_r(str_copy, ",", &saveptr);
     while (token) {
-        // Trim whitespace
+        // Trim leading whitespace
         while (*token == ' ' || *token == '\t') token++;
+        if (*token == '\0') {
+            token = strtok_r(NULL, ",", &saveptr);
+            continue;
+        }
+        // Trim trailing whitespace
         char *end = token + strlen(token) - 1;
         while (end > token && (*end == ' ' || *end == '\t')) {
             *end = '\0';
@@ -267,11 +278,13 @@ void log_init(void) {
     if (log_spec && log_spec[0]) {
         // FRONTIER_LOG is set — use it, ignore legacy vars
         // Set defaults first, then parse_spec will override
+        // Migration component is disabled by default to avoid verbose migration diagnostics
         g_log_level = LOG_LEVEL_WARN;
         for (int i = 0; i < LOG_COMP_COUNT; i++) {
             g_component_enabled[i] = (i != LOG_COMP_MIGRATION);
         }
-        g_initialized = true;  // Set before parse_spec since it calls log_init()
+        // Set initialized before parse_spec to prevent recursion (parse_spec calls log_init)
+        g_initialized = true;
         log_parse_spec(log_spec);
     } else {
         // Legacy path: FRONTIER_LOG_LEVEL + FRONTIER_LOG_COMPONENT

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -54,6 +54,8 @@ Minimum expectations:
 - Use Frontier structured logging for diagnostics (`log_trace`, `log_debug`, `log_info`, `log_warn`, `log_error`).
 - Do not use ad hoc `fprintf(stderr, ...)` for diagnostic logging.
 - User-facing terminal output may use `fputs` when appropriate.
+- Per-component log levels are supported via `FRONTIER_LOG` env var or `--log` CLI flag.
+- See `docs/LOGGING_STANDARDS.md` for full logging reference including per-component levels, recipes, and API.
 
 ## UserTalk and Integration Test Constraints
 

--- a/docs/LOGGING_STANDARDS.md
+++ b/docs/LOGGING_STANDARDS.md
@@ -210,9 +210,49 @@ log_debug(LOG_COMP_TABLE, "Inserting table='%.*s'", (int)bsname[0], (char *)&bsn
 
 ## Runtime Control
 
-### Environment Variables
+### Per-Component Log Levels (`FRONTIER_LOG`)
 
-Control logging at runtime without recompilation:
+The unified `FRONTIER_LOG` environment variable lets you set different log levels for different components. This is the recommended way to control logging.
+
+**Syntax**: `FRONTIER_LOG=comp:level,comp:level,...`
+
+```bash
+# Per-component levels — trace db, but only errors from lang
+FRONTIER_LOG=db:trace,lang:error ./frontier-cli -e "..."
+
+# Component without level — uses global default (warn)
+FRONTIER_LOG=db,hash:trace ./frontier-cli -e "..."
+
+# Global level shorthand (no colon) — same as FRONTIER_LOG_LEVEL
+FRONTIER_LOG=debug ./frontier-cli -e "..."
+
+# Mix per-component and global: migration at trace, everything else at warn
+FRONTIER_LOG=migration:trace ./frontier-cli --system-root old.root -e "..."
+```
+
+### CLI `--log` Flag
+
+The `--log` flag provides the same syntax as `FRONTIER_LOG`, and can be specified multiple times:
+
+```bash
+# Single --log
+frontier-cli --log db:trace,lang:error -e "..."
+
+# Multiple --log (concatenated with commas)
+frontier-cli --log db:trace --log lang:error -e "..."
+```
+
+### Precedence
+
+When multiple logging configuration sources are present, they are applied in this order (highest to lowest precedence):
+
+1. **`--log` CLI argument** — applied after env vars, overrides everything
+2. **`FRONTIER_LOG` env var** — when set, ignores `FRONTIER_LOG_LEVEL` and `FRONTIER_LOG_COMPONENT`
+3. **`FRONTIER_LOG_LEVEL` + `FRONTIER_LOG_COMPONENT`** — legacy vars, used when `FRONTIER_LOG` is not set
+
+### Legacy Environment Variables
+
+These still work when `FRONTIER_LOG` is **not** set:
 
 ```bash
 # Set log level (default: WARN)
@@ -223,7 +263,7 @@ export FRONTIER_LOG_LEVEL=debug
 export FRONTIER_LOG_COMPONENT=hash   # Single component
 export FRONTIER_LOG_COMPONENT=db,hash  # Multiple components (comma-separated)
 
-# Output format
+# Output format (always respected, independent of log spec)
 export FRONTIER_LOG_FORMAT=json      # json or text (default: text)
 export FRONTIER_LOG_FORMAT=text
 
@@ -235,6 +275,25 @@ FRONTIER_LOG_LEVEL=trace FRONTIER_LOG_FORMAT=json ./frontier-cli --system-root d
 
 # Example: Trace table lookups in hot path (reduce noise from general language runtime)
 FRONTIER_LOG_LEVEL=trace FRONTIER_LOG_COMPONENT=table_lookup ./frontier-cli --system-root db.root -e "sizeOf(system)"
+```
+
+### Common Recipes
+
+```bash
+# Debug database issues without noise from other components
+FRONTIER_LOG=db:debug ./frontier-cli --system-root Frontier.root -e "..."
+
+# Trace hash table operations, warn on everything else
+FRONTIER_LOG=hash:trace ./frontier-cli -e "..."
+
+# Full trace on multiple components
+FRONTIER_LOG=db:trace,hash:trace,table:trace ./frontier-cli -e "..."
+
+# Migration diagnostics (migration is disabled by default)
+FRONTIER_LOG=migration:trace,db:debug ./frontier-cli --system-root old.root -e "1"
+
+# Same via CLI flag
+./frontier-cli --log migration:trace --log db:debug --system-root old.root -e "1"
 ```
 
 ### Programmatic Control
@@ -251,6 +310,12 @@ log_init();
 log_set_level(LOG_LEVEL_DEBUG);
 log_set_component_enabled(LOG_COMP_HASH, true);
 log_set_component_enabled(LOG_COMP_DB, false);  // Disable DB logging
+
+// Per-component log level (overrides global for this component)
+log_set_component_level(LOG_COMP_DB, LOG_LEVEL_TRACE);
+
+// Parse a log spec string programmatically
+log_parse_spec("db:trace,lang:warn");
 ```
 
 ---
@@ -406,10 +471,16 @@ log_error(LOG_COMP_DB, "something failed");
 
 **Cause**: Log level is too verbose
 
-**Solution**: Lower the log level:
+**Solution**: Use per-component levels to focus on what matters:
 ```bash
-FRONTIER_LOG_LEVEL=warn ./frontier-cli -e "..."  # Only errors and warnings
-FRONTIER_LOG_COMPONENT=db ./frontier-cli -e "..."  # Only DB component
+# Only errors and warnings (global)
+FRONTIER_LOG_LEVEL=warn ./frontier-cli -e "..."
+
+# Only DB component
+FRONTIER_LOG_COMPONENT=db ./frontier-cli -e "..."
+
+# Per-component: trace db, but only errors from everything else
+FRONTIER_LOG=db:trace ./frontier-cli -e "..."
 ```
 
 ---

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -248,6 +248,10 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                     options->log_spec = combined;
                 } else {
                     options->log_spec = strdup(optarg);
+                    if (options->log_spec == NULL) {
+                        log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for --log");
+                        return false;
+                    }
                 }
                 break;
 

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -140,6 +140,7 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
         {"output-json", no_argument, 0, 'J'},
         {"verbose", no_argument, 0, 'v'},
         {"debug", no_argument, 0, 'D'},
+        {"log", required_argument, 0, 'L'},
         {"skip-startup", no_argument, 0, 'S'},
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'V'},
@@ -227,6 +228,27 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
             case 'D':
                 // Debug mode
                 options->debug = true;
+                break;
+
+            case 'L':
+                // Log spec (--log comp:level,...)
+                if (options->log_spec != NULL) {
+                    // Multiple --log args: concatenate with commas
+                    size_t old_len = strlen(options->log_spec);
+                    size_t new_len = strlen(optarg);
+                    char *combined = malloc(old_len + 1 + new_len + 1);
+                    if (combined == NULL) {
+                        log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for --log");
+                        return false;
+                    }
+                    memcpy(combined, options->log_spec, old_len);
+                    combined[old_len] = ',';
+                    memcpy(combined + old_len + 1, optarg, new_len + 1);
+                    free(options->log_spec);
+                    options->log_spec = combined;
+                } else {
+                    options->log_spec = strdup(optarg);
+                }
                 break;
 
             case 'S':
@@ -334,6 +356,11 @@ void cli_free_options(cli_options_t* options) {
     if (options->output_path != NULL) {
         free(options->output_path);
         options->output_path = NULL;
+    }
+
+    if (options->log_spec != NULL) {
+        free(options->log_spec);
+        options->log_spec = NULL;
     }
 }
 

--- a/frontier-cli/cli_parser.h
+++ b/frontier-cli/cli_parser.h
@@ -27,6 +27,7 @@ typedef struct {
     char* system_root;          // Path to system/root database (e.g., Frontier.root)
     char* migrate_database;     // Path to database to migrate (--migrate)
     char* output_path;          // Output path for migration (--output)
+    char* log_spec;             // Log spec string (--log comp:level,...)
     boolean verbose;            // Verbose output
     boolean debug;              // Debug output
     boolean output_json;        // Output results as JSON

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -302,10 +302,13 @@ int main(int argc, char* argv[]) {
     cli_set_json_mode(g_cli_options.output_json);
     log_set_suppressed(g_cli_options.output_json);
 
-    /* Set default log level to ERROR for REPL mode (unless user explicitly set FRONTIER_LOG_LEVEL)
+    /* Set default log level to ERROR for REPL mode (unless user explicitly configured logging)
      * This reduces startup noise from database warnings and WPText conversion messages.
-     * Script mode keeps default WARN level for better diagnostics. */
+     * Script mode keeps default WARN level for better diagnostics.
+     * Respect explicit logging config: FRONTIER_LOG, FRONTIER_LOG_LEVEL, or --log */
     if (getenv("FRONTIER_LOG_LEVEL") == NULL &&
+        getenv("FRONTIER_LOG") == NULL &&
+        g_cli_options.log_spec == NULL &&
         g_cli_options.script_file == NULL &&
         g_cli_options.inline_script == NULL) {
         log_set_level(LOG_LEVEL_ERROR);
@@ -604,10 +607,10 @@ static void print_usage(const char* program_name) {
     printf("  --output PATH            Output path for migrated database (default: <input>.root7)\n");
     printf("  -f, --force              Force overwrite if output file exists\n");
     printf("  --skip-startup           Skip system.startup scripts (they run by default)\n");
-    printf("  --log SPEC               Set per-component log levels (e.g., db:trace,lang:warn)\n");
     printf("  --output-json            Output results in JSON format\n");
     printf("  -v, --verbose            Verbose output\n");
     printf("  --debug                  Debug mode\n");
+    printf("  --log SPEC               Set per-component log levels (e.g., db:trace,lang:warn)\n");
     printf("  -h, --help               Show this help message\n");
     printf("  --version                Show version information\n");
     printf("\n");

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -174,6 +174,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // Apply --log spec if provided (overrides env var settings)
+    if (g_cli_options.log_spec != NULL) {
+        log_parse_spec(g_cli_options.log_spec);
+    }
+
     // Handle help and version requests
     if (g_cli_options.show_help) {
         print_usage(argv[0]);
@@ -599,6 +604,7 @@ static void print_usage(const char* program_name) {
     printf("  --output PATH            Output path for migrated database (default: <input>.root7)\n");
     printf("  -f, --force              Force overwrite if output file exists\n");
     printf("  --skip-startup           Skip system.startup scripts (they run by default)\n");
+    printf("  --log SPEC               Set per-component log levels (e.g., db:trace,lang:warn)\n");
     printf("  --output-json            Output results in JSON format\n");
     printf("  -v, --verbose            Verbose output\n");
     printf("  --debug                  Debug mode\n");
@@ -607,8 +613,10 @@ static void print_usage(const char* program_name) {
     printf("\n");
 
     printf("Environment Variables:\n");
-    printf("  FRONTIER_LOG_LEVEL       Set log level (TRACE, DEBUG, INFO, WARN, ERROR)\n");
-    printf("  FRONTIER_LOG_COMPONENT   Filter logs by component (DB, HASH, LANG, etc.)\n");
+    printf("  FRONTIER_LOG             Per-component log levels (e.g., db:trace,lang:warn)\n");
+    printf("                           Overrides FRONTIER_LOG_LEVEL and FRONTIER_LOG_COMPONENT\n");
+    printf("  FRONTIER_LOG_LEVEL       Set global log level (TRACE, DEBUG, INFO, WARN, ERROR)\n");
+    printf("  FRONTIER_LOG_COMPONENT   Filter logs by component (db, hash, lang, etc.)\n");
     printf("  FRONTIER_HEADLESS_RUN_STARTUP  Set to 0 to skip system.startup scripts (default: run)\n");
     printf("\n");
 

--- a/tests/test_logging.c
+++ b/tests/test_logging.c
@@ -246,6 +246,143 @@ void test_disabled_logging_has_no_effect(void) {
     PASS();
 }
 
+void test_per_component_levels(void) {
+    TEST("per-component log levels via log_parse_spec");
+
+    // Reset state
+    log_set_level(LOG_LEVEL_WARN);
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        log_set_component_enabled(i, true);
+    }
+
+    log_parse_spec("db:trace,lang:error");
+
+    // DB should be at TRACE level
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_DB) == true);
+    ASSERT(log_is_enabled(LOG_LEVEL_DEBUG, LOG_COMP_DB) == true);
+
+    // LANG should be at ERROR level (only errors pass)
+    ASSERT(log_is_enabled(LOG_LEVEL_WARN, LOG_COMP_LANG) == false);
+    ASSERT(log_is_enabled(LOG_LEVEL_ERROR, LOG_COMP_LANG) == true);
+
+    // HASH was not mentioned — should be disabled
+    ASSERT(log_is_enabled(LOG_LEVEL_WARN, LOG_COMP_HASH) == false);
+    // But errors are always shown regardless
+    ASSERT(log_is_enabled(LOG_LEVEL_ERROR, LOG_COMP_HASH) == true);
+
+    // Restore defaults
+    log_set_level(LOG_LEVEL_WARN);
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        log_set_component_enabled(i, true);
+    }
+
+    PASS();
+}
+
+void test_bare_level_spec(void) {
+    TEST("bare level spec sets global level");
+
+    log_parse_spec("debug");
+
+    // All components should be enabled at DEBUG
+    ASSERT(log_is_enabled(LOG_LEVEL_DEBUG, LOG_COMP_DB) == true);
+    ASSERT(log_is_enabled(LOG_LEVEL_DEBUG, LOG_COMP_HASH) == true);
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_DB) == false);
+
+    // Restore
+    log_set_level(LOG_LEVEL_WARN);
+
+    PASS();
+}
+
+void test_component_level_overrides_global(void) {
+    TEST("per-component level overrides global");
+
+    log_set_level(LOG_LEVEL_WARN);
+    log_set_component_level(LOG_COMP_DB, LOG_LEVEL_TRACE);
+
+    // DB at TRACE (per-component override)
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_DB) == true);
+
+    // HASH at WARN (global default, no override)
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_HASH) == false);
+    ASSERT(log_is_enabled(LOG_LEVEL_WARN, LOG_COMP_HASH) == true);
+
+    // Restore
+    log_set_level(LOG_LEVEL_WARN);
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        log_set_component_enabled(i, true);
+    }
+
+    PASS();
+}
+
+void test_bare_level_clears_overrides(void) {
+    TEST("bare level spec clears prior per-component overrides");
+
+    // Set a per-component override first
+    log_parse_spec("db:trace");
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_DB) == true);
+
+    // Now set a bare global level — should clear the db:trace override
+    log_parse_spec("info");
+    ASSERT(log_is_enabled(LOG_LEVEL_INFO, LOG_COMP_DB) == true);
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_DB) == false);
+    ASSERT(log_is_enabled(LOG_LEVEL_DEBUG, LOG_COMP_DB) == false);
+
+    // Restore
+    log_set_level(LOG_LEVEL_WARN);
+
+    PASS();
+}
+
+void test_component_without_level(void) {
+    TEST("component without level uses global default");
+
+    log_set_level(LOG_LEVEL_WARN);
+    log_parse_spec("db,hash:trace");
+
+    // DB enabled at global default (WARN)
+    ASSERT(log_is_enabled(LOG_LEVEL_WARN, LOG_COMP_DB) == true);
+    ASSERT(log_is_enabled(LOG_LEVEL_DEBUG, LOG_COMP_DB) == false);
+
+    // HASH at TRACE
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_HASH) == true);
+
+    // Restore
+    log_set_level(LOG_LEVEL_WARN);
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        log_set_component_enabled(i, true);
+    }
+
+    PASS();
+}
+
+void test_empty_and_malformed_specs(void) {
+    TEST("empty and edge case specs don't crash");
+
+    // Empty and null specs should be no-ops
+    log_parse_spec("");
+    log_parse_spec(NULL);
+
+    // Trailing/leading commas (empty tokens)
+    log_set_level(LOG_LEVEL_WARN);
+    log_parse_spec(",db:trace,");
+    ASSERT(log_is_enabled(LOG_LEVEL_TRACE, LOG_COMP_DB) == true);
+
+    // Whitespace-only token
+    log_parse_spec("  , db:debug , ");
+    ASSERT(log_is_enabled(LOG_LEVEL_DEBUG, LOG_COMP_DB) == true);
+
+    // Restore
+    log_set_level(LOG_LEVEL_WARN);
+    for (int i = 0; i < LOG_COMP_COUNT; i++) {
+        log_set_component_enabled(i, true);
+    }
+
+    PASS();
+}
+
 int main(void) {
     printf("=== Frontier Logging System Unit Tests ===\n\n");
 
@@ -259,6 +396,12 @@ int main(void) {
     test_level_hierarchy();
     test_macro_interface();
     test_disabled_logging_has_no_effect();
+    test_per_component_levels();
+    test_bare_level_spec();
+    test_component_level_overrides_global();
+    test_bare_level_clears_overrides();
+    test_component_without_level();
+    test_empty_and_malformed_specs();
 
     // Print summary
     printf("\n=== Test Summary ===\n");


### PR DESCRIPTION
## Summary

- Add `FRONTIER_LOG` env var for per-component log levels (`db:trace,lang:warn`)
- Add `--log` CLI flag with the same syntax (supports multiple `--log` args)
- Full backward compatibility with `FRONTIER_LOG_LEVEL` and `FRONTIER_LOG_COMPONENT`
- Document all logging capabilities in `docs/LOGGING_STANDARDS.md`

## Test plan

- [x] Clean build with zero errors
- [x] Unit tests: all pass (no regressions)
- [x] Integration tests: no regressions (1660 pass, 32 pre-existing failures)
- [x] Manual: `FRONTIER_LOG=startup:info` shows only startup INFO messages
- [x] Manual: `--log startup:info` same behavior via CLI
- [x] Manual: Legacy `FRONTIER_LOG_LEVEL`/`FRONTIER_LOG_COMPONENT` still work
- [x] Manual: `FRONTIER_LOG` takes precedence over legacy vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)