### PR TITLE
fix: Build proper function call AST for TCP callbacks

### DIFF
--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -43,7 +43,7 @@
 #include "tcpverbs.h"
 #include "langexternal.h"
 #include "langinternal.h"
-#include "lang.h"  /* langruncallbackwithparams() */
+#include "lang.h"  /* functionop, moduleop, setaddressvalue */
 #include "memory.h"
 #include "strings.h"
 #include "logging.h"
@@ -148,6 +148,16 @@ static boolean tcp_enqueue_callback(hdlhashtable htable, bigstring callback_name
 }
 
 /* Process pending callbacks (called from main thread)
+ *
+ * Builds a proper function call AST for each callback, following the legacy
+ * fwsruncallback pattern (WinSockNetEvents.c:1585-1637). This creates:
+ *   module(function(callback_address, [stream_param, refcon_param]), nil)
+ *
+ * The AST-based approach is required because callbacks like inetd.supervisor
+ * are `on handler(stream, refcon)` functions — the formal parameter binding
+ * only works when params are in the function call tree (hparam1), not as
+ * local variables.
+ *
  * Returns number of callbacks processed */
 int tcp_process_callbacks(void) {
     int processed = 0;
@@ -174,26 +184,90 @@ int tcp_process_callbacks(void) {
                  stringlength(item.callback_name), item.callback_name + 1,
                  item.stream_id, item.refcon);
 
-        tyvaluerecord params[2];
-        setlongvalue(item.stream_id, &params[0]);
-        setlongvalue(item.refcon, &params[1]);
+        /* Build function call AST: callback(stream_id, refcon)
+         * Following fwsruncallback pattern from WinSockNetEvents.c */
 
+        grabthreadglobals();
+
+        /* Build callback address → function reference */
+        tyvaluerecord addrval;
+        hdltreenode hfunctionref;
+
+        if (!setaddressvalue(item.callback_table, item.callback_name, &addrval)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: setaddressvalue failed for stream_id=%ld", item.stream_id);
+            releasethreadglobals();
+            processed++;
+            continue;
+        }
+
+        if (!pushfunctionreference(addrval, &hfunctionref)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: pushfunctionreference failed for stream_id=%ld", item.stream_id);
+            releasethreadglobals();
+            processed++;
+            continue;
+        }
+
+        /* Build parameter nodes: [stream_id, refcon] */
+        tyvaluerecord val;
+        hdltreenode hparam1;
+        hdltreenode hparam2;
+
+        setlongvalue(item.stream_id, &val);
+
+        if (!newconstnode(val, &hparam1)) {
+            langdisposetree(hfunctionref);
+            releasethreadglobals();
+            processed++;
+            continue;
+        }
+
+        setlongvalue(item.refcon, &val);
+
+        if (!newconstnode(val, &hparam2)) {
+            langdisposetree(hfunctionref);
+            langdisposetree(hparam1);
+            releasethreadglobals();
+            processed++;
+            continue;
+        }
+
+        /* Link params: hparam1 → hparam2 */
+        pushlastlink(hparam2, hparam1);
+
+        /* Build function call: function(callback_ref, param_list) */
+        hdltreenode hfunctioncall;
+
+        if (!pushbinaryoperation(functionop, hfunctionref, hparam1, &hfunctioncall)) {
+            releasethreadglobals();
+            processed++;
+            continue;
+        }
+
+        /* Wrap in module: module(functioncall, nil) */
+        hdltreenode hcode;
+
+        if (!pushbinaryoperation(moduleop, hfunctioncall, nil, &hcode)) {
+            releasethreadglobals();
+            processed++;
+            continue;
+        }
+
+        /* Evaluate the function call on the main thread */
         tyvaluerecord result;
-        initvalue(&result, novaluetype);
+        boolean callback_success;
 
-        boolean callback_success = langruncallbackwithparams(
-            item.callback_table,
-            item.callback_name,
-            2,
-            params,
-            &result
-        );
+        callback_success = evaluatelist(hcode, &result);
 
         if (!callback_success) {
             log_warn(LOG_COMP_LANG, "tcp_process_callbacks: callback failed for stream_id=%ld", item.stream_id);
+        } else {
+            disposevaluerecord(result, false);
         }
 
-        disposevaluerecord(result, false);
+        langdisposetree(hcode);
+
+        releasethreadglobals();
+
         processed++;
     }
 

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -250,6 +250,7 @@ int tcp_process_callbacks(void) {
         hdltreenode hfunctioncall;
 
         if (!pushbinaryoperation(functionop, hfunctionref, hparam1, &hfunctioncall)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: pushbinaryoperation(functionop) failed for stream_id=%ld", item.stream_id);
             releasethreadglobals();
             processed++;
             continue;
@@ -259,6 +260,7 @@ int tcp_process_callbacks(void) {
         hdltreenode hcode;
 
         if (!pushbinaryoperation(moduleop, hfunctioncall, nil, &hcode)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: pushbinaryoperation(moduleop) failed for stream_id=%ld", item.stream_id);
             releasethreadglobals();
             processed++;
             continue;

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -44,6 +44,7 @@
 #include "langexternal.h"
 #include "langinternal.h"
 #include "lang.h"  /* functionop, moduleop, setaddressvalue */
+#include "process.h"  /* newprocess, addprocess */
 #include "memory.h"
 #include "strings.h"
 #include "logging.h"
@@ -158,7 +159,14 @@ static boolean tcp_enqueue_callback(hdlhashtable htable, bigstring callback_name
  * only works when params are in the function call tree (hparam1), not as
  * local variables.
  *
- * Returns number of callbacks processed */
+ * Each callback is queued as a one-shot process via newprocess + addprocess,
+ * matching the legacy fwsruncallback behavior. This is critical: callbacks
+ * (e.g. inetd.supervisor → HTTP response rendering) can yield at
+ * langbackgroundtask() and thread.sleepTicks() points. Synchronous evaluation
+ * would hold the GIL for the entire callback duration, blocking all other
+ * threads and preventing concurrent request handling.
+ *
+ * Returns number of callbacks enqueued */
 int tcp_process_callbacks(void) {
     int processed = 0;
 
@@ -179,13 +187,14 @@ int tcp_process_callbacks(void) {
         if (!have_item)
             break;
 
-        /* Invoke callback on main thread (safe for ODB access) */
-        log_debug(LOG_COMP_LANG, "tcp_process_callbacks: invoking callback '%.*s' stream_id=%ld refcon=%ld",
+        log_debug(LOG_COMP_LANG, "tcp_process_callbacks: enqueueing callback '%.*s' stream_id=%ld refcon=%ld",
                  stringlength(item.callback_name), item.callback_name + 1,
                  item.stream_id, item.refcon);
 
         /* Build function call AST: callback(stream_id, refcon)
-         * Following fwsruncallback pattern from WinSockNetEvents.c */
+         * Following fwsruncallback pattern from WinSockNetEvents.c.
+         * Thread globals needed for setaddressvalue/pushfunctionreference
+         * which access ODB structures. */
 
         grabthreadglobals();
 
@@ -202,6 +211,7 @@ int tcp_process_callbacks(void) {
 
         if (!pushfunctionreference(addrval, &hfunctionref)) {
             log_warn(LOG_COMP_LANG, "tcp_process_callbacks: pushfunctionreference failed for stream_id=%ld", item.stream_id);
+            disposevaluerecord(addrval, false);
             releasethreadglobals();
             processed++;
             continue;
@@ -252,21 +262,24 @@ int tcp_process_callbacks(void) {
             continue;
         }
 
-        /* Evaluate the function call on the main thread */
-        tyvaluerecord result;
-        boolean callback_success;
+        /* Create a one-shot process and add to the process queue.
+         * This allows the callback to yield at langbackgroundtask() and
+         * thread.sleepTicks() points, matching legacy fwsruncallback behavior. */
+        hdlprocessrecord hprocess;
 
-        callback_success = evaluatelist(hcode, &result);
-
-        if (!callback_success) {
-            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: callback failed for stream_id=%ld", item.stream_id);
-        } else {
-            disposevaluerecord(result, false);
+        if (!newprocess(hcode, true, nil, 0, &hprocess)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: newprocess failed for stream_id=%ld", item.stream_id);
+            langdisposetree(hcode);
+            releasethreadglobals();
+            processed++;
+            continue;
         }
 
-        langdisposetree(hcode);
-
         releasethreadglobals();
+
+        if (!addprocess(hprocess)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: addprocess failed for stream_id=%ld", item.stream_id);
+        }
 
         processed++;
     }

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -166,7 +166,8 @@ static boolean tcp_enqueue_callback(hdlhashtable htable, bigstring callback_name
  * would hold the GIL for the entire callback duration, blocking all other
  * threads and preventing concurrent request handling.
  *
- * Returns number of callbacks enqueued */
+ * Returns number of callbacks processed (dequeued, whether or not
+ * they were successfully enqueued as processes) */
 int tcp_process_callbacks(void) {
     int processed = 0;
 
@@ -210,8 +211,9 @@ int tcp_process_callbacks(void) {
         }
 
         if (!pushfunctionreference(addrval, &hfunctionref)) {
+            /* Don't dispose addrval here — pushfunctionreference may have
+             * already consumed it via newconstnode + pushunaryoperation. */
             log_warn(LOG_COMP_LANG, "tcp_process_callbacks: pushfunctionreference failed for stream_id=%ld", item.stream_id);
-            disposevaluerecord(addrval, false);
             releasethreadglobals();
             processed++;
             continue;
@@ -279,6 +281,7 @@ int tcp_process_callbacks(void) {
 
         if (!addprocess(hprocess)) {
             log_warn(LOG_COMP_LANG, "tcp_process_callbacks: addprocess failed for stream_id=%ld", item.stream_id);
+            disposeprocess(hprocess);
         }
 
         processed++;


### PR DESCRIPTION
## Summary

- Fixed "Can't call supervisor because there aren't enough parameters" error when HTTP requests hit the headless webserver
- Root cause: tcp_process_callbacks used langruncallbackwithparams which passes params as local variables (param1, param2), but inetd.supervisor is an on handler(stream, refcon) function — the kernel verb handler extracts params from the function call's hparam1 AST node, which was nil
- Rewrote tcp_process_callbacks to build a proper function call AST following the legacy fwsruncallback pattern (WinSockNetEvents.c:1585-1637): const nodes → linked param list → functionop → moduleop → evaluatelist

## Test plan

- [x] 284 unit tests pass (including 14 callback infrastructure tests)
- [x] 1702/1703 integration tests pass (1 pre-existing failure on develop)
- [x] Startup completes without inetd.supervisor parameter error
- [x] No regressions in file dialog, menu save, or startup error handling