### PR TITLE
fix: Fix startup bootstrap - random() params and log corruption

### DIFF
--- a/Common/source/langverbs.c
+++ b/Common/source/langverbs.c
@@ -1065,26 +1065,41 @@ boolean langabsfunc (hdltreenode hparam1, tyvaluerecord *vreturned) {
 
 boolean langrandomfunc (hdltreenode hparam1, tyvaluerecord *vreturned) {
 	/*
-	Return random number from 0 to max-1.
-	Uses standard C rand() function.
+	Return random number in [lower, upper] inclusive.
+	Matches original GUI kernel 2-param signature: random(lower, upper).
+
+	Uses unsigned arithmetic for the span to avoid signed overflow when
+	(upper - lower + 1) exceeds LONG_MAX, and rejection sampling to
+	eliminate modulo bias.
 	*/
-	long max;
-	long result;
+	long lower, upper;
+	unsigned long span, limit, r;
+
+	if (!getlongvalue (hparam1, 1, &lower))
+		return (false);
 
 	flnextparamislast = true;
 
-	if (!getlongvalue (hparam1, 1, &max))
+	if (!getlongvalue (hparam1, 2, &upper))
 		return (false);
 
-	if (max <= 0) {
+	if (lower > upper) {
 		langerror (badrandomboundserror);
 		return (false);
 		}
 
-	/* Use rand() modulo max to get value in [0, max-1] */
-	result = rand() % max;
+	span = (unsigned long) upper - (unsigned long) lower + 1UL;
 
-	return (setlongvalue (result, vreturned));
+	/* Rejection sampling: discard values that would cause modulo bias.
+	   For typical small ranges this almost never rejects. */
+
+	limit = ((unsigned long) RAND_MAX + 1UL) - (((unsigned long) RAND_MAX + 1UL) % span);
+
+	do {
+		r = (unsigned long) rand ();
+		} while (r >= limit);
+
+	return (setlongvalue (lower + (long) (r % span), vreturned));
 	} /*langrandomfunc*/
 
 

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -34,6 +34,18 @@
 #include "cancoon.h"
 #include "ops.h"
 
+/*
+ * Safe null-termination for bigstring before passing to C string APIs.
+ * bigstring is unsigned char[256]: byte 0 = length (0-255), bytes 1-255 = data.
+ * If length is 255, nullterminate would write at s[256] (1 byte OOB).
+ * This macro caps the length at 254 before null-terminating to stay in bounds,
+ * which is acceptable for logging — paths over 254 chars are truncated.
+ */
+#define safenullterminate(s) do { \
+    if (stringlength(s) > 254) setstringlength(s, 254); \
+    nullterminate(s); \
+} while (0)
+
 /* tyodbrecord/hdlodbrecord defined in odbinternal.h (shared with dbverbs.c) */
 extern hdlodbrecord hodblist;
 
@@ -171,6 +183,7 @@ static boolean filemenu_save_guestdb(hdltreenode hparam1) {
     }
 
     filespectopath(&fs, bspath);
+    safenullterminate(bspath);
     log_debug(LOG_COMP_DB, "filemenu_save_guestdb: looking for database at path=%s",
               stringbaseaddress(bspath));
 
@@ -270,6 +283,7 @@ static boolean filemenu_open(hdltreenode hparam1, tyvaluerecord *vreturned) {
     flhidden = vhidden.data.flvalue;
 
     filespectopath(&odbrec.fs, bspath);
+    safenullterminate(bspath);
     log_debug(LOG_COMP_DB, "filemenu_open: opening %s", stringbaseaddress(bspath));
 
     /* Check if already open in hodblist */
@@ -382,6 +396,7 @@ static boolean filemenu_close_guestdb(hdlodbrecord hodb) {
     bigstring bspath;
 
     filespectopath(&(**hodb).fs, bspath);
+    safenullterminate(bspath);
     log_debug(LOG_COMP_DB, "filemenu_close_guestdb: closing %s", stringbaseaddress(bspath));
 
     /* Close the ODB file first — use context guard to protect system root globals */
@@ -453,6 +468,7 @@ static boolean filemenu_close(tyvaluerecord *vreturned) {
     for (hodb = (**hodblist).hnext; hodb != nil; hodb = (**hodb).hnext) {
         bigstring bsodbpath;
         filespectopath(&(**hodb).fs, bsodbpath);
+        safenullterminate(bsodbpath);
 
         if (equalstrings(bstargetname, bsodbpath)) {
             return filemenu_close_guestdb(hodb) ? true : false;
@@ -546,6 +562,7 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
         return false;
 
     filespectopath(&fsdest, bsdest);
+    safenullterminate(bsdest);
     log_debug(LOG_COMP_DB, "filemenu_saveas: destination=%s", stringbaseaddress(bsdest));
 
     /* Determine source database: check current target */
@@ -644,9 +661,9 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
         filespectopath(&fssource, bssource);
 
-        /* Use nullterminate to get C strings from Pascal strings */
-        nullterminate(bssource);
-        nullterminate(bsdest);
+        /* Use safenullterminate to get C strings from Pascal strings */
+        safenullterminate(bssource);
+        safenullterminate(bsdest);
 
         fin = fopen(stringbaseaddress(bssource), "rb");
 
@@ -742,6 +759,7 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
     flhidden = vhidden.data.flvalue;
 
     filespectopath(&fs, bspath);
+    safenullterminate(bspath);
     log_debug(LOG_COMP_DB, "filemenu_new: creating new database at %s", stringbaseaddress(bspath));
 
     /* Check if file already exists - don't overwrite.

--- a/tests/integration/test_cases/lang_verbs.yaml
+++ b/tests/integration/test_cases/lang_verbs.yaml
@@ -278,52 +278,52 @@ tests:
     script: 'lang.abs(1, 2)'
     expected_success: false
 
-  # lang.random - Random number generator
+  # lang.random - Random number generator (2-param: lower, upper)
   - name: "lang.random - in range"
-    description: "Random number should be in valid range [0, max-1]"
+    description: "Random number should be in valid range [1, 100] inclusive"
     script: |
-      local (x = lang.random(100));
-      return (x >= 0) and (x < 100)
+      local (x = lang.random(1, 100));
+      return (x >= 1) and (x <= 100)
     expected_success: true
     expected_result: "true"
 
-  - name: "lang.random - max=1"
-    description: "Random(1) should always return 0"
-    script: 'lang.random(1)'
+  - name: "lang.random - equal bounds"
+    description: "random(5, 5) should always return 5"
+    script: 'lang.random(5, 5)'
     expected_success: true
-    expected_result: "0"
+    expected_result: "5"
 
-  - name: "lang.random - max=10"
-    description: "Random(10) should be in [0,9]"
+  - name: "lang.random - small range"
+    description: "Random(1, 10) should be in [1, 10]"
     script: |
-      local (x = lang.random(10));
-      return (x >= 0) and (x <= 9)
+      local (x = lang.random(1, 10));
+      return (x >= 1) and (x <= 10)
     expected_success: true
     expected_result: "true"
 
   - name: "lang.random - multiple calls differ"
     description: "Multiple random calls should (usually) produce different values"
     script: |
-      local (x = lang.random(1000));
-      local (y = lang.random(1000));
-      local (z = lang.random(1000));
+      local (x = lang.random(1, 1000));
+      local (y = lang.random(1, 1000));
+      local (z = lang.random(1, 1000));
       return (x != y) or (y != z)
     expected_success: true
     expected_result: "true"
 
-  - name: "lang.random - max=0 error"
-    description: "Random(0) should fail (invalid range)"
-    script: 'lang.random(0)'
-    expected_success: false
-
-  - name: "lang.random - negative max error"
-    description: "Random with negative max should fail"
-    script: 'lang.random(-10)'
+  - name: "lang.random - lower greater than upper error"
+    description: "random(10, 1) should fail (lower > upper)"
+    script: 'lang.random(10, 1)'
     expected_success: false
 
   - name: "lang.random - no parameters"
-    description: "Parameter validation: missing parameter should fail"
+    description: "Parameter validation: missing parameters should fail"
     script: 'lang.random()'
+    expected_success: false
+
+  - name: "lang.random - one parameter error"
+    description: "Parameter validation: single parameter should fail (needs 2)"
+    script: 'lang.random(100)'
     expected_success: false
 
   # lang.memavail - Available memory


### PR DESCRIPTION
## Summary

Three fixes for issues discovered during manual `startup.startupScript()` walkthrough:

- **`langrandomfunc` 2-param signature**: Changed from 1-param (`max`) to 2-param (`lower, upper`) to match the original GUI kernel at `langverbs.c:3410`. The UserTalk glue script `random(lower, upper)` calls `kernel(lang.random)` passing both bounds. Uses unsigned arithmetic for span to avoid signed overflow on wide bounds (e.g. `random(0, LONG_MAX)`), and rejection sampling to eliminate modulo bias.
- **Null-terminate Pascal strings before logging/C APIs**: Added `safenullterminate()` macro that caps length at 254 before null-terminating, preventing 1-byte OOB write when `bigstring` path is exactly 255 bytes. Applied to all 8 `filespectopath()` call sites in `headless_filemenu_verbs.c`.
- **Missing null-termination in `filemenu_saveas`**: Added null-termination before the early `log_debug` call for the destination path.

## Reviewer feedback addressed

| Priority | Issue | Resolution |
|----------|-------|------------|
| P1 | Missing nullterminate in `filemenu_saveas` log call | Added `safenullterminate(bsdest)` before log_debug |
| P1 | Overflow in `(upper - lower + 1)` for extreme bounds | Use unsigned arithmetic: `(unsigned long) upper - (unsigned long) lower + 1UL` |
| P2 | `nullterminate` OOB on 255-byte paths | `safenullterminate()` macro caps at 254 before null-terminating |
| P2 | Modulo bias in random | Rejection sampling: discard values >= `(RAND_MAX+1) - ((RAND_MAX+1) % span)` |

## Test plan

- [x] Unit tests pass (`./tools/run_headless_tests.sh`)
- [x] All 7 `lang.random` integration tests pass (2-param range, equal bounds, error cases)
- [x] All 33 filemenu integration tests pass
- [x] No new test failures (32 pre-existing failures unchanged)
- [x] Manual startup: `random(5, 55)` no longer errors during nightly updates task creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)