### PR TITLE
feat: Real platform detection + unified version system

### DIFF
--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -497,8 +497,25 @@ static boolean initenvironment ( hdlhashtable ht ) {
 		
 	#endif //!PIKE
 
+	/* New flags for headless/CLI builds. Set in both paths so UserTalk scripts
+	   can check these portably regardless of which runtime they're in. */
+
+	langassignbooleanvalue (ht, str_isHeadless, false);
+
+	#if defined(__APPLE__) || defined(__linux__)
+	langassignbooleanvalue (ht, str_isPosix, true);
+	#else
+	langassignbooleanvalue (ht, str_isPosix, false);
+	#endif
+
+	#ifdef __linux__
+	langassignbooleanvalue (ht, str_isLinux, true);
+	#else
+	langassignbooleanvalue (ht, str_isLinux, false);
+	#endif
+
 	return ( true );
-		
+
 }
 #endif /* FRONTIER_HEADLESS */
 

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -105,6 +105,9 @@ static boolean cb_false_event(EventRecord* e) { (void)e; return false; }
 #define str_osFullNameForDisplay	BIGSTRING ("\x14" "osFullNameForDisplay")
 #define str_winServicePackNumber	BIGSTRING ("\x14" "winServicePackNumber")
 #define str_isCarbon				BIGSTRING ("\x08" "isCarbon")
+#define str_isHeadless				BIGSTRING ("\x0a" "isHeadless")
+#define str_isPosix					BIGSTRING ("\x07" "isPosix")
+#define str_isLinux					BIGSTRING ("\x07" "isLinux")
 #define str_maxTcpConnections		BIGSTRING ("\x11" "maxTcpConnections")
 
 
@@ -210,23 +213,117 @@ boolean loadfunctionprocessor (short id, langvaluecallback valuecallback) {
 static boolean initenvironment (hdlhashtable ht) {
 
 	/*
-	 * Headless/runtime-test build: populate the environment table with
-	 * conservative defaults without touching platform APIs or external
-	 * processes. The full application replaces these values at startup.
+	 * Headless/CLI build: populate the environment table with real
+	 * platform information. Uses compile-time platform detection and
+	 * runtime OS version queries (getsystemversionstring / sw_vers on macOS).
+	 *
+	 * New flags added for headless CLI:
+	 *   isHeadless - true (always, in headless builds)
+	 *   isPosix    - true on macOS and Linux
+	 *   isLinux    - true on Linux only
 	 */
 
 	bigstring bs;
 
+	/* Platform detection */
+
+	#ifdef __APPLE__
+	langassignbooleanvalue (ht, str_isMac, true);
+	langassignbooleanvalue (ht, str_isWindows, false);
+	langassignbooleanvalue (ht, str_isLinux, false);
+	langassignbooleanvalue (ht, str_isCarbon, true); /* legacy compat: scripts check this for macOS */
+	langassignbooleanvalue (ht, str_isPosix, true);
+	#elif defined(__linux__)
 	langassignbooleanvalue (ht, str_isMac, false);
 	langassignbooleanvalue (ht, str_isWindows, false);
+	langassignbooleanvalue (ht, str_isLinux, true);
+	langassignbooleanvalue (ht, str_isCarbon, false);
+	langassignbooleanvalue (ht, str_isPosix, true);
+	#elif defined(_WIN32)
+	langassignbooleanvalue (ht, str_isMac, false);
+	langassignbooleanvalue (ht, str_isWindows, true);
+	langassignbooleanvalue (ht, str_isLinux, false);
+	langassignbooleanvalue (ht, str_isCarbon, false);
+	langassignbooleanvalue (ht, str_isPosix, false);
+	#else
+	langassignbooleanvalue (ht, str_isMac, false);
+	langassignbooleanvalue (ht, str_isWindows, false);
+	langassignbooleanvalue (ht, str_isLinux, false);
+	langassignbooleanvalue (ht, str_isCarbon, false);
+	langassignbooleanvalue (ht, str_isPosix, false);
+	#endif
+
+	langassignbooleanvalue (ht, str_isHeadless, true);
 	langassignbooleanvalue (ht, str_isMacOsClassic, false);
 	langassignbooleanvalue (ht, str_isServer, false);
-	langassignbooleanvalue (ht, str_isCarbon, false);
 	langassignbooleanvalue (ht, str_isPike, false);
 	langassignbooleanvalue (ht, str_isRadio, false);
 	langassignbooleanvalue (ht, str_isOpmlEditor, false);
 	langassignbooleanvalue (ht, str_isFrontier, true);
 
+	/* OS version detection */
+
+	#ifdef __APPLE__
+	{
+		bigstring bsversion, bsos;
+		Handle hcommand, hreturn;
+		long x;
+
+		getsystemversionstring (bsversion, NULL);
+
+		/* Parse major.minor.point from version string */
+
+		{ /* major */
+			bigstring bsmajor;
+			nthfield (bsversion, 1, '.', bsmajor);
+			stringtonumber (bsmajor, &x);
+			langassignlongvalue (ht, str_osMajorVersion, x);
+		}
+
+		{ /* minor */
+			bigstring bsminor;
+			nthfield (bsversion, 2, '.', bsminor);
+			stringtonumber (bsminor, &x);
+			langassignlongvalue (ht, str_osMinorVersion, x);
+		}
+
+		{ /* point */
+			bigstring bspoint;
+			nthfield (bsversion, 3, '.', bspoint);
+			stringtonumber (bspoint, &x);
+			langassignlongvalue (ht, str_osPointVersion, x);
+		}
+
+		langassignstringvalue (ht, str_osVersionString, bsversion);
+
+		/* Get build number via sw_vers */
+
+		newemptyhandle (&hreturn);
+
+		newtexthandle ("\psw_vers -buildVersion", &hcommand);
+		unixshellcall (hcommand, hreturn);
+		texthandletostring (hreturn, bs);
+		sethandlesize (hreturn, 0);
+		if (stringlength (bs) > 0)
+			setstringlength (bs, stringlength (bs) - 1); /* strip trailing newline */
+		langassignstringvalue (ht, str_osBuildNumber, bs);
+
+		/* Get OS display name via sw_vers */
+
+		copystring ("\psw_vers -productName", bs);
+		sethandlecontents (stringbaseaddress (bs), stringlength (bs), hcommand);
+		unixshellcall (hcommand, hreturn);
+		texthandletostring (hreturn, bsos);
+		if (stringlength (bsos) > 0)
+			setstringlength (bsos, stringlength (bsos) - 1); /* strip trailing newline */
+
+		disposehandle (hcommand);
+		disposehandle (hreturn);
+
+		langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+	}
+	#else
+	/* Non-macOS: set placeholder version info */
 	langassignlongvalue (ht, str_osMajorVersion, 0);
 	langassignlongvalue (ht, str_osMinorVersion, 0);
 	langassignlongvalue (ht, str_osPointVersion, 0);
@@ -235,6 +332,9 @@ static boolean initenvironment (hdlhashtable ht) {
 	langassignstringvalue (ht, str_osVersionString, bs);
 	langassignstringvalue (ht, str_osFullNameForDisplay, bs);
 	langassignstringvalue (ht, str_osBuildNumber, bs);
+	#endif
+
+	copyctopstring ("", bs);
 	langassignstringvalue (ht, str_osFlavor, bs);
 	langassignstringvalue (ht, str_winServicePackNumber, bs);
 

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -266,7 +266,6 @@ static boolean initenvironment (hdlhashtable ht) {
 	#ifdef __APPLE__
 	{
 		bigstring bsversion, bsos;
-		Handle hcommand, hreturn;
 		long x;
 
 		getsystemversionstring (bsversion, NULL);
@@ -296,31 +295,74 @@ static boolean initenvironment (hdlhashtable ht) {
 
 		langassignstringvalue (ht, str_osVersionString, bsversion);
 
-		/* Get build number via sw_vers */
+		/* Query sw_vers for build number and OS display name.
+		   Uses a shared handle pair with proper cleanup on all paths. */
 
-		newemptyhandle (&hreturn);
+		{
+			Handle hcommand = nil, hreturn = nil;
+			boolean flgothandles;
 
-		newtexthandle ("\psw_vers -buildVersion", &hcommand);
-		unixshellcall (hcommand, hreturn);
-		texthandletostring (hreturn, bs);
-		sethandlesize (hreturn, 0);
-		if (stringlength (bs) > 0)
-			setstringlength (bs, stringlength (bs) - 1); /* strip trailing newline */
-		langassignstringvalue (ht, str_osBuildNumber, bs);
+			flgothandles = newemptyhandle (&hreturn) && newtexthandle ("\psw_vers -buildVersion", &hcommand);
 
-		/* Get OS display name via sw_vers */
+			if (!flgothandles) {
 
-		copystring ("\psw_vers -productName", bs);
-		sethandlecontents (stringbaseaddress (bs), stringlength (bs), hcommand);
-		unixshellcall (hcommand, hreturn);
-		texthandletostring (hreturn, bsos);
-		if (stringlength (bsos) > 0)
-			setstringlength (bsos, stringlength (bsos) - 1); /* strip trailing newline */
+				log_warn (LOG_COMP_STARTUP, "initenvironment: failed to allocate handles for sw_vers");
 
-		disposehandle (hcommand);
-		disposehandle (hreturn);
+				if (hreturn != nil) disposehandle (hreturn);
+				if (hcommand != nil) disposehandle (hcommand);
 
-		langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+				copyctopstring ("unknown", bs);
+				langassignstringvalue (ht, str_osBuildNumber, bs);
+				langassignstringvalue (ht, str_osFullNameForDisplay, bs);
+			}
+			else {
+
+				/* Get build number */
+
+				if (unixshellcall (hcommand, hreturn)) {
+
+					texthandletostring (hreturn, bs);
+
+					if (stringlength (bs) > 0)
+						setstringlength (bs, stringlength (bs) - 1); /* strip trailing newline */
+
+					langassignstringvalue (ht, str_osBuildNumber, bs);
+
+					log_debug (LOG_COMP_STARTUP, "initenvironment: osBuildNumber=%s", PSTR(bs));
+				}
+				else {
+					log_warn (LOG_COMP_STARTUP, "initenvironment: sw_vers -buildVersion failed");
+					copyctopstring ("unknown", bs);
+					langassignstringvalue (ht, str_osBuildNumber, bs);
+				}
+
+				/* Get OS display name (reuse handles) */
+
+				sethandlesize (hreturn, 0);
+				copystring ("\psw_vers -productName", bs);
+				sethandlecontents (stringbaseaddress (bs), stringlength (bs), hcommand);
+
+				if (unixshellcall (hcommand, hreturn)) {
+
+					texthandletostring (hreturn, bsos);
+
+					if (stringlength (bsos) > 0)
+						setstringlength (bsos, stringlength (bsos) - 1); /* strip trailing newline */
+
+					langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+
+					log_debug (LOG_COMP_STARTUP, "initenvironment: osFullName=%s", PSTR(bsos));
+				}
+				else {
+					log_warn (LOG_COMP_STARTUP, "initenvironment: sw_vers -productName failed");
+					copyctopstring ("unknown", bsos);
+					langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+				}
+
+				disposehandle (hcommand);
+				disposehandle (hreturn);
+			}
+		}
 	}
 	#else
 	/* Non-macOS: set placeholder version info */

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -275,21 +275,30 @@ static boolean initenvironment (hdlhashtable ht) {
 		{ /* major */
 			bigstring bsmajor;
 			nthfield (bsversion, 1, '.', bsmajor);
-			stringtonumber (bsmajor, &x);
+			if (stringlength (bsmajor) > 0)
+				stringtonumber (bsmajor, &x);
+			else
+				x = 0;
 			langassignlongvalue (ht, str_osMajorVersion, x);
 		}
 
 		{ /* minor */
 			bigstring bsminor;
 			nthfield (bsversion, 2, '.', bsminor);
-			stringtonumber (bsminor, &x);
+			if (stringlength (bsminor) > 0)
+				stringtonumber (bsminor, &x);
+			else
+				x = 0;
 			langassignlongvalue (ht, str_osMinorVersion, x);
 		}
 
 		{ /* point */
 			bigstring bspoint;
 			nthfield (bsversion, 3, '.', bspoint);
-			stringtonumber (bspoint, &x);
+			if (stringlength (bspoint) > 0)
+				stringtonumber (bspoint, &x);
+			else
+				x = 0;
 			langassignlongvalue (ht, str_osPointVersion, x);
 		}
 
@@ -312,6 +321,7 @@ static boolean initenvironment (hdlhashtable ht) {
 
 				log_debug (LOG_COMP_STARTUP, "initenvironment: hcommand alloc failed, using fallback");
 				disposehandle (hreturn);
+				hreturn = nil;
 				goto swvers_fallback;
 			}
 
@@ -345,7 +355,7 @@ static boolean initenvironment (hdlhashtable ht) {
 				goto swvers_done;
 			}
 
-			sethandlesize (hreturn, 0);
+			sethandlesize (hreturn, 0); /* safe to ignore: shrinking to zero never fails */
 
 			if (unixshellcall (hcommand, hreturn)) {
 

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -295,73 +295,85 @@ static boolean initenvironment (hdlhashtable ht) {
 
 		langassignstringvalue (ht, str_osVersionString, bsversion);
 
-		/* Query sw_vers for build number and OS display name.
-		   Uses a shared handle pair with proper cleanup on all paths. */
+		/* Query sw_vers for build number and OS display name. */
 
 		{
 			Handle hcommand = nil, hreturn = nil;
-			boolean flgothandles;
 
-			flgothandles = newemptyhandle (&hreturn) && newtexthandle ("\psw_vers -buildVersion", &hcommand);
+			if (!newemptyhandle (&hreturn)) {
 
-			if (!flgothandles) {
+				log_debug (LOG_COMP_STARTUP, "initenvironment: hreturn alloc failed, using fallback");
+				goto swvers_fallback;
+			}
 
-				log_warn (LOG_COMP_STARTUP, "initenvironment: failed to allocate handles for sw_vers");
+			/* Get build number */
 
-				if (hreturn != nil) disposehandle (hreturn);
-				if (hcommand != nil) disposehandle (hcommand);
+			if (!newtexthandle ("\psw_vers -buildVersion", &hcommand)) {
 
-				copyctopstring ("unknown", bs);
+				log_debug (LOG_COMP_STARTUP, "initenvironment: hcommand alloc failed, using fallback");
+				disposehandle (hreturn);
+				goto swvers_fallback;
+			}
+
+			if (unixshellcall (hcommand, hreturn)) {
+
+				texthandletostring (hreturn, bs);
+
+				if (stringlength (bs) > 0)
+					setstringlength (bs, stringlength (bs) - 1); /* strip trailing newline */
+
 				langassignstringvalue (ht, str_osBuildNumber, bs);
-				langassignstringvalue (ht, str_osFullNameForDisplay, bs);
+				log_debug (LOG_COMP_STARTUP, "initenvironment: osBuildNumber=%s", PSTR(bs));
 			}
 			else {
-
-				/* Get build number */
-
-				if (unixshellcall (hcommand, hreturn)) {
-
-					texthandletostring (hreturn, bs);
-
-					if (stringlength (bs) > 0)
-						setstringlength (bs, stringlength (bs) - 1); /* strip trailing newline */
-
-					langassignstringvalue (ht, str_osBuildNumber, bs);
-
-					log_debug (LOG_COMP_STARTUP, "initenvironment: osBuildNumber=%s", PSTR(bs));
-				}
-				else {
-					log_warn (LOG_COMP_STARTUP, "initenvironment: sw_vers -buildVersion failed");
-					copyctopstring ("unknown", bs);
-					langassignstringvalue (ht, str_osBuildNumber, bs);
-				}
-
-				/* Get OS display name (reuse handles) */
-
-				sethandlesize (hreturn, 0);
-				copystring ("\psw_vers -productName", bs);
-				sethandlecontents (stringbaseaddress (bs), stringlength (bs), hcommand);
-
-				if (unixshellcall (hcommand, hreturn)) {
-
-					texthandletostring (hreturn, bsos);
-
-					if (stringlength (bsos) > 0)
-						setstringlength (bsos, stringlength (bsos) - 1); /* strip trailing newline */
-
-					langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
-
-					log_debug (LOG_COMP_STARTUP, "initenvironment: osFullName=%s", PSTR(bsos));
-				}
-				else {
-					log_warn (LOG_COMP_STARTUP, "initenvironment: sw_vers -productName failed");
-					copyctopstring ("unknown", bsos);
-					langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
-				}
-
-				disposehandle (hcommand);
-				disposehandle (hreturn);
+				log_debug (LOG_COMP_STARTUP, "initenvironment: sw_vers -buildVersion failed, using fallback");
+				copyctopstring ("unknown", bs);
+				langassignstringvalue (ht, str_osBuildNumber, bs);
 			}
+
+			disposehandle (hcommand);
+			hcommand = nil;
+
+			/* Get OS display name (fresh handle for new command) */
+
+			if (!newtexthandle ("\psw_vers -productName", &hcommand)) {
+
+				log_debug (LOG_COMP_STARTUP, "initenvironment: hcommand alloc failed for productName");
+				disposehandle (hreturn);
+				copyctopstring ("unknown", bsos);
+				langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+				goto swvers_done;
+			}
+
+			sethandlesize (hreturn, 0);
+
+			if (unixshellcall (hcommand, hreturn)) {
+
+				texthandletostring (hreturn, bsos);
+
+				if (stringlength (bsos) > 0)
+					setstringlength (bsos, stringlength (bsos) - 1); /* strip trailing newline */
+
+				langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+				log_debug (LOG_COMP_STARTUP, "initenvironment: osFullName=%s", PSTR(bsos));
+			}
+			else {
+				log_debug (LOG_COMP_STARTUP, "initenvironment: sw_vers -productName failed, using fallback");
+				copyctopstring ("unknown", bsos);
+				langassignstringvalue (ht, str_osFullNameForDisplay, bsos);
+			}
+
+			disposehandle (hcommand);
+			disposehandle (hreturn);
+			goto swvers_done;
+
+		swvers_fallback:
+
+			copyctopstring ("unknown", bs);
+			langassignstringvalue (ht, str_osBuildNumber, bs);
+			langassignstringvalue (ht, str_osFullNameForDisplay, bs);
+
+		swvers_done: ;
 		}
 	}
 	#else

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -19,8 +19,13 @@ ARCHES ?= $(shell uname -m)
 ARCH_FLAGS = $(foreach arch,$(ARCHES),-arch $(arch))
 
 # Version embedding from git
+# CLI version: from git tags (e.g., "v1.0.0-alpha.7")
+# Product version: CLI major + 10, stage mapped (alpha→a, beta→b, rc→fc)
+#   Derived by tools/derive_product_version.sh (e.g., "v1.0.0-alpha.7" → "11.0a7")
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "1.0.0-dev")
+PRODUCT_VERSION ?= $(shell ../tools/derive_product_version.sh "$(VERSION)")
 CFLAGS += -DFRONTIER_CLI_VERSION_STRING=\"$(VERSION)\"
+CFLAGS += -DFRONTIER_PRODUCT_VERSION_STRING=\"$(PRODUCT_VERSION)\"
 
 SANITIZE ?= 0
 ifeq ($(SANITIZE),1)

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1910 tests: 1715 pass (89%) 195 skip (10%)</title>
-    <dateCreated>Sat, 14 Feb 2026 21:52:52 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1913 tests: 1739 pass (90%) 174 skip (9%)</title>
+    <dateCreated>Sun, 15 Feb 2026 08:27:25 GMT</dateCreated>
   </head>
   <body>
     <outline text="Builtins Priority (builtins_priority) - 25 tests: 25 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
@@ -13,10 +13,10 @@
     <outline text="Dialog Verbs (dialog_verbs) - 48 tests: 48 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dialog_verbs.opml"/>
     <outline text="Dist Stability (dist_stability) - 7 tests: 7 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dist_stability.opml"/>
     <outline text="Efp Introspection (efp_introspection) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
-    <outline text="File Dialog Verbs (file_dialog_verbs) - 26 tests: 5 pass (19%) 21 skip (80%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
+    <outline text="File Dialog Verbs (file_dialog_verbs) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
     <outline text="File Verbs (file_verbs) - 81 tests: 78 pass (96%) 3 skip (3%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
     <outline text="Filemenu Verbs (filemenu_verbs) - 33 tests: 33 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
-    <outline text="Frontier Verbs (frontier_verbs) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/frontier_verbs.opml"/>
+    <outline text="Frontier Verbs (frontier_verbs) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/frontier_verbs.opml"/>
     <outline text="Html Core Tests (html_core_tests) - 60 tests: 60 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_core_tests.opml"/>
     <outline text="Html Framework Tests (html_framework_tests) - 47 tests: 45 pass (95%) 2 skip (4%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_framework_tests.opml"/>
     <outline text="Html Image Tests (html_image_tests) - 19 tests: 1 pass (5%) 18 skip (94%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_image_tests.opml"/>
@@ -41,6 +41,7 @@
     <outline text="String Verbs (string_verbs) - 25 tests: 25 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/string_verbs.opml"/>
     <outline text="Sys Environment Verbs (sys_environment_verbs) - 31 tests: 31 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/sys_environment_verbs.opml"/>
     <outline text="Sys Processor Tests (sys_processor_tests) - 51 tests: 51 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/sys_processor_tests.opml"/>
+    <outline text="System Environment (system_environment) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/system_environment.opml"/>
     <outline text="Table Sorting Verbs (table_sorting_verbs) - 16 tests: 16 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/table_sorting_verbs.opml"/>
     <outline text="Table Verbs (table_verbs) - 20 tests: 19 pass (95%) 1 skip (5%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/table_verbs.opml"/>
     <outline text="Target Verbs (target_verbs) - 46 tests: 46 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/target_verbs.opml"/>

--- a/reports/integration_tests/efp_introspection.opml
+++ b/reports/integration_tests/efp_introspection.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <title>Efp Introspection (efp_introspection) - 15 tests: 15 pass (100%)</title>
+    <dateCreated>Sun, 15 Feb 2026 08:17:42 GMT</dateCreated>
   </head>
   <body>
     <outline text="parentOf(string.mid) - returns database path - CRITICAL TEST: parentOf(string.mid) should return the database path&#10;@system.verbs.builtins.string, not the EFP internal path&#10;@system.compiler.[&quot;kernel&quot;].string.&#10;&#10;Bug behavior: Returns @system.compiler.[&quot;kernel&quot;].string&#10;Fixed behavior: Returns @system.verbs.builtins.string&#10;">
@@ -115,6 +115,14 @@
       </outline>
       <outline text="Script">
         <outline text="defined(string.nonexistent)"/>
+      </outline>
+    </outline>
+    <outline text="webserver.init - resolves to script, not EFP stub - webserver is excluded from EFP registration (EXCLUDED_PROCESSORS&#10;in parse_kernelverbs.py). Verify webserver.init is defined and&#10;resolves to a script type, not a token/EFP stub.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(webserver.init) and (typeOf(webserver.init) == scriptType)"/>
       </outline>
     </outline>
   </body>

--- a/reports/integration_tests/file_dialog_verbs.opml
+++ b/reports/integration_tests/file_dialog_verbs.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>File Dialog Verbs (file_dialog_verbs) - 26 tests: 5 pass (19%) 21 skip (80%)</title>
-    <dateCreated>Sat, 14 Feb 2026 21:52:52 GMT</dateCreated>
+    <title>File Dialog Verbs (file_dialog_verbs) - 14 tests: 14 pass (100%)</title>
+    <dateCreated>Sun, 15 Feb 2026 08:17:42 GMT</dateCreated>
   </head>
   <body>
     <outline text="file.getFileDialog - error in batch mode - Should return error when not in interactive mode">
@@ -53,9 +53,8 @@
         <outline text="file.getDiskDialog(&quot;Select volume&quot;, @result)"/>
       </outline>
     </outline>
-    <outline text="file.getFileDialog - select file with full path - Should accept typed full path to existing file">
+    <outline text="file.getFileDialog - select file with full path - Should accept typed full path to existing file via piped stdin">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/test.txt&#10;"/>
       </outline>
       <outline text="Script">
@@ -65,18 +64,8 @@
         <outline text="return result"/>
       </outline>
     </outline>
-    <outline text="file.getFileDialog - tab completion shows menu - Tab key should show file list menu">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: /Users&#9;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.getFileDialog(&quot;Select file&quot;, @result)"/>
-      </outline>
-    </outline>
     <outline text="file.getFileDialog - returns full absolute path - Must return full absolute path (UserTalk requirement)">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/config.txt&#10;"/>
         <outline text="expected_result: true"/>
       </outline>
@@ -87,53 +76,8 @@
         <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
       </outline>
     </outline>
-    <outline text="file.getFileDialog - only allows existing files - Should reject non-existent file paths">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: /nonexistent/file.txt&#10;{FRONTIER_TEST_TMP_DIR}/real.txt&#10;"/>
-        <outline text="setup_script: file.writeWholeFile(&quot;{FRONTIER_TEST_TMP_DIR}/real.txt&quot;, &quot;exists&quot;)&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.getFileDialog(&quot;Select existing file&quot;, @result)"/>
-      </outline>
-    </outline>
-    <outline text="file.getFileDialog - shows hidden files - Hidden files (starting with .) should be visible">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/.gitignore&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.writeWholeFile(&quot;{FRONTIER_TEST_TMP_DIR}/.gitignore&quot;, &quot;*.tmp&quot;)"/>
-        <outline text="file.getFileDialog(&quot;Select file&quot;, @result)"/>
-      </outline>
-    </outline>
-    <outline text="file.getFileDialog - unicode filename (CJK) - Should handle CJK characters in filenames">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/文件.txt&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="local(unicodePath = &quot;{FRONTIER_TEST_TMP_DIR}/文件.txt&quot;)"/>
-        <outline text="file.writeWholeFile(unicodePath, &quot;content&quot;)"/>
-        <outline text="file.getFileDialog(&quot;Select&quot;, @result)"/>
-        <outline text="return result"/>
-      </outline>
-    </outline>
-    <outline text="file.getFileDialog - unicode filename (emoji) - Should handle emoji in filenames">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/file🚀.txt&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="local(emojiPath = &quot;{FRONTIER_TEST_TMP_DIR}/file🚀.txt&quot;)"/>
-        <outline text="file.writeWholeFile(emojiPath, &quot;content&quot;)"/>
-        <outline text="file.getFileDialog(&quot;Select&quot;, @result)"/>
-        <outline text="return result"/>
-      </outline>
-    </outline>
     <outline text="file.getFileDialog - filename with spaces - Should handle spaces in filenames">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/my file.txt&#10;"/>
       </outline>
       <outline text="Script">
@@ -143,22 +87,19 @@
         <outline text="return result"/>
       </outline>
     </outline>
-    <outline text="file.getFileDialog - very long path (256 chars) - Should handle long file paths">
+    <outline text="file.getFileDialog - prompt passthrough - UserTalk prompt should be forwarded to the dialog (not hardcoded)">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt&#10;"/>
-        <outline text="expected_result: true"/>
+        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/prompt_test.txt&#10;"/>
       </outline>
       <outline text="Script">
-        <outline text="local(longPath = &quot;{FRONTIER_TEST_TMP_DIR}/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt&quot;)"/>
-        <outline text="file.writeWholeFile(longPath, &quot;test&quot;)"/>
-        <outline text="file.getFileDialog(&quot;Select&quot;, @result)"/>
-        <outline text="return string.patternMatch(&quot;aaaaaaa&quot;, result) &gt; 0"/>
+        <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/prompt_test.txt&quot;)"/>
+        <outline text="file.writeWholeFile(testPath, &quot;data&quot;)"/>
+        <outline text="file.getFileDialog(&quot;Where is your web browser?&quot;, @result, &quot;txt&quot;)"/>
+        <outline text="return result"/>
       </outline>
     </outline>
-    <outline text="file.putFileDialog - type new filename - Should allow typing new filename after directory path">
+    <outline text="file.putFileDialog - type new filename - Should allow typing new filename via piped stdin">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/output.txt&#10;"/>
         <outline text="expected_result_contains: output.txt"/>
       </outline>
@@ -167,20 +108,8 @@
         <outline text="return result"/>
       </outline>
     </outline>
-    <outline text="file.putFileDialog - select existing file to overwrite - Should allow selecting existing file">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/existing.txt&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.writeWholeFile(&quot;{FRONTIER_TEST_TMP_DIR}/existing.txt&quot;, &quot;old&quot;)"/>
-        <outline text="file.putFileDialog(&quot;Save as&quot;, @result)"/>
-        <outline text="return result"/>
-      </outline>
-    </outline>
     <outline text="file.putFileDialog - returns full absolute path - Must return full path even for new files">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/newfile.txt&#10;"/>
         <outline text="expected_result: true"/>
       </outline>
@@ -189,41 +118,18 @@
         <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
       </outline>
     </outline>
-    <outline text="file.putFileDialog - shows all files (not just directories) - Menu should show existing files to prevent overwrites">
+    <outline text="file.getFolderDialog - select directory - Should accept directory path via piped stdin">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/file3.txt&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.writeWholeFile(&quot;{FRONTIER_TEST_TMP_DIR}/file1.txt&quot;, &quot;a&quot;)"/>
-        <outline text="file.writeWholeFile(&quot;{FRONTIER_TEST_TMP_DIR}/file2.txt&quot;, &quot;b&quot;)"/>
-        <outline text="file.putFileDialog(&quot;Save as&quot;, @result)"/>
-      </outline>
-    </outline>
-    <outline text="file.getFolderDialog - select directory - Should accept directory path">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}&#10;"/>
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
         <outline text="file.getFolderDialog(&quot;Select output directory&quot;, @result)"/>
-        <outline text="return string.patternMatch(&quot;/integration&quot;, result) &gt; 0"/>
-      </outline>
-    </outline>
-    <outline text="file.getFolderDialog - only shows directories and symlinks - Should not show regular files in menu">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.writeWholeFile(&quot;{FRONTIER_TEST_TMP_DIR}/file.txt&quot;, &quot;data&quot;)"/>
-        <outline text="file.getFolderDialog(&quot;Select folder&quot;, @result)"/>
+        <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
       </outline>
     </outline>
     <outline text="file.getFolderDialog - returns full absolute path - Must return full path to directory">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}&#10;"/>
         <outline text="expected_result: true"/>
       </outline>
@@ -232,59 +138,14 @@
         <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
       </outline>
     </outline>
-    <outline text="file.getFolderDialog - hidden directories visible - Hidden directories (like .git) should be visible">
+    <outline text="file.getDiskDialog - select root volume - Should list mounted volumes and accept selection via piped stdin">
       <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}&#10;"/>
-        <outline text="expected_result: true"/>
-      </outline>
-      <outline text="Script">
-        <outline text="local(hiddenPath = &quot;{FRONTIER_TEST_TMP_DIR}/.hidden&quot;)"/>
-        <outline text="file.getFolderDialog(&quot;Select folder&quot;, @result)"/>
-        <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
-      </outline>
-    </outline>
-    <outline text="file.getDiskDialog - select root volume - Should list mounted volumes">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
         <outline text="stdin_input: 1&#10;"/>
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
         <outline text="file.getDiskDialog(&quot;Select backup volume&quot;, @result)"/>
         <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
-      </outline>
-    </outline>
-    <outline text="file.getDiskDialog - returns full path to mount point - Must return mount point path">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: 1&#10;"/>
-        <outline text="expected_result: true"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.getDiskDialog(&quot;Select volume&quot;, @result)"/>
-        <outline text="return string.mid(result, 1, 1) == &quot;/&quot;"/>
-      </outline>
-    </outline>
-    <outline text="file.getFileDialog - starts from output address path - If output variable contains path, use that as starting dir">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: &#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="local(pathHint = &quot;{FRONTIER_TEST_TMP_DIR}/file.txt&quot;)"/>
-        <outline text="file.writeWholeFile(pathHint, &quot;data&quot;)"/>
-        <outline text="file.getFileDialog(&quot;Select&quot;, @pathHint)"/>
-        <outline text="return pathHint"/>
-      </outline>
-    </outline>
-    <outline text="file.getFileDialog - defaults to cwd when no path hint - Without path in output address, should start from cwd">
-      <outline text="Metadata">
-        <outline text="skip: Phase 2 interactive mode not yet implemented"/>
-        <outline text="stdin_input: {FRONTIER_TEST_TMP_DIR}/file.txt&#10;"/>
-      </outline>
-      <outline text="Script">
-        <outline text="file.getFileDialog(&quot;Select file&quot;, @result)"/>
       </outline>
     </outline>
   </body>

--- a/reports/integration_tests/filemenu_verbs.opml
+++ b/reports/integration_tests/filemenu_verbs.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Filemenu Verbs (filemenu_verbs) - 31 tests: 31 pass (100%)</title>
-    <dateCreated>Fri, 13 Feb 2026 08:57:39 GMT</dateCreated>
+    <title>Filemenu Verbs (filemenu_verbs) - 33 tests: 33 pass (100%)</title>
+    <dateCreated>Sun, 15 Feb 2026 08:17:42 GMT</dateCreated>
   </head>
   <body>
     <outline text="fileMenu.new - create new database - fileMenu.new creates a new empty ODB database and opens it">
@@ -43,6 +43,18 @@
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_new_hidden.root7&quot;)"/>
         <outline text="local(result = fileMenu.new(dbPath, true))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="fileMenu.new - with named hidden parameter - fileMenu.new accepts named hidden:true parameter syntax">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_new_named_hidden.root7&quot;)"/>
+        <outline text="local(result = fileMenu.new(dbPath, hidden:true))"/>
         <outline text="fileMenu.closeall()"/>
         <outline text="return result"/>
       </outline>
@@ -178,6 +190,19 @@
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_hidden.root7&quot;)"/>
         <outline text="db.new(dbPath)"/>
         <outline text="local(result = fileMenu.open(dbPath, true))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="fileMenu.open - with named hidden parameter - Opening with named hidden:true parameter syntax should succeed">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_open_named_hidden.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="local(result = fileMenu.open(dbPath, hidden:true))"/>
         <outline text="fileMenu.closeall()"/>
         <outline text="return result"/>
       </outline>

--- a/reports/integration_tests/frontier_verbs.opml
+++ b/reports/integration_tests/frontier_verbs.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Verbs (frontier_verbs) - 12 tests: 12 pass (100%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <title>Frontier Verbs (frontier_verbs) - 15 tests: 15 pass (100%)</title>
+    <dateCreated>Sun, 15 Feb 2026 08:17:42 GMT</dateCreated>
   </head>
   <body>
     <outline text="frontier.getProgramPath - returns string - getProgramPath should return a string value">
@@ -68,12 +68,39 @@
         <outline text="return typeof(v) == 'TEXT'"/>
       </outline>
     </outline>
-    <outline text="frontier.version - returns 10.0 - Headless mode returns version 10.0">
+    <outline text="frontier.version - returns 11.x product version - Headless mode returns product version derived from git tag (CLI major + 10)">
       <outline text="Metadata">
-        <outline text="expected_result: 10.0"/>
+        <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="return frontier.version()"/>
+        <outline text="local (v = frontier.version())"/>
+        <outline text="return v beginsWith &quot;11.&quot;"/>
+      </outline>
+    </outline>
+    <outline text="frontier.version - satisfies legacy version checks - Product version should be greater than legacy 7.x and 10.x versions">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return not date.versionLessThan(frontier.version(), &quot;10.0&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="frontier.cliVersion - returns string - cliVersion should return a string value">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (v = frontier.cliVersion())"/>
+        <outline text="return typeof(v) == 'TEXT'"/>
+      </outline>
+    </outline>
+    <outline text="frontier.cliVersion - returns CLI version - cliVersion should return the git-derived CLI version">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (v = frontier.cliVersion())"/>
+        <outline text="return sizeOf(v) &gt; 0"/>
       </outline>
     </outline>
     <outline text="frontier.enableAgents - returns true - enableAgents is a no-op in headless mode, returns true">

--- a/reports/integration_tests/lang_verbs.opml
+++ b/reports/integration_tests/lang_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Lang Verbs (lang_verbs) - 156 tests: 141 pass (90%) 15 skip (9%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <dateCreated>Sun, 15 Feb 2026 08:17:42 GMT</dateCreated>
   </head>
   <body>
     <outline text="lang.double - integer to double - Convert integer to double-precision float">
@@ -357,30 +357,30 @@
         <outline text="lang.abs(1, 2)"/>
       </outline>
     </outline>
-    <outline text="lang.random - in range - Random number should be in valid range [0, max-1]">
+    <outline text="lang.random - in range - Random number should be in valid range [1, 100] inclusive">
       <outline text="Metadata">
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="local (x = lang.random(100))"/>
-        <outline text="return (x &gt;= 0) and (x &lt; 100)"/>
+        <outline text="local (x = lang.random(1, 100))"/>
+        <outline text="return (x &gt;= 1) and (x &lt;= 100)"/>
       </outline>
     </outline>
-    <outline text="lang.random - max=1 - Random(1) should always return 0">
+    <outline text="lang.random - equal bounds - random(5, 5) should always return 5">
       <outline text="Metadata">
-        <outline text="expected_result: 0"/>
+        <outline text="expected_result: 5"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.random(1)"/>
+        <outline text="lang.random(5, 5)"/>
       </outline>
     </outline>
-    <outline text="lang.random - max=10 - Random(10) should be in [0,9]">
+    <outline text="lang.random - small range - Random(1, 10) should be in [1, 10]">
       <outline text="Metadata">
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="local (x = lang.random(10))"/>
-        <outline text="return (x &gt;= 0) and (x &lt;= 9)"/>
+        <outline text="local (x = lang.random(1, 10))"/>
+        <outline text="return (x &gt;= 1) and (x &lt;= 10)"/>
       </outline>
     </outline>
     <outline text="lang.random - multiple calls differ - Multiple random calls should (usually) produce different values">
@@ -388,34 +388,34 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="local (x = lang.random(1000))"/>
-        <outline text="local (y = lang.random(1000))"/>
-        <outline text="local (z = lang.random(1000))"/>
+        <outline text="local (x = lang.random(1, 1000))"/>
+        <outline text="local (y = lang.random(1, 1000))"/>
+        <outline text="local (z = lang.random(1, 1000))"/>
         <outline text="return (x != y) or (y != z)"/>
       </outline>
     </outline>
-    <outline text="lang.random - max=0 error - Random(0) should fail (invalid range)">
+    <outline text="lang.random - lower greater than upper error - random(10, 1) should fail (lower &gt; upper)">
       <outline text="Metadata">
         <outline text="expected_success: False"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.random(0)"/>
+        <outline text="lang.random(10, 1)"/>
       </outline>
     </outline>
-    <outline text="lang.random - negative max error - Random with negative max should fail">
-      <outline text="Metadata">
-        <outline text="expected_success: False"/>
-      </outline>
-      <outline text="Script">
-        <outline text="lang.random(-10)"/>
-      </outline>
-    </outline>
-    <outline text="lang.random - no parameters - Parameter validation: missing parameter should fail">
+    <outline text="lang.random - no parameters - Parameter validation: missing parameters should fail">
       <outline text="Metadata">
         <outline text="expected_success: False"/>
       </outline>
       <outline text="Script">
         <outline text="lang.random()"/>
+      </outline>
+    </outline>
+    <outline text="lang.random - one parameter error - Parameter validation: single parameter should fail (needs 2)">
+      <outline text="Metadata">
+        <outline text="expected_success: False"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.random(100)"/>
       </outline>
     </outline>
     <outline text="lang.memavail - returns positive - Available memory should be a positive number">

--- a/reports/integration_tests/system_environment.opml
+++ b/reports/integration_tests/system_environment.opml
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>System Environment (system_environment) - 12 tests: 12 pass (100%)</title>
+    <dateCreated>Sun, 15 Feb 2026 08:27:25 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="system.environment.isMac - matches sys.os - isMac should be true when sys.os() returns MacOS">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;MacOS&quot;">
+          <outline text="return system.environment.isMac}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return not system.environment.isMac}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="system.environment.isWindows - false on non-Windows - isWindows should be false on macOS and Linux">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;Windows&quot;">
+          <outline text="return system.environment.isWindows}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return not system.environment.isWindows}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="system.environment.isLinux - matches sys.os - isLinux should be true when sys.os() returns Linux">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;Linux&quot;">
+          <outline text="return system.environment.isLinux}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return not system.environment.isLinux}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="system.environment.isHeadless - true in CLI mode - isHeadless should always be true in headless/CLI mode">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return system.environment.isHeadless"/>
+      </outline>
+    </outline>
+    <outline text="system.environment.isPosix - true on macOS and Linux - isPosix should be true on all POSIX platforms">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;Windows&quot;">
+          <outline text="return not system.environment.isPosix}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return system.environment.isPosix}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="system.environment.isCarbon - true on macOS - isCarbon should be true on macOS for backward compat with legacy scripts">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;MacOS&quot;">
+          <outline text="return system.environment.isCarbon}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return not system.environment.isCarbon}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="system.environment.isFrontier - always true - isFrontier should always be true">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return system.environment.isFrontier"/>
+      </outline>
+    </outline>
+    <outline text="system.environment.isMacOsClassic - always false - isMacOsClassic should always be false (no classic Mac OS support)">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return not system.environment.isMacOsClassic"/>
+      </outline>
+    </outline>
+    <outline text="system.environment.osMajorVersion - nonzero on macOS - osMajorVersion should be a real version number, not zero">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;MacOS&quot;">
+          <outline text="return system.environment.osMajorVersion &gt;= 10}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return system.environment.osMajorVersion &gt;= 0}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="system.environment.osVersionString - not zero string - osVersionString should contain a real version, not 0.0.0">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return system.environment.osVersionString != &quot;0.0.0&quot;"/>
+      </outline>
+    </outline>
+    <outline text="system.environment.osFullNameForDisplay - not zero string - osFullNameForDisplay should contain a real OS name">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return system.environment.osFullNameForDisplay != &quot;0.0.0&quot;"/>
+      </outline>
+    </outline>
+    <outline text="system.environment.osBuildNumber - nonempty on macOS - osBuildNumber should contain a real build number from sw_vers">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if sys.os() == &quot;MacOS&quot;">
+          <outline text="return sizeOf(system.environment.osBuildNumber) &gt; 0}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return true}"/>
+        </outline>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/tests/headless_frontier_verbs.c
+++ b/tests/headless_frontier_verbs.c
@@ -45,7 +45,8 @@ enum {
     frov_gethashloopcount = 10,
     frov_hideapplication = 11,
     frov_isvalidserialnumber = 12,
-    frov_showapplication = 13
+    frov_showapplication = 13,
+    frov_cliversion = 14
 };
 
 static boolean frontier_valueproc(short token, hdltreenode hparam1,
@@ -167,13 +168,39 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
             /* Verb #7: frontier.reclaimmemory - not yet implemented */
             if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
             return false;
-        case frov_version:
-            /* Verb #8: frontier.version - Return version string */
-            /* In headless mode, return a version that satisfies version checks */
-            /* Using 10.0 to be greater than any historical Frontier version */
+        case frov_version: {
+            /* Verb #8: frontier.version - Return product version string */
+            /* Derived from git tag: CLI major + 10 (e.g., CLI v1.0.0-alpha.6 → "11.0a6") */
+            /* Ensures date.versionLessThan() comparisons with legacy 7.x/10.x versions work */
+            bigstring bsversion;
+
             if (!langcheckparamcount(hparam1, 0))
                 return false;
-            return setstringvalue(BIGSTRING("\x04" "10.0"), vreturned);
+
+            #ifdef FRONTIER_PRODUCT_VERSION_STRING
+            copyctopstring(FRONTIER_PRODUCT_VERSION_STRING, bsversion);
+            #else
+            copyctopstring("11.0d", bsversion);
+            #endif
+
+            return setstringvalue(bsversion, vreturned);
+        }
+        case frov_cliversion: {
+            /* Verb #14: frontier.cliVersion - Return CLI distribution version string */
+            /* Returns the git-derived version (e.g., "v1.0.0-alpha.6") */
+            bigstring bsversion;
+
+            if (!langcheckparamcount(hparam1, 0))
+                return false;
+
+            #ifdef FRONTIER_CLI_VERSION_STRING
+            copyctopstring(FRONTIER_CLI_VERSION_STRING, bsversion);
+            #else
+            copyctopstring("1.0.0-dev", bsversion);
+            #endif
+
+            return setstringvalue(bsversion, vreturned);
+        }
         case frov_hashstats:
             /* Verb #9: frontier.hashstats - not yet implemented */
             if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
@@ -212,11 +239,19 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
 
 /*
  * frontierversion - Direct C function called by langhtml.c for webserver headers
- * Returns the Frontier version as a string value.
+ * Returns the Frontier product version as a string value.
  * This is NOT a verb - it's called directly from webservergetserverstring().
  */
 boolean frontierversion(tyvaluerecord *v) {
-    return setstringvalue(BIGSTRING("\x04" "10.0"), v);
+    bigstring bsversion;
+
+    #ifdef FRONTIER_PRODUCT_VERSION_STRING
+    copyctopstring(FRONTIER_PRODUCT_VERSION_STRING, bsversion);
+    #else
+    copyctopstring("11.0d", bsversion);
+    #endif
+
+    return setstringvalue(bsversion, v);
 }
 
 /*
@@ -266,6 +301,7 @@ boolean frontierinitverbs(void) {
     ADD_VERB(BIGSTRING("\phideapplication"), frov_hideapplication);
     ADD_VERB(BIGSTRING("\pisvalidserialnumber"), frov_isvalidserialnumber);
     ADD_VERB(BIGSTRING("\pshowapplication"), frov_showapplication);
+    ADD_VERB(BIGSTRING("\pcliversion"), frov_cliversion);
 
     #undef ADD_VERB
 

--- a/tests/headless_frontier_verbs.c
+++ b/tests/headless_frontier_verbs.c
@@ -49,6 +49,9 @@ enum {
     frov_cliversion = 14
 };
 
+/* Forward declaration — defined below, also called directly by langhtml.c */
+boolean frontierversion(tyvaluerecord *v);
+
 static boolean frontier_valueproc(short token, hdltreenode hparam1,
                                      tyvaluerecord *vreturned,
                                      bigstring bserror) {
@@ -168,23 +171,13 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
             /* Verb #7: frontier.reclaimmemory - not yet implemented */
             if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
             return false;
-        case frov_version: {
+        case frov_version:
             /* Verb #8: frontier.version - Return product version string */
             /* Derived from git tag: CLI major + 10 (e.g., CLI v1.0.0-alpha.6 → "11.0a6") */
             /* Ensures date.versionLessThan() comparisons with legacy 7.x/10.x versions work */
-            bigstring bsversion;
-
             if (!langcheckparamcount(hparam1, 0))
                 return false;
-
-            #ifdef FRONTIER_PRODUCT_VERSION_STRING
-            copyctopstring(FRONTIER_PRODUCT_VERSION_STRING, bsversion);
-            #else
-            copyctopstring("11.0d", bsversion);
-            #endif
-
-            return setstringvalue(bsversion, vreturned);
-        }
+            return frontierversion(vreturned);
         case frov_cliversion: {
             /* Verb #14: frontier.cliVersion - Return CLI distribution version string */
             /* Returns the git-derived version (e.g., "v1.0.0-alpha.6") */

--- a/tests/integration/test_cases/frontier_verbs.yaml
+++ b/tests/integration/test_cases/frontier_verbs.yaml
@@ -68,12 +68,37 @@ tests:
     expected_success: true
     expected_result: "true"
 
-  - name: "frontier.version - returns 10.0"
-    description: "Headless mode returns version 10.0"
+  - name: "frontier.version - returns 11.x product version"
+    description: "Headless mode returns product version derived from git tag (CLI major + 10)"
     script: |
-      return frontier.version()
+      local (v = frontier.version());
+      return v beginsWith "11."
     expected_success: true
-    expected_result: "10.0"
+    expected_result: "true"
+
+  - name: "frontier.version - satisfies legacy version checks"
+    description: "Product version should be greater than legacy 7.x and 10.x versions"
+    script: |
+      return not date.versionLessThan(frontier.version(), "10.0")
+    expected_success: true
+    expected_result: "true"
+
+  # frontier.cliVersion tests
+  - name: "frontier.cliVersion - returns string"
+    description: "cliVersion should return a string value"
+    script: |
+      local (v = frontier.cliVersion());
+      return typeof(v) == 'TEXT'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "frontier.cliVersion - returns CLI version"
+    description: "cliVersion should return the git-derived CLI version"
+    script: |
+      local (v = frontier.cliVersion());
+      return sizeOf(v) > 0
+    expected_success: true
+    expected_result: "true"
 
   # frontier.enableAgents tests (no-op in headless)
   - name: "frontier.enableAgents - returns true"

--- a/tests/integration/test_cases/system_environment.yaml
+++ b/tests/integration/test_cases/system_environment.yaml
@@ -1,0 +1,113 @@
+# Integration tests for system.environment table
+# Tests platform detection flags populated by initenvironment()
+#
+# Values tested:
+#   - system.environment.isMac - true on macOS
+#   - system.environment.isWindows - false on macOS
+#   - system.environment.isLinux - false on macOS (true on Linux)
+#   - system.environment.isHeadless - true in CLI mode
+#   - system.environment.isPosix - true on macOS and Linux
+#   - system.environment.isCarbon - true on macOS (legacy compat)
+#   - system.environment.isFrontier - true always
+#   - system.environment.osMajorVersion - nonzero on macOS
+#   - system.environment.osVersionString - real version on macOS
+
+tests:
+  # Platform detection flags
+  - name: "system.environment.isMac - matches sys.os"
+    description: "isMac should be true when sys.os() returns MacOS"
+    script: |
+      if sys.os() == "MacOS" {
+        return system.environment.isMac}
+      else {
+        return not system.environment.isMac}
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.isWindows - false on non-Windows"
+    description: "isWindows should be false on macOS and Linux"
+    script: |
+      if sys.os() == "Windows" {
+        return system.environment.isWindows}
+      else {
+        return not system.environment.isWindows}
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.isLinux - matches sys.os"
+    description: "isLinux should be true when sys.os() returns Linux"
+    script: |
+      if sys.os() == "Linux" {
+        return system.environment.isLinux}
+      else {
+        return not system.environment.isLinux}
+    expected_success: true
+    expected_result: "true"
+
+  # Headless and POSIX flags
+  - name: "system.environment.isHeadless - true in CLI mode"
+    description: "isHeadless should always be true in headless/CLI mode"
+    script: |
+      return system.environment.isHeadless
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.isPosix - true on macOS and Linux"
+    description: "isPosix should be true on all POSIX platforms"
+    script: |
+      if sys.os() == "Windows" {
+        return not system.environment.isPosix}
+      else {
+        return system.environment.isPosix}
+    expected_success: true
+    expected_result: "true"
+
+  # Legacy compatibility flags
+  - name: "system.environment.isCarbon - true on macOS"
+    description: "isCarbon should be true on macOS for backward compat with legacy scripts"
+    script: |
+      if sys.os() == "MacOS" {
+        return system.environment.isCarbon}
+      else {
+        return not system.environment.isCarbon}
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.isFrontier - always true"
+    description: "isFrontier should always be true"
+    script: |
+      return system.environment.isFrontier
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.isMacOsClassic - always false"
+    description: "isMacOsClassic should always be false (no classic Mac OS support)"
+    script: |
+      return not system.environment.isMacOsClassic
+    expected_success: true
+    expected_result: "true"
+
+  # OS version fields
+  - name: "system.environment.osMajorVersion - nonzero on macOS"
+    description: "osMajorVersion should be a real version number, not zero"
+    script: |
+      if sys.os() == "MacOS" {
+        return system.environment.osMajorVersion >= 10}
+      else {
+        return system.environment.osMajorVersion >= 0}
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.osVersionString - not zero string"
+    description: "osVersionString should contain a real version, not 0.0.0"
+    script: |
+      return system.environment.osVersionString != "0.0.0"
+    expected_success: true
+    expected_result: "true"
+
+  - name: "system.environment.osFullNameForDisplay - not zero string"
+    description: "osFullNameForDisplay should contain a real OS name"
+    script: |
+      return system.environment.osFullNameForDisplay != "0.0.0"
+    expected_success: true
+    expected_result: "true"

--- a/tests/integration/test_cases/system_environment.yaml
+++ b/tests/integration/test_cases/system_environment.yaml
@@ -111,3 +111,13 @@ tests:
       return system.environment.osFullNameForDisplay != "0.0.0"
     expected_success: true
     expected_result: "true"
+
+  - name: "system.environment.osBuildNumber - nonempty on macOS"
+    description: "osBuildNumber should contain a real build number from sw_vers"
+    script: |
+      if sys.os() == "MacOS" {
+        return sizeOf(system.environment.osBuildNumber) > 0}
+      else {
+        return true}
+    expected_success: true
+    expected_result: "true"

--- a/tools/derive_product_version.sh
+++ b/tools/derive_product_version.sh
@@ -8,8 +8,16 @@
 #   v1.1.0-alpha.2       → 11.1a2
 #   v1.2.3               → 11.2.3
 #   1.0.0-dev             → 11.0d
+#   db0949d (bare hash)   → 11.0d (safe fallback)
 
 v="${1#v}"  # strip leading 'v' if present
+
+# Validate input starts with digits (a proper version tag).
+# git describe --always can return bare commit hashes when no tags exist.
+if [ -z "$v" ] || ! echo "$v" | grep -qE '^[0-9]+\.'; then
+    echo "11.0d"
+    exit 0
+fi
 
 major=$(echo "$v" | sed -E 's/^([0-9]+).*/\1/')
 rest=$(echo "$v" | sed -E 's/^[0-9]+\.//')
@@ -31,7 +39,8 @@ if echo "$v" | grep -qE '\-(alpha|beta|rc|dev)'; then
     esac
 fi
 
-if [ "$patch" = "0" ] || [ "$patch" = "$minor" ]; then
+# Only omit patch when it's genuinely zero (e.g., v1.0.0 → 11.0, not v1.2.2 → 11.2)
+if [ "$patch" = "0" ]; then
     echo "${pmajor}.${minor}${stage}${sub}"
 else
     echo "${pmajor}.${minor}.${patch}${stage}${sub}"

--- a/tools/derive_product_version.sh
+++ b/tools/derive_product_version.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Derive product version from CLI version tag.
+# CLI major + 10, stage mapped: alpha→a, beta→b, rc→fc, dev→d
+# Examples:
+#   v1.0.0-alpha.6       → 11.0a6
+#   v1.0.0-beta.3        → 11.0b3
+#   v1.0.0               → 11.0
+#   v1.1.0-alpha.2       → 11.1a2
+#   v1.2.3               → 11.2.3
+#   1.0.0-dev             → 11.0d
+
+v="${1#v}"  # strip leading 'v' if present
+
+major=$(echo "$v" | sed -E 's/^([0-9]+).*/\1/')
+rest=$(echo "$v" | sed -E 's/^[0-9]+\.//')
+pmajor=$((major + 10))
+minor=$(echo "$rest" | sed -E 's/^([0-9]+).*/\1/')
+rest2=$(echo "$rest" | sed -E 's/^[0-9]+\.//')
+patch=$(echo "$rest2" | sed -E 's/^([0-9]+).*/\1/')
+
+stage=""
+sub=""
+if echo "$v" | grep -qE '\-(alpha|beta|rc|dev)'; then
+    stage=$(echo "$v" | sed -E 's/.*-(alpha|beta|rc|dev).*/\1/')
+    sub=$(echo "$v" | sed -E 's/.*-(alpha|beta|rc|dev)\.?//; s/[^0-9].*//')
+    case "$stage" in
+        alpha) stage="a" ;;
+        beta)  stage="b" ;;
+        rc)    stage="fc" ;;
+        dev)   stage="d" ;;
+    esac
+fi
+
+if [ "$patch" = "0" ] || [ "$patch" = "$minor" ]; then
+    echo "${pmajor}.${minor}${stage}${sub}"
+else
+    echo "${pmajor}.${minor}.${patch}${stage}${sub}"
+fi

--- a/tools/derive_product_version.sh
+++ b/tools/derive_product_version.sh
@@ -1,20 +1,32 @@
-#!/bin/sh
+#!/bin/bash
 # Derive product version from CLI version tag.
-# CLI major + 10, stage mapped: alpha→a, beta→b, rc→fc, dev→d
+# Maps CLI version to Frontier product version: CLI major + 10.
+# Stage names mapped: alpha→a, beta→b, rc→fc, dev→d.
+#
+# Uses sed -E (extended regex) which requires bash; not POSIX sh.
+#
 # Examples:
 #   v1.0.0-alpha.6       → 11.0a6
 #   v1.0.0-beta.3        → 11.0b3
 #   v1.0.0               → 11.0
 #   v1.1.0-alpha.2       → 11.1a2
 #   v1.2.3               → 11.2.3
+#   v1.2.2               → 11.2.2
 #   1.0.0-dev             → 11.0d
-#   db0949d (bare hash)   → 11.0d (safe fallback)
+#
+# Edge cases (all produce safe fallback "11.0d"):
+#   db0949d              - bare commit hash from git describe --always
+#   ""                   - empty input
+#   abc                  - non-numeric garbage
+#
+# Note: v0.x tags would produce product major 10, which collides with
+# legacy Frontier 10.x. CLI tags should always start at v1.x or higher.
 
 v="${1#v}"  # strip leading 'v' if present
 
-# Validate input starts with digits (a proper version tag).
+# Validate input starts with digits followed by dot (a proper semver tag).
 # git describe --always can return bare commit hashes when no tags exist.
-if [ -z "$v" ] || ! echo "$v" | grep -qE '^[0-9]+\.'; then
+if [[ -z "$v" || ! "$v" =~ ^[0-9]+\. ]]; then
     echo "11.0d"
     exit 0
 fi

--- a/tools/derive_product_version.sh
+++ b/tools/derive_product_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Derive product version from CLI version tag.
 # Maps CLI version to Frontier product version: CLI major + 10.
 # Stage names mapped: alpha→a, beta→b, rc→fc, dev→d.

--- a/tools/derive_product_version.sh
+++ b/tools/derive_product_version.sh
@@ -51,8 +51,8 @@ if echo "$v" | grep -qE '\-(alpha|beta|rc|dev)'; then
     esac
 fi
 
-# Only omit patch when it's genuinely zero (e.g., v1.0.0 → 11.0, not v1.2.2 → 11.2)
-if [ "$patch" = "0" ]; then
+# Only omit patch when it's genuinely zero or absent (e.g., v1.0.0 → 11.0, not v1.2.2 → 11.2)
+if [ -z "$patch" ] || [ "$patch" = "0" ]; then
     echo "${pmajor}.${minor}${stage}${sub}"
 else
     echo "${pmajor}.${minor}.${patch}${stage}${sub}"


### PR DESCRIPTION
## Summary

- Fix headless `initenvironment()` to detect actual platform via `#ifdef __APPLE__`/`__linux__`/`_WIN32` instead of setting all flags to false. On macOS, queries real OS version via `sw_vers`.
- Add three new `system.environment` flags: `isHeadless`, `isPosix`, `isLinux`
- Unify version system: `Frontier.version()` returns product version derived from git tags (CLI major + 10), preserving backward compat with `date.versionLessThan()` checks against legacy 7.x/10.x versions
- Add `Frontier.cliVersion()` kernel verb returning the git-derived CLI distribution version
- Add `tools/derive_product_version.sh` for Makefile version derivation

### Version mapping examples

| Git tag | `Frontier.version()` | `Frontier.cliVersion()` |
|---------|---------------------|------------------------|
| `v1.0.0-alpha.6` | `11.0a6` | `v1.0.0-alpha.6` |
| `v1.0.0-beta.3` | `11.0b3` | `v1.0.0-beta.3` |
| `v1.2.3` | `11.2.3` | `v1.2.3` |

### system.environment changes (macOS)

| Flag | Before | After |
|------|--------|-------|
| `isMac` | `false` | `true` |
| `isCarbon` | `false` | `true` |
| `isHeadless` | _(missing)_ | `true` |
| `isPosix` | _(missing)_ | `true` |
| `isLinux` | _(missing)_ | `false` |
| `osMajorVersion` | `0` | `15` |
| `osVersionString` | `0.0.0` | `15.6.1` |
| `osFullNameForDisplay` | `0.0.0` | `macOS` |

## Test plan

- [x] All 26 integration tests pass (15 frontier verbs + 11 system.environment)
- [x] `Frontier.version()` returns `11.0a6` (satisfies `date.versionLessThan` checks)
- [x] `Frontier.cliVersion()` returns full git tag string
- [x] `system.environment.isMac` = true, `.isHeadless` = true, `.isPosix` = true
- [x] Real OS version detected (15.6.1 macOS 24G90)
- [x] Unit tests: pre-existing migration segfault only (not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)