### PR TITLE
fix: Execute TCP callbacks directly in headless mode

### DIFF
--- a/Common/headers/threadregistry.h
+++ b/Common/headers/threadregistry.h
@@ -64,6 +64,9 @@
 /* For thread registry, we just need to store a pointer */
 typedef struct tythreadglobals **hdlthreadglobals;
 
+/* Forward declaration - actual definition in lang.h */
+typedef struct tytreenode **hdltreenode;
+
 /* Use portable boolean if available, otherwise define it */
 #ifndef boolean
 typedef unsigned char boolean;
@@ -314,5 +317,18 @@ void headless_threading_shutdown(void);
  * Thread Safety: Must be called while holding the GIL
  */
 boolean headless_backgroundtask(boolean flresting);
+
+/*
+ * headless_spawn_callback_thread - Spawn a GIL-aware thread for a TCP callback
+ *
+ * Takes ownership of hcode (the callback AST). The spawned thread acquires the
+ * GIL, executes the callback, performs error cleanup (fifcloseallfiles,
+ * langreleasesemaphores), and disposes all resources.
+ *
+ * Must be called while holding the GIL (i.e., from the main REPL loop).
+ *
+ * Thread Safety: Thread-safe (GIL serialization)
+ */
+boolean headless_spawn_callback_thread(hdltreenode hcode, long stream_id);
 
 #endif /* THREADREGISTRY_H */

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -45,6 +45,7 @@
 #include "langinternal.h"
 #include "lang.h"  /* functionop, moduleop, setaddressvalue */
 #include "process.h"  /* newprocess, addprocess */
+#include "threadregistry.h"  /* headless_spawn_callback_thread */
 #include "memory.h"
 #include "strings.h"
 #include "logging.h"
@@ -159,15 +160,23 @@ static boolean tcp_enqueue_callback(hdlhashtable htable, bigstring callback_name
  * only works when params are in the function call tree (hparam1), not as
  * local variables.
  *
- * Each callback is queued as a one-shot process via newprocess + addprocess,
- * matching the legacy fwsruncallback behavior. This is critical: callbacks
- * (e.g. inetd.supervisor → HTTP response rendering) can yield at
- * langbackgroundtask() and thread.sleepTicks() points. Synchronous evaluation
- * would hold the GIL for the entire callback duration, blocking all other
- * threads and preventing concurrent request handling.
+ * Execution model differs by build target:
+ *
+ * Full Frontier: Each callback is queued as a one-shot process via
+ * newprocess + addprocess, matching the legacy fwsruncallback behavior.
+ *
+ * Headless mode: The process scheduler (newprocess/addprocess) is not
+ * available. Instead, each callback is spawned as a GIL-aware POSIX thread
+ * via headless_spawn_callback_thread(). The thread blocks on GIL acquisition
+ * until the main thread yields at langbackgroundtask(), then executes the
+ * callback with full error cleanup (fifcloseallfiles/langreleasesemaphores).
+ * See ADR-014 for the GIL cooperative threading model.
+ *
+ * In both cases, callbacks can yield at langbackgroundtask() and
+ * thread.sleepTicks() points, allowing concurrent request handling.
  *
  * Returns number of callbacks processed (dequeued, whether or not
- * they were successfully enqueued as processes) */
+ * they were successfully dispatched) */
 int tcp_process_callbacks(void) {
     int processed = 0;
 
@@ -269,21 +278,15 @@ int tcp_process_callbacks(void) {
         }
 
         #if defined(FRONTIER_HEADLESS)
-        /* Headless mode: execute callback directly via langruncode.
+        /* Headless mode: spawn a GIL-aware thread per callback.
          * The process scheduler (newprocess/addprocess) is not available
-         * in the headless build. Direct execution is acceptable here
-         * because the headless REPL is single-threaded. */
-        {
-            tyvaluerecord result;
+         * in the headless build. Each callback runs in its own POSIX thread
+         * that acquires the GIL cooperatively (see ADR-014), allowing
+         * concurrent request handling without blocking the REPL or other
+         * threads. headless_spawn_callback_thread() takes ownership of hcode. */
 
-            initvalue (&result, novaluetype);
-
-            if (!langruncode(hcode, nil, &result)) {
-                log_warn(LOG_COMP_LANG, "tcp_process_callbacks: langruncode failed for stream_id=%ld", item.stream_id);
-            }
-
-            langdisposetree(hcode);
-            disposevaluerecord(result, false);
+        if (!headless_spawn_callback_thread(hcode, item.stream_id)) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: headless_spawn_callback_thread failed for stream_id=%ld", item.stream_id);
         }
 
         releasethreadglobals();

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -268,7 +268,27 @@ int tcp_process_callbacks(void) {
             continue;
         }
 
-        /* Create a one-shot process and add to the process queue.
+        #if defined(FRONTIER_HEADLESS)
+        /* Headless mode: execute callback directly via langruncode.
+         * The process scheduler (newprocess/addprocess) is not available
+         * in the headless build. Direct execution is acceptable here
+         * because the headless REPL is single-threaded. */
+        {
+            tyvaluerecord result;
+
+            initvalue (&result, novaluetype);
+
+            if (!langruncode(hcode, nil, &result)) {
+                log_warn(LOG_COMP_LANG, "tcp_process_callbacks: langruncode failed for stream_id=%ld", item.stream_id);
+            }
+
+            langdisposetree(hcode);
+            disposevaluerecord(result, false);
+        }
+
+        releasethreadglobals();
+        #else
+        /* Full Frontier: queue as one-shot process for the scheduler.
          * This allows the callback to yield at langbackgroundtask() and
          * thread.sleepTicks() points, matching legacy fwsruncallback behavior. */
         hdlprocessrecord hprocess;
@@ -287,6 +307,7 @@ int tcp_process_callbacks(void) {
             log_warn(LOG_COMP_LANG, "tcp_process_callbacks: addprocess failed for stream_id=%ld", item.stream_id);
             disposeprocess(hprocess);
         }
+        #endif
 
         processed++;
     }

--- a/tests/headless_lang_runtime_more_stubs.c
+++ b/tests/headless_lang_runtime_more_stubs.c
@@ -4,6 +4,7 @@
 #include "osincludes_portable.h"
 
 #include "process.h"
+#include "threadregistry.h"  /* headless_backgroundtask */
 #include "threads.h"
 #include "fileloop.h"
 #include "launch.h"
@@ -182,10 +183,17 @@ boolean processsleep (hdlprocessthread t, unsigned long timeout) {
     const unsigned long poll_interval_ms = 50;  /* Poll every 50ms */
 
     while (elapsed < ms) {
-        /* Process any pending TCP callbacks */
+        /* Process any pending TCP callbacks (spawns GIL-aware threads) */
         tcp_process_callbacks();
 
-        /* Sleep for poll interval or remaining time, whichever is less */
+        /* Yield the GIL so spawned callback threads can run during our sleep.
+         * Without this, callback threads spawned by tcp_process_callbacks()
+         * would block on GIL acquisition for the entire sleep duration. */
+        headless_backgroundtask(true);
+
+        /* Sleep for poll interval or remaining time, whichever is less.
+         * We hold the GIL here but only for a short interval before
+         * yielding again at the top of the loop. */
         unsigned long sleep_time = (ms - elapsed < poll_interval_ms) ? (ms - elapsed) : poll_interval_ms;
         usleep((useconds_t)(sleep_time * 1000));  /* usleep takes microseconds */
         elapsed += sleep_time;

--- a/tests/headless_thread_verbs.c
+++ b/tests/headless_thread_verbs.c
@@ -304,8 +304,16 @@ static void *callback_thread_entry_point(void *arg) {
     fl = langruncode(params->hcode, nil, &result);
 
     if (!fl) {
-        /* Error cleanup matching process.c one-shot behavior:
-         * close any files opened during callback, release any semaphores held */
+        /* Error cleanup matching process.c one-shot behavior (lines 2565-2576).
+         *
+         * fifcloseallfiles(0L): In process.c, the refcon is (long)hp (the process
+         * handle). In headless mode, process.c is not compiled — there are no
+         * process handles. File verbs in headless mode open files with refcon 0,
+         * so 0L is the correct value here.
+         *
+         * langreleasesemaphores(nil): The hp parameter is #pragma unused in the
+         * implementation — it uses getcurrentthreadglobals() internally. nil is
+         * functionally equivalent to passing a process handle. */
         fifcloseallfiles(0L);
         langreleasesemaphores(nil);
         log_warn(LOG_COMP_LANG, "callback_thread_entry_point: langruncode failed for stream_id=%ld",

--- a/tests/headless_thread_verbs.c
+++ b/tests/headless_thread_verbs.c
@@ -32,6 +32,7 @@
 #include "process.h"
 #include "shellthreads.h"
 #include "logging.h"
+#include "file.h"  /* fifcloseallfiles */
 #include "threadregistry.h"
 #include "processinternal.h"
 #include "script_portable.h"
@@ -270,6 +271,160 @@ static void *thread_entry_point(void *arg) {
     pthread_cond_broadcast(&gil_available);
 
     return NULL;
+}
+
+/*
+ * callback_thread_entry_point - POSIX thread entry for TCP callback threads
+ *
+ * Similar to thread_entry_point but tailored for fire-and-forget callbacks:
+ * - Performs error cleanup (fifcloseallfiles, langreleasesemaphores) on failure,
+ *   matching the one-shot process cleanup in process.c:2565-2576
+ * - Does not register in system.compiler.threads (callbacks are transient)
+ * - Always disposes hcode (callback AST is owned by this thread)
+ */
+static void *callback_thread_entry_point(void *arg) {
+    thread_launch_params *params = (thread_launch_params *)arg;
+    tyvaluerecord result;
+    boolean fl;
+
+    if (params == NULL) {
+        log_error(LOG_COMP_THREAD, "callback_thread_entry_point: NULL params — aborting thread");
+        return NULL;
+    }
+
+    /* Block until we can acquire the GIL */
+    pthread_mutex_lock(&frontier_gil);
+
+    /* Restore this thread's globals (makes C globals point to our state) */
+    headless_restore_threadglobals(params->hglobals);
+
+    /* Execute the callback */
+    initvalue(&result, novaluetype);
+
+    fl = langruncode(params->hcode, nil, &result);
+
+    if (!fl) {
+        /* Error cleanup matching process.c one-shot behavior:
+         * close any files opened during callback, release any semaphores held */
+        fifcloseallfiles(0L);
+        langreleasesemaphores(nil);
+        log_warn(LOG_COMP_LANG, "callback_thread_entry_point: langruncode failed for stream_id=%ld",
+                 params->rec->user_thread_id);
+    }
+
+    /* Save our globals before cleanup (while we still hold the GIL) */
+    headless_save_threadglobals(params->hglobals);
+
+    /* Clear global error buffer (fire-and-forget) */
+    headless_clear_last_lang_error();
+
+    /* Cleanup */
+    langdisposetree(params->hcode);
+    disposevaluerecord(result, false);
+    headless_dispose_threadglobals(params->hglobals);
+    free_thread_record(params->rec);
+    free(params);
+
+    /* Release the GIL and signal other threads */
+    pthread_mutex_unlock(&frontier_gil);
+    pthread_cond_broadcast(&gil_available);
+
+    return NULL;
+}
+
+/*
+ * headless_spawn_callback_thread - Spawn a GIL-aware thread for a TCP callback
+ *
+ * Takes ownership of hcode. The caller must hold the GIL.
+ * The spawned thread blocks on GIL acquisition until the main thread yields
+ * at the next langbackgroundtask() call.
+ *
+ * stream_id is used only for logging — the callback AST already encodes
+ * the stream and refcon as parameters in the function call tree.
+ */
+boolean headless_spawn_callback_thread(hdltreenode hcode, long stream_id) {
+    frontier_pthread_record *rec = nil;
+    hdlthreadglobals new_hglobals = nil;
+    thread_launch_params *params = nil;
+    pthread_t tid;
+    pthread_attr_t attr;
+
+    /* Allocate thread record from registry */
+    rec = allocate_thread_record();
+
+    if (rec == NULL) {
+        langdisposetree(hcode);
+        return false;
+    }
+
+    /* Allocate new thread globals */
+    new_hglobals = headless_new_threadglobals();
+
+    if (new_hglobals == nil) {
+        langdisposetree(hcode);
+        free_thread_record(rec);
+        return false;
+    }
+
+    /* Set thread ID in the new globals */
+    (**new_hglobals).idthread = (hdlthread) rec->user_thread_id;
+
+    /* Link globals to registry record */
+    rec->hglobals = new_hglobals;
+
+    /* Deep-copy the calling thread's hashtablestack so the callback gets its
+     * own stack pointer/index state. Shared underlying hash table pointers are
+     * safe under GIL serialization. */
+    {
+        Handle hcopy;
+
+        if (!newfilledhandle((char *)(*hashtablestack), sizeof(tytablestack), &hcopy)) {
+            langdisposetree(hcode);
+            headless_dispose_threadglobals(new_hglobals);
+            free_thread_record(rec);
+            return false;
+        }
+
+        (**new_hglobals).htablestack = (hdltablestack)hcopy;
+    }
+    (**new_hglobals).hcurrenthashtable = currenthashtable;
+
+    /* Package launch parameters */
+    params = (thread_launch_params *)malloc(sizeof(thread_launch_params));
+
+    if (params == NULL) {
+        langdisposetree(hcode);
+        headless_dispose_threadglobals(new_hglobals);
+        free_thread_record(rec);
+        return false;
+    }
+
+    params->hcode = hcode;
+    params->hglobals = new_hglobals;
+    params->rec = rec;
+    params->is_callscript = false;
+
+    /* Spawn detached POSIX thread — it will block on GIL until main thread yields */
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+    if (pthread_create(&tid, &attr, callback_thread_entry_point, params) != 0) {
+        log_error(LOG_COMP_THREAD, "pthread_create failed for TCP callback (stream_id=%ld)", stream_id);
+        pthread_attr_destroy(&attr);
+        langdisposetree(hcode);
+        headless_dispose_threadglobals(new_hglobals);
+        free_thread_record(rec);
+        free(params);
+        return false;
+    }
+
+    pthread_attr_destroy(&attr);
+    rec->pthread_id = tid;
+
+    log_debug(LOG_COMP_THREAD, "headless_spawn_callback_thread: spawned thread %ld for stream_id=%ld",
+              rec->user_thread_id, stream_id);
+
+    return true;
 }
 
 /*


### PR DESCRIPTION
## Summary

Fix a SIGSEGV in the headless binary when a TCP listener callback fires (e.g., HTTP request to port 5336).

**Root cause:** `tcp_process_callbacks()` calls `newprocess()`/`addprocess()` from `process.c`, which is not compiled into the headless build. With `-Wl,-undefined,dynamic_lookup`, those symbols resolve to NULL at runtime, causing a SIGSEGV on the first callback invocation.

**Fix:** In headless mode, spawn a GIL-aware POSIX thread per callback via `headless_spawn_callback_thread()` instead of queuing through the process scheduler. Each callback thread:
- Acquires the GIL cooperatively (ADR-014 threading model)
- Executes the callback AST via `langruncode()`
- Performs error cleanup (`fifcloseallfiles`/`langreleasesemaphores`) on failure
- Disposes all resources and releases the GIL

This preserves concurrent request handling -- callbacks do not block the REPL or other threads.

## Changes

- `Common/source/tcpverbs.c`: Replace synchronous execution with `headless_spawn_callback_thread()` call; update function-level comment documenting headless vs full Frontier execution models
- `tests/headless_thread_verbs.c`: Add `callback_thread_entry_point()` and `headless_spawn_callback_thread()` -- GIL-aware thread spawning for TCP callbacks with proper error cleanup
- `Common/headers/threadregistry.h`: Declare `headless_spawn_callback_thread()` and forward-declare `hdltreenode`
- `tests/headless_lang_runtime_more_stubs.c`: Update `processsleep()` to yield GIL via `headless_backgroundtask()` so callback threads can execute during sleep loops

## Test plan

- [x] 284/284 unit tests pass
- [x] 1703/1703 integration tests pass (0 failures)
- [x] Manual verification: dist build + curl to port 5336 -- no crash, 3 consecutive requests succeed
- [x] Existing `tcp_verbs_network.yaml` integration tests exercise the full callback path