### PR TITLE
fix: Support named parameters in headless filemenu verbs

### DIFF
--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -240,37 +240,34 @@ static boolean filemenu_open(hdltreenode hparam1, tyvaluerecord *vreturned) {
     tyodbrecord odbrec;
     hdlodbrecord hodb;
     bigstring bspath;
-    short ctparams;
     boolean flhidden = false;
+    short ctconsumed = 0;
+    short ctpositional;
+    tyvaluerecord vhidden;
 
     setbooleanvalue(false, vreturned);
 
     odbrec.fref = 0;
     odbrec.flreadonly = false;
 
-    ctparams = langgetparamcount(hparam1);
-
-    if (ctparams < 1 || ctparams > 2) {
-        langerrormessage(BIGSTRING("\x2f" "fileMenu.open requires 1 or 2 parameters (path, hidden)"));
-        return false;
-    }
-
     /* Get the file path (param 1) */
-    if (ctparams == 1)
-        flnextparamislast = true;
-
-    if (!getfilespecvalue(hparam1, 1, &odbrec.fs)) {
+    if (!getfilespecvalue(hparam1, ++ctconsumed, &odbrec.fs)) {
         log_error(LOG_COMP_DB, "filemenu_open: getfilespecvalue failed");
         return false;
     }
 
-    /* Consume optional 'hidden' param (ignored in headless mode) */
-    if (ctparams > 1) {
-        flnextparamislast = true;
+    /* Consume optional 'hidden' param — supports both positional and named styles:
+     *   filemenu.open(f, true)         — positional
+     *   filemenu.open(f, hidden:true)  — named
+     */
+    flnextparamislast = true;
+    ctpositional = ctconsumed;
+    setbooleanvalue(false, &vhidden);
 
-        if (!getbooleanvalue(hparam1, 2, &flhidden))
-            return false;
-    }
+    if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\x06" "hidden"), &vhidden))
+        return false;
+
+    flhidden = vhidden.data.flvalue;
 
     filespectopath(&odbrec.fs, bspath);
     log_debug(LOG_COMP_DB, "filemenu_open: opening %s", stringbaseaddress(bspath));
@@ -718,34 +715,31 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
     tyfilespec fs;
     hdlfilenum fnum;
     bigstring bspath;
-    short ctparams;
     boolean flhidden = false;
+    short ctconsumed = 0;
+    short ctpositional;
+    tyvaluerecord vhidden;
 
     setbooleanvalue(false, vreturned);
 
-    ctparams = langgetparamcount(hparam1);
-
-    if (ctparams < 1 || ctparams > 2) {
-        langerrormessage(BIGSTRING("\x2e" "fileMenu.new requires 1 or 2 parameters (path, hidden)"));
-        return false;
-    }
-
-    /* Get the file path (param 1) - don't mark as last yet if there's a second param */
-    if (ctparams == 1)
-        flnextparamislast = true;
-
-    if (!getfilespecvalue(hparam1, 1, &fs)) {
+    /* Get the file path (param 1) */
+    if (!getfilespecvalue(hparam1, ++ctconsumed, &fs)) {
         log_error(LOG_COMP_DB, "filemenu_new: getfilespecvalue failed");
         return false;
     }
 
-    /* Consume optional 'hidden' param (ignored in headless mode) */
-    if (ctparams > 1) {
-        flnextparamislast = true;
+    /* Consume optional 'hidden' param — supports both positional and named styles:
+     *   filemenu.new(f, true)         — positional
+     *   filemenu.new(f, hidden:true)  — named
+     */
+    flnextparamislast = true;
+    ctpositional = ctconsumed;
+    setbooleanvalue(false, &vhidden);
 
-        if (!getbooleanvalue(hparam1, 2, &flhidden))
-            return false;
-    }
+    if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\x06" "hidden"), &vhidden))
+        return false;
+
+    flhidden = vhidden.data.flvalue;
 
     filespectopath(&fs, bspath);
     log_debug(LOG_COMP_DB, "filemenu_new: creating new database at %s", stringbaseaddress(bspath));

--- a/tests/integration/test_cases/filemenu_verbs.yaml
+++ b/tests/integration/test_cases/filemenu_verbs.yaml
@@ -68,6 +68,17 @@ tests:
     expected_success: true
     expected_result: "true"
 
+  - name: "fileMenu.new - with named hidden parameter"
+    description: "fileMenu.new accepts named hidden:true parameter syntax"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_new_named_hidden.root7");
+      local(result = fileMenu.new(dbPath, hidden:true));
+      fileMenu.closeall();
+      return result
+    expected_success: true
+    expected_result: "true"
+
   - name: "fileMenu.new - database is usable after creation"
     description: "A database created with fileMenu.new can be written to and read from"
     script: |
@@ -200,6 +211,18 @@ tests:
       local(dbPath = tmpDir + "/" + "filemenu_hidden.root7");
       db.new(dbPath);
       local(result = fileMenu.open(dbPath, true));
+      fileMenu.closeall();
+      return result
+    expected_success: true
+    expected_result: "true"
+
+  - name: "fileMenu.open - with named hidden parameter"
+    description: "Opening with named hidden:true parameter syntax should succeed"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_open_named_hidden.root7");
+      db.new(dbPath);
+      local(result = fileMenu.open(dbPath, hidden:true));
       fileMenu.closeall();
       return result
     expected_success: true


### PR DESCRIPTION
## Summary

- Replace positional-only `getbooleanvalue()` with `getoptionalparamvalue()` for the `hidden` parameter in `filemenu_open` and `filemenu_new`
- This follows the same pattern used in `shellverbs.c` (the GUI implementation) and allows both calling styles: `filemenu.open(f, true)` (positional) and `filemenu.open(f, hidden:true)` (named)
- Add integration tests for both verbs with named `hidden:` parameter syntax

## Test plan

- [x] Unit tests pass (`./tools/run_headless_tests.sh`)
- [x] Integration tests pass for all filemenu tests (33/33)
- [x] New named parameter tests pass: `fileMenu.open(path, hidden:true)` and `fileMenu.new(path, hidden:true)`
- [x] Existing positional parameter tests still pass (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)