### PR TITLE
fix: Use correct database context when packing guest database externals

### DIFF
--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -129,6 +129,7 @@ void db_saveas_state_apply(const db_saveas_state *state);
 void db_context_init(db_context *context);
 void db_context_init_with_mode(db_context *context, const db_format_mode *mode);
 void db_context_init_legacy_read(db_context *context, hdldatabaserecord db);
+void db_context_init_v7_read(db_context *context, hdldatabaserecord db);
 void db_context_init_v7_write(db_context *context, hdldatabaserecord db);
 void db_context_clone_with_mode(const db_context *src, db_context *dst, const db_format_mode *mode);
 void db_context_apply(const db_context *context);

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2511,10 +2511,18 @@ void db_context_init_legacy_read(db_context *context, hdldatabaserecord db) {
     context->database = db;
 }
 
-void db_context_init_v7_write(db_context *context, hdldatabaserecord db) {
+void db_context_init_v7_read(db_context *context, hdldatabaserecord db) {
     db_format_mode v7_mode = {true, false, false};
     db_context_init_with_mode(context, &v7_mode);
     context->database = db;
+}
+
+void db_context_init_v7_write(db_context *context, hdldatabaserecord db) {
+    /* Currently identical to v7_read: use_64bit_format=true, adapter_repack=false.
+     * Kept as a separate function so callers express intent (read vs write) and
+     * the two paths can diverge if v7_write ever needs write-specific state
+     * (e.g., dirty flags, journal references). */
+    db_context_init_v7_read(context, db);
 }
 
 void db_context_clone_with_mode(const db_context *src, db_context *dst, const db_format_mode *mode) {

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -3325,11 +3325,9 @@ boolean langexternalrefdata (hdlexternalvariable hv, Handle *hdata) {
 		db_context ctx;
 		/* Use version-aware helpers that inherit saveas state from globals.
 		   Guest databases are never the target of Save-As, but inheriting the
-		   state keeps behavior consistent if db_context gains new fields.
-		   Despite the "write" name, v7_write just sets use_64bit_format=true
-		   with adapter_repack=false — safe for read operations. */
+		   state keeps behavior consistent if db_context gains new fields. */
 		if ((**(**hv).hdatabase).versionnumber >= 7)
-			db_context_init_v7_write (&ctx, (**hv).hdatabase);
+			db_context_init_v7_read (&ctx, (**hv).hdatabase);
 		else
 			db_context_init_legacy_read (&ctx, (**hv).hdatabase);
 		return langexternalrefdata_context (&ctx, hv, hdata);

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -3323,9 +3323,13 @@ boolean langexternalrefdata (hdlexternalvariable hv, Handle *hdata) {
 
 	if ((**hv).hdatabase != nil) {
 		db_context ctx;
-		memset(&ctx, 0, sizeof(ctx));
-		ctx.database = (**hv).hdatabase;
-		ctx.mode.use_64bit_format = ((**(**hv).hdatabase).versionnumber >= 7);
+		/* Use version-aware helpers that inherit saveas state from globals.
+		   Guest databases are never the target of Save-As, but inheriting the
+		   state keeps behavior consistent if db_context gains new fields. */
+		if ((**(**hv).hdatabase).versionnumber >= 7)
+			db_context_init_v7_write (&ctx, (**hv).hdatabase);
+		else
+			db_context_init_legacy_read (&ctx, (**hv).hdatabase);
 		return langexternalrefdata_context (&ctx, hv, hdata);
 	}
 

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -3315,8 +3315,19 @@ tyvaluetype langexternalgetvaluetype (OSType typeid) {
 boolean langexternalrefdata (hdlexternalvariable hv, Handle *hdata) {
 	/*
 	2025-12-23: Refactored to use explicit context instead of push/pop pattern
-	Wrapper for backward compatibility - calls context-aware variant with NULL
+	2026-02-17: Build context from variable's own database handle instead of passing
+	NULL. Fixes guest database externals (outlines, WP text, menus, pictures) where
+	the global databasedata points to the system root but the variable belongs to a
+	guest database opened via fileMenu.open().
 	*/
+
+	if ((**hv).hdatabase != nil) {
+		db_context ctx;
+		memset(&ctx, 0, sizeof(ctx));
+		ctx.database = (**hv).hdatabase;
+		ctx.mode.use_64bit_format = ((**(**hv).hdatabase).versionnumber >= 7);
+		return langexternalrefdata_context (&ctx, hv, hdata);
+	}
 
 	return langexternalrefdata_context (NULL, hv, hdata);
 	} /*langexternalrefdata*/

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -3325,7 +3325,9 @@ boolean langexternalrefdata (hdlexternalvariable hv, Handle *hdata) {
 		db_context ctx;
 		/* Use version-aware helpers that inherit saveas state from globals.
 		   Guest databases are never the target of Save-As, but inheriting the
-		   state keeps behavior consistent if db_context gains new fields. */
+		   state keeps behavior consistent if db_context gains new fields.
+		   Despite the "write" name, v7_write just sets use_64bit_format=true
+		   with adapter_repack=false — safe for read operations. */
 		if ((**(**hv).hdatabase).versionnumber >= 7)
 			db_context_init_v7_write (&ctx, (**hv).hdatabase);
 		else

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -3690,6 +3690,19 @@ boolean hashpacktable_internal (const db_context *ctx, hdlhashtable htable, bool
 		db_context_init(&working_context);
 		use_64bit = db_format_mode_current().use_64bit_format;
 
+		/* For guest database tables, use the table's own database handle
+		 * instead of the global databasedata (which points to the system root).
+		 * Without this, disk reads for external values (WP text, outlines,
+		 * sub-tables) use the wrong file at the wrong address. */
+		if (flmemory) {
+			hdldatabaserecord hdb = tablegetdatabase (htable);
+			if (hdb != nil) {
+				working_context.database = hdb;
+				working_context.mode.use_64bit_format = ((**hdb).versionnumber >= 7);
+				use_64bit = working_context.mode.use_64bit_format;
+			}
+		}
+
 		/* CRITICAL MIGRATION FIX: During migration (adapter active), force v7 format
 		 * even if mode stack is corrupted. This prevents legacy format tables from
 		 * being written to v7 databases during migration due to mode stack issues.

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -3682,7 +3682,13 @@ boolean hashpacktable_internal (const db_context *ctx, hdlhashtable htable, bool
 	Handle h1, h2;
 	db_context working_context;
 
-	/* Phase 1: Initialize working context (never NULL for child operations) */
+	/* Phase 1: Initialize working context (never NULL for child operations).
+	 *
+	 * The NULL path is reached only from the legacy hashpacktable() wrapper
+	 * (langhash.c), which is called by runtime_tests.c and any code not yet
+	 * migrated to hashpacktable_context(). Recursive calls from
+	 * hashpackvisit_v7 → hashpackexternal → langexternalmemorypack →
+	 * tableverbmemorypack always pass explicit context via tablepacktable_internal. */
 	if (ctx != NULL) {
 		working_context = *ctx;
 		use_64bit = ctx->mode.use_64bit_format;

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -3693,7 +3693,11 @@ boolean hashpacktable_internal (const db_context *ctx, hdlhashtable htable, bool
 		/* For guest database tables, use the table's own database handle
 		 * instead of the global databasedata (which points to the system root).
 		 * Without this, disk reads for external values (WP text, outlines,
-		 * sub-tables) use the wrong file at the wrong address. */
+		 * sub-tables) use the wrong file at the wrong address.
+		 *
+		 * adapter_repack stays false (from db_context_init above): migration
+		 * operates on the system root, never on guest databases, so guest DB
+		 * tables should never be packed with adapter_repack semantics. */
 		if (flmemory) {
 			hdldatabaserecord hdb = tablegetdatabase (htable);
 			if (hdb != nil) {
@@ -3802,7 +3806,11 @@ log_debug(LOG_COMP_HASH, "hashpacktable_internal use_64bit=%d (ctx=%p ctx_mode=%
 #endif
 	
 	flexternalmemorypack = flmemory;
-	
+
+	/* hexternalpackdatabase is the same derivation as working_context.database
+	 * above but stored as a file-scoped global for hashpackvisit callbacks
+	 * that don't receive the working_context. Both paths will be unified
+	 * when hexternalpackdatabase is eliminated in favor of explicit context. */
 	if (flexternalmemorypack)
 		hexternalpackdatabase = tablegetdatabase (htable);
 	

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -251,11 +251,15 @@ boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode
 	fltempload = !(**hv).flinmemory;
 
 	/* Use the variable's own database handle so guest database
-	 * sub-tables are loaded and packed from the correct file. */
+	 * sub-tables are loaded and packed from the correct file.
+	 * Version-aware helpers inherit saveas state from globals;
+	 * guest databases are never Save-As targets but this keeps
+	 * behavior consistent if db_context gains new fields. */
 	if ((**hv).hdatabase != nil) {
-		memset(&ctx, 0, sizeof(ctx));
-		ctx.database = (**hv).hdatabase;
-		ctx.mode.use_64bit_format = ((**(**hv).hdatabase).versionnumber >= 7);
+		if ((**(**hv).hdatabase).versionnumber >= 7)
+			db_context_init_v7_write (&ctx, (**hv).hdatabase);
+		else
+			db_context_init_legacy_read (&ctx, (**hv).hdatabase);
 	} else {
 		db_context_init(&ctx);
 	}

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -252,9 +252,11 @@ boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode
 
 	/* Use the variable's own database handle so guest database
 	 * sub-tables are loaded and packed from the correct file.
-	 * Version-aware helpers inherit saveas state from globals;
-	 * guest databases are never Save-As targets but this keeps
-	 * behavior consistent if db_context gains new fields. */
+	 * This context is used for both loading (tableverbinmemory) and
+	 * re-packing (tablepacktable_internal), so v7_write is the
+	 * correct intent. Version-aware helpers inherit saveas state
+	 * from globals; guest databases are never Save-As targets but
+	 * this keeps behavior consistent if db_context gains new fields. */
 	if ((**hv).hdatabase != nil) {
 		if ((**(**hv).hdatabase).versionnumber >= 7)
 			db_context_init_v7_write (&ctx, (**hv).hdatabase);

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -246,7 +246,7 @@ boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode
 	register boolean fl;
 	boolean fltempload;
 	boolean fldummy;
-	db_context ctx;
+	db_context ctx = {0};
 
 	fltempload = !(**hv).flinmemory;
 

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -246,22 +246,28 @@ boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode
 	register boolean fl;
 	boolean fltempload;
 	boolean fldummy;
+	db_context ctx;
 
 	fltempload = !(**hv).flinmemory;
 
-	{
-		db_context ctx;
+	/* Use the variable's own database handle so guest database
+	 * sub-tables are loaded and packed from the correct file. */
+	if ((**hv).hdatabase != nil) {
+		memset(&ctx, 0, sizeof(ctx));
+		ctx.database = (**hv).hdatabase;
+		ctx.mode.use_64bit_format = ((**(**hv).hdatabase).versionnumber >= 7);
+	} else {
 		db_context_init(&ctx);
-
-		if (!tableverbinmemory (&ctx, hv, hnode))
-			return (false);
 	}
 
-	ht = (hdlhashtable) (**hv).variabledata; 
-	
-	tablecheckwindowrect (ht); 
-	
-	fl = tablepacktable (ht, true, &hpush, &fldummy);
+	if (!tableverbinmemory (&ctx, hv, hnode))
+		return (false);
+
+	ht = (hdlhashtable) (**hv).variabledata;
+
+	tablecheckwindowrect (ht);
+
+	fl = tablepacktable_internal (&ctx, ht, true, &hpush, &fldummy);
 	
 	if (fltempload)
 		tableverbunload (hv);

--- a/docs/ARCHITECTURAL_ANTIPATTERNS.md
+++ b/docs/ARCHITECTURAL_ANTIPATTERNS.md
@@ -276,6 +276,8 @@ Frontier has multiple global mutable state variables that must be eliminated bef
 3. Maintain backward-compatible wrappers using default context
 4. Gradually eliminate global variable access
 
+**Gotcha: Zero-initialized context with conditional branches.** When declaring `db_context ctx = {0}` and initializing in conditional branches (e.g., `if (hdb != nil) ... else db_context_init(&ctx)`), ensure every branch populates the context. An all-zeros `db_context` has `database = NULL` and `mode = {false, false, false}`, which silently differs from `db_context_init()` defaults (which snapshot the current global state). If a future refactor removes the `else` branch, the context silently becomes all-zeros instead of failing loudly.
+
 **When to Use Which**:
 - **Thread-Local**: Per-thread execution state (flnextparamislast, flscriptrunning, current outline)
 - **Explicit Context**: Per-operation state (database operations, outline operations)


### PR DESCRIPTION
## Summary

- Fix guest database external packing failures during startup (outlines, WP text, menus, pictures)
- Root cause: `langexternalrefdata` passed NULL context to `dbrefhandle_context`, falling back to global `databasedata` (system root) instead of the guest database
- Three targeted fixes in the database read chain -- zero changes to existing function signatures

## Problem

When `manilaSuite.init` packs theme data from guest databases (e.g., `manila.root`), external values like `dayListItemTemplate` (an outline) are still on disk in the guest database. The packing chain called `langexternalrefdata` -> `langexternalrefdata_context(NULL)` -> `dbrefhandle_context(NULL)` -> `dbrefhandle(global)`, which read from the system root file at guest database addresses:

```
[db-ERROR] dbread read failed fnum=2 adr=0xf8a5a6 bytes=12
[hash-ERROR] hashpackvisit_v7 failed name=dayListItemTemplate reason=hashpackexternal
```

## Changes

| File | Change |
|------|--------|
| `langexternal.c` | `langexternalrefdata`: Build `db_context` from `(**hv).hdatabase` instead of passing NULL -- fixes ALL non-table external types in guest databases |
| `langhash.c` | `hashpacktable_internal`: When `ctx==NULL` and `flmemory==true`, derive context from `tablegetdatabase(htable)` |
| `tablepack.c` | `tableverbmemorypack`: Use variable own `hdatabase` for both loading and re-packing sub-tables via `tablepacktable_internal(&ctx)` |

## Design rationale

- **Explicit context over global mutation** -- aligns with Pattern 2 in `docs/ARCHITECTURAL_ANTIPATTERNS.md`
- **Zero signature changes** -- all fixes use existing parameters or data already on the variable handle
- **`langexternalrefdata` fix is the broadest** -- single fix point covers outlines, WP text, menus, and pictures for any guest database

## Test plan

- [x] Unit tests: 0 failures
- [x] Integration tests: 1702 passed, 189 skipped, 0 failed
- [x] Migration tests: pre-existing segfault on develop (not caused by this PR)
- [x] Guest database startup verification:
  ```
  cd dist && ./frontier-cli --system-root Frontier.root -e "defined(system.temp.Frontier)"
  ```
  Returns `true` with no hashpackvisit or dbread errors

Generated with [Claude Code](https://claude.com/claude-code)
