### PR TITLE
fix: Yield GIL in REPL event loop and fix headless thread identity stubs

### DIFF
--- a/Common/source/stringverbs.c
+++ b/Common/source/stringverbs.c
@@ -1240,14 +1240,20 @@ exit:
 
 
 void latintomac (Handle h) {
-	
+
 	/*
 	7.0b28 PBS: convert text from Latin to Mac character sets.
 	*/
-	
+
+	if (h == nil)
+		return;
+
 	long ix = 0;
 	long lentext = gethandlesize (h);
-	
+
+	if (lentext <= 0)
+		return;
+
 	while (true) {
 	
 		unsigned char ch = (*h) [ix];
@@ -1269,14 +1275,20 @@ void latintomac (Handle h) {
 
 
 void mactolatin (Handle h) {
-	
+
 	/*
 	7.0b35 PBS: convert text from Mac to Latin character sets.
 	*/
-	
+
+	if (h == nil)
+		return;
+
 	long ix = 0;
 	long lentext = gethandlesize (h);
-	
+
+	if (lentext <= 0)
+		return;
+
 	while (true) {
 	
 		unsigned char ch = (*h) [ix];

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -42,6 +42,7 @@
 #include "../Common/headers/tcpverbs.h"     /* tcp_process_callbacks */
 #include "../Common/headers/process.h"      /* agentsenabled, agentscheduler_tick */
 #include "../Common/headers/langinternal.h" /* flreplmode */
+#include "../Common/headers/threadregistry.h" /* headless_backgroundtask */
 
 // History configuration
 #define HISTORY_FILE ".frontier_history"
@@ -2087,6 +2088,11 @@ int repl_main(cli_options_t *options) {
 
         // 6.3 Process TCP callbacks (webserver)
         tcp_process_callbacks();
+
+        // 6.3.1 Yield GIL so callback threads spawned above can execute.
+        // Without this, the main thread holds the GIL for the entire idle
+        // loop and spawned callback threads deadlock on GIL acquisition.
+        headless_backgroundtask(true);
 
         // 6.4 Run agent scheduler tick (if agents enabled)
         if (agentsenabled()) {

--- a/tests/headless_lang_runtime_more_stubs.c
+++ b/tests/headless_lang_runtime_more_stubs.c
@@ -153,9 +153,34 @@ boolean myMoof (short a, long b) { (void)a; (void)b; return false; }
 // 2025-12-15 Codex: Time functions moved to Common/source/timedate.c with headless guards
 // These functions are no longer needed here as stubs
 
-// Threading helpers referenced by langxml
+// Threading helpers referenced by langxml and langhtml
 boolean inmainthread (void) { return true; }
-hdlprocessthread getcurrentthread (void) { return nil; }
+
+/* In full Frontier, getcurrentthread() returns the current process's thread
+ * handle from the process scheduler. In headless mode there is no process
+ * scheduler, but hthreadglobals always points to the GIL holder's globals.
+ * Callers like langhtml.c use getthreadid(getcurrentthread()) to key
+ * per-thread data — returning hthreadglobals ensures the thread ID matches
+ * what the thread registry assigned.
+ *
+ * We use a weak reference because some unit test binaries link this stubs
+ * file but not the threading infrastructure (headless_threadglobals.c). */
+extern hdlthreadglobals hthreadglobals __attribute__((weak));
+hdlprocessthread getcurrentthread (void) {
+    if (&hthreadglobals != NULL)
+        return (hdlprocessthread) hthreadglobals;
+    return nil;
+}
+
+/* getthreadid - return thread ID from a thread globals handle.
+ * In full Frontier this lives in process.c. The headless build needs it
+ * because langhtml.c (getpagetableaddressverb, inetdsupervisor logging)
+ * calls getthreadid(getcurrentthread()). */
+long getthreadid (hdlprocessthread hthread) {
+    if (hthread == nil)
+        return ((long) idnullthread);
+    return ((long) (**(hdlthreadglobals) hthread).idthread);
+}
 
 /* Forward declaration for TCP callback processing */
 extern int tcp_process_callbacks(void);


### PR DESCRIPTION
## Summary
- Add `headless_backgroundtask(true)` call in the REPL event loop after `tcp_process_callbacks()` to yield the GIL, allowing spawned callback threads to execute instead of deadlocking on GIL acquisition
- Fix `getcurrentthread()` to return `hthreadglobals` (the GIL holder thread globals) instead of nil, so callers like `langhtml.c:getpagetableaddressverb()` get a valid thread identity
- Add `getthreadid()` stub (from process.c) to headless stubs so thread ID lookups work in the webserver callback chain
- Use `__attribute__((weak))` on the `hthreadglobals` extern so unit test binaries that do not link the threading infrastructure still compile and run
- Add nil-handle and zero-length guards to `mactolatin()` and `latintomac()` — these were discovered as crashes in the webserver page rendering path exercised by the same TCP callback chain fixed above

## Context
After PR #442 (GIL-aware thread spawning for TCP callbacks), the webserver startup page would hang because the REPL main thread held the GIL continuously during its idle loop. Callback threads spawned by `tcp_process_callbacks()` would block forever waiting for the GIL. Additionally, the webserver rendering path through `langhtml.c` called `getthreadid(getcurrentthread())` which crashed on undefined symbols in the headless build. Once those were fixed, the rendering path hit `mactolatin()` with a nil handle during character set conversion, causing another segfault.

## Test plan
- [x] 284/284 unit tests pass
- [x] 1703/1703 integration tests pass (0 failures)
- [x] Manual verification: setupFrontier page loads in browser after these fixes

Generated with [Claude Code](https://claude.com/claude-code)