### PR TITLE
fix: Migration segfault when opening v6 guest databases

### DIFF
--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2288,6 +2288,8 @@ cleanup:
     db_format_mode_apply(&entry_mode);
     db_saveas_state_apply(&entry_saveas);
 
+    db_format_adapter_reset(); /* Clear mode lock so subsequent v6 guest DB opens work */
+
     /* Postcondition: databasedata should be nil after cleanup */
     assert(databasedata == nil);
 

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -953,6 +953,8 @@ boolean tableloadsystemtable (dbaddress adr, Handle *hvariable, hdlhashtable *ht
 
 			tableverbdispose (hv, true);
 
+			*hvariable = nil;
+
 			return (false);
 			}
 		}
@@ -967,6 +969,8 @@ boolean tableloadsystemtable (dbaddress adr, Handle *hvariable, hdlhashtable *ht
 		if (!tableverbinmemory (&ctx, hv, HNoNode)) {
 
 			disposehandle ((Handle) hv);
+
+			*hvariable = nil;
 
 			return (false);
 			}


### PR DESCRIPTION
## Summary

Fixes a segfault that occurred when the startup script opened v6 guest databases (discuss.root, members.root, manila.root) after the system root had been migrated from v6 to v7 in the same process.

## Root Cause

Two interacting bugs:

1. **Mode lock not cleared** (`db_format.c`): `db_format_adapter_enable_wide_writes()` sets `g_legacy_adapter_mode_locked = true` during system root migration. This lock was never cleared after migration completed. When guest databases (v6) were subsequently opened, the lock prevented switching to v6 mode, causing v6 blocks to be read with v7 header sizes (12 bytes instead of 8). This 4-byte offset produced garbage root addresses like `0x17f011f`.

2. **Use-after-free** (`tablestructure.c`): When `tableloadsystemtable()` failed (due to the garbage address), it called `disposehandle()` but didn't nil the caller's pointer. `migrate_internal()` cleanup then called `tableverbdispose()` on the dangling pointer, crashing at `(**hv).flinmemory` (address `0x2` = NULL + field offset).

## Changes

| File | Change |
|------|--------|
| `Common/source/db_format.c` | Call `db_format_adapter_reset()` after migration cleanup to clear mode lock |
| `Common/source/tablestructure.c` | Set `*hvariable = nil` after dispose in two error paths |

## Test plan

- [x] `./frontier-cli --system-root databases/Frontier.root -e "1"` no longer segfaults (was exit 139, now exit 0)
- [x] Guest databases (discuss.root, members.root) open successfully during startup
- [x] Integration test runner works (previously crashed during migration step)
- [x] 27 integration tests passing (frontier_verbs + system_environment + db_migration)
- [x] `make -C frontier-cli` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
