### PR TITLE
Implement real wp.getText() and wp.setText() for headless mode

### DIFF
--- a/portable/wptext_portable.h
+++ b/portable/wptext_portable.h
@@ -18,6 +18,7 @@ void wp_portable_note_drop_logged(hdlexternalvariable hv, const char *name_hint)
 Boolean wp_portable_external_was_legacy_ws(hdlexternalvariable hv);
 void wp_portable_note_conversion_logged(hdlexternalvariable hv, const char *name_hint);
 Boolean wp_portable_extract_plaintext(hdlexternalvariable hv, Handle *hout_utf8);
+Boolean wp_portable_set_plaintext(hdlexternalvariable hv, Handle hutf8);
 #endif
 
 int wp_portable_get_last_error_line(void);

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -947,6 +947,12 @@ boolean wp_portable_set_plaintext(hdlexternalvariable hv, Handle hutf8) {
     if (state == NULL)
         return false;
 
+    /* Load existing metadata (timecreated, timelastsave, ctsaves) from disk
+     * before replacing content. Without this, a disk-backed object edited via
+     * setText would lose its document timestamps. Failure is non-fatal — a
+     * newly created object has no disk metadata to load. */
+    wp_portable_state_refresh_metadata(hv, state);
+
     Handle hrtf = nil;
     long char_count = 0;
     if (!wp_portable_utf8_to_rtf(hutf8, &hrtf, &char_count))
@@ -955,6 +961,8 @@ boolean wp_portable_set_plaintext(hdlexternalvariable hv, Handle hutf8) {
     if (state->portable_rtf_cache != nil)
         disposehandle(state->portable_rtf_cache);
 
+    /* hrtf is a fresh handle from newclearhandle() inside wp_portable_utf8_to_rtf,
+     * never added to tmp stack — safe to store in persistent state. */
     state->portable_rtf_cache = hrtf;
     state->portable_payload_size = gethandlesize(hrtf);
     state->maxpos = char_count;

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -17,7 +17,7 @@ extern boolean flconvertingolddatabase;
 #define BlockMoveData(src, dst, size) memmove((dst), (src), (size))
 #endif
 
-#if defined(FRONTIER_HEADLESS) && defined(FRONTIER_TESTS)
+#ifdef FRONTIER_HEADLESS
 static boolean wp_portable_utf8_to_rtf(Handle hutf8, Handle *hrtf, long *out_chars);
 #endif
 static boolean wp_portable_rtf_to_utf8(const uint8_t *rtf, long len, Handle *hout_utf8);
@@ -716,6 +716,26 @@ Boolean wp_portable_extract_plaintext(hdlexternalvariable hv, Handle *hout_utf8)
         (state->portable_rtf_cache != nil) ? "yes" : "no");
 #endif
 
+    /* Fast path: if RTF cache is available in memory, extract from it directly.
+     * This handles newly created objects and objects modified by wp.setText()
+     * that haven't been saved to disk yet. */
+    if (state->portable_rtf_cache != nil && state->portable_format) {
+        const uint8_t *rtf = (const uint8_t *)*state->portable_rtf_cache;
+        long rtf_len = gethandlesize(state->portable_rtf_cache);
+        Handle hutf8 = nil;
+        if (wp_portable_rtf_to_utf8(rtf, rtf_len, &hutf8)) {
+            *hout_utf8 = hutf8;
+            return true;
+        }
+        /* RTF decode failed — fall through to raw cache copy */
+        log_warn(LOG_COMP_GENERAL, "[wp-plain] unable to decode cached RTF, returning raw bytes");
+        if (!newclearhandle(rtf_len, &hutf8))
+            return false;
+        BlockMoveData(rtf, *hutf8, rtf_len);
+        *hout_utf8 = hutf8;
+        return true;
+    }
+
     Handle hpacked = nil;
     if (!wp_portable_state_dbref(NULL, hv, state, &hpacked))
         return false;
@@ -809,73 +829,6 @@ void wp_portable_note_drop_logged(hdlexternalvariable hv, const char *name_hint)
 
 void wp_portable_note_conversion_logged(hdlexternalvariable hv, const char *name_hint) {
     wp_portable_log_event("converted-to-plain-text", hv, name_hint);
-}
-
-#ifdef FRONTIER_TESTS
-Boolean wp_portable_pack_text_for_test(const char *utf8text, Handle *hpacked) {
-    if (utf8text == NULL || hpacked == NULL)
-        return false;
-
-    long textlen = (long)strlen(utf8text);
-    Handle hutf8 = nil;
-    if (!newclearhandle(textlen, &hutf8))
-        return false;
-    if (textlen > 0)
-        BlockMoveData(utf8text, *hutf8, (size_t)textlen);
-
-    Handle hrtf = nil;
-    long char_count = 0;
-    if (!wp_portable_utf8_to_rtf(hutf8, &hrtf, &char_count)) {
-        disposehandle(hutf8);
-        return false;
-    }
-    disposehandle(hutf8);
-
-    wp_portable_state temp = {0};
-    temp.maxpos = char_count;
-    temp.timecreated = 0;
-    temp.timelastsave = 0;
-    temp.ctsaves = 0;
-    temp.portable_format = true;
-    temp.header_valid = true;
-
-    Handle payload = nil;
-    boolean ok = wp_portable_wrap_rtf_payload(&temp, hrtf, &payload);
-    disposehandle(hrtf);
-    if (!ok)
-        return false;
-
-    *hpacked = payload;
-    return true;
-}
-
-Boolean wp_portable_load_portable_blob_for_test(const unsigned char *blob, long len) {
-    if (blob == NULL || len < (long)sizeof(wp_portable_diskheader))
-        return false;
-
-    wp_portable_diskheader disk;
-    BlockMoveData(blob, &disk, sizeof(disk));
-
-    if (conditionallongswap(disk.magic) != WP_PORTABLE_MAGIC)
-        return false;
-    if (conditionalshortswap(disk.version) != WP_PORTABLE_VERSION)
-        return false;
-
-    uint32_t utf8len = conditionallongswap(disk.utf8bytelen);
-    uint32_t reserved_len = conditionallongswap(disk.reservedlength);
-    if (reserved_len != 0)
-        return false;
-
-    size_t header_size = sizeof(wp_portable_diskheader);
-    if ((long)header_size + (long)utf8len != len)
-        return false;
-
-    const uint8_t *payload = blob + header_size;
-    Handle hutf8 = nil;
-    boolean ok = wp_portable_rtf_to_utf8(payload, (long)utf8len, &hutf8);
-    if (ok && hutf8 != nil)
-        disposehandle(hutf8);
-    return ok;
 }
 
 #define RTF_PREFIX "{\\rtf1\\ansi\\deff0\\pard "
@@ -988,6 +941,95 @@ static boolean wp_portable_utf8_to_rtf(Handle hutf8, Handle *hrtf, long *out_cha
     *hrtf = hrtf_local;
     return true;
 }
+
+boolean wp_portable_set_plaintext(hdlexternalvariable hv, Handle hutf8) {
+    wp_portable_state *state = wp_portable_state_require(hv);
+    if (state == NULL)
+        return false;
+
+    Handle hrtf = nil;
+    long char_count = 0;
+    if (!wp_portable_utf8_to_rtf(hutf8, &hrtf, &char_count))
+        return false;
+
+    if (state->portable_rtf_cache != nil)
+        disposehandle(state->portable_rtf_cache);
+
+    state->portable_rtf_cache = hrtf;
+    state->portable_payload_size = gethandlesize(hrtf);
+    state->maxpos = char_count;
+    state->dirty = true;
+    state->portable_format = true;
+    state->header_valid = true;
+    return true;
+}
+
+#ifdef FRONTIER_TESTS
+Boolean wp_portable_pack_text_for_test(const char *utf8text, Handle *hpacked) {
+    if (utf8text == NULL || hpacked == NULL)
+        return false;
+
+    long textlen = (long)strlen(utf8text);
+    Handle hutf8 = nil;
+    if (!newclearhandle(textlen, &hutf8))
+        return false;
+    if (textlen > 0)
+        BlockMoveData(utf8text, *hutf8, (size_t)textlen);
+
+    Handle hrtf = nil;
+    long char_count = 0;
+    if (!wp_portable_utf8_to_rtf(hutf8, &hrtf, &char_count)) {
+        disposehandle(hutf8);
+        return false;
+    }
+    disposehandle(hutf8);
+
+    wp_portable_state temp = {0};
+    temp.maxpos = char_count;
+    temp.timecreated = 0;
+    temp.timelastsave = 0;
+    temp.ctsaves = 0;
+    temp.portable_format = true;
+    temp.header_valid = true;
+
+    Handle payload = nil;
+    boolean ok = wp_portable_wrap_rtf_payload(&temp, hrtf, &payload);
+    disposehandle(hrtf);
+    if (!ok)
+        return false;
+
+    *hpacked = payload;
+    return true;
+}
+
+Boolean wp_portable_load_portable_blob_for_test(const unsigned char *blob, long len) {
+    if (blob == NULL || len < (long)sizeof(wp_portable_diskheader))
+        return false;
+
+    wp_portable_diskheader disk;
+    BlockMoveData(blob, &disk, sizeof(disk));
+
+    if (conditionallongswap(disk.magic) != WP_PORTABLE_MAGIC)
+        return false;
+    if (conditionalshortswap(disk.version) != WP_PORTABLE_VERSION)
+        return false;
+
+    uint32_t utf8len = conditionallongswap(disk.utf8bytelen);
+    uint32_t reserved_len = conditionallongswap(disk.reservedlength);
+    if (reserved_len != 0)
+        return false;
+
+    size_t header_size = sizeof(wp_portable_diskheader);
+    if ((long)header_size + (long)utf8len != len)
+        return false;
+
+    const uint8_t *payload = blob + header_size;
+    Handle hutf8 = nil;
+    boolean ok = wp_portable_rtf_to_utf8(payload, (long)utf8len, &hutf8);
+    if (ok && hutf8 != nil)
+        disposehandle(hutf8);
+    return ok;
+}
 #endif /* FRONTIER_TESTS */
 
 #endif /* FRONTIER_HEADLESS */
@@ -996,7 +1038,7 @@ static boolean wp_portable_utf8_to_rtf(Handle hutf8, Handle *hrtf, long *out_cha
  * Helper function for RTF-to-UTF8 conversion (wp_portable_rtf_to_utf8).
  * Defined outside FRONTIER_HEADLESS since wp_portable_rtf_to_utf8 is used unconditionally.
  * Note: wp_portable_append_bytes_unconditionals (inside FRONTIER_HEADLESS) serves the same purpose for
- * wp_portable_utf8_to_rtf, but that function is test-only.
+ * wp_portable_utf8_to_rtf.
  */
 static boolean wp_portable_append_bytes_unconditional(Handle h, const void *data, size_t len) {
     if (h == nil || data == NULL || len == 0)

--- a/tests/headless_wp_verbs.c
+++ b/tests/headless_wp_verbs.c
@@ -6,8 +6,8 @@
  * return true so scripts don't fail.
  *
  * Key implementations:
- *   - wp.setText: consumes text parameter, returns true
- *   - wp.getText: returns empty string
+ *   - wp.getText: returns plaintext from targeted WPText object
+ *   - wp.setText: sets plaintext on targeted WPText object
  *   - wp.intextmode: returns false (not in text edit mode)
  *   - wp.getselect/setselect: use thread-local selection state (GIL-safe)
  *   - All formatting verbs: no-op returning true
@@ -20,8 +20,11 @@
 #include "strings.h"
 #include "lang.h"
 #include "langinternal.h"
+#include "langexternal.h"
 #include "processinternal.h"  /* wp_sel_start/wp_sel_end macros (thread-local via GIL) */
 #include "tablestructure.h"
+#include "wpverbs.h"
+#include "wptext_portable.h"
 #include "logging.h"
 
 /* Token enum matching GUI wp verbs (from wpverbs.c) */
@@ -55,10 +58,58 @@ enum {
     wpv_selectparagraph = 26
 };
 
+static void seterrorstring(const char *msg, bigstring bserror) {
+    if (bserror == NULL)
+        return;
+    copyctopstring(msg, bserror);
+}
+
+/*
+ * wp_resolve_target - Resolve the current target to a WPText external variable.
+ *
+ * Returns the hdlexternalvariable if the target is a WPText object, or NULL
+ * with a descriptive error in bserror on failure.
+ */
+static hdlexternalvariable wp_resolve_target(bigstring bserror) {
+    hdlhashtable htable;
+    bigstring bsname;
+    tyvaluerecord val;
+    hdlhashnode hnode;
+    hdlexternalvariable hv;
+
+    if (!langgettarget(&htable, bsname)) {
+        seterrorstring("no wp target set", bserror);
+        return NULL;
+    }
+
+    if (!hashtablelookup(htable, bsname, &val, &hnode)) {
+        seterrorstring("wp target variable not found", bserror);
+        return NULL;
+    }
+
+    if (val.valuetype != externalvaluetype) {
+        seterrorstring("target is not a wp text object", bserror);
+        return NULL;
+    }
+
+    hv = (hdlexternalvariable)val.data.externalvalue;
+
+    if (hv == NULL) {
+        seterrorstring("target is not a wp text object", bserror);
+        return NULL;
+    }
+
+    if ((**hv).id != idwordprocessor) {
+        seterrorstring("target is not a wp text object", bserror);
+        return NULL;
+    }
+
+    return hv;
+}
+
 static boolean wp_valueproc(short token, hdltreenode hparam1,
                                    tyvaluerecord *vreturned,
                                    bigstring bserror) {
-    (void)bserror;
 
     switch (token) {
         case wpv_intextmode:
@@ -69,20 +120,53 @@ static boolean wp_valueproc(short token, hdltreenode hparam1,
             /* wp.setTextMode(fl) - no-op in headless mode */
             return setbooleanvalue(true, vreturned);
 
-        case wpv_gettext:
-            /* wp.getText() - return empty string in headless mode */
-            return setstringvalue(BIGSTRING("\p"), vreturned);
+        case wpv_gettext: {
+            /* wp.getText() - return plaintext from targeted WPText object */
+            hdlexternalvariable hv;
+            Handle htext;
+
+            if (!langcheckparamcount(hparam1, 0))
+                return false;
+
+            hv = wp_resolve_target(bserror);
+            if (hv == NULL)
+                return false;
+
+            if (!newemptyhandle(&htext))
+                return false;
+
+            if (!wpverbpacktotext(hv, htext)) {
+                disposehandle(htext);
+                seterrorstring("failed to extract text from wp object", bserror);
+                return false;
+            }
+
+            return setheapvalue(htext, stringvaluetype, vreturned);
+        }
 
         case wpv_settext: {
-            /* wp.setText(s) - consume text parameter without validation.
-             * In headless mode we accept any type to avoid script failures
-             * during startup bootstrap. The value is intentionally discarded. */
-            tyvaluerecord val;
+            /* wp.setText(s) - set plaintext on targeted WPText object */
+            hdlexternalvariable hv;
+            Handle hutf8;
 
             flnextparamislast = true;
 
-            if (!getparamvalue(hparam1, 1, &val))
+            if (!getexempttextvalue(hparam1, 1, &hutf8))
                 return false;
+
+            hv = wp_resolve_target(bserror);
+            if (hv == NULL) {
+                disposehandle(hutf8);
+                return false;
+            }
+
+            if (!wp_portable_set_plaintext(hv, hutf8)) {
+                disposehandle(hutf8);
+                seterrorstring("failed to set text on wp object", bserror);
+                return false;
+            }
+
+            disposehandle(hutf8);
 
             return setbooleanvalue(true, vreturned);
         }

--- a/tests/integration/test_cases/wp_verbs.yaml
+++ b/tests/integration/test_cases/wp_verbs.yaml
@@ -39,9 +39,55 @@ tests:
     expected_success: true
     expected_result: "300"
 
+  - name: "wp.getText - returns text from targeted WPText object"
+    description: "Create a WPText object, set text, and verify getText returns the text"
+    script: |
+      new(wpTextType, @workspace.wpGetTextTest);
+      target.set(@workspace.wpGetTextTest);
+      wp.setText("hello from getText test");
+      local(t = wp.getText());
+      return(sizeOf(t) > 0)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "wp.getText equivalence with string()"
+    description: "wp.getText() should produce the same result as string() coercion on the target"
+    script: |
+      new(wpTextType, @workspace.wpEquivTest);
+      target.set(@workspace.wpEquivTest);
+      wp.setText("equivalence test content");
+      return(wp.getText() == string(workspace.wpEquivTest))
+    expected_success: true
+    expected_result: "true"
+
+  - name: "wp.setText/getText roundtrip"
+    description: "Set text on a WPText object, then get it back and verify match"
+    script: |
+      new(wpTextType, @workspace.wpRoundtripTest);
+      target.set(@workspace.wpRoundtripTest);
+      wp.setText("hello world");
+      return(wp.getText() == "hello world")
+    expected_success: true
+    expected_result: "true"
+
+  - name: "wp.getText - no target generates script error"
+    description: "Calling wp.getText with no target set should fail with an error"
+    script: 'wp.getText()'
+    expected_success: false
+
+  - name: "wp.getText - non-WP target generates script error"
+    description: "Targeting a table (not a WPText object) should produce an error"
+    script: |
+      target.set(@examples);
+      wp.getText()
+    expected_success: false
+
   - name: "wp.setText - accepts text parameter"
-    description: "wp.setText should accept a string parameter without error"
-    script: 'wp.setText("hello world")'
+    description: "wp.setText should accept a string parameter when target is a WPText object"
+    script: |
+      new(wpTextType, @workspace.wpSetTextTest);
+      target.set(@workspace.wpSetTextTest);
+      wp.setText("hello world")
     expected_success: true
     expected_result: "true"
 


### PR DESCRIPTION
## Summary
- Replace wp.getText()/wp.setText() no-op stubs with target-aware implementations that operate on WPText portable state
- Add `wp_portable_set_plaintext()` to wptext_runtime.c for converting UTF-8 text to RTF portable format
- Add fast path in `wp_portable_extract_plaintext()` for in-memory RTF cache (handles newly created or modified objects not yet saved to disk)
- Move `wp_portable_utf8_to_rtf` helpers from FRONTIER_TESTS to FRONTIER_HEADLESS scope (needed at runtime by set_plaintext)
- Add `wp_resolve_target()` helper with descriptive error messages for missing/wrong target
- Add 5 new integration tests plus update 1 existing test (18 total wp verb tests, all passing)

## Files Changed

| File | Change |
|------|--------|
| `portable/wptext_runtime.c` | Add `wp_portable_set_plaintext()`, fast path for in-memory cache, move utf8-to-rtf helpers to HEADLESS scope |
| `portable/wptext_portable.h` | Declare `wp_portable_set_plaintext()` |
| `tests/headless_wp_verbs.c` | Replace getText/setText stubs with target-aware implementations |
| `tests/integration/test_cases/wp_verbs.yaml` | Add getText, setText/getText roundtrip, string() equivalence, error case tests |

## Test plan
- [x] `make -C frontier-cli` builds cleanly
- [x] All 18 wp_verbs integration tests pass
- [x] Full integration suite (1910 tests): 1686 pass, 174 skip, 50 fail (all pre-existing)
- [x] Error cases tested: no target set, non-WP target
- [x] getText/setText roundtrip verified
- [x] getText equivalence with string() coercion verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)