### PR TITLE
feat: Implement filemenu.new and window verb no-ops

### DIFF
--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1886 tests: 1712 pass (90%) 174 skip (9%)</title>
-    <dateCreated>Thu, 12 Feb 2026 00:58:53 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1889 tests: 1715 pass (90%) 174 skip (9%)</title>
+    <dateCreated>Fri, 13 Feb 2026 08:57:39 GMT</dateCreated>
   </head>
   <body>
     <outline text="Builtins Priority (builtins_priority) - 25 tests: 25 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
@@ -15,7 +15,7 @@
     <outline text="Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs) - 26 tests: 26 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
     <outline text="File Verbs (file_verbs) - 81 tests: 78 pass (96%) 3 skip (3%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
-    <outline text="Filemenu Verbs (filemenu_verbs) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
+    <outline text="Filemenu Verbs (filemenu_verbs) - 31 tests: 31 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
     <outline text="Frontier Verbs (frontier_verbs) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/frontier_verbs.opml"/>
     <outline text="Html Core Tests (html_core_tests) - 60 tests: 60 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_core_tests.opml"/>
     <outline text="Html Framework Tests (html_framework_tests) - 47 tests: 45 pass (95%) 2 skip (4%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_framework_tests.opml"/>

--- a/reports/integration_tests/filemenu_verbs.opml
+++ b/reports/integration_tests/filemenu_verbs.opml
@@ -1,22 +1,64 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Filemenu Verbs (filemenu_verbs) - 28 tests: 28 pass (100%)</title>
-    <dateCreated>Sat, 07 Feb 2026 05:27:06 GMT</dateCreated>
+    <title>Filemenu Verbs (filemenu_verbs) - 31 tests: 31 pass (100%)</title>
+    <dateCreated>Fri, 13 Feb 2026 08:57:39 GMT</dateCreated>
   </head>
   <body>
-    <outline text="fileMenu.new - returns not implemented - fileMenu.new is a stub verb that returns 'not implemented' error">
+    <outline text="fileMenu.new - create new database - fileMenu.new creates a new empty ODB database and opens it">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_new_basic.root7&quot;)"/>
+        <outline text="local(result = fileMenu.new(dbPath))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="fileMenu.new - file already exists error - fileMenu.new returns error if file already exists">
       <outline text="Metadata">
         <outline text="expected_result: error_caught"/>
       </outline>
       <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_new_exists.root7&quot;)"/>
+        <outline text="fileMenu.new(dbPath)"/>
+        <outline text="fileMenu.closeall()"/>
         <outline text="try">
-          <outline text="fileMenu.new(&quot;test&quot;)"/>
+          <outline text="fileMenu.new(dbPath)"/>
           <outline text="return &quot;should_have_failed&quot;"/>
         </outline>
         <outline text="} else">
           <outline text="return &quot;error_caught&quot;"/>
         </outline>
+      </outline>
+    </outline>
+    <outline text="fileMenu.new - with hidden parameter - fileMenu.new accepts optional hidden parameter (ignored in headless)">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_new_hidden.root7&quot;)"/>
+        <outline text="local(result = fileMenu.new(dbPath, true))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="fileMenu.new - database is usable after creation - A database created with fileMenu.new can be written to and read from">
+      <outline text="Metadata">
+        <outline text="expected_result: testValue"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_new_usable.root7&quot;)"/>
+        <outline text="fileMenu.new(dbPath)"/>
+        <outline text="db.setvalue(dbPath, &quot;testKey&quot;, &quot;testValue&quot;)"/>
+        <outline text="local(val = db.getvalue(dbPath, &quot;testKey&quot;))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return val"/>
       </outline>
     </outline>
     <outline text="fileMenu.savecopy - error with no params - fileMenu.savecopy requires exactly 1 parameter">
@@ -47,13 +89,12 @@
         </outline>
       </outline>
     </outline>
-    <outline text="fileMenu stub verbs - multiple stubs return not implemented - Verify that new and revert return errors">
+    <outline text="fileMenu stub verbs - revert returns not implemented - Verify that revert returns error">
       <outline text="Metadata">
-        <outline text="expected_result: 2"/>
+        <outline text="expected_result: 1"/>
       </outline>
       <outline text="Script">
         <outline text="local(caught = 0)"/>
-        <outline text="try { fileMenu.new(&quot;test&quot;) } else { caught = caught + 1 }"/>
         <outline text="try { fileMenu.revert() } else { caught = caught + 1 }"/>
         <outline text="return caught"/>
       </outline>

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -720,7 +720,6 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
     bigstring bspath;
     short ctparams;
     boolean flhidden = false;
-    boolean flexists = false;
 
     setbooleanvalue(false, vreturned);
 
@@ -751,9 +750,12 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
     filespectopath(&fs, bspath);
     log_debug(LOG_COMP_DB, "filemenu_new: creating new database at %s", stringbaseaddress(bspath));
 
-    /* Check if file already exists - don't overwrite */
-    if (fileexists(&fs, &flexists)) {
-        if (flexists) {
+    /* Check if file already exists - don't overwrite.
+     * fileexists() returns true if the file exists, false otherwise.
+     * The second parameter receives the is-folder flag, not existence. */
+    {
+        boolean flfolder = false;
+        if (fileexists(&fs, &flfolder)) {
             log_error(LOG_COMP_DB, "filemenu_new: file already exists at %s", stringbaseaddress(bspath));
             langerrormessage(BIGSTRING("\x27" "Can't create: file already exists at path"));
             return false;

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -10,11 +10,12 @@
  *   - fileMenu.closeall() - Closes all guest databases
  *   - fileMenu.save([f]) - Saves system root or guest database
  *
- * Implemented (Save As / Save Copy):
+ * Implemented (New / Save As / Save Copy):
+ *   - fileMenu.new(path, hidden=false) - Creates new empty ODB database, opens and mounts it
  *   - fileMenu.saveAs(path) / fileMenu.saveCopy(path) - Saves copy of current target database
  *
  * Stub implementations (return "not implemented"):
- *   - fileMenu.new, revert, print, quit
+ *   - fileMenu.revert, print, quit
  */
 
 #include "frontier.h"
@@ -697,15 +698,109 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
 }
 
 
+/*
+ * filemenu_new - Create a new empty ODB database and open it
+ *
+ * This is the headless equivalent of File > New in the GUI. It:
+ *   1. Validates the file does not already exist (won't overwrite)
+ *   2. Creates a new file with opennewfile
+ *   3. Initializes ODB structure with odbNewFile
+ *   4. Closes the file
+ *   5. Reopens and mounts via filemenu_open
+ *
+ * Parameters:
+ *   hparam1 - Tree node: param 1 = file path (required), param 2 = hidden (optional, ignored)
+ *   vreturned - Return value (boolean)
+ *
+ * Returns: true on success, false on failure
+ */
+static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
+    tyfilespec fs;
+    hdlfilenum fnum;
+    bigstring bspath;
+    short ctparams;
+    boolean flhidden = false;
+    boolean flexists = false;
+
+    setbooleanvalue(false, vreturned);
+
+    ctparams = langgetparamcount(hparam1);
+
+    if (ctparams < 1 || ctparams > 2) {
+        langerrormessage(BIGSTRING("\x2e" "fileMenu.new requires 1 or 2 parameters (path, hidden)"));
+        return false;
+    }
+
+    /* Get the file path (param 1) - don't mark as last yet if there's a second param */
+    if (ctparams == 1)
+        flnextparamislast = true;
+
+    if (!getfilespecvalue(hparam1, 1, &fs)) {
+        log_error(LOG_COMP_DB, "filemenu_new: getfilespecvalue failed");
+        return false;
+    }
+
+    /* Consume optional 'hidden' param (ignored in headless mode) */
+    if (ctparams > 1) {
+        flnextparamislast = true;
+
+        if (!getbooleanvalue(hparam1, 2, &flhidden))
+            return false;
+    }
+
+    filespectopath(&fs, bspath);
+    log_debug(LOG_COMP_DB, "filemenu_new: creating new database at %s", stringbaseaddress(bspath));
+
+    /* Check if file already exists - don't overwrite */
+    if (fileexists(&fs, &flexists)) {
+        if (flexists) {
+            log_error(LOG_COMP_DB, "filemenu_new: file already exists at %s", stringbaseaddress(bspath));
+            langerrormessage(BIGSTRING("\x27" "Can't create: file already exists at path"));
+            return false;
+        }
+    }
+
+    /* Create the new file */
+    if (!opennewfile(&fs, 'LAND', 'ROOT', &fnum)) {
+        log_error(LOG_COMP_DB, "filemenu_new: opennewfile failed for %s", stringbaseaddress(bspath));
+        langerrormessage(BIGSTRING("\x24" "Can't create: failed to create new file"));
+        return false;
+    }
+
+    /* Initialize the ODB structure — guard globals since odbNewFile touches database state */
+    {
+        odb_context_guard guard;
+        boolean fl;
+
+        odb_guard_enter(&guard);
+        fl = odbNewFile(fnum);
+        odb_guard_exit(&guard);
+
+        if (!fl) {
+            log_error(LOG_COMP_DB, "filemenu_new: odbNewFile failed");
+            closefile(fnum);
+            langerrormessage(BIGSTRING("\x29" "Can't create: failed to initialize database"));
+            return false;
+        }
+    }
+
+    /* Close the OS file — odbNewFile closed the DB internals but not the file handle */
+    closefile(fnum);
+
+    log_debug(LOG_COMP_DB, "filemenu_new: created and initialized, now opening via filemenu_open");
+
+    /* Reopen and mount using the same logic as fileMenu.open */
+    return filemenu_open(hparam1, vreturned);
+}
+
+
 static boolean filemenu_valueproc(short token, hdltreenode hparam1,
                                      tyvaluerecord *vreturned,
                                      bigstring bserror) {
     (void)bserror;
     switch(token) {
         case filv_new:
-            /* Verb #0: filemenu.new - not yet implemented */
-            langerrormessage(BIGSTRING("\x0fnot implemented"));
-            return false;
+            return filemenu_new(hparam1, vreturned);
 
         case filv_open:
             return filemenu_open(hparam1, vreturned);

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -791,8 +791,17 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
     log_debug(LOG_COMP_DB, "filemenu_new: created and initialized, now opening via filemenu_open");
 
-    /* Reopen and mount using the same logic as fileMenu.open */
-    return filemenu_open(hparam1, vreturned);
+    /* Reopen and mount via filemenu_open. We use a create-close-reopen pattern because
+     * odbNewFile() closes the database internally (it's designed for minimal creation),
+     * so we must reopen it through the normal open path which handles hodblist insertion
+     * and system.compiler.files mounting. */
+    if (!filemenu_open(hparam1, vreturned)) {
+        log_warn(LOG_COMP_DB, "filemenu_new: filemenu_open failed after creation, cleaning up orphaned file");
+        deletefile(&fs);
+        return false;
+    }
+
+    return true;
 }
 
 

--- a/tests/headless_window_verbs.c
+++ b/tests/headless_window_verbs.c
@@ -10,6 +10,8 @@
  * - window.setSize/setPosition: accept params but return false (no-op indicator)
  * - window.getTitle: returns object's full dot-path, returns the path string
  * - window.setTitle: accepts params but returns false (no-op indicator)
+ * - window.show/hide: consume title param, return true (no-op)
+ * - window.isVisible: consumes title param, returns false (nothing visible)
  *
  * Note on setter return values: Setter verbs (setSize, setPosition, setTitle)
  * return false in headless mode to indicate the operation was a no-op. This
@@ -244,18 +246,27 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
             /* Verb: window.next - not yet implemented */
             if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
             return false;
-        case winv_isvisible:
-            /* Verb: window.isvisible - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
-            return false;
+        case winv_isvisible: {
+            /* window.isVisible(title) - always false in headless mode */
+            bigstring bstitle;
+
+            flnextparamislast = true;
+            if (!getstringvalue(hparam1, 1, bstitle))
+                return false;
+
+            return setbooleanvalue(false, vreturned);
+        }
         case winv_show:
-            /* Verb: window.show - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
-            return false;
-        case winv_hide:
-            /* Verb: window.hide - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
-            return false;
+        case winv_hide: {
+            /* window.show/hide(title) - no-op in headless mode */
+            bigstring bstitle;
+
+            flnextparamislast = true;
+            if (!getstringvalue(hparam1, 1, bstitle))
+                return false;
+
+            return setbooleanvalue(true, vreturned);
+        }
         case winv_close:
             /* Verb: window.close - not yet implemented */
             if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);

--- a/tests/integration/test_cases/filemenu_verbs.yaml
+++ b/tests/integration/test_cases/filemenu_verbs.yaml
@@ -7,7 +7,7 @@
 #   - fileMenu.save([path]) - Save system root or guest database (implemented in prior PR)
 #
 # Stub implementations (return "not implemented"):
-#   - fileMenu.new, savecopy, revert, print, quit, saveas
+#   - fileMenu.revert, print, quit
 #
 # Guest Database Concepts:
 #   - A "guest database" is any ODB file opened via fileMenu.open or db.open
@@ -30,17 +30,56 @@ tests:
   # Stub Verbs - Not Yet Implemented
   # ========================================================================
 
-  - name: "fileMenu.new - returns not implemented"
-    description: "fileMenu.new is a stub verb that returns 'not implemented' error"
+  - name: "fileMenu.new - create new database"
+    description: "fileMenu.new creates a new empty ODB database and opens it"
     script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_new_basic.root7");
+      local(result = fileMenu.new(dbPath));
+      fileMenu.closeall();
+      return result
+    expected_success: true
+    expected_result: "true"
+
+  - name: "fileMenu.new - file already exists error"
+    description: "fileMenu.new returns error if file already exists"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_new_exists.root7");
+      fileMenu.new(dbPath);
+      fileMenu.closeall();
       try {
-        fileMenu.new("test");
+        fileMenu.new(dbPath);
         return "should_have_failed"
       } else {
         return "error_caught"
       }
     expected_success: true
     expected_result: "error_caught"
+
+  - name: "fileMenu.new - with hidden parameter"
+    description: "fileMenu.new accepts optional hidden parameter (ignored in headless)"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_new_hidden.root7");
+      local(result = fileMenu.new(dbPath, true));
+      fileMenu.closeall();
+      return result
+    expected_success: true
+    expected_result: "true"
+
+  - name: "fileMenu.new - database is usable after creation"
+    description: "A database created with fileMenu.new can be written to and read from"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_new_usable.root7");
+      fileMenu.new(dbPath);
+      db.setvalue(dbPath, "testKey", "testValue");
+      local(val = db.getvalue(dbPath, "testKey"));
+      fileMenu.closeall();
+      return val
+    expected_success: true
+    expected_result: "testValue"
 
   - name: "fileMenu.savecopy - error with no params"
     description: "fileMenu.savecopy requires exactly 1 parameter"
@@ -66,15 +105,14 @@ tests:
     expected_success: true
     expected_result: "error_caught"
 
-  - name: "fileMenu stub verbs - multiple stubs return not implemented"
-    description: "Verify that new and revert return errors"
+  - name: "fileMenu stub verbs - revert returns not implemented"
+    description: "Verify that revert returns error"
     script: |
       local(caught = 0);
-      try { fileMenu.new("test") } else { caught = caught + 1 };
       try { fileMenu.revert() } else { caught = caught + 1 };
       return caught
     expected_success: true
-    expected_result: "2"
+    expected_result: "1"
 
   # ========================================================================
   # fileMenu.closeall - Empty/No-Op Cases


### PR DESCRIPTION
## Summary

- Implement `fileMenu.new(path, hidden)` verb to create new empty ODB databases. This unblocks `mainResponder.startup()` which needs to create `config.root` on first run when it doesn't already exist.
- Make `window.show`, `window.hide`, and `window.isVisible` harmless no-ops instead of "not implemented" errors. These are called by `mainResponder.openFile()` after creating a new database.

## Details

**filemenu.new** (`headless_filemenu_verbs.c`):
- Parses path + optional hidden parameter (same as `filemenu.open`)
- Validates file doesn't already exist (prevents accidental overwrites)
- Creates file with `opennewfile`, initializes ODB structure with `odbNewFile`
- Reopens via existing `filemenu_open` to add to hodblist and mount in `system.compiler.files`

**Window verbs** (`headless_window_verbs.c`):
- `window.show`/`window.hide`: consume title param, return true (no-op)
- `window.isVisible`: consume title param, return false (nothing visible in headless)

## Test plan

- [x] Unit tests pass (`run_headless_tests.sh`)
- [x] `filemenu.new("/tmp/test.root", true)` creates and opens database successfully
- [x] Build succeeds with no warnings
- [x] Startup progresses past "Opening config.root" (previously failed with "not implemented")
- [ ] Note: `mainResponder.startup` still fails on `hidden:true` named parameter syntax — this is a separate UserTalk evaluator issue, not related to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)