### PR TITLE
fix: Use correct database format when packing cross-database externals

### DIFF
--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -37,6 +37,11 @@ struct db_context {
     db_saveas_state saveas;
 };
 
+/* True if the database handle points to a v7 (64-bit) format database.
+   Safe when hdb is nil (returns false). Used to choose between v7 and
+   legacy read/write contexts throughout the packing code. */
+#define db_is_v7(hdb) ((hdb) != nil && (**(hdb)).versionnumber >= 7)
+
 #define LEGACY_DB_HEADER_BYTES 88
 
 static inline uint16_t db_format_read_be16(const unsigned char *p) {

--- a/Common/source/cancoon.c
+++ b/Common/source/cancoon.c
@@ -568,7 +568,7 @@ void setcancoonglobals (hdlcancoonrecord hcancoon) {
 			   state) are intentionally preserved. */
 			db_format_mode mode = db_format_mode_current();
 
-			mode.use_64bit_format = ((**databasedata).versionnumber >= 7);
+			mode.use_64bit_format = db_is_v7(databasedata);
 
 			db_format_mode_apply (&mode);
 		}

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1010,15 +1010,20 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 		if (!(**hv).flinmemory) {
 			/* Create read context matching the source database format.
 			 * The source may be v6 (original migration) or v7 (cross-database
-			 * assignment from an already-migrated database like StartupTasks.root). */
-			legacy_context = working_context;
-			legacy_context.mode.adapter_repack = false;  /* Pure read mode */
-			/* CRITICAL: Use the external's own database handle for reading, not the current global */
-			legacy_context.database = (**hv).hdatabase;
-			if (legacy_context.database != nil && (**legacy_context.database).versionnumber >= 7)
-				legacy_context.mode.use_64bit_format = true;
-			else
-				legacy_context.mode.use_64bit_format = false;
+			 * assignment from an already-migrated database like StartupTasks.root).
+			 * Use the dedicated initializers so all mode bits are set cleanly. */
+			if ((**hv).hdatabase == nil) {
+				/* nil hdatabase is unexpected during adapter-repack — the migration
+				 * controller should always supply a source database. Fall back to
+				 * legacy read, but warn so this doesn't pass silently. */
+				log_warn(LOG_COMP_EXTERNAL, "langexternalpack: nil hdatabase in adapter_repack path id=%d, defaulting to legacy read",
+				        (int)(**hv).id);
+				db_context_init_legacy_read (&legacy_context, (**hv).hdatabase);
+			} else if (db_is_v7 ((**hv).hdatabase)) {
+				db_context_init_v7_read (&legacy_context, (**hv).hdatabase);
+			} else {
+				db_context_init_legacy_read (&legacy_context, (**hv).hdatabase);
+			}
 
 			log_trace(LOG_COMP_EXTERNAL, "langexternalpack: loading external id=%d (explicit context) db=%p v7=%d",
 			        (int)(**hv).id, (void*)legacy_context.database, (int)legacy_context.mode.use_64bit_format);
@@ -1051,10 +1056,12 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 			 * database being packed. Same pattern as the adapter_repack path above. */
 			db_context read_context = working_context;
 			if ((**hv).hdatabase != nil && (**hv).hdatabase != working_context.database) {
-				if ((**(**hv).hdatabase).versionnumber >= 7)
+				if (db_is_v7 ((**hv).hdatabase))
 					db_context_init_v7_read (&read_context, (**hv).hdatabase);
 				else
 					db_context_init_legacy_read (&read_context, (**hv).hdatabase);
+				log_debug(LOG_COMP_EXTERNAL, "langexternalpack: cross-db external id=%d, reading from db=%p v7=%d",
+				        (int)(**hv).id, (void*)(**hv).hdatabase, (int)read_context.mode.use_64bit_format);
 			}
 			if (!ensure_external_in_memory (&read_context, hv)) {
 				log_error(LOG_COMP_EXTERNAL, "langexternalpack_internal: ensure_external_in_memory FAILED (normal save) id=%d",
@@ -3343,7 +3350,7 @@ boolean langexternalrefdata (hdlexternalvariable hv, Handle *hdata) {
 		/* Use version-aware helpers that inherit saveas state from globals.
 		   Guest databases are never the target of Save-As, but inheriting the
 		   state keeps behavior consistent if db_context gains new fields. */
-		if ((**(**hv).hdatabase).versionnumber >= 7)
+		if (db_is_v7 ((**hv).hdatabase))
 			db_context_init_v7_read (&ctx, (**hv).hdatabase);
 		else
 			db_context_init_legacy_read (&ctx, (**hv).hdatabase);

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1006,19 +1006,24 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	        (int)(**hv).id, (int)adapter_repack, (int)(**hv).flinmemory);
 
 	if (adapter_repack) {
-		/* If not already in memory, load from v6 source */
+		/* If not already in memory, load from source database */
 		if (!(**hv).flinmemory) {
-			/* Create v6 read context for loading from source database */
+			/* Create read context matching the source database format.
+			 * The source may be v6 (original migration) or v7 (cross-database
+			 * assignment from an already-migrated database like StartupTasks.root). */
 			legacy_context = working_context;
-			legacy_context.mode.use_64bit_format = false;
 			legacy_context.mode.adapter_repack = false;  /* Pure read mode */
 			/* CRITICAL: Use the external's own database handle for reading, not the current global */
 			legacy_context.database = (**hv).hdatabase;
+			if (legacy_context.database != nil && (**legacy_context.database).versionnumber >= 7)
+				legacy_context.mode.use_64bit_format = true;
+			else
+				legacy_context.mode.use_64bit_format = false;
 
-			log_trace(LOG_COMP_EXTERNAL, "langexternalpack: loading external from v6 id=%d (explicit context) db=%p",
-			        (int)(**hv).id, (void*)legacy_context.database);
+			log_trace(LOG_COMP_EXTERNAL, "langexternalpack: loading external id=%d (explicit context) db=%p v7=%d",
+			        (int)(**hv).id, (void*)legacy_context.database, (int)legacy_context.mode.use_64bit_format);
 
-			/* Load external into memory using explicit v6 context */
+			/* Load external into memory using source database context */
 			if (!ensure_external_in_memory (&legacy_context, hv)) {
 				log_error(LOG_COMP_EXTERNAL, "langexternalpack_internal: ensure_external_in_memory FAILED id=%d",
 				        (int)(**hv).id);
@@ -1039,7 +1044,19 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	} else {
 		/* Normal save: load from current database if not already in memory */
 		if (!(**hv).flinmemory) {
-			if (!ensure_external_in_memory (&working_context, hv)) {
+			/* For cross-database assignments (e.g., copying a script from
+			 * StartupTasks.root into Frontier.root), the external's data is
+			 * still on disk in the source database. Override the read context
+			 * to use the variable's own database handle, not the destination
+			 * database being packed. Same pattern as the adapter_repack path above. */
+			db_context read_context = working_context;
+			if ((**hv).hdatabase != nil && (**hv).hdatabase != working_context.database) {
+				if ((**(**hv).hdatabase).versionnumber >= 7)
+					db_context_init_v7_read (&read_context, (**hv).hdatabase);
+				else
+					db_context_init_legacy_read (&read_context, (**hv).hdatabase);
+			}
+			if (!ensure_external_in_memory (&read_context, hv)) {
 				log_error(LOG_COMP_EXTERNAL, "langexternalpack_internal: ensure_external_in_memory FAILED (normal save) id=%d",
 				        (int)(**hv).id);
 				return (false);

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -789,7 +789,7 @@ static hdldatabaserecord hexternalpackdatabase;
 static void db_context_init_from_handle(db_context *ctx, hdldatabaserecord hdb) {
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->database = hdb;
-	ctx->mode.use_64bit_format = ((**hdb).versionnumber >= 7);
+	ctx->mode.use_64bit_format = db_is_v7(hdb);
 }
 #endif
 
@@ -3708,7 +3708,7 @@ boolean hashpacktable_internal (const db_context *ctx, hdlhashtable htable, bool
 			hdldatabaserecord hdb = tablegetdatabase (htable);
 			if (hdb != nil) {
 				working_context.database = hdb;
-				working_context.mode.use_64bit_format = ((**hdb).versionnumber >= 7);
+				working_context.mode.use_64bit_format = db_is_v7(hdb);
 				use_64bit = working_context.mode.use_64bit_format;
 			}
 		}

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -258,7 +258,7 @@ boolean tableverbmemorypack (hdlexternalvariable h, Handle *hpacked, hdlhashnode
 	 * from globals; guest databases are never Save-As targets but
 	 * this keeps behavior consistent if db_context gains new fields. */
 	if ((**hv).hdatabase != nil) {
-		if ((**(**hv).hdatabase).versionnumber >= 7)
+		if (db_is_v7 ((**hv).hdatabase))
 			db_context_init_v7_write (&ctx, (**hv).hdatabase);
 		else
 			db_context_init_legacy_read (&ctx, (**hv).hdatabase);

--- a/tests/integration/test_cases/guest_db_externals.yaml
+++ b/tests/integration/test_cases/guest_db_externals.yaml
@@ -160,6 +160,34 @@ tests:
     expected_result: "true"
 
   # ========================================================================
+  # Cross-Database External Packing (PR #438 regression test)
+  # ========================================================================
+
+  - name: "cross-db external pack - copy script from guest db, save system root"
+    description: |
+      Opens StartupTasks.root as a guest database, copies a script external
+      into a system root table via address assignment, then saves the system
+      root. This exercises langexternalpack_internal with a cross-database
+      external whose data is on disk in the source (guest) database.
+      Previously failed with dbrefhandle FAILED when the pack context used
+      the destination database instead of the source.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      new(tableType, @system.temp.crossDbPack);
+      system.temp.crossDbPack.copiedScript = StartupTasksSuite.main;
+      fileMenu.save();
+      local(t = typeOf(system.temp.crossDbPack.copiedScript));
+      delete(@system.temp.crossDbPack);
+      fileMenu.save();
+      return t
+    expected_success: true
+    expected_result: "scpt"
+
+  # ========================================================================
   # Format Mode Restoration After Guest Database Access
   # ========================================================================
 

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -1,8 +1,10 @@
 #!/bin/bash
-# Pre-commit hook: Auto-regenerate OPML export when integration tests change
+# Pre-commit hook for Frontier development
 #
-# This hook runs before git commit and regenerates reports/integration_tests.opml
-# whenever any test YAML files in tests/integration/test_cases/ are modified.
+# Checks:
+#   1. Block commits to develop in the main worktree (use feature branches)
+#   2. Auto-regenerate OPML export when integration tests change
+#   3. Validate documentation references when docs change
 #
 # Install: Run tools/install_git_hooks.sh
 
@@ -17,31 +19,71 @@ NC='\033[0m' # No Color
 # Get the root of the git repo
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
-# Check if any integration test YAML files are being committed
-TEST_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^tests/integration/test_cases/.*\.yaml$' || true)
+# ──────────────────────────────────────────────────────────────
+# Guard: Block commits to develop in the main worktree
+# ──────────────────────────────────────────────────────────────
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 
-if [ -z "$TEST_FILES_CHANGED" ]; then
-    # No test files changed, skip OPML regeneration
-    exit 0
-fi
-
-echo -e "${YELLOW}Integration test files changed, regenerating OPML export...${NC}"
-
-# Regenerate OPML
-cd "$GIT_ROOT"
-if ! python3 tools/export_tests_to_opml.py; then
-    echo -e "${RED}Error: Failed to regenerate OPML export${NC}" >&2
+# Main worktree: .git dir IS the common dir (worktrees have .git/worktrees/<name>)
+if [ "$BRANCH" = "develop" ] && [ "$COMMON_DIR" = "$GIT_DIR" ]; then
+    echo -e "${RED}ERROR: Direct commits to 'develop' in the main worktree are blocked.${NC}" >&2
+    echo "" >&2
+    echo "Use a feature branch in a worktree instead:" >&2
+    echo "  git worktree add Frontier-<feature> -b feature/<name>" >&2
+    echo "" >&2
+    echo "Or use the /doit workflow which handles this automatically." >&2
+    echo "" >&2
+    echo "To bypass this check (rare): git commit --no-verify" >&2
     exit 1
 fi
 
-# Check if OPML file changed
-OPML_FILE="reports/integration_tests.opml"
-if git diff --exit-code "$OPML_FILE" > /dev/null 2>&1; then
-    echo -e "${GREEN}OPML export is up to date${NC}"
-else
-    echo -e "${GREEN}OPML export updated, adding to commit${NC}"
-    git add "$OPML_FILE"
+# ──────────────────────────────────────────────────────────────
+# OPML export: Regenerate when integration tests change
+# ──────────────────────────────────────────────────────────────
+
+# Check if any integration test YAML files are being committed
+TEST_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^tests/integration/test_cases/.*\.yaml$' || true)
+
+if [ -n "$TEST_FILES_CHANGED" ]; then
+    echo -e "${YELLOW}Integration test files changed, regenerating OPML export...${NC}"
+
+    # Regenerate OPML
+    cd "$GIT_ROOT"
+    if ! python3 tools/export_tests_to_opml.py; then
+        echo -e "${RED}Error: Failed to regenerate OPML export${NC}" >&2
+        exit 1
+    fi
+
+    # Check if OPML files changed (dated file and symlink)
+    TODAY=$(date +%Y-%m-%d)
+    DATED_OPML="reports/integration_tests_${TODAY}.opml"
+    SYMLINK_OPML="reports/integration_tests.opml"
+
+    OPML_CHANGED=false
+
+    # Check if dated file is new or modified
+    if [ -f "$DATED_OPML" ] && ! git diff --exit-code "$DATED_OPML" > /dev/null 2>&1; then
+        OPML_CHANGED=true
+    fi
+
+    # Check if symlink changed
+    if [ -L "$SYMLINK_OPML" ] && ! git diff --exit-code "$SYMLINK_OPML" > /dev/null 2>&1; then
+        OPML_CHANGED=true
+    fi
+
+    if [ "$OPML_CHANGED" = true ]; then
+        echo -e "${GREEN}OPML export updated, adding to commit${NC}"
+        git add "$DATED_OPML" "$SYMLINK_OPML" 2>/dev/null || true
+    else
+        echo -e "${GREEN}OPML export is up to date${NC}"
+    fi
 fi
+
+# ──────────────────────────────────────────────────────────────
+# Doc validation: Check references when documentation changes
+# ──────────────────────────────────────────────────────────────
 
 # Check if CLAUDE.md or docs/ files are being committed
 DOC_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(CLAUDE\.md|docs/.*\.md)$' || true)

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -27,16 +27,23 @@ COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 
 # Main worktree: .git dir IS the common dir (worktrees have .git/worktrees/<name>)
+# Only block if code/build files are staged — allow docs, OPML, YAML, markdown commits
 if [ "$BRANCH" = "develop" ] && [ "$COMMON_DIR" = "$GIT_DIR" ]; then
-    echo -e "${RED}ERROR: Direct commits to 'develop' in the main worktree are blocked.${NC}" >&2
-    echo "" >&2
-    echo "Use a feature branch in a worktree instead:" >&2
-    echo "  git worktree add Frontier-<feature> -b feature/<name>" >&2
-    echo "" >&2
-    echo "Or use the /doit workflow which handles this automatically." >&2
-    echo "" >&2
-    echo "To bypass this check (rare): git commit --no-verify" >&2
-    exit 1
+    CODE_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -vE '\.(md|opml|yaml|yml|json|txt)$' | grep -vE '^(reports/|docs/|planning/)' || true)
+    if [ -n "$CODE_FILES" ]; then
+        echo -e "${RED}ERROR: Code changes on 'develop' in the main worktree are blocked.${NC}" >&2
+        echo "" >&2
+        echo "Blocked files:" >&2
+        echo "$CODE_FILES" | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "Use a feature branch in a worktree instead:" >&2
+        echo "  git worktree add Frontier-<feature> -b feature/<name>" >&2
+        echo "" >&2
+        echo "Or use the /doit workflow which handles this automatically." >&2
+        echo "" >&2
+        echo "To bypass this check (rare): git commit --no-verify" >&2
+        exit 1
+    fi
 fi
 
 # ──────────────────────────────────────────────────────────────

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -70,13 +70,13 @@ if [ -n "$TEST_FILES_CHANGED" ]; then
 
     OPML_CHANGED=false
 
-    # Check if dated file is new or modified
-    if [ -f "$DATED_OPML" ] && ! git diff --exit-code "$DATED_OPML" > /dev/null 2>&1; then
+    # Check if dated file is new, modified, or untracked
+    if [ -f "$DATED_OPML" ] && [ -n "$(git status --porcelain "$DATED_OPML" 2>/dev/null)" ]; then
         OPML_CHANGED=true
     fi
 
-    # Check if symlink changed
-    if [ -L "$SYMLINK_OPML" ] && ! git diff --exit-code "$SYMLINK_OPML" > /dev/null 2>&1; then
+    # Check if symlink is new, modified, or untracked
+    if [ -L "$SYMLINK_OPML" ] && [ -n "$(git status --porcelain "$SYMLINK_OPML" 2>/dev/null)" ]; then
         OPML_CHANGED=true
     fi
 

--- a/tools/install_git_hooks.sh
+++ b/tools/install_git_hooks.sh
@@ -24,8 +24,13 @@ PRE_COMMIT_DST="$HOOKS_DIR/pre-commit"
 
 if [ -f "$PRE_COMMIT_DST" ]; then
     # Existing pre-commit hook - check if it's ours
-    if grep -q "pre-commit-integration-tests" "$PRE_COMMIT_DST" 2>/dev/null; then
-        echo -e "${YELLOW}Pre-commit hook already installed${NC}"
+    if grep -q "Block commits to develop" "$PRE_COMMIT_DST" 2>/dev/null; then
+        echo -e "${YELLOW}Pre-commit hook already installed (up to date)${NC}"
+    elif grep -q "pre-commit-integration-tests" "$PRE_COMMIT_DST" 2>/dev/null; then
+        # Older version without develop guard — upgrade it
+        cp "$PRE_COMMIT_SRC" "$PRE_COMMIT_DST"
+        chmod +x "$PRE_COMMIT_DST"
+        echo -e "${GREEN}✓ Upgraded pre-commit hook (added develop branch guard)${NC}"
     else
         echo -e "${YELLOW}Warning: Existing pre-commit hook found${NC}"
         echo "You have an existing pre-commit hook. To use both hooks:"
@@ -45,11 +50,12 @@ echo ""
 echo -e "${GREEN}Git hooks installed successfully!${NC}"
 echo ""
 echo "What this does:"
+echo "  • Blocks commits to 'develop' in the main worktree"
+echo "    - Use feature branches in worktrees instead"
+echo "    - Bypass with: git commit --no-verify"
 echo "  • When you commit changes to tests/integration/test_cases/*.yaml"
 echo "    - The hook automatically regenerates reports/integration_tests.opml"
 echo "    - The updated OPML is added to your commit"
 echo "  • When you commit changes to CLAUDE.md or docs/*.md"
 echo "    - The hook validates all documentation references"
 echo "    - Prevents broken links and missing doc files"
-echo ""
-echo "This ensures Dave's OPML subscription stays current and docs stay valid!"


### PR DESCRIPTION
## Summary

- **Adapter-repack path**: Fixed hardcoded v6 read format (`use_64bit_format=false`) to check the source database version number. After migration, source databases like StartupTasks.root are v7, so the read context must use 64-bit format.
- **Normal save path**: Added cross-database context override — when the external's `hdatabase` differs from the destination database being packed, the read context now uses `db_context_init_v7_read`/`db_context_init_legacy_read` to match the source format.

Both fixes are in `langexternalpack_internal` in `Common/source/langexternal.c`.

### Root cause

When `StartupTasksSuite.updateGlue()` copies script values from StartupTasks.root into Frontier.root via `adrTarget^ = adr^`, the external variable's data remains on disk in the **source** database. During packing, the read context was either hardcoded to v6 (adapter-repack path) or pointed at the wrong database (normal save path), causing `dbrefhandle FAILED` errors.

### Error before fix
```
[op-ERROR] opverbs.c:661: opverbinmemory: dbrefhandle FAILED adr=0x5a
[external-ERROR] langexternal.c:1024: langexternalpack_internal: ensure_external_in_memory FAILED id=4
[hash-ERROR] langhash.c:3650: hashpackvisit_v7 failed name='cliVersion' reason=hashpackexternal
```

## Test plan

- [x] `make -C frontier-cli` — clean build
- [x] `cd tests && make test-all` — 16/16 tests pass
- [x] Cross-database startup test — no dbrefhandle/ensure_external_in_memory errors
- [x] Full startup flow (`defined(system.temp.Frontier)`) — returns `true` with no pack errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)