### PR TITLE
Fix WP text extraction for guest database values

### DIFF
--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -118,7 +118,7 @@ extern long filespecsize(tyfilespec fs);
 // 2025-11-16 Codex: Added helpers to materialize disk-backed table values before packing.
 
 #if defined(FRONTIER_HEADLESS)
-static boolean langhash_convert_wordprocessor_external(hdlexternalvariable hv, const char *path_hint, tyvaluerecord *replacement) {
+static boolean langhash_convert_wordprocessor_external(const db_context *ctx, hdlexternalvariable hv, const char *path_hint, tyvaluerecord *replacement) {
 	if (hv == nil || replacement == NULL)
 		return false;
 
@@ -133,7 +133,7 @@ static boolean langhash_convert_wordprocessor_external(hdlexternalvariable hv, c
 	 * code calls langerrormessage() which would set fllangerror and kill the
 	 * calling script (e.g. startup.startupScript during migration). */
 	disablelangerror();
-	boolean extracted = wp_portable_extract_plaintext(hv, &hplain_utf8);
+	boolean extracted = wp_portable_extract_plaintext(ctx, hv, &hplain_utf8);
 	enablelangerror();
 
 	if (!extracted) {
@@ -157,7 +157,7 @@ static boolean langhash_convert_wordprocessor_external(hdlexternalvariable hv, c
 	return true;
 }
 
-static boolean langhash_prepare_wordprocessor_value(bigstring bsname, hdlhashnode hnode, tyvaluerecord *val) {
+static boolean langhash_prepare_wordprocessor_value(const db_context *ctx, bigstring bsname, hdlhashnode hnode, tyvaluerecord *val) {
 	hdlexternalvariable hv;
 	bigstring bspath;
 	char pathbuf[512];
@@ -181,7 +181,7 @@ static boolean langhash_prepare_wordprocessor_value(bigstring bsname, hdlhashnod
 	copyptocstring(bspath, pathbuf);
 
 	tyvaluerecord replacement;
-	if (!langhash_convert_wordprocessor_external(hv, pathbuf, &replacement))
+	if (!langhash_convert_wordprocessor_external(ctx, hv, pathbuf, &replacement))
 		return false;
 
 	disposevaluerecord(*val, false);
@@ -365,7 +365,7 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 				        path ? path : "<nil>");
 			}
 			tyvaluerecord replacement;
-			if (!langhash_convert_wordprocessor_external(hv, "<materialize>", &replacement)) {
+			if (!langhash_convert_wordprocessor_external(NULL, hv, "<materialize>", &replacement)) {
 				langhash_materialize_current_path = prior_path;
 				return false;
 			}
@@ -2651,7 +2651,9 @@ static boolean hashpackscalar (handlestream *s, hdlhashnode hnode, int32_t *ix, 
 			db_context context_local;
 			const db_context *ctx_to_use = NULL;
 			if (hdb != NULL) {
+				memset(&context_local, 0, sizeof(context_local));
 				context_local.database = hdb;
+				context_local.mode.use_64bit_format = ((**hdb).versionnumber >= 7);
 				ctx_to_use = &context_local;
 			}
 			dbaddress diskadr = (**hnode).val.data.diskvalue;
@@ -2906,7 +2908,15 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 
 #if defined(FRONTIER_HEADLESS)
 	if (hnode != nil) { /* tests may call with nil hnode */
-		if (!langhash_prepare_wordprocessor_value(bsname, hnode, &(**hnode).val))
+		db_context wp_ctx_local;
+		const db_context *wp_ctx = NULL;
+		if (hexternalpackdatabase != NULL) {
+			memset(&wp_ctx_local, 0, sizeof(wp_ctx_local));
+			wp_ctx_local.database = hexternalpackdatabase;
+			wp_ctx_local.mode.use_64bit_format = ((**hexternalpackdatabase).versionnumber >= 7);
+			wp_ctx = &wp_ctx_local;
+		}
+		if (!langhash_prepare_wordprocessor_value(wp_ctx, bsname, hnode, &(**hnode).val))
 			return true;
 		val = (**hnode).val;
 	}
@@ -3306,7 +3316,15 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 
 #if defined(FRONTIER_HEADLESS)
 	if (hnode != nil) { /* tests may call with nil hnode */
-		if (!langhash_prepare_wordprocessor_value(bsname, hnode, &(**hnode).val))
+		db_context wp_ctx_local;
+		const db_context *wp_ctx = NULL;
+		if (hexternalpackdatabase != NULL) {
+			memset(&wp_ctx_local, 0, sizeof(wp_ctx_local));
+			wp_ctx_local.database = hexternalpackdatabase;
+			wp_ctx_local.mode.use_64bit_format = ((**hexternalpackdatabase).versionnumber >= 7);
+			wp_ctx = &wp_ctx_local;
+		}
+		if (!langhash_prepare_wordprocessor_value(wp_ctx, bsname, hnode, &(**hnode).val))
 			return true;
 		val = (**hnode).val;
 	}

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -365,6 +365,8 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 				        path ? path : "<nil>");
 			}
 			tyvaluerecord replacement;
+			/* NULL context: materialize is only called during table
+			   hydration of the system root, not guest databases. */
 			if (!langhash_convert_wordprocessor_external(NULL, hv, "<materialize>", &replacement)) {
 				langhash_materialize_current_path = prior_path;
 				return false;
@@ -781,6 +783,15 @@ static boolean flexternalmemorypack = false;
 
 static hdldatabaserecord hexternalpackdatabase;
 
+#if defined(FRONTIER_HEADLESS)
+/* Initialize a db_context from a database handle for guest DB reads.
+   Zeroes the struct and derives use_64bit_format from the version number. */
+static void db_context_init_from_handle(db_context *ctx, hdldatabaserecord hdb) {
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->database = hdb;
+	ctx->mode.use_64bit_format = ((**hdb).versionnumber >= 7);
+}
+#endif
 
 
 static hdlhashtable hfirstfreetable = nil; /*private free list for hash tables*/
@@ -2651,9 +2662,7 @@ static boolean hashpackscalar (handlestream *s, hdlhashnode hnode, int32_t *ix, 
 			db_context context_local;
 			const db_context *ctx_to_use = NULL;
 			if (hdb != NULL) {
-				memset(&context_local, 0, sizeof(context_local));
-				context_local.database = hdb;
-				context_local.mode.use_64bit_format = ((**hdb).versionnumber >= 7);
+				db_context_init_from_handle(&context_local, hdb);
 				ctx_to_use = &context_local;
 			}
 			dbaddress diskadr = (**hnode).val.data.diskvalue;
@@ -2911,9 +2920,7 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 		db_context wp_ctx_local;
 		const db_context *wp_ctx = NULL;
 		if (hexternalpackdatabase != NULL) {
-			memset(&wp_ctx_local, 0, sizeof(wp_ctx_local));
-			wp_ctx_local.database = hexternalpackdatabase;
-			wp_ctx_local.mode.use_64bit_format = ((**hexternalpackdatabase).versionnumber >= 7);
+			db_context_init_from_handle(&wp_ctx_local, hexternalpackdatabase);
 			wp_ctx = &wp_ctx_local;
 		}
 		if (!langhash_prepare_wordprocessor_value(wp_ctx, bsname, hnode, &(**hnode).val))
@@ -3319,9 +3326,7 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 		db_context wp_ctx_local;
 		const db_context *wp_ctx = NULL;
 		if (hexternalpackdatabase != NULL) {
-			memset(&wp_ctx_local, 0, sizeof(wp_ctx_local));
-			wp_ctx_local.database = hexternalpackdatabase;
-			wp_ctx_local.mode.use_64bit_format = ((**hexternalpackdatabase).versionnumber >= 7);
+			db_context_init_from_handle(&wp_ctx_local, hexternalpackdatabase);
 			wp_ctx = &wp_ctx_local;
 		}
 		if (!langhash_prepare_wordprocessor_value(wp_ctx, bsname, hnode, &(**hnode).val))

--- a/portable/wptext_portable.h
+++ b/portable/wptext_portable.h
@@ -17,7 +17,7 @@ Boolean wp_portable_external_should_drop(hdlexternalvariable hv);
 void wp_portable_note_drop_logged(hdlexternalvariable hv, const char *name_hint);
 Boolean wp_portable_external_was_legacy_ws(hdlexternalvariable hv);
 void wp_portable_note_conversion_logged(hdlexternalvariable hv, const char *name_hint);
-Boolean wp_portable_extract_plaintext(hdlexternalvariable hv, Handle *hout_utf8);
+Boolean wp_portable_extract_plaintext(const db_context *ctx, hdlexternalvariable hv, Handle *hout_utf8);
 Boolean wp_portable_set_plaintext(hdlexternalvariable hv, Handle hutf8);
 #endif
 

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -605,7 +605,7 @@ boolean wpverbpacktotext(hdlexternalvariable h, Handle htext) {
         return false;
 
     Handle hplain = nil;
-    if (!wp_portable_extract_plaintext(h, &hplain))
+    if (!wp_portable_extract_plaintext(NULL, h, &hplain))
         return false;
 
     boolean ok = pushhandle(hplain, htext);
@@ -696,7 +696,7 @@ boolean wpsetselection(long startsel, long endsel) {
     return true;
 }
 
-Boolean wp_portable_extract_plaintext(hdlexternalvariable hv, Handle *hout_utf8) {
+Boolean wp_portable_extract_plaintext(const db_context *ctx, hdlexternalvariable hv, Handle *hout_utf8) {
     if (hv == NULL || hout_utf8 == NULL)
         return false;
 
@@ -737,7 +737,7 @@ Boolean wp_portable_extract_plaintext(hdlexternalvariable hv, Handle *hout_utf8)
     }
 
     Handle hpacked = nil;
-    if (!wp_portable_state_dbref(NULL, hv, state, &hpacked))
+    if (!wp_portable_state_dbref(ctx, hv, state, &hpacked))
         return false;
 
     const uint8_t *bytes = (const uint8_t *)*hpacked;


### PR DESCRIPTION
## Summary

- Thread `db_context` through `wp_portable_extract_plaintext()` so WP text values in guest databases (e.g., `topicMsgTemplate` in manila.root) are read from the correct file instead of falling back to the global `databasedata` (Frontier.root)
- Fix latent bug in `hashpackscalar` where `db_context` was stack-allocated without zeroing or setting `mode.use_64bit_format`, risking incorrect header size for v7 databases
- Same class of fix as #434 (guest DB script execution), extending the explicit-context pattern to the WP text extraction path

## Call chain fixed

```
hashpacktable_internal (hexternalpackdatabase set)
  → hashpackvisit_v7
    → langhash_prepare_wordprocessor_value(ctx, ...)
      → langhash_convert_wordprocessor_external(ctx, ...)
        → wp_portable_extract_plaintext(ctx, ...)
          → wp_portable_state_dbref(ctx, ...)   // was NULL, now receives guest DB context
            → dbrefhandle_context(ctx, ...)      // reads from correct file
```

## Test plan

- [x] Clean `make dist` + startup: `topicMsgTemplate` error eliminated
- [x] Unit tests pass (all 30 binaries)
- [x] Integration tests pass (1891 total, 1702 passed, 189 skipped, 0 failed)
- [x] Verified `lang.double`/`lang.single` flaky failures are pre-existing (pass on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)