### PR TITLE
fix: Replace broken Pascal string prefixes in all headless verb registrations

### DIFF
--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8531,10 +8531,18 @@ boolean langgetnodecode (hdlhashtable ht, bigstring bs, hdlhashnode hnode, hdltr
 			}
 
 			#if defined(FRONTIER_HEADLESS)
-			/* Stale code detection: v6 databases may contain pre-compiled code trees
-			 * that are not valid in the headless runtime. If the linked code has a nil
-			 * param1 (no statements), force recompilation from source text. This is
-			 * safe because headless_scriptcompiler always recompiles from the outline. */
+			/* Stale code detection: v6 databases contain pre-compiled code trees
+			 * from the original Mac runtime that are not valid in the headless build.
+			 * These trees have nil param1 because they were compiled against a
+			 * different verb table layout.
+			 *
+			 * Known false positive: a legitimately empty script also compiles to a
+			 * tree with nil param1. In headless mode this causes an extra recompile
+			 * per access, which is acceptable — empty scripts are rare in practice
+			 * and recompilation is cheap (produces the same empty tree).
+			 *
+			 * The master pointer dereference (*(*hcode)) is safe here because
+			 * langexternalvaltocode just populated the handle from a live node. */
 			if (*hcode != nil && (**(*hcode)).param1 == nil) {
 				log_debug(LOG_COMP_LANG, "langgetnodecode: stale linked code for %s (nil param1), forcing recompile", PSTR(bs));
 				*hcode = nil;

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8542,7 +8542,11 @@ boolean langgetnodecode (hdlhashtable ht, bigstring bs, hdlhashnode hnode, hdltr
 			 * and recompilation is cheap (produces the same empty tree).
 			 *
 			 * The master pointer dereference (*(*hcode)) is safe here because
-			 * langexternalvaltocode just populated the handle from a live node. */
+			 * langexternalvaltocode just populated the handle from a live node.
+			 *
+			 * No handle leak: *hcode is a borrowed reference into the node's
+			 * stored data (via opverbgetlinkedcode), not an owned allocation.
+			 * Setting it to nil just tells the caller to recompile. */
 			if (*hcode != nil && (**(*hcode)).param1 == nil) {
 				log_debug(LOG_COMP_LANG, "langgetnodecode: stale linked code for %s (nil param1), forcing recompile", PSTR(bs));
 				*hcode = nil;

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8529,6 +8529,18 @@ boolean langgetnodecode (hdlhashtable ht, bigstring bs, hdlhashnode hnode, hdltr
 				log_error(LOG_COMP_LANG, "langgetnodecode: langexternalvaltocode FAILED for %s", PSTR(bs));
 				return (false);
 			}
+
+			#if defined(FRONTIER_HEADLESS)
+			/* Stale code detection: v6 databases may contain pre-compiled code trees
+			 * that are not valid in the headless runtime. If the linked code has a nil
+			 * param1 (no statements), force recompilation from source text. This is
+			 * safe because headless_scriptcompiler always recompiles from the outline. */
+			if (*hcode != nil && (**(*hcode)).param1 == nil) {
+				log_debug(LOG_COMP_LANG, "langgetnodecode: stale linked code for %s (nil param1), forcing recompile", PSTR(bs));
+				*hcode = nil;
+			}
+			#endif
+
 			if (*hcode == nil) { /*it needs to be compiled*/
 
 				log_trace(LOG_COMP_LANG, "langgetnodecode: script needs compilation for %s", PSTR(bs));

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8536,10 +8536,14 @@ boolean langgetnodecode (hdlhashtable ht, bigstring bs, hdlhashnode hnode, hdltr
 			 * These trees have nil param1 because they were compiled against a
 			 * different verb table layout.
 			 *
+			 * The recompile is a one-time cost per stale node: the script compiler
+			 * (scriptcompilecallback) writes back the freshly compiled tree via
+			 * opverblinkcode(), so subsequent calls find valid compiled code.
+			 *
 			 * Known false positive: a legitimately empty script also compiles to a
-			 * tree with nil param1. In headless mode this causes an extra recompile
-			 * per access, which is acceptable — empty scripts are rare in practice
-			 * and recompilation is cheap (produces the same empty tree).
+			 * tree with nil param1, causing repeated recompilation on every access.
+			 * This is acceptable — empty scripts are rare in practice and
+			 * recompilation is cheap (produces the same empty tree).
 			 *
 			 * The master pointer dereference (*(*hcode)) is safe here because
 			 * langexternalvaltocode just populated the handle from a live node.

--- a/tests/headless_base64_verbs.c
+++ b/tests/headless_base64_verbs.c
@@ -48,7 +48,7 @@ static boolean base64_valueproc(short token, hdltreenode hparam1,
             /* @IMPLEMENTED base64.encode - delegates to base64encodeverb in base64.c */
             result = base64encodeverb(hparam1, vreturned);
             if (!result && bserror) {
-                copystring(BIGSTRING("\pbase64.encode failed"), bserror);
+                copystring(BIGSTRING("\024base64.encode failed"), bserror);
             }
             return result;
 
@@ -56,12 +56,12 @@ static boolean base64_valueproc(short token, hdltreenode hparam1,
             /* @IMPLEMENTED base64.decode - delegates to base64decodeverb in base64.c */
             result = base64decodeverb(hparam1, vreturned);
             if (!result && bserror) {
-                copystring(BIGSTRING("\pbase64.decode failed"), bserror);
+                copystring(BIGSTRING("\024base64.decode failed"), bserror);
             }
             return result;
 
         default:
-            if (bserror) copystring(BIGSTRING("\punknown base64 verb"), bserror);
+            if (bserror) copystring(BIGSTRING("\023unknown base64 verb"), bserror);
             return false;
     }
 }
@@ -70,7 +70,7 @@ boolean base64initverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pbase64"), bsname);
+    copystring(BIGSTRING("\006base64"), bsname);
 
     if (!newfunctionprocessor(bsname, &base64_valueproc, false, &htable))
         return false;
@@ -86,8 +86,8 @@ boolean base64initverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pencode"), basv_encode);
-    ADD_VERB(BIGSTRING("\pdecode"), basv_decode);
+    ADD_VERB(BIGSTRING("\006encode"), basv_encode);
+    ADD_VERB(BIGSTRING("\006decode"), basv_decode);
 
     #undef ADD_VERB
 

--- a/tests/headless_bit_verbs.c
+++ b/tests/headless_bit_verbs.c
@@ -38,35 +38,35 @@ static boolean bit_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case bitv_get:
             /* Verb #0: bit.get - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_set:
             /* Verb #1: bit.set - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_clear:
             /* Verb #2: bit.clear - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_logicaland:
             /* Verb #3: bit.logicaland - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_logicalor:
             /* Verb #4: bit.logicalor - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_logicalxor:
             /* Verb #5: bit.logicalxor - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_shiftleft:
             /* Verb #6: bit.shiftleft - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case bitv_shiftright:
             /* Verb #7: bit.shiftright - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -77,7 +77,7 @@ boolean bitinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pbit"), bsname);
+    copystring(BIGSTRING("\003bit"), bsname);
 
     if (!newfunctionprocessor(bsname, &bit_valueproc, false, &htable))
         return false;
@@ -93,14 +93,14 @@ boolean bitinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), bitv_get);
-    ADD_VERB(BIGSTRING("\pset"), bitv_set);
-    ADD_VERB(BIGSTRING("\pclear"), bitv_clear);
-    ADD_VERB(BIGSTRING("\plogicaland"), bitv_logicaland);
-    ADD_VERB(BIGSTRING("\plogicalor"), bitv_logicalor);
-    ADD_VERB(BIGSTRING("\plogicalxor"), bitv_logicalxor);
-    ADD_VERB(BIGSTRING("\pshiftleft"), bitv_shiftleft);
-    ADD_VERB(BIGSTRING("\pshiftright"), bitv_shiftright);
+    ADD_VERB(BIGSTRING("\003get"), bitv_get);
+    ADD_VERB(BIGSTRING("\003set"), bitv_set);
+    ADD_VERB(BIGSTRING("\005clear"), bitv_clear);
+    ADD_VERB(BIGSTRING("\012logicaland"), bitv_logicaland);
+    ADD_VERB(BIGSTRING("\011logicalor"), bitv_logicalor);
+    ADD_VERB(BIGSTRING("\012logicalxor"), bitv_logicalxor);
+    ADD_VERB(BIGSTRING("\011shiftleft"), bitv_shiftleft);
+    ADD_VERB(BIGSTRING("\012shiftright"), bitv_shiftright);
 
     #undef ADD_VERB
 

--- a/tests/headless_clipboard_verbs.c
+++ b/tests/headless_clipboard_verbs.c
@@ -32,11 +32,11 @@ static boolean clipboard_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case cliv_get:
             /* Verb #0: clipboard.get - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case cliv_put:
             /* Verb #1: clipboard.put - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -47,7 +47,7 @@ boolean clipboardinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pclipboard"), bsname);
+    copystring(BIGSTRING("\011clipboard"), bsname);
 
     if (!newfunctionprocessor(bsname, &clipboard_valueproc, false, &htable))
         return false;
@@ -63,8 +63,8 @@ boolean clipboardinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), cliv_get);
-    ADD_VERB(BIGSTRING("\pput"), cliv_put);
+    ADD_VERB(BIGSTRING("\003get"), cliv_get);
+    ADD_VERB(BIGSTRING("\003put"), cliv_put);
 
     #undef ADD_VERB
 

--- a/tests/headless_clock_verbs.c
+++ b/tests/headless_clock_verbs.c
@@ -51,7 +51,7 @@ static boolean clock_valueproc(short token, hdltreenode hparam1,
             /* clock.set - returns appropriate error (not a stub)
              * @IMPLEMENTED - Correctly implemented to return security error */
             if (bserror)
-                copystring(BIGSTRING("\pCan't set system time because it requires administrator privileges"), bserror);
+                copystring(BIGSTRING("\102Can't set system time because it requires administrator privileges"), bserror);
             return false;
 
         case clov_sleepfor: {
@@ -65,7 +65,7 @@ static boolean clock_valueproc(short token, hdltreenode hparam1,
 
             /* Validate non-negative duration */
             if (ctseconds < 0) {
-                if (bserror) copystring(BIGSTRING("\pCan't sleep because negative duration is invalid"), bserror);
+                if (bserror) copystring(BIGSTRING("\060Can't sleep because negative duration is invalid"), bserror);
                 return false;
             }
 
@@ -100,7 +100,7 @@ static boolean clock_valueproc(short token, hdltreenode hparam1,
 
             /* Validate non-negative duration */
             if (ctseconds < 0) {
-                if (bserror) copystring(BIGSTRING("\pCan't wait because negative duration is invalid"), bserror);
+                if (bserror) copystring(BIGSTRING("\057Can't wait because negative duration is invalid"), bserror);
                 return false;
             }
 
@@ -124,7 +124,7 @@ static boolean clock_valueproc(short token, hdltreenode hparam1,
 
             /* Convert 60ths of a second to milliseconds */
             if (ctsixtieths < 0) {
-                if (bserror) copystring(BIGSTRING("\pCan't wait because negative duration is invalid"), bserror);
+                if (bserror) copystring(BIGSTRING("\057Can't wait because negative duration is invalid"), bserror);
                 return false;
             }
 
@@ -147,7 +147,7 @@ boolean clockinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pclock"), bsname);
+    copystring(BIGSTRING("\005clock"), bsname);
 
     if (!newfunctionprocessor(bsname, &clock_valueproc, false, &htable))
         return false;
@@ -163,13 +163,13 @@ boolean clockinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pnow"), clov_now);
-    ADD_VERB(BIGSTRING("\pset"), clov_set);
-    ADD_VERB(BIGSTRING("\psleepfor"), clov_sleepfor);
-    ADD_VERB(BIGSTRING("\pticks"), clov_ticks);
-    ADD_VERB(BIGSTRING("\pmilliseconds"), clov_milliseconds);
-    ADD_VERB(BIGSTRING("\pwaitseconds"), clov_waitseconds);
-    ADD_VERB(BIGSTRING("\pwaitsixtieths"), clov_waitsixtieths);
+    ADD_VERB(BIGSTRING("\003now"), clov_now);
+    ADD_VERB(BIGSTRING("\003set"), clov_set);
+    ADD_VERB(BIGSTRING("\010sleepfor"), clov_sleepfor);
+    ADD_VERB(BIGSTRING("\005ticks"), clov_ticks);
+    ADD_VERB(BIGSTRING("\014milliseconds"), clov_milliseconds);
+    ADD_VERB(BIGSTRING("\013waitseconds"), clov_waitseconds);
+    ADD_VERB(BIGSTRING("\015waitsixtieths"), clov_waitsixtieths);
 
     #undef ADD_VERB
 

--- a/tests/headless_crypt_verbs.c
+++ b/tests/headless_crypt_verbs.c
@@ -37,7 +37,7 @@ boolean cryptinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pcrypt"), bsname);
+    copystring(BIGSTRING("\005crypt"), bsname);
 
     if (!newfunctionprocessor(bsname, &crypt_valueproc, false, &htable))
         return false;
@@ -53,11 +53,11 @@ boolean cryptinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pwhirlpool"), cryv_whirlpool);
-    ADD_VERB(BIGSTRING("\phmacMD5"), cryv_hmacMD5);
-    ADD_VERB(BIGSTRING("\pMD5"), cryv_MD5);
-    ADD_VERB(BIGSTRING("\pSHA1"), cryv_SHA1);
-    ADD_VERB(BIGSTRING("\phmacSHA1"), cryv_hmacSHA1);
+    ADD_VERB(BIGSTRING("\011whirlpool"), cryv_whirlpool);
+    ADD_VERB(BIGSTRING("\007hmacMD5"), cryv_hmacMD5);
+    ADD_VERB(BIGSTRING("\003MD5"), cryv_MD5);
+    ADD_VERB(BIGSTRING("\004SHA1"), cryv_SHA1);
+    ADD_VERB(BIGSTRING("\010hmacSHA1"), cryv_hmacSHA1);
 
     #undef ADD_VERB
 

--- a/tests/headless_date_verbs.c
+++ b/tests/headless_date_verbs.c
@@ -537,7 +537,7 @@ boolean dateinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pdate"), bsname);
+    copystring(BIGSTRING("\004date"), bsname);
 
     if (!newfunctionprocessor(bsname, &date_valueproc, false, &htable))
         return false;
@@ -553,36 +553,36 @@ boolean dateinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), datv_get);
-    ADD_VERB(BIGSTRING("\pset"), datv_set);
-    ADD_VERB(BIGSTRING("\pabbrevstring"), datv_abbrevstring);
-    ADD_VERB(BIGSTRING("\pdayofweek"), datv_dayofweek);
-    ADD_VERB(BIGSTRING("\pdaysinmonth"), datv_daysinmonth);
-    ADD_VERB(BIGSTRING("\pdaystring"), datv_daystring);
-    ADD_VERB(BIGSTRING("\pfirstofmonth"), datv_firstofmonth);
-    ADD_VERB(BIGSTRING("\plastofmonth"), datv_lastofmonth);
-    ADD_VERB(BIGSTRING("\plongstring"), datv_longstring);
-    ADD_VERB(BIGSTRING("\pnextmonth"), datv_nextmonth);
-    ADD_VERB(BIGSTRING("\pnextweek"), datv_nextweek);
-    ADD_VERB(BIGSTRING("\pnextyear"), datv_nextyear);
-    ADD_VERB(BIGSTRING("\pprevmonth"), datv_prevmonth);
-    ADD_VERB(BIGSTRING("\pprevweek"), datv_prevweek);
-    ADD_VERB(BIGSTRING("\pprevyear"), datv_prevyear);
-    ADD_VERB(BIGSTRING("\pshortstring"), datv_shortstring);
-    ADD_VERB(BIGSTRING("\ptomorrow"), datv_tomorrow);
-    ADD_VERB(BIGSTRING("\pweeksinmonth"), datv_weeksinmonth);
-    ADD_VERB(BIGSTRING("\pyesterday"), datv_yesterday);
-    ADD_VERB(BIGSTRING("\pgetcurrenttimezone"), datv_getcurrenttimezone);
-    ADD_VERB(BIGSTRING("\pnetstandardstring"), datv_netstandardstring);
-    ADD_VERB(BIGSTRING("\pmonthtostring"), datv_monthtostring);
-    ADD_VERB(BIGSTRING("\pdayofweektostring"), datv_dayofweektostring);
-    ADD_VERB(BIGSTRING("\pversionlessthan"), datv_versionlessthan);
-    ADD_VERB(BIGSTRING("\pday"), datv_day);
-    ADD_VERB(BIGSTRING("\pmonth"), datv_month);
-    ADD_VERB(BIGSTRING("\pyear"), datv_year);
-    ADD_VERB(BIGSTRING("\phour"), datv_hour);
-    ADD_VERB(BIGSTRING("\pminute"), datv_minute);
-    ADD_VERB(BIGSTRING("\pseconds"), datv_seconds);
+    ADD_VERB(BIGSTRING("\003get"), datv_get);
+    ADD_VERB(BIGSTRING("\003set"), datv_set);
+    ADD_VERB(BIGSTRING("\014abbrevstring"), datv_abbrevstring);
+    ADD_VERB(BIGSTRING("\011dayofweek"), datv_dayofweek);
+    ADD_VERB(BIGSTRING("\013daysinmonth"), datv_daysinmonth);
+    ADD_VERB(BIGSTRING("\011daystring"), datv_daystring);
+    ADD_VERB(BIGSTRING("\014firstofmonth"), datv_firstofmonth);
+    ADD_VERB(BIGSTRING("\013lastofmonth"), datv_lastofmonth);
+    ADD_VERB(BIGSTRING("\012longstring"), datv_longstring);
+    ADD_VERB(BIGSTRING("\011nextmonth"), datv_nextmonth);
+    ADD_VERB(BIGSTRING("\010nextweek"), datv_nextweek);
+    ADD_VERB(BIGSTRING("\010nextyear"), datv_nextyear);
+    ADD_VERB(BIGSTRING("\011prevmonth"), datv_prevmonth);
+    ADD_VERB(BIGSTRING("\010prevweek"), datv_prevweek);
+    ADD_VERB(BIGSTRING("\010prevyear"), datv_prevyear);
+    ADD_VERB(BIGSTRING("\013shortstring"), datv_shortstring);
+    ADD_VERB(BIGSTRING("\010tomorrow"), datv_tomorrow);
+    ADD_VERB(BIGSTRING("\014weeksinmonth"), datv_weeksinmonth);
+    ADD_VERB(BIGSTRING("\011yesterday"), datv_yesterday);
+    ADD_VERB(BIGSTRING("\022getcurrenttimezone"), datv_getcurrenttimezone);
+    ADD_VERB(BIGSTRING("\021netstandardstring"), datv_netstandardstring);
+    ADD_VERB(BIGSTRING("\015monthtostring"), datv_monthtostring);
+    ADD_VERB(BIGSTRING("\021dayofweektostring"), datv_dayofweektostring);
+    ADD_VERB(BIGSTRING("\017versionlessthan"), datv_versionlessthan);
+    ADD_VERB(BIGSTRING("\003day"), datv_day);
+    ADD_VERB(BIGSTRING("\005month"), datv_month);
+    ADD_VERB(BIGSTRING("\004year"), datv_year);
+    ADD_VERB(BIGSTRING("\004hour"), datv_hour);
+    ADD_VERB(BIGSTRING("\006minute"), datv_minute);
+    ADD_VERB(BIGSTRING("\007seconds"), datv_seconds);
 
     #undef ADD_VERB
 

--- a/tests/headless_dialog_verbs.c
+++ b/tests/headless_dialog_verbs.c
@@ -60,7 +60,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsmessage;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -82,7 +82,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsmessage;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -104,7 +104,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsprompt, bsbutton1, bsbutton2;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -133,7 +133,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsprompt, bsbutton1, bsbutton2, bsbutton3;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -165,59 +165,59 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
         case diav_run:
             /* dialog.run - @PLATFORM_SPECIFIC (requires DLOG resources from Mac/Windows resource fork) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.run requires GUI resources (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\064dialog.run requires GUI resources (Mac/Windows only)"), bserror);
             return false;
         case diav_runmodeless:
             /* dialog.runModeless - @PLATFORM_SPECIFIC (requires DLOG resources) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.runModeless requires GUI resources (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\074dialog.runModeless requires GUI resources (Mac/Windows only)"), bserror);
             return false;
         case diav_getvalue:
             /* dialog.getValue - @PLATFORM_SPECIFIC (only works within dialog.run itemhit callback) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.getValue only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\105dialog.getValue only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
             return false;
         case diav_setvalue:
             /* dialog.setValue - @PLATFORM_SPECIFIC (only works within dialog.run itemhit callback) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.setValue only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\105dialog.setValue only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
             return false;
         case diav_setitemenable:
             /* dialog.setItemEnable - @PLATFORM_SPECIFIC (only works within dialog.run itemhit callback) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.setItemEnable only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\112dialog.setItemEnable only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
             return false;
         case diav_showitem:
             /* dialog.showItem - @PLATFORM_SPECIFIC (only works within dialog.run itemhit callback) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.showItem only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\105dialog.showItem only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
             return false;
         case diav_hideitem:
             /* dialog.hideItem - @PLATFORM_SPECIFIC (only works within dialog.run itemhit callback) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.hideItem only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
+                copystring(BIGSTRING("\105dialog.hideItem only works in GUI dialog callbacks (Mac/Windows only)"), bserror);
             return false;
 
         /* @IMPLEMENTED - Ghost cruft (card-based dialogs never had UserTalk glue) */
         case diav_runcard:
             /* dialog.runcard - @IMPLEMENTED (ghost cruft, no glue ever existed) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.runcard was never implemented"), bserror);
+                copystring(BIGSTRING("\044dialog.runcard was never implemented"), bserror);
             return false;
         case diav_runmodalcard:
             /* dialog.runmodalcard - @IMPLEMENTED (ghost cruft, no glue ever existed) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.runmodalcard was never implemented"), bserror);
+                copystring(BIGSTRING("\051dialog.runmodalcard was never implemented"), bserror);
             return false;
         case diav_ismodalcard:
             /* dialog.ismodalcard - @IMPLEMENTED (ghost cruft, no glue ever existed) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.ismodalcard was never implemented"), bserror);
+                copystring(BIGSTRING("\050dialog.ismodalcard was never implemented"), bserror);
             return false;
         case diav_setmodalcardtimeout:
             /* dialog.setmodalcardtimeout - @IMPLEMENTED (ghost cruft, no glue ever existed) */
             if (bserror)
-                copystring(BIGSTRING("\pdialog.setmodalcardtimeout was never implemented"), bserror);
+                copystring(BIGSTRING("\060dialog.setmodalcardtimeout was never implemented"), bserror);
             return false;
         case diav_ask: {
             /* dialog.ask(prompt, @adr) - Text input dialog with OK/Cancel.
@@ -228,7 +228,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsvarname;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -301,7 +301,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsvarname;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -361,7 +361,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             (void)has_default;  /* Reserved for future default handling */
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -391,7 +391,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             /* Call interactive prompt */
             char *result = dialog_get_string(prompt, default_value);
             if (!result) {
-                if (bserror) copystring(BIGSTRING("\pUser cancelled string entry"), bserror);
+                if (bserror) copystring(BIGSTRING("\033User cancelled string entry"), bserror);
                 return false;
             }
 
@@ -411,7 +411,7 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             bigstring bsvarname;
 
             if (!isInteractiveMode()) {
-                if (bserror) copystring(BIGSTRING("\pCan't use dialog verbs in batch mode"), bserror);
+                if (bserror) copystring(BIGSTRING("\044Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
 
@@ -464,7 +464,7 @@ boolean dialoginitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pdialog"), bsname);
+    copystring(BIGSTRING("\006dialog"), bsname);
 
     if (!newfunctionprocessor(bsname, &dialog_valueproc, false, &htable))
         return false;
@@ -480,25 +480,25 @@ boolean dialoginitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\palert"), diav_alert);
-    ADD_VERB(BIGSTRING("\prun"), diav_run);
-    ADD_VERB(BIGSTRING("\prunmodeless"), diav_runmodeless);
-    ADD_VERB(BIGSTRING("\pruncard"), diav_runcard);
-    ADD_VERB(BIGSTRING("\prunmodalcard"), diav_runmodalcard);
-    ADD_VERB(BIGSTRING("\pismodalcard"), diav_ismodalcard);
-    ADD_VERB(BIGSTRING("\psetmodalcardtimeout"), diav_setmodalcardtimeout);
-    ADD_VERB(BIGSTRING("\pgetvalue"), diav_getvalue);
-    ADD_VERB(BIGSTRING("\psetvalue"), diav_setvalue);
-    ADD_VERB(BIGSTRING("\psetitemenable"), diav_setitemenable);
-    ADD_VERB(BIGSTRING("\pshowitem"), diav_showitem);
-    ADD_VERB(BIGSTRING("\phideitem"), diav_hideitem);
-    ADD_VERB(BIGSTRING("\ptwoway"), diav_twoway);
-    ADD_VERB(BIGSTRING("\pthreeway"), diav_threeway);
-    ADD_VERB(BIGSTRING("\pask"), diav_ask);
-    ADD_VERB(BIGSTRING("\pgetint"), diav_getint);
-    ADD_VERB(BIGSTRING("\pnotify"), diav_notify);
-    ADD_VERB(BIGSTRING("\pgetuserinfo"), diav_getuserinfo);
-    ADD_VERB(BIGSTRING("\pgetpassword"), diav_getpassword);
+    ADD_VERB(BIGSTRING("\005alert"), diav_alert);
+    ADD_VERB(BIGSTRING("\003run"), diav_run);
+    ADD_VERB(BIGSTRING("\013runmodeless"), diav_runmodeless);
+    ADD_VERB(BIGSTRING("\007runcard"), diav_runcard);
+    ADD_VERB(BIGSTRING("\014runmodalcard"), diav_runmodalcard);
+    ADD_VERB(BIGSTRING("\013ismodalcard"), diav_ismodalcard);
+    ADD_VERB(BIGSTRING("\023setmodalcardtimeout"), diav_setmodalcardtimeout);
+    ADD_VERB(BIGSTRING("\010getvalue"), diav_getvalue);
+    ADD_VERB(BIGSTRING("\010setvalue"), diav_setvalue);
+    ADD_VERB(BIGSTRING("\015setitemenable"), diav_setitemenable);
+    ADD_VERB(BIGSTRING("\010showitem"), diav_showitem);
+    ADD_VERB(BIGSTRING("\010hideitem"), diav_hideitem);
+    ADD_VERB(BIGSTRING("\006twoway"), diav_twoway);
+    ADD_VERB(BIGSTRING("\010threeway"), diav_threeway);
+    ADD_VERB(BIGSTRING("\003ask"), diav_ask);
+    ADD_VERB(BIGSTRING("\006getint"), diav_getint);
+    ADD_VERB(BIGSTRING("\006notify"), diav_notify);
+    ADD_VERB(BIGSTRING("\013getuserinfo"), diav_getuserinfo);
+    ADD_VERB(BIGSTRING("\013getpassword"), diav_getpassword);
 
     #undef ADD_VERB
 

--- a/tests/headless_dll_verbs.c
+++ b/tests/headless_dll_verbs.c
@@ -34,19 +34,19 @@ static boolean dll_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case dllv_call:
             /* Verb #0: dll.call - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case dllv_load:
             /* Verb #1: dll.load - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case dllv_unload:
             /* Verb #2: dll.unload - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case dllv_isloaded:
             /* Verb #3: dll.isloaded - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -57,7 +57,7 @@ boolean dllinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pdll"), bsname);
+    copystring(BIGSTRING("\003dll"), bsname);
 
     if (!newfunctionprocessor(bsname, &dll_valueproc, false, &htable))
         return false;
@@ -73,10 +73,10 @@ boolean dllinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pcall"), dllv_call);
-    ADD_VERB(BIGSTRING("\pload"), dllv_load);
-    ADD_VERB(BIGSTRING("\punload"), dllv_unload);
-    ADD_VERB(BIGSTRING("\pisloaded"), dllv_isloaded);
+    ADD_VERB(BIGSTRING("\004call"), dllv_call);
+    ADD_VERB(BIGSTRING("\004load"), dllv_load);
+    ADD_VERB(BIGSTRING("\006unload"), dllv_unload);
+    ADD_VERB(BIGSTRING("\010isloaded"), dllv_isloaded);
 
     #undef ADD_VERB
 

--- a/tests/headless_editmenu_verbs.c
+++ b/tests/headless_editmenu_verbs.c
@@ -46,67 +46,67 @@ static boolean editmenu_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case ediv_undo:
             /* Verb #0: editmenu.undo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_cut:
             /* Verb #1: editmenu.cut - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_copy:
             /* Verb #2: editmenu.copy - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_paste:
             /* Verb #3: editmenu.paste - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_clear:
             /* Verb #4: editmenu.clear - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_selectall:
             /* Verb #5: editmenu.selectall - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_getfont:
             /* Verb #6: editmenu.getfont - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_getfontsize:
             /* Verb #7: editmenu.getfontsize - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setfont:
             /* Verb #8: editmenu.setfont - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setfontsize:
             /* Verb #9: editmenu.setfontsize - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_plaintext:
             /* Verb #10: editmenu.plaintext - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setbold:
             /* Verb #11: editmenu.setbold - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setitalic:
             /* Verb #12: editmenu.setitalic - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setunderline:
             /* Verb #13: editmenu.setunderline - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setoutline:
             /* Verb #14: editmenu.setoutline - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case ediv_setshadow:
             /* Verb #15: editmenu.setshadow - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -117,7 +117,7 @@ boolean editmenuinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\peditmenu"), bsname);
+    copystring(BIGSTRING("\010editmenu"), bsname);
 
     if (!newfunctionprocessor(bsname, &editmenu_valueproc, false, &htable))
         return false;
@@ -133,22 +133,22 @@ boolean editmenuinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pundo"), ediv_undo);
-    ADD_VERB(BIGSTRING("\pcut"), ediv_cut);
-    ADD_VERB(BIGSTRING("\pcopy"), ediv_copy);
-    ADD_VERB(BIGSTRING("\ppaste"), ediv_paste);
-    ADD_VERB(BIGSTRING("\pclear"), ediv_clear);
-    ADD_VERB(BIGSTRING("\pselectall"), ediv_selectall);
-    ADD_VERB(BIGSTRING("\pgetfont"), ediv_getfont);
-    ADD_VERB(BIGSTRING("\pgetfontsize"), ediv_getfontsize);
-    ADD_VERB(BIGSTRING("\psetfont"), ediv_setfont);
-    ADD_VERB(BIGSTRING("\psetfontsize"), ediv_setfontsize);
-    ADD_VERB(BIGSTRING("\pplaintext"), ediv_plaintext);
-    ADD_VERB(BIGSTRING("\psetbold"), ediv_setbold);
-    ADD_VERB(BIGSTRING("\psetitalic"), ediv_setitalic);
-    ADD_VERB(BIGSTRING("\psetunderline"), ediv_setunderline);
-    ADD_VERB(BIGSTRING("\psetoutline"), ediv_setoutline);
-    ADD_VERB(BIGSTRING("\psetshadow"), ediv_setshadow);
+    ADD_VERB(BIGSTRING("\004undo"), ediv_undo);
+    ADD_VERB(BIGSTRING("\003cut"), ediv_cut);
+    ADD_VERB(BIGSTRING("\004copy"), ediv_copy);
+    ADD_VERB(BIGSTRING("\005paste"), ediv_paste);
+    ADD_VERB(BIGSTRING("\005clear"), ediv_clear);
+    ADD_VERB(BIGSTRING("\011selectall"), ediv_selectall);
+    ADD_VERB(BIGSTRING("\007getfont"), ediv_getfont);
+    ADD_VERB(BIGSTRING("\013getfontsize"), ediv_getfontsize);
+    ADD_VERB(BIGSTRING("\007setfont"), ediv_setfont);
+    ADD_VERB(BIGSTRING("\013setfontsize"), ediv_setfontsize);
+    ADD_VERB(BIGSTRING("\011plaintext"), ediv_plaintext);
+    ADD_VERB(BIGSTRING("\007setbold"), ediv_setbold);
+    ADD_VERB(BIGSTRING("\011setitalic"), ediv_setitalic);
+    ADD_VERB(BIGSTRING("\014setunderline"), ediv_setunderline);
+    ADD_VERB(BIGSTRING("\012setoutline"), ediv_setoutline);
+    ADD_VERB(BIGSTRING("\011setshadow"), ediv_setshadow);
 
     #undef ADD_VERB
 

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -203,7 +203,7 @@ static boolean filemenu_save_guestdb(hdltreenode hparam1) {
     /* Search hodblist for the database (skip sentinel at hodblist itself) */
     if (hodblist == nil) {
         log_verb_error(LOG_COMP_DB, "filemenu_save_guestdb: hodblist not initialized");
-        langerrormessage(BIGSTRING("\pdb: no databases are open"));
+        langerrormessage(BIGSTRING("\031db: no databases are open"));
         return false;
     }
 
@@ -217,7 +217,7 @@ static boolean filemenu_save_guestdb(hdltreenode hparam1) {
             /* Found it - check if read-only */
             if ((**hodb).flreadonly) {
                 log_verb_error(LOG_COMP_DB, "filemenu_save_guestdb: database is read-only");
-                langerrormessage(BIGSTRING("\pCan't save: database is read-only"));
+                langerrormessage(BIGSTRING("\041Can't save: database is read-only"));
                 return false;
             }
 
@@ -908,7 +908,7 @@ boolean filemenuinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pfilemenu"), bsname);
+    copystring(BIGSTRING("\010filemenu"), bsname);
 
     if (!newfunctionprocessor(bsname, &filemenu_valueproc, false, &htable))
         return false;
@@ -924,16 +924,16 @@ boolean filemenuinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pnew"), filv_new);
-    ADD_VERB(BIGSTRING("\popen"), filv_open);
-    ADD_VERB(BIGSTRING("\pclose"), filv_close);
-    ADD_VERB(BIGSTRING("\pcloseall"), filv_closeall);
-    ADD_VERB(BIGSTRING("\psave"), filv_save);
-    ADD_VERB(BIGSTRING("\psavecopy"), filv_savecopy);
-    ADD_VERB(BIGSTRING("\prevert"), filv_revert);
-    ADD_VERB(BIGSTRING("\pprint"), filv_print);
-    ADD_VERB(BIGSTRING("\pquit"), filv_quit);
-    ADD_VERB(BIGSTRING("\psaveas"), filv_saveas);
+    ADD_VERB(BIGSTRING("\003new"), filv_new);
+    ADD_VERB(BIGSTRING("\004open"), filv_open);
+    ADD_VERB(BIGSTRING("\005close"), filv_close);
+    ADD_VERB(BIGSTRING("\010closeall"), filv_closeall);
+    ADD_VERB(BIGSTRING("\004save"), filv_save);
+    ADD_VERB(BIGSTRING("\010savecopy"), filv_savecopy);
+    ADD_VERB(BIGSTRING("\006revert"), filv_revert);
+    ADD_VERB(BIGSTRING("\005print"), filv_print);
+    ADD_VERB(BIGSTRING("\004quit"), filv_quit);
+    ADD_VERB(BIGSTRING("\006saveas"), filv_saveas);
 
     #undef ADD_VERB
 

--- a/tests/headless_frontier_verbs.c
+++ b/tests/headless_frontier_verbs.c
@@ -70,14 +70,14 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
 #ifdef __APPLE__
             uint32_t size = sizeof(path);
             if (_NSGetExecutablePath(path, &size) != 0) {
-                if (bserror) copystring(BIGSTRING("\pcould not get program path"), bserror);
+                if (bserror) copystring(BIGSTRING("\032could not get program path"), bserror);
                 return false;
             }
 #else
             /* Linux: read /proc/self/exe symlink */
             ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
             if (len == -1) {
-                if (bserror) copystring(BIGSTRING("\pcould not get program path"), bserror);
+                if (bserror) copystring(BIGSTRING("\032could not get program path"), bserror);
                 return false;
             }
             path[len] = '\0';
@@ -102,7 +102,7 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
 
             root_path = cli_get_system_root_path();
             if (!cli_is_system_root_loaded() || root_path[0] == '\0') {
-                if (bserror) copystring(BIGSTRING("\pno database file loaded"), bserror);
+                if (bserror) copystring(BIGSTRING("\027no database file loaded"), bserror);
                 return false;
             }
 
@@ -112,7 +112,7 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
                 size_t cwd_len, path_len;
 
                 if (getcwd(cwd, sizeof(cwd)) == NULL) {
-                    if (bserror) copystring(BIGSTRING("\pcould not get current directory"), bserror);
+                    if (bserror) copystring(BIGSTRING("\037could not get current directory"), bserror);
                     return false;
                 }
 
@@ -120,25 +120,25 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
                 cwd_len = strlen(cwd);
                 path_len = strlen(root_path);
                 if (cwd_len + 1 + path_len >= sizeof(fullpath)) {
-                    if (bserror) copystring(BIGSTRING("\ppath too long"), bserror);
+                    if (bserror) copystring(BIGSTRING("\015path too long"), bserror);
                     return false;
                 }
 
                 len = snprintf(fullpath, sizeof(fullpath), "%s/%s", cwd, root_path);
                 if (len < 0 || len >= (int)sizeof(fullpath)) {
-                    if (bserror) copystring(BIGSTRING("\ppath too long"), bserror);
+                    if (bserror) copystring(BIGSTRING("\015path too long"), bserror);
                     return false;
                 }
             } else {
                 /* Pre-check path length */
                 if (strlen(root_path) >= sizeof(fullpath)) {
-                    if (bserror) copystring(BIGSTRING("\ppath too long"), bserror);
+                    if (bserror) copystring(BIGSTRING("\015path too long"), bserror);
                     return false;
                 }
 
                 len = snprintf(fullpath, sizeof(fullpath), "%s", root_path);
                 if (len < 0 || len >= (int)sizeof(fullpath)) {
-                    if (bserror) copystring(BIGSTRING("\ppath too long"), bserror);
+                    if (bserror) copystring(BIGSTRING("\015path too long"), bserror);
                     return false;
                 }
             }
@@ -153,23 +153,23 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
             return true;
         case frov_requesttofront:
             /* Verb #3: frontier.requesttofront - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_isruntime:
             /* Verb #4: frontier.isruntime - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_countthreads:
             /* Verb #5: frontier.countthreads - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_ispowerpc:
             /* Verb #6: frontier.ispowerpc - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_reclaimmemory:
             /* Verb #7: frontier.reclaimmemory - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_version:
             /* Verb #8: frontier.version - Return product version string */
@@ -196,15 +196,15 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
         }
         case frov_hashstats:
             /* Verb #9: frontier.hashstats - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_gethashloopcount:
             /* Verb #10: frontier.gethashloopcount - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_hideapplication:
             /* Verb #11: frontier.hideapplication - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case frov_isvalidserialnumber: {
             /* frontier.isvalidSerialNumber - in headless mode, always return true.
@@ -223,7 +223,7 @@ static boolean frontier_valueproc(short token, hdltreenode hparam1,
         }
         case frov_showapplication:
             /* Verb #13: frontier.showapplication - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -264,7 +264,7 @@ boolean frontierinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pfrontier"), bsname);
+    copystring(BIGSTRING("\010frontier"), bsname);
 
     if (!newfunctionprocessor(bsname, &frontier_valueproc, false, &htable))
         return false;
@@ -280,21 +280,21 @@ boolean frontierinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pgetprogrampath"), frov_getprogrampath);
-    ADD_VERB(BIGSTRING("\pgetfilepath"), frov_getfilepath);
-    ADD_VERB(BIGSTRING("\penableagents"), frov_enableagents);
-    ADD_VERB(BIGSTRING("\prequesttofront"), frov_requesttofront);
-    ADD_VERB(BIGSTRING("\pisruntime"), frov_isruntime);
-    ADD_VERB(BIGSTRING("\pcountthreads"), frov_countthreads);
-    ADD_VERB(BIGSTRING("\pispowerpc"), frov_ispowerpc);
-    ADD_VERB(BIGSTRING("\preclaimmemory"), frov_reclaimmemory);
-    ADD_VERB(BIGSTRING("\pversion"), frov_version);
-    ADD_VERB(BIGSTRING("\phashstats"), frov_hashstats);
-    ADD_VERB(BIGSTRING("\pgethashloopcount"), frov_gethashloopcount);
-    ADD_VERB(BIGSTRING("\phideapplication"), frov_hideapplication);
-    ADD_VERB(BIGSTRING("\pisvalidserialnumber"), frov_isvalidserialnumber);
-    ADD_VERB(BIGSTRING("\pshowapplication"), frov_showapplication);
-    ADD_VERB(BIGSTRING("\pcliversion"), frov_cliversion);
+    ADD_VERB(BIGSTRING("\016getprogrampath"), frov_getprogrampath);
+    ADD_VERB(BIGSTRING("\013getfilepath"), frov_getfilepath);
+    ADD_VERB(BIGSTRING("\014enableagents"), frov_enableagents);
+    ADD_VERB(BIGSTRING("\016requesttofront"), frov_requesttofront);
+    ADD_VERB(BIGSTRING("\011isruntime"), frov_isruntime);
+    ADD_VERB(BIGSTRING("\014countthreads"), frov_countthreads);
+    ADD_VERB(BIGSTRING("\011ispowerpc"), frov_ispowerpc);
+    ADD_VERB(BIGSTRING("\015reclaimmemory"), frov_reclaimmemory);
+    ADD_VERB(BIGSTRING("\007version"), frov_version);
+    ADD_VERB(BIGSTRING("\011hashstats"), frov_hashstats);
+    ADD_VERB(BIGSTRING("\020gethashloopcount"), frov_gethashloopcount);
+    ADD_VERB(BIGSTRING("\017hideapplication"), frov_hideapplication);
+    ADD_VERB(BIGSTRING("\023isvalidserialnumber"), frov_isvalidserialnumber);
+    ADD_VERB(BIGSTRING("\017showapplication"), frov_showapplication);
+    ADD_VERB(BIGSTRING("\012cliversion"), frov_cliversion);
 
     #undef ADD_VERB
 

--- a/tests/headless_html_verbs.c
+++ b/tests/headless_html_verbs.c
@@ -85,14 +85,14 @@ static boolean html_valueproc(short token, hdltreenode hparam1,
         case htmv_refglossary:
             /* Verb #8: html.refglossary - @SCRIPT_IMPLEMENTED in system.verbs.builtins.html */
             /* C helper htmlrefglossary() calls this via langrunscript() during macro processing */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_getpref:
             /* Phase 2: Forward to C implementation in langhtml.c */
             return getprefverb(hparam1, vreturned);
         case htmv_getonedirective:
             /* Verb #10: html.getonedirective - @SCRIPT_IMPLEMENTED in system.verbs.builtins.html */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_rundirective:
             /* Phase 2: Forward to C implementation in langhtml.c */
@@ -108,7 +108,7 @@ static boolean html_valueproc(short token, hdltreenode hparam1,
             return cleanforexportverb(hparam1, vreturned);
         case htmv_normalizename:
             /* Verb #15: html.normalizename - @SCRIPT_IMPLEMENTED in system.verbs.builtins.html */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_glossarypatcher:
             /* Phase 2: Forward to C implementation in langhtml.c */
@@ -133,7 +133,7 @@ static boolean html_valueproc(short token, hdltreenode hparam1,
             /* Listed in kernelverbs.rc but no C implementation ever existed */
             /* defined(html.drawcalendar) returns false in legacy Windows Frontier */
             /* IOA calendar widget in cal.c was never wired up as a callable verb */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -144,7 +144,7 @@ boolean htmlinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\phtml"), bsname);
+    copystring(BIGSTRING("\004html"), bsname);
 
     if (!newfunctionprocessor(bsname, &html_valueproc, false, &htable))
         return false;
@@ -160,29 +160,29 @@ boolean htmlinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pprocessmacros"), htmv_processmacros);
-    ADD_VERB(BIGSTRING("\purldecode"), htmv_urldecode);
-    ADD_VERB(BIGSTRING("\purlencode"), htmv_urlencode);
-    ADD_VERB(BIGSTRING("\pparsehttpargs"), htmv_parsehttpargs);
-    ADD_VERB(BIGSTRING("\piso8859encode"), htmv_iso8859encode);
-    ADD_VERB(BIGSTRING("\pgetgifheightwidth"), htmv_getgifheightwidth);
-    ADD_VERB(BIGSTRING("\pgetjpegheightwidth"), htmv_getjpegheightwidth);
-    ADD_VERB(BIGSTRING("\pbuildpagetable"), htmv_buildpagetable);
-    ADD_VERB(BIGSTRING("\prefglossary"), htmv_refglossary);
-    ADD_VERB(BIGSTRING("\pgetpref"), htmv_getpref);
-    ADD_VERB(BIGSTRING("\pgetonedirective"), htmv_getonedirective);
-    ADD_VERB(BIGSTRING("\prundirective"), htmv_rundirective);
-    ADD_VERB(BIGSTRING("\prundirectives"), htmv_rundirectives);
-    ADD_VERB(BIGSTRING("\prunoutlinedirectives"), htmv_runoutlinedirectives);
-    ADD_VERB(BIGSTRING("\pcleanforexport"), htmv_cleanforexport);
-    ADD_VERB(BIGSTRING("\pnormalizename"), htmv_normalizename);
-    ADD_VERB(BIGSTRING("\pglossarypatcher"), htmv_glossarypatcher);
-    ADD_VERB(BIGSTRING("\pexpandurls"), htmv_expandurls);
-    ADD_VERB(BIGSTRING("\ptraversalskip"), htmv_traversalskip);
-    ADD_VERB(BIGSTRING("\pgetpagetableaddress"), htmv_getpagetableaddress);
-    ADD_VERB(BIGSTRING("\pneutermacros"), htmv_neutermacros);
-    ADD_VERB(BIGSTRING("\pneutertags"), htmv_neutertags);
-    ADD_VERB(BIGSTRING("\pdrawcalendar"), htmv_drawcalendar);
+    ADD_VERB(BIGSTRING("\015processmacros"), htmv_processmacros);
+    ADD_VERB(BIGSTRING("\011urldecode"), htmv_urldecode);
+    ADD_VERB(BIGSTRING("\011urlencode"), htmv_urlencode);
+    ADD_VERB(BIGSTRING("\015parsehttpargs"), htmv_parsehttpargs);
+    ADD_VERB(BIGSTRING("\015iso8859encode"), htmv_iso8859encode);
+    ADD_VERB(BIGSTRING("\021getgifheightwidth"), htmv_getgifheightwidth);
+    ADD_VERB(BIGSTRING("\022getjpegheightwidth"), htmv_getjpegheightwidth);
+    ADD_VERB(BIGSTRING("\016buildpagetable"), htmv_buildpagetable);
+    ADD_VERB(BIGSTRING("\013refglossary"), htmv_refglossary);
+    ADD_VERB(BIGSTRING("\007getpref"), htmv_getpref);
+    ADD_VERB(BIGSTRING("\017getonedirective"), htmv_getonedirective);
+    ADD_VERB(BIGSTRING("\014rundirective"), htmv_rundirective);
+    ADD_VERB(BIGSTRING("\015rundirectives"), htmv_rundirectives);
+    ADD_VERB(BIGSTRING("\024runoutlinedirectives"), htmv_runoutlinedirectives);
+    ADD_VERB(BIGSTRING("\016cleanforexport"), htmv_cleanforexport);
+    ADD_VERB(BIGSTRING("\015normalizename"), htmv_normalizename);
+    ADD_VERB(BIGSTRING("\017glossarypatcher"), htmv_glossarypatcher);
+    ADD_VERB(BIGSTRING("\012expandurls"), htmv_expandurls);
+    ADD_VERB(BIGSTRING("\015traversalskip"), htmv_traversalskip);
+    ADD_VERB(BIGSTRING("\023getpagetableaddress"), htmv_getpagetableaddress);
+    ADD_VERB(BIGSTRING("\014neutermacros"), htmv_neutermacros);
+    ADD_VERB(BIGSTRING("\012neutertags"), htmv_neutertags);
+    ADD_VERB(BIGSTRING("\014drawcalendar"), htmv_drawcalendar);
 
     #undef ADD_VERB
 

--- a/tests/headless_htmlcontrol_verbs.c
+++ b/tests/headless_htmlcontrol_verbs.c
@@ -38,35 +38,35 @@ static boolean htmlcontrol_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case htmv_back:
             /* Verb #0: htmlcontrol.back - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_forward:
             /* Verb #1: htmlcontrol.forward - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_refresh:
             /* Verb #2: htmlcontrol.refresh - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_home:
             /* Verb #3: htmlcontrol.home - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_stop:
             /* Verb #4: htmlcontrol.stop - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_navigate:
             /* Verb #5: htmlcontrol.navigate - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_isoffline:
             /* Verb #6: htmlcontrol.isoffline - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case htmv_setoffline:
             /* Verb #7: htmlcontrol.setoffline - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -77,7 +77,7 @@ boolean htmlcontrolinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\phtmlcontrol"), bsname);
+    copystring(BIGSTRING("\013htmlcontrol"), bsname);
 
     if (!newfunctionprocessor(bsname, &htmlcontrol_valueproc, false, &htable))
         return false;
@@ -93,14 +93,14 @@ boolean htmlcontrolinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pback"), htmv_back);
-    ADD_VERB(BIGSTRING("\pforward"), htmv_forward);
-    ADD_VERB(BIGSTRING("\prefresh"), htmv_refresh);
-    ADD_VERB(BIGSTRING("\phome"), htmv_home);
-    ADD_VERB(BIGSTRING("\pstop"), htmv_stop);
-    ADD_VERB(BIGSTRING("\pnavigate"), htmv_navigate);
-    ADD_VERB(BIGSTRING("\pisoffline"), htmv_isoffline);
-    ADD_VERB(BIGSTRING("\psetoffline"), htmv_setoffline);
+    ADD_VERB(BIGSTRING("\004back"), htmv_back);
+    ADD_VERB(BIGSTRING("\007forward"), htmv_forward);
+    ADD_VERB(BIGSTRING("\007refresh"), htmv_refresh);
+    ADD_VERB(BIGSTRING("\004home"), htmv_home);
+    ADD_VERB(BIGSTRING("\004stop"), htmv_stop);
+    ADD_VERB(BIGSTRING("\010navigate"), htmv_navigate);
+    ADD_VERB(BIGSTRING("\011isoffline"), htmv_isoffline);
+    ADD_VERB(BIGSTRING("\012setoffline"), htmv_setoffline);
 
     #undef ADD_VERB
 

--- a/tests/headless_inetd_verbs.c
+++ b/tests/headless_inetd_verbs.c
@@ -54,7 +54,7 @@ boolean inetdinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pinetd"), bsname);
+    copystring(BIGSTRING("\005inetd"), bsname);
 
     if (!newfunctionprocessor(bsname, &inetd_valueproc, false, &htable))
         return false;
@@ -70,7 +70,7 @@ boolean inetdinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\psupervisor"), inev_supervisor);
+    ADD_VERB(BIGSTRING("\012supervisor"), inev_supervisor);
 
     #undef ADD_VERB
 

--- a/tests/headless_kb_verbs.c
+++ b/tests/headless_kb_verbs.c
@@ -53,7 +53,7 @@ boolean kbinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pkb"), bsname);
+    copystring(BIGSTRING("\002kb"), bsname);
 
     if (!newfunctionprocessor(bsname, &kb_valueproc, false, &htable))
         return false;
@@ -69,10 +69,10 @@ boolean kbinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\poptionkey"), kbv_optionkey);
-    ADD_VERB(BIGSTRING("\pcmdkey"), kbv_cmdkey);
-    ADD_VERB(BIGSTRING("\pshiftkey"), kbv_shiftkey);
-    ADD_VERB(BIGSTRING("\pcontrolkey"), kbv_controlkey);
+    ADD_VERB(BIGSTRING("\011optionkey"), kbv_optionkey);
+    ADD_VERB(BIGSTRING("\006cmdkey"), kbv_cmdkey);
+    ADD_VERB(BIGSTRING("\010shiftkey"), kbv_shiftkey);
+    ADD_VERB(BIGSTRING("\012controlkey"), kbv_controlkey);
 
     #undef ADD_VERB
 

--- a/tests/headless_lang_verbs.c
+++ b/tests/headless_lang_verbs.c
@@ -229,66 +229,66 @@ static boolean lang_valueproc(short token, hdltreenode hparam1,
             return langabsfunc(hparam1, vreturned);
         case lanv_seteventtimeout:
             /* Verb: lang.seteventtimeout - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_seteventtransactionid:
             /* Verb: lang.seteventtransactionid - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_seteventinteraction:
             /* Verb: lang.seteventinteraction - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_geteventattribute:
             /* Verb: lang.geteventattribute - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_coerceappleitem:
             /* Verb: lang.coerceappleitem - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_getapplelistitem:
             /* Verb: lang.getapplelistitem - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_putapplelistitem:
             /* Verb: lang.putapplelistitem - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_countapplelistitems:
             /* Verb: lang.countapplelistitems - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_systemevent:
             /* Verb: lang.systemevent - AppleEvent verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_ddeevent:
             /* Verb: lang.ddeevent - Legacy Windows DDE verb not supported on this platform (Issue #284) @IMPLEMENTED */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_transactionevent:
             /* Verb: lang.transactionevent - AppleEvent verb not supported on this platform (Issue #284) @IMPLEMENTED */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_msg:
             /* Verb: lang.msg - forward to real implementation */
             return langmsgfunc(hparam1, vreturned);
         case lanv_callxcmd:
             /* Verb: lang.callxcmd - Legacy HyperCard XCMD verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_calldll:
             /* Verb: lang.calldll - Legacy Windows DLL verb not supported on this platform (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_packwindow:
             /* Verb: lang.packwindow - Window management verb not supported in headless mode (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_unpackwindow:
             /* Verb: lang.unpackwindow - Window management verb not supported in headless mode (Issue #284) */
-            if (bserror) copystring(BIGSTRING("\pnot supported on this platform"), bserror);
+            if (bserror) copystring(BIGSTRING("\036not supported on this platform"), bserror);
             return false;
         case lanv_callscript:
             /* Verb: lang.callscript - forward to real implementation */
@@ -302,7 +302,7 @@ boolean langinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\plang"), bsname);
+    copystring(BIGSTRING("\004lang"), bsname);
 
     if (!newfunctionprocessor(bsname, &lang_valueproc, false, &htable))
         return false;
@@ -318,67 +318,67 @@ boolean langinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pscripterror"), lanv_scripterror);
-    ADD_VERB(BIGSTRING("\pnew"), lanv_new);
-    ADD_VERB(BIGSTRING("\pdelete"), lanv_delete);
-    ADD_VERB(BIGSTRING("\pedit"), lanv_edit);
-    ADD_VERB(BIGSTRING("\pgettarget"), lanv_gettarget);
-    ADD_VERB(BIGSTRING("\psettarget"), lanv_settarget);
-    ADD_VERB(BIGSTRING("\pcleartarget"), lanv_cleartarget);
-    ADD_VERB(BIGSTRING("\pclose"), lanv_close);
-    ADD_VERB(BIGSTRING("\ptimecreated"), lanv_timecreated);
-    ADD_VERB(BIGSTRING("\ptimemodified"), lanv_timemodified);
-    ADD_VERB(BIGSTRING("\psettimecreated"), lanv_settimecreated);
-    ADD_VERB(BIGSTRING("\psettimemodified"), lanv_settimemodified);
-    ADD_VERB(BIGSTRING("\pboolean"), lanv_boolean);
-    ADD_VERB(BIGSTRING("\pchar"), lanv_char);
-    ADD_VERB(BIGSTRING("\pshort"), lanv_short);
-    ADD_VERB(BIGSTRING("\plong"), lanv_long);
-    ADD_VERB(BIGSTRING("\pdate"), lanv_date);
-    ADD_VERB(BIGSTRING("\pdirection"), lanv_direction);
-    ADD_VERB(BIGSTRING("\pstring4"), lanv_string4);
-    ADD_VERB(BIGSTRING("\pstring"), lanv_string);
-    ADD_VERB(BIGSTRING("\pdisplaystring"), lanv_displaystring);
-    ADD_VERB(BIGSTRING("\paddress"), lanv_address);
-    ADD_VERB(BIGSTRING("\pbinary"), lanv_binary);
-    ADD_VERB(BIGSTRING("\pgetbinarytype"), lanv_getbinarytype);
-    ADD_VERB(BIGSTRING("\psetbinarytype"), lanv_setbinarytype);
-    ADD_VERB(BIGSTRING("\ppoint"), lanv_point);
-    ADD_VERB(BIGSTRING("\prect"), lanv_rect);
-    ADD_VERB(BIGSTRING("\prgb"), lanv_rgb);
-    ADD_VERB(BIGSTRING("\ppattern"), lanv_pattern);
-    ADD_VERB(BIGSTRING("\pfixed"), lanv_fixed);
-    ADD_VERB(BIGSTRING("\psingle"), lanv_single);
-    ADD_VERB(BIGSTRING("\pdouble"), lanv_double);
-    ADD_VERB(BIGSTRING("\pfilespec"), lanv_filespec);
-    ADD_VERB(BIGSTRING("\palias"), lanv_alias);
-    ADD_VERB(BIGSTRING("\plist"), lanv_list);
-    ADD_VERB(BIGSTRING("\precord"), lanv_record);
-    ADD_VERB(BIGSTRING("\penum"), lanv_enum);
-    ADD_VERB(BIGSTRING("\pmemavail"), lanv_memavail);
-    ADD_VERB(BIGSTRING("\pflushmemory"), lanv_flushmemory);
-    ADD_VERB(BIGSTRING("\prandom"), lanv_random);
-    ADD_VERB(BIGSTRING("\pevaluate"), lanv_evaluate);
-    ADD_VERB(BIGSTRING("\pevaluatethread"), lanv_evaluatethread);
-    ADD_VERB(BIGSTRING("\prollbeachball"), lanv_rollbeachball);
-    ADD_VERB(BIGSTRING("\pabs"), lanv_abs);
-    ADD_VERB(BIGSTRING("\pseteventtimeout"), lanv_seteventtimeout);
-    ADD_VERB(BIGSTRING("\pseteventtransactionid"), lanv_seteventtransactionid);
-    ADD_VERB(BIGSTRING("\pseteventinteraction"), lanv_seteventinteraction);
-    ADD_VERB(BIGSTRING("\pgeteventattribute"), lanv_geteventattribute);
-    ADD_VERB(BIGSTRING("\pcoerceappleitem"), lanv_coerceappleitem);
-    ADD_VERB(BIGSTRING("\pgetapplelistitem"), lanv_getapplelistitem);
-    ADD_VERB(BIGSTRING("\pputapplelistitem"), lanv_putapplelistitem);
-    ADD_VERB(BIGSTRING("\pcountapplelistitems"), lanv_countapplelistitems);
-    ADD_VERB(BIGSTRING("\psystemevent"), lanv_systemevent);
-    ADD_VERB(BIGSTRING("\pDDEevent"), lanv_ddeevent);
-    ADD_VERB(BIGSTRING("\ptransactionEvent"), lanv_transactionevent);
-    ADD_VERB(BIGSTRING("\pmsg"), lanv_msg);
-    ADD_VERB(BIGSTRING("\pcallxcmd"), lanv_callxcmd);
-    ADD_VERB(BIGSTRING("\pcalldll"), lanv_calldll);
-    ADD_VERB(BIGSTRING("\ppackwindow"), lanv_packwindow);
-    ADD_VERB(BIGSTRING("\punpackwindow"), lanv_unpackwindow);
-    ADD_VERB(BIGSTRING("\pcallscript"), lanv_callscript);
+    ADD_VERB(BIGSTRING("\013scripterror"), lanv_scripterror);
+    ADD_VERB(BIGSTRING("\003new"), lanv_new);
+    ADD_VERB(BIGSTRING("\006delete"), lanv_delete);
+    ADD_VERB(BIGSTRING("\004edit"), lanv_edit);
+    ADD_VERB(BIGSTRING("\011gettarget"), lanv_gettarget);
+    ADD_VERB(BIGSTRING("\011settarget"), lanv_settarget);
+    ADD_VERB(BIGSTRING("\013cleartarget"), lanv_cleartarget);
+    ADD_VERB(BIGSTRING("\005close"), lanv_close);
+    ADD_VERB(BIGSTRING("\013timecreated"), lanv_timecreated);
+    ADD_VERB(BIGSTRING("\014timemodified"), lanv_timemodified);
+    ADD_VERB(BIGSTRING("\016settimecreated"), lanv_settimecreated);
+    ADD_VERB(BIGSTRING("\017settimemodified"), lanv_settimemodified);
+    ADD_VERB(BIGSTRING("\007boolean"), lanv_boolean);
+    ADD_VERB(BIGSTRING("\004char"), lanv_char);
+    ADD_VERB(BIGSTRING("\005short"), lanv_short);
+    ADD_VERB(BIGSTRING("\004long"), lanv_long);
+    ADD_VERB(BIGSTRING("\004date"), lanv_date);
+    ADD_VERB(BIGSTRING("\011direction"), lanv_direction);
+    ADD_VERB(BIGSTRING("\007string4"), lanv_string4);
+    ADD_VERB(BIGSTRING("\006string"), lanv_string);
+    ADD_VERB(BIGSTRING("\015displaystring"), lanv_displaystring);
+    ADD_VERB(BIGSTRING("\007address"), lanv_address);
+    ADD_VERB(BIGSTRING("\006binary"), lanv_binary);
+    ADD_VERB(BIGSTRING("\015getbinarytype"), lanv_getbinarytype);
+    ADD_VERB(BIGSTRING("\015setbinarytype"), lanv_setbinarytype);
+    ADD_VERB(BIGSTRING("\005point"), lanv_point);
+    ADD_VERB(BIGSTRING("\004rect"), lanv_rect);
+    ADD_VERB(BIGSTRING("\003rgb"), lanv_rgb);
+    ADD_VERB(BIGSTRING("\007pattern"), lanv_pattern);
+    ADD_VERB(BIGSTRING("\005fixed"), lanv_fixed);
+    ADD_VERB(BIGSTRING("\006single"), lanv_single);
+    ADD_VERB(BIGSTRING("\006double"), lanv_double);
+    ADD_VERB(BIGSTRING("\010filespec"), lanv_filespec);
+    ADD_VERB(BIGSTRING("\005alias"), lanv_alias);
+    ADD_VERB(BIGSTRING("\004list"), lanv_list);
+    ADD_VERB(BIGSTRING("\006record"), lanv_record);
+    ADD_VERB(BIGSTRING("\004enum"), lanv_enum);
+    ADD_VERB(BIGSTRING("\010memavail"), lanv_memavail);
+    ADD_VERB(BIGSTRING("\013flushmemory"), lanv_flushmemory);
+    ADD_VERB(BIGSTRING("\006random"), lanv_random);
+    ADD_VERB(BIGSTRING("\010evaluate"), lanv_evaluate);
+    ADD_VERB(BIGSTRING("\016evaluatethread"), lanv_evaluatethread);
+    ADD_VERB(BIGSTRING("\015rollbeachball"), lanv_rollbeachball);
+    ADD_VERB(BIGSTRING("\003abs"), lanv_abs);
+    ADD_VERB(BIGSTRING("\017seteventtimeout"), lanv_seteventtimeout);
+    ADD_VERB(BIGSTRING("\025seteventtransactionid"), lanv_seteventtransactionid);
+    ADD_VERB(BIGSTRING("\023seteventinteraction"), lanv_seteventinteraction);
+    ADD_VERB(BIGSTRING("\021geteventattribute"), lanv_geteventattribute);
+    ADD_VERB(BIGSTRING("\017coerceappleitem"), lanv_coerceappleitem);
+    ADD_VERB(BIGSTRING("\020getapplelistitem"), lanv_getapplelistitem);
+    ADD_VERB(BIGSTRING("\020putapplelistitem"), lanv_putapplelistitem);
+    ADD_VERB(BIGSTRING("\023countapplelistitems"), lanv_countapplelistitems);
+    ADD_VERB(BIGSTRING("\013systemevent"), lanv_systemevent);
+    ADD_VERB(BIGSTRING("\010DDEevent"), lanv_ddeevent);
+    ADD_VERB(BIGSTRING("\020transactionEvent"), lanv_transactionevent);
+    ADD_VERB(BIGSTRING("\003msg"), lanv_msg);
+    ADD_VERB(BIGSTRING("\010callxcmd"), lanv_callxcmd);
+    ADD_VERB(BIGSTRING("\007calldll"), lanv_calldll);
+    ADD_VERB(BIGSTRING("\012packwindow"), lanv_packwindow);
+    ADD_VERB(BIGSTRING("\014unpackwindow"), lanv_unpackwindow);
+    ADD_VERB(BIGSTRING("\012callscript"), lanv_callscript);
 
     #undef ADD_VERB
 

--- a/tests/headless_launch_verbs.c
+++ b/tests/headless_launch_verbs.c
@@ -36,23 +36,23 @@ static boolean launch_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case lauv_applemenu:
             /* Verb #0: launch.applemenu - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case lauv_application:
             /* Verb #1: launch.application - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case lauv_appwithdocument:
             /* Verb #2: launch.appwithdocument - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case lauv_resource:
             /* Verb #3: launch.resource - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case lauv_anything:
             /* Verb #4: launch.anything - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -63,7 +63,7 @@ boolean launchinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\plaunch"), bsname);
+    copystring(BIGSTRING("\006launch"), bsname);
 
     if (!newfunctionprocessor(bsname, &launch_valueproc, false, &htable))
         return false;
@@ -79,11 +79,11 @@ boolean launchinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\papplemenu"), lauv_applemenu);
-    ADD_VERB(BIGSTRING("\papplication"), lauv_application);
-    ADD_VERB(BIGSTRING("\pappwithdocument"), lauv_appwithdocument);
-    ADD_VERB(BIGSTRING("\presource"), lauv_resource);
-    ADD_VERB(BIGSTRING("\panything"), lauv_anything);
+    ADD_VERB(BIGSTRING("\011applemenu"), lauv_applemenu);
+    ADD_VERB(BIGSTRING("\013application"), lauv_application);
+    ADD_VERB(BIGSTRING("\017appwithdocument"), lauv_appwithdocument);
+    ADD_VERB(BIGSTRING("\010resource"), lauv_resource);
+    ADD_VERB(BIGSTRING("\010anything"), lauv_anything);
 
     #undef ADD_VERB
 

--- a/tests/headless_mainwindow_verbs.c
+++ b/tests/headless_mainwindow_verbs.c
@@ -38,31 +38,31 @@ static boolean mainwindow_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case maiv_showflag:
             /* Verb #0: mainwindow.showflag - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         case maiv_hideflag:
             /* Verb #1: mainwindow.hideflag - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         case maiv_showpopup:
             /* Verb #2: mainwindow.showpopup - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         case maiv_hidepopup:
             /* Verb #3: mainwindow.hidepopup - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         case maiv_showbuttons:
             /* Verb #4: mainwindow.showbuttons - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         case maiv_hidebuttons:
             /* Verb #5: mainwindow.hidebuttons - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         case maiv_showserverstats:
             /* Verb #6: mainwindow.showserverstats - GUI not available */
-            if (bserror) copystring(BIGSTRING("\pCan't use mainwindow verbs because GUI is not available in headless mode"), bserror);
+            if (bserror) copystring(BIGSTRING("\110Can't use mainwindow verbs because GUI is not available in headless mode"), bserror);
             return false;
         default:
             return false;
@@ -73,7 +73,7 @@ boolean mainwindowinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pmainwindow"), bsname);
+    copystring(BIGSTRING("\012mainwindow"), bsname);
 
     if (!newfunctionprocessor(bsname, &mainwindow_valueproc, false, &htable))
         return false;
@@ -89,13 +89,13 @@ boolean mainwindowinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pshowflag"), maiv_showflag);
-    ADD_VERB(BIGSTRING("\phideflag"), maiv_hideflag);
-    ADD_VERB(BIGSTRING("\pshowpopup"), maiv_showpopup);
-    ADD_VERB(BIGSTRING("\phidepopup"), maiv_hidepopup);
-    ADD_VERB(BIGSTRING("\pshowbuttons"), maiv_showbuttons);
-    ADD_VERB(BIGSTRING("\phidebuttons"), maiv_hidebuttons);
-    ADD_VERB(BIGSTRING("\pshowserverstats"), maiv_showserverstats);
+    ADD_VERB(BIGSTRING("\010showflag"), maiv_showflag);
+    ADD_VERB(BIGSTRING("\010hideflag"), maiv_hideflag);
+    ADD_VERB(BIGSTRING("\011showpopup"), maiv_showpopup);
+    ADD_VERB(BIGSTRING("\011hidepopup"), maiv_hidepopup);
+    ADD_VERB(BIGSTRING("\013showbuttons"), maiv_showbuttons);
+    ADD_VERB(BIGSTRING("\013hidebuttons"), maiv_hidebuttons);
+    ADD_VERB(BIGSTRING("\017showserverstats"), maiv_showserverstats);
 
     #undef ADD_VERB
 

--- a/tests/headless_math_verbs.c
+++ b/tests/headless_math_verbs.c
@@ -33,15 +33,15 @@ static boolean math_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case matv_min:
             /* Verb #0: math.min - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case matv_max:
             /* Verb #1: math.max - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case matv_sqrt:
             /* Verb #2: math.sqrt - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case matv_random: {
             long lower, upper;
@@ -55,7 +55,7 @@ static boolean math_valueproc(short token, hdltreenode hparam1,
 
             if (lower > upper) {
                 if (bserror)
-                    copystring(BIGSTRING("\pbounds error"), bserror);
+                    copystring(BIGSTRING("\014bounds error"), bserror);
                 return false;
             }
 
@@ -72,7 +72,7 @@ boolean mathinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pmath"), bsname);
+    copystring(BIGSTRING("\004math"), bsname);
 
     if (!newfunctionprocessor(bsname, &math_valueproc, false, &htable))
         return false;
@@ -88,10 +88,10 @@ boolean mathinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pmin"), matv_min);
-    ADD_VERB(BIGSTRING("\pmax"), matv_max);
-    ADD_VERB(BIGSTRING("\psqrt"), matv_sqrt);
-    ADD_VERB(BIGSTRING("\prandom"), matv_random);
+    ADD_VERB(BIGSTRING("\003min"), matv_min);
+    ADD_VERB(BIGSTRING("\003max"), matv_max);
+    ADD_VERB(BIGSTRING("\004sqrt"), matv_sqrt);
+    ADD_VERB(BIGSTRING("\006random"), matv_random);
 
     #undef ADD_VERB
 

--- a/tests/headless_menu_verbs.c
+++ b/tests/headless_menu_verbs.c
@@ -51,7 +51,7 @@ static boolean menu_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case menv_zoomscript:
             /* menu.zoomScript - requires menu editor window, keep as stub */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
 
         case menv_buildmenubar:
@@ -124,7 +124,7 @@ boolean menuinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pmenu"), bsname);
+    copystring(BIGSTRING("\004menu"), bsname);
 
     if (!newfunctionprocessor(bsname, &menu_valueproc, false, &htable))
         return false;
@@ -140,20 +140,20 @@ boolean menuinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pzoomscript"), menv_zoomscript);
-    ADD_VERB(BIGSTRING("\pbuildmenubar"), menv_buildmenubar);
-    ADD_VERB(BIGSTRING("\pclearmenubar"), menv_clearmenubar);
-    ADD_VERB(BIGSTRING("\pisinstalled"), menv_isinstalled);
-    ADD_VERB(BIGSTRING("\pinstall"), menv_install);
-    ADD_VERB(BIGSTRING("\premove"), menv_remove);
-    ADD_VERB(BIGSTRING("\pgetscript"), menv_getscript);
-    ADD_VERB(BIGSTRING("\psetscript"), menv_setscript);
-    ADD_VERB(BIGSTRING("\paddmenucommand"), menv_addmenucommand);
-    ADD_VERB(BIGSTRING("\pdeletemenucommand"), menv_deletemenucommand);
-    ADD_VERB(BIGSTRING("\paddsubmenu"), menv_addsubmenu);
-    ADD_VERB(BIGSTRING("\pdeletesubmenu"), menv_deletesubmenu);
-    ADD_VERB(BIGSTRING("\pgetcommandkey"), menv_getcommandkey);
-    ADD_VERB(BIGSTRING("\psetcommandkey"), menv_setcommandkey);
+    ADD_VERB(BIGSTRING("\012zoomscript"), menv_zoomscript);
+    ADD_VERB(BIGSTRING("\014buildmenubar"), menv_buildmenubar);
+    ADD_VERB(BIGSTRING("\014clearmenubar"), menv_clearmenubar);
+    ADD_VERB(BIGSTRING("\013isinstalled"), menv_isinstalled);
+    ADD_VERB(BIGSTRING("\007install"), menv_install);
+    ADD_VERB(BIGSTRING("\006remove"), menv_remove);
+    ADD_VERB(BIGSTRING("\011getscript"), menv_getscript);
+    ADD_VERB(BIGSTRING("\011setscript"), menv_setscript);
+    ADD_VERB(BIGSTRING("\016addmenucommand"), menv_addmenucommand);
+    ADD_VERB(BIGSTRING("\021deletemenucommand"), menv_deletemenucommand);
+    ADD_VERB(BIGSTRING("\012addsubmenu"), menv_addsubmenu);
+    ADD_VERB(BIGSTRING("\015deletesubmenu"), menv_deletesubmenu);
+    ADD_VERB(BIGSTRING("\015getcommandkey"), menv_getcommandkey);
+    ADD_VERB(BIGSTRING("\015setcommandkey"), menv_setcommandkey);
 
     #undef ADD_VERB
 

--- a/tests/headless_mouse_verbs.c
+++ b/tests/headless_mouse_verbs.c
@@ -32,11 +32,11 @@ static boolean mouse_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case mouv_button:
             /* Verb #0: mouse.button - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mouv_location:
             /* Verb #1: mouse.location - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -47,7 +47,7 @@ boolean mouseinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pmouse"), bsname);
+    copystring(BIGSTRING("\005mouse"), bsname);
 
     if (!newfunctionprocessor(bsname, &mouse_valueproc, false, &htable))
         return false;
@@ -63,8 +63,8 @@ boolean mouseinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pbutton"), mouv_button);
-    ADD_VERB(BIGSTRING("\plocation"), mouv_location);
+    ADD_VERB(BIGSTRING("\006button"), mouv_button);
+    ADD_VERB(BIGSTRING("\010location"), mouv_location);
 
     #undef ADD_VERB
 

--- a/tests/headless_mrcalendar_verbs.c
+++ b/tests/headless_mrcalendar_verbs.c
@@ -41,47 +41,47 @@ static boolean mrcalendar_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case mrcv_getaddressday:
             /* Verb #0: mrcalendar.getaddressday - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getdayaddress:
             /* Verb #1: mrcalendar.getdayaddress - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getfirstaddress:
             /* Verb #2: mrcalendar.getfirstaddress - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getfirstday:
             /* Verb #3: mrcalendar.getfirstday - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getlastaddress:
             /* Verb #4: mrcalendar.getlastaddress - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getlastday:
             /* Verb #5: mrcalendar.getlastday - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getmostrecentaddress:
             /* Verb #6: mrcalendar.getmostrecentaddress - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getmostrecentday:
             /* Verb #7: mrcalendar.getmostrecentday - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getnextaddress:
             /* Verb #8: mrcalendar.getnextaddress - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_getnextday:
             /* Verb #9: mrcalendar.getnextday - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mrcv_navigate:
             /* Verb #10: mrcalendar.navigate - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -92,7 +92,7 @@ boolean mrcalendarinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pmrcalendar"), bsname);
+    copystring(BIGSTRING("\012mrcalendar"), bsname);
 
     if (!newfunctionprocessor(bsname, &mrcalendar_valueproc, false, &htable))
         return false;
@@ -108,17 +108,17 @@ boolean mrcalendarinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pgetaddressday"), mrcv_getaddressday);
-    ADD_VERB(BIGSTRING("\pgetdayaddress"), mrcv_getdayaddress);
-    ADD_VERB(BIGSTRING("\pgetfirstaddress"), mrcv_getfirstaddress);
-    ADD_VERB(BIGSTRING("\pgetfirstday"), mrcv_getfirstday);
-    ADD_VERB(BIGSTRING("\pgetlastaddress"), mrcv_getlastaddress);
-    ADD_VERB(BIGSTRING("\pgetlastday"), mrcv_getlastday);
-    ADD_VERB(BIGSTRING("\pgetmostrecentaddress"), mrcv_getmostrecentaddress);
-    ADD_VERB(BIGSTRING("\pgetmostrecentday"), mrcv_getmostrecentday);
-    ADD_VERB(BIGSTRING("\pgetnextaddress"), mrcv_getnextaddress);
-    ADD_VERB(BIGSTRING("\pgetnextday"), mrcv_getnextday);
-    ADD_VERB(BIGSTRING("\pnavigate"), mrcv_navigate);
+    ADD_VERB(BIGSTRING("\015getaddressday"), mrcv_getaddressday);
+    ADD_VERB(BIGSTRING("\015getdayaddress"), mrcv_getdayaddress);
+    ADD_VERB(BIGSTRING("\017getfirstaddress"), mrcv_getfirstaddress);
+    ADD_VERB(BIGSTRING("\013getfirstday"), mrcv_getfirstday);
+    ADD_VERB(BIGSTRING("\016getlastaddress"), mrcv_getlastaddress);
+    ADD_VERB(BIGSTRING("\012getlastday"), mrcv_getlastday);
+    ADD_VERB(BIGSTRING("\024getmostrecentaddress"), mrcv_getmostrecentaddress);
+    ADD_VERB(BIGSTRING("\020getmostrecentday"), mrcv_getmostrecentday);
+    ADD_VERB(BIGSTRING("\016getnextaddress"), mrcv_getnextaddress);
+    ADD_VERB(BIGSTRING("\012getnextday"), mrcv_getnextday);
+    ADD_VERB(BIGSTRING("\010navigate"), mrcv_navigate);
 
     #undef ADD_VERB
 

--- a/tests/headless_mysql_verbs.c
+++ b/tests/headless_mysql_verbs.c
@@ -57,111 +57,111 @@ static boolean mysql_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case mysv_init:
             /* Verb #0: mysql.init - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_end:
             /* Verb #1: mysql.end - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_connect:
             /* Verb #2: mysql.connect - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_compileQuery:
             /* Verb #3: mysql.compileQuery - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_clearQuery:
             /* Verb #4: mysql.clearQuery - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getRow:
             /* Verb #5: mysql.getRow - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getErrorNumber:
             /* Verb #6: mysql.getErrorNumber - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getErrorMessage:
             /* Verb #7: mysql.getErrorMessage - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getClientInfo:
             /* Verb #8: mysql.getClientInfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getClientVersion:
             /* Verb #9: mysql.getClientVersion - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getHostInfo:
             /* Verb #10: mysql.getHostInfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getServerVersion:
             /* Verb #11: mysql.getServerVersion - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getProtocolInfo:
             /* Verb #12: mysql.getProtocolInfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getServerInfo:
             /* Verb #13: mysql.getServerInfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getQueryInfo:
             /* Verb #14: mysql.getQueryInfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getAffectedRowCount:
             /* Verb #15: mysql.getAffectedRowCount - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getSelectedRowCount:
             /* Verb #16: mysql.getSelectedRowCount - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getColumnCount:
             /* Verb #17: mysql.getColumnCount - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getServerStatus:
             /* Verb #18: mysql.getServerStatus - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getQueryWarningCount:
             /* Verb #19: mysql.getQueryWarningCount - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_pingServer:
             /* Verb #20: mysql.pingServer - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_seekRow:
             /* Verb #21: mysql.seekRow - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_selectDatabase:
             /* Verb #22: mysql.selectDatabase - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_getSQLSTATE:
             /* Verb #23: mysql.getSQLSTATE - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_escapeString:
             /* Verb #24: mysql.escapeString - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_isThreadSafe:
             /* Verb #25: mysql.isThreadSafe - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case mysv_close:
             /* Verb #26: mysql.close - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -172,7 +172,7 @@ boolean mysqlinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pmysql"), bsname);
+    copystring(BIGSTRING("\005mysql"), bsname);
 
     if (!newfunctionprocessor(bsname, &mysql_valueproc, false, &htable))
         return false;
@@ -188,33 +188,33 @@ boolean mysqlinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pinit"), mysv_init);
-    ADD_VERB(BIGSTRING("\pend"), mysv_end);
-    ADD_VERB(BIGSTRING("\pconnect"), mysv_connect);
-    ADD_VERB(BIGSTRING("\pcompileQuery"), mysv_compileQuery);
-    ADD_VERB(BIGSTRING("\pclearQuery"), mysv_clearQuery);
-    ADD_VERB(BIGSTRING("\pgetRow"), mysv_getRow);
-    ADD_VERB(BIGSTRING("\pgetErrorNumber"), mysv_getErrorNumber);
-    ADD_VERB(BIGSTRING("\pgetErrorMessage"), mysv_getErrorMessage);
-    ADD_VERB(BIGSTRING("\pgetClientInfo"), mysv_getClientInfo);
-    ADD_VERB(BIGSTRING("\pgetClientVersion"), mysv_getClientVersion);
-    ADD_VERB(BIGSTRING("\pgetHostInfo"), mysv_getHostInfo);
-    ADD_VERB(BIGSTRING("\pgetServerVersion"), mysv_getServerVersion);
-    ADD_VERB(BIGSTRING("\pgetProtocolInfo"), mysv_getProtocolInfo);
-    ADD_VERB(BIGSTRING("\pgetServerInfo"), mysv_getServerInfo);
-    ADD_VERB(BIGSTRING("\pgetQueryInfo"), mysv_getQueryInfo);
-    ADD_VERB(BIGSTRING("\pgetAffectedRowCount"), mysv_getAffectedRowCount);
-    ADD_VERB(BIGSTRING("\pgetSelectedRowCount"), mysv_getSelectedRowCount);
-    ADD_VERB(BIGSTRING("\pgetColumnCount"), mysv_getColumnCount);
-    ADD_VERB(BIGSTRING("\pgetServerStatus"), mysv_getServerStatus);
-    ADD_VERB(BIGSTRING("\pgetQueryWarningCount"), mysv_getQueryWarningCount);
-    ADD_VERB(BIGSTRING("\ppingServer"), mysv_pingServer);
-    ADD_VERB(BIGSTRING("\pseekRow"), mysv_seekRow);
-    ADD_VERB(BIGSTRING("\pselectDatabase"), mysv_selectDatabase);
-    ADD_VERB(BIGSTRING("\pgetSQLSTATE"), mysv_getSQLSTATE);
-    ADD_VERB(BIGSTRING("\pescapeString"), mysv_escapeString);
-    ADD_VERB(BIGSTRING("\pisThreadSafe"), mysv_isThreadSafe);
-    ADD_VERB(BIGSTRING("\pclose"), mysv_close);
+    ADD_VERB(BIGSTRING("\004init"), mysv_init);
+    ADD_VERB(BIGSTRING("\003end"), mysv_end);
+    ADD_VERB(BIGSTRING("\007connect"), mysv_connect);
+    ADD_VERB(BIGSTRING("\014compileQuery"), mysv_compileQuery);
+    ADD_VERB(BIGSTRING("\012clearQuery"), mysv_clearQuery);
+    ADD_VERB(BIGSTRING("\006getRow"), mysv_getRow);
+    ADD_VERB(BIGSTRING("\016getErrorNumber"), mysv_getErrorNumber);
+    ADD_VERB(BIGSTRING("\017getErrorMessage"), mysv_getErrorMessage);
+    ADD_VERB(BIGSTRING("\015getClientInfo"), mysv_getClientInfo);
+    ADD_VERB(BIGSTRING("\020getClientVersion"), mysv_getClientVersion);
+    ADD_VERB(BIGSTRING("\013getHostInfo"), mysv_getHostInfo);
+    ADD_VERB(BIGSTRING("\020getServerVersion"), mysv_getServerVersion);
+    ADD_VERB(BIGSTRING("\017getProtocolInfo"), mysv_getProtocolInfo);
+    ADD_VERB(BIGSTRING("\015getServerInfo"), mysv_getServerInfo);
+    ADD_VERB(BIGSTRING("\014getQueryInfo"), mysv_getQueryInfo);
+    ADD_VERB(BIGSTRING("\023getAffectedRowCount"), mysv_getAffectedRowCount);
+    ADD_VERB(BIGSTRING("\023getSelectedRowCount"), mysv_getSelectedRowCount);
+    ADD_VERB(BIGSTRING("\016getColumnCount"), mysv_getColumnCount);
+    ADD_VERB(BIGSTRING("\017getServerStatus"), mysv_getServerStatus);
+    ADD_VERB(BIGSTRING("\024getQueryWarningCount"), mysv_getQueryWarningCount);
+    ADD_VERB(BIGSTRING("\012pingServer"), mysv_pingServer);
+    ADD_VERB(BIGSTRING("\007seekRow"), mysv_seekRow);
+    ADD_VERB(BIGSTRING("\016selectDatabase"), mysv_selectDatabase);
+    ADD_VERB(BIGSTRING("\013getSQLSTATE"), mysv_getSQLSTATE);
+    ADD_VERB(BIGSTRING("\014escapeString"), mysv_escapeString);
+    ADD_VERB(BIGSTRING("\014isThreadSafe"), mysv_isThreadSafe);
+    ADD_VERB(BIGSTRING("\005close"), mysv_close);
 
     #undef ADD_VERB
 

--- a/tests/headless_op_verbs.c
+++ b/tests/headless_op_verbs.c
@@ -2080,7 +2080,7 @@ boolean opinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pop"), bsname);
+    copystring(BIGSTRING("\002op"), bsname);
 
     if (!newfunctionprocessor(bsname, &op_valueproc, false, &htable))
         return false;
@@ -2096,51 +2096,51 @@ boolean opinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pgetlinetext"), opv_getlinetext);
-    ADD_VERB(BIGSTRING("\plevel"), opv_level);
-    ADD_VERB(BIGSTRING("\pcountsubs"), opv_countsubs);
-    ADD_VERB(BIGSTRING("\pcountsummits"), opv_countsummits);
-    ADD_VERB(BIGSTRING("\pgo"), opv_go);
-    ADD_VERB(BIGSTRING("\pfirstsummit"), opv_firstsummit);
-    ADD_VERB(BIGSTRING("\pexpand"), opv_expand);
-    ADD_VERB(BIGSTRING("\pcollapse"), opv_collapse);
-    ADD_VERB(BIGSTRING("\psubsexpanded"), opv_subsexpanded);
-    ADD_VERB(BIGSTRING("\pinsert"), opv_insert);
-    ADD_VERB(BIGSTRING("\pfind"), opv_find);
-    ADD_VERB(BIGSTRING("\psort"), opv_sort);
-    ADD_VERB(BIGSTRING("\psetlinetext"), opv_setlinetext);
-    ADD_VERB(BIGSTRING("\preorg"), opv_reorg);
-    ADD_VERB(BIGSTRING("\ppromote"), opv_promote);
-    ADD_VERB(BIGSTRING("\pdemote"), opv_demote);
-    ADD_VERB(BIGSTRING("\phoist"), opv_hoist);
-    ADD_VERB(BIGSTRING("\pdehoist"), opv_dehoist);
-    ADD_VERB(BIGSTRING("\pdeletesubs"), opv_deletesubs);
-    ADD_VERB(BIGSTRING("\pdeleteline"), opv_deleteline);
-    ADD_VERB(BIGSTRING("\ptabkeyreorg"), opv_tabkeyreorg);
-    ADD_VERB(BIGSTRING("\pflatcursorkeys"), opv_flatcursorkeys);
-    ADD_VERB(BIGSTRING("\pgetdisplay"), opv_getdisplay);
-    ADD_VERB(BIGSTRING("\psetdisplay"), opv_setdisplay);
-    ADD_VERB(BIGSTRING("\pgetcursor"), opv_getcursor);
-    ADD_VERB(BIGSTRING("\psetcursor"), opv_setcursor);
-    ADD_VERB(BIGSTRING("\pgetrefcon"), opv_getrefcon);
-    ADD_VERB(BIGSTRING("\psetrefcon"), opv_setrefcon);
-    ADD_VERB(BIGSTRING("\pgetexpansionstate"), opv_getexpansionstate);
-    ADD_VERB(BIGSTRING("\psetexpansionstate"), opv_setexpansionstate);
-    ADD_VERB(BIGSTRING("\pgetscrollstate"), opv_getscrollstate);
-    ADD_VERB(BIGSTRING("\psetscrollstate"), opv_setscrollstate);
-    ADD_VERB(BIGSTRING("\pgetsuboutline"), opv_getsuboutline);
-    ADD_VERB(BIGSTRING("\pinsertoutline"), opv_insertoutline);
-    ADD_VERB(BIGSTRING("\psetmodified"), opv_setmodified);
-    ADD_VERB(BIGSTRING("\pgetselection"), opv_getselection);
-    ADD_VERB(BIGSTRING("\pgetheadnumber"), opv_getheadnumber);
-    ADD_VERB(BIGSTRING("\pvisitall"), opv_visitall);
-    ADD_VERB(BIGSTRING("\pgetselectedsuboutlines"), opv_getselectedsuboutlines);
-    ADD_VERB(BIGSTRING("\pxmltooutline"), opv_xmltooutline);
-    ADD_VERB(BIGSTRING("\poutlinetoxml"), opv_outlinetoxml);
-    ADD_VERB(BIGSTRING("\psethtmlformatting"), opv_sethtmlformatting);
-    ADD_VERB(BIGSTRING("\pgethtmlformatting"), opv_gethtmlformatting);
-    ADD_VERB(BIGSTRING("\psetdynamic"), opv_setdynamic);
-    ADD_VERB(BIGSTRING("\pgetdynamic"), opv_getdynamic);
+    ADD_VERB(BIGSTRING("\013getlinetext"), opv_getlinetext);
+    ADD_VERB(BIGSTRING("\005level"), opv_level);
+    ADD_VERB(BIGSTRING("\011countsubs"), opv_countsubs);
+    ADD_VERB(BIGSTRING("\014countsummits"), opv_countsummits);
+    ADD_VERB(BIGSTRING("\002go"), opv_go);
+    ADD_VERB(BIGSTRING("\013firstsummit"), opv_firstsummit);
+    ADD_VERB(BIGSTRING("\006expand"), opv_expand);
+    ADD_VERB(BIGSTRING("\010collapse"), opv_collapse);
+    ADD_VERB(BIGSTRING("\014subsexpanded"), opv_subsexpanded);
+    ADD_VERB(BIGSTRING("\006insert"), opv_insert);
+    ADD_VERB(BIGSTRING("\004find"), opv_find);
+    ADD_VERB(BIGSTRING("\004sort"), opv_sort);
+    ADD_VERB(BIGSTRING("\013setlinetext"), opv_setlinetext);
+    ADD_VERB(BIGSTRING("\005reorg"), opv_reorg);
+    ADD_VERB(BIGSTRING("\007promote"), opv_promote);
+    ADD_VERB(BIGSTRING("\006demote"), opv_demote);
+    ADD_VERB(BIGSTRING("\005hoist"), opv_hoist);
+    ADD_VERB(BIGSTRING("\007dehoist"), opv_dehoist);
+    ADD_VERB(BIGSTRING("\012deletesubs"), opv_deletesubs);
+    ADD_VERB(BIGSTRING("\012deleteline"), opv_deleteline);
+    ADD_VERB(BIGSTRING("\013tabkeyreorg"), opv_tabkeyreorg);
+    ADD_VERB(BIGSTRING("\016flatcursorkeys"), opv_flatcursorkeys);
+    ADD_VERB(BIGSTRING("\012getdisplay"), opv_getdisplay);
+    ADD_VERB(BIGSTRING("\012setdisplay"), opv_setdisplay);
+    ADD_VERB(BIGSTRING("\011getcursor"), opv_getcursor);
+    ADD_VERB(BIGSTRING("\011setcursor"), opv_setcursor);
+    ADD_VERB(BIGSTRING("\011getrefcon"), opv_getrefcon);
+    ADD_VERB(BIGSTRING("\011setrefcon"), opv_setrefcon);
+    ADD_VERB(BIGSTRING("\021getexpansionstate"), opv_getexpansionstate);
+    ADD_VERB(BIGSTRING("\021setexpansionstate"), opv_setexpansionstate);
+    ADD_VERB(BIGSTRING("\016getscrollstate"), opv_getscrollstate);
+    ADD_VERB(BIGSTRING("\016setscrollstate"), opv_setscrollstate);
+    ADD_VERB(BIGSTRING("\015getsuboutline"), opv_getsuboutline);
+    ADD_VERB(BIGSTRING("\015insertoutline"), opv_insertoutline);
+    ADD_VERB(BIGSTRING("\013setmodified"), opv_setmodified);
+    ADD_VERB(BIGSTRING("\014getselection"), opv_getselection);
+    ADD_VERB(BIGSTRING("\015getheadnumber"), opv_getheadnumber);
+    ADD_VERB(BIGSTRING("\010visitall"), opv_visitall);
+    ADD_VERB(BIGSTRING("\026getselectedsuboutlines"), opv_getselectedsuboutlines);
+    ADD_VERB(BIGSTRING("\014xmltooutline"), opv_xmltooutline);
+    ADD_VERB(BIGSTRING("\014outlinetoxml"), opv_outlinetoxml);
+    ADD_VERB(BIGSTRING("\021sethtmlformatting"), opv_sethtmlformatting);
+    ADD_VERB(BIGSTRING("\021gethtmlformatting"), opv_gethtmlformatting);
+    ADD_VERB(BIGSTRING("\012setdynamic"), opv_setdynamic);
+    ADD_VERB(BIGSTRING("\012getdynamic"), opv_getdynamic);
 
     #undef ADD_VERB
 

--- a/tests/headless_opattributes_verbs.c
+++ b/tests/headless_opattributes_verbs.c
@@ -76,7 +76,7 @@ boolean opattributesinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\popattributes"), bsname);
+    copystring(BIGSTRING("\014opattributes"), bsname);
 
     if (!newfunctionprocessor(bsname, &opattributes_valueproc, false, &htable))
         return false;
@@ -92,11 +92,11 @@ boolean opattributesinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\paddgroup"), opav_addgroup);
-    ADD_VERB(BIGSTRING("\pgetall"), opav_getall);
-    ADD_VERB(BIGSTRING("\pgetone"), opav_getone);
-    ADD_VERB(BIGSTRING("\pmakeempty"), opav_makeempty);
-    ADD_VERB(BIGSTRING("\psetone"), opav_setone);
+    ADD_VERB(BIGSTRING("\010addgroup"), opav_addgroup);
+    ADD_VERB(BIGSTRING("\006getall"), opav_getall);
+    ADD_VERB(BIGSTRING("\006getone"), opav_getone);
+    ADD_VERB(BIGSTRING("\011makeempty"), opav_makeempty);
+    ADD_VERB(BIGSTRING("\006setone"), opav_setone);
 
     #undef ADD_VERB
 

--- a/tests/headless_osa_verbs.c
+++ b/tests/headless_osa_verbs.c
@@ -32,11 +32,11 @@ static boolean osa_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case osav_compile:
             /* Verb #0: osa.compile - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case osav_getsource:
             /* Verb #1: osa.getsource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -47,7 +47,7 @@ boolean osainitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\posa"), bsname);
+    copystring(BIGSTRING("\003osa"), bsname);
 
     if (!newfunctionprocessor(bsname, &osa_valueproc, false, &htable))
         return false;
@@ -63,8 +63,8 @@ boolean osainitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pcompile"), osav_compile);
-    ADD_VERB(BIGSTRING("\pgetsource"), osav_getsource);
+    ADD_VERB(BIGSTRING("\007compile"), osav_compile);
+    ADD_VERB(BIGSTRING("\011getsource"), osav_getsource);
 
     #undef ADD_VERB
 

--- a/tests/headless_pict_verbs.c
+++ b/tests/headless_pict_verbs.c
@@ -34,19 +34,19 @@ static boolean pict_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case picv_scheduleupdate:
             /* Verb #0: pict.scheduleupdate - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case picv_expressions:
             /* Verb #1: pict.expressions - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case picv_getpicture:
             /* Verb #2: pict.getpicture - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case picv_setpicture:
             /* Verb #3: pict.setpicture - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -57,7 +57,7 @@ boolean pictinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\ppict"), bsname);
+    copystring(BIGSTRING("\004pict"), bsname);
 
     if (!newfunctionprocessor(bsname, &pict_valueproc, false, &htable))
         return false;
@@ -73,10 +73,10 @@ boolean pictinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pscheduleupdate"), picv_scheduleupdate);
-    ADD_VERB(BIGSTRING("\pexpressions"), picv_expressions);
-    ADD_VERB(BIGSTRING("\pgetpicture"), picv_getpicture);
-    ADD_VERB(BIGSTRING("\psetpicture"), picv_setpicture);
+    ADD_VERB(BIGSTRING("\016scheduleupdate"), picv_scheduleupdate);
+    ADD_VERB(BIGSTRING("\013expressions"), picv_expressions);
+    ADD_VERB(BIGSTRING("\012getpicture"), picv_getpicture);
+    ADD_VERB(BIGSTRING("\012setpicture"), picv_setpicture);
 
     #undef ADD_VERB
 

--- a/tests/headless_point_verbs.c
+++ b/tests/headless_point_verbs.c
@@ -82,7 +82,7 @@ boolean pointinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\ppoint"), bsname);
+    copystring(BIGSTRING("\005point"), bsname);
 
     if (!newfunctionprocessor(bsname, &point_valueproc, false, &htable))
         return false;
@@ -98,8 +98,8 @@ boolean pointinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), poiv_get);
-    ADD_VERB(BIGSTRING("\pset"), poiv_set);
+    ADD_VERB(BIGSTRING("\003get"), poiv_get);
+    ADD_VERB(BIGSTRING("\003set"), poiv_set);
 
     #undef ADD_VERB
 

--- a/tests/headless_python_verbs.c
+++ b/tests/headless_python_verbs.c
@@ -31,7 +31,7 @@ static boolean python_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case pytv_doscript:
             /* Verb #0: python.doscript - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -42,7 +42,7 @@ boolean pythoninitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\ppython"), bsname);
+    copystring(BIGSTRING("\006python"), bsname);
 
     if (!newfunctionprocessor(bsname, &python_valueproc, false, &htable))
         return false;
@@ -58,7 +58,7 @@ boolean pythoninitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pdoscript"), pytv_doscript);
+    ADD_VERB(BIGSTRING("\010doscript"), pytv_doscript);
 
     #undef ADD_VERB
 

--- a/tests/headless_re_verbs.c
+++ b/tests/headless_re_verbs.c
@@ -40,43 +40,43 @@ static boolean re_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case rev_compile:
             /* Verb #0: re.compile - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_match:
             /* Verb #1: re.match - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_replace:
             /* Verb #2: re.replace - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_extract:
             /* Verb #3: re.extract - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_split:
             /* Verb #4: re.split - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_join:
             /* Verb #5: re.join - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_visit:
             /* Verb #6: re.visit - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_grep:
             /* Verb #7: re.grep - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_getpatterninfo:
             /* Verb #8: re.getpatterninfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rev_expand:
             /* Verb #9: re.expand - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -87,7 +87,7 @@ boolean reinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pre"), bsname);
+    copystring(BIGSTRING("\002re"), bsname);
 
     if (!newfunctionprocessor(bsname, &re_valueproc, false, &htable))
         return false;
@@ -103,16 +103,16 @@ boolean reinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pcompile"), rev_compile);
-    ADD_VERB(BIGSTRING("\pmatch"), rev_match);
-    ADD_VERB(BIGSTRING("\preplace"), rev_replace);
-    ADD_VERB(BIGSTRING("\pextract"), rev_extract);
-    ADD_VERB(BIGSTRING("\psplit"), rev_split);
-    ADD_VERB(BIGSTRING("\pjoin"), rev_join);
-    ADD_VERB(BIGSTRING("\pvisit"), rev_visit);
-    ADD_VERB(BIGSTRING("\pgrep"), rev_grep);
-    ADD_VERB(BIGSTRING("\pgetpatterninfo"), rev_getpatterninfo);
-    ADD_VERB(BIGSTRING("\pexpand"), rev_expand);
+    ADD_VERB(BIGSTRING("\007compile"), rev_compile);
+    ADD_VERB(BIGSTRING("\005match"), rev_match);
+    ADD_VERB(BIGSTRING("\007replace"), rev_replace);
+    ADD_VERB(BIGSTRING("\007extract"), rev_extract);
+    ADD_VERB(BIGSTRING("\005split"), rev_split);
+    ADD_VERB(BIGSTRING("\004join"), rev_join);
+    ADD_VERB(BIGSTRING("\005visit"), rev_visit);
+    ADD_VERB(BIGSTRING("\004grep"), rev_grep);
+    ADD_VERB(BIGSTRING("\016getpatterninfo"), rev_getpatterninfo);
+    ADD_VERB(BIGSTRING("\006expand"), rev_expand);
 
     #undef ADD_VERB
 

--- a/tests/headless_rectangle_verbs.c
+++ b/tests/headless_rectangle_verbs.c
@@ -97,7 +97,7 @@ boolean rectangleinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\prectangle"), bsname);
+    copystring(BIGSTRING("\011rectangle"), bsname);
 
     if (!newfunctionprocessor(bsname, &rectangle_valueproc, false, &htable))
         return false;
@@ -113,8 +113,8 @@ boolean rectangleinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), recv_get);
-    ADD_VERB(BIGSTRING("\pset"), recv_set);
+    ADD_VERB(BIGSTRING("\003get"), recv_get);
+    ADD_VERB(BIGSTRING("\003set"), recv_set);
 
     #undef ADD_VERB
 

--- a/tests/headless_rez_verbs.c
+++ b/tests/headless_rez_verbs.c
@@ -45,63 +45,63 @@ static boolean rez_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case rezv_getresource:
             /* Verb #0: rez.getresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_putresource:
             /* Verb #1: rez.putresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_getnamedresource:
             /* Verb #2: rez.getnamedresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_putnamedresource:
             /* Verb #3: rez.putnamedresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_countrestypes:
             /* Verb #4: rez.countrestypes - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_getnthrestype:
             /* Verb #5: rez.getnthrestype - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_countresources:
             /* Verb #6: rez.countresources - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_getnthresource:
             /* Verb #7: rez.getnthresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_getnthresinfo:
             /* Verb #8: rez.getnthresinfo - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_resourceexists:
             /* Verb #9: rez.resourceexists - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_namedresourceexists:
             /* Verb #10: rez.namedresourceexists - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_deleteresource:
             /* Verb #11: rez.deleteresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_deletenamedresource:
             /* Verb #12: rez.deletenamedresource - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_getresourceattributes:
             /* Verb #13: rez.getresourceattributes - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case rezv_setresourceattributes:
             /* Verb #14: rez.setresourceattributes - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -112,7 +112,7 @@ boolean rezinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\prez"), bsname);
+    copystring(BIGSTRING("\003rez"), bsname);
 
     if (!newfunctionprocessor(bsname, &rez_valueproc, false, &htable))
         return false;
@@ -128,21 +128,21 @@ boolean rezinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pgetresource"), rezv_getresource);
-    ADD_VERB(BIGSTRING("\pputresource"), rezv_putresource);
-    ADD_VERB(BIGSTRING("\pgetnamedresource"), rezv_getnamedresource);
-    ADD_VERB(BIGSTRING("\pputnamedresource"), rezv_putnamedresource);
-    ADD_VERB(BIGSTRING("\pcountrestypes"), rezv_countrestypes);
-    ADD_VERB(BIGSTRING("\pgetnthrestype"), rezv_getnthrestype);
-    ADD_VERB(BIGSTRING("\pcountresources"), rezv_countresources);
-    ADD_VERB(BIGSTRING("\pgetnthresource"), rezv_getnthresource);
-    ADD_VERB(BIGSTRING("\pgetnthresinfo"), rezv_getnthresinfo);
-    ADD_VERB(BIGSTRING("\presourceexists"), rezv_resourceexists);
-    ADD_VERB(BIGSTRING("\pnamedresourceexists"), rezv_namedresourceexists);
-    ADD_VERB(BIGSTRING("\pdeleteresource"), rezv_deleteresource);
-    ADD_VERB(BIGSTRING("\pdeletenamedresource"), rezv_deletenamedresource);
-    ADD_VERB(BIGSTRING("\pgetresourceattributes"), rezv_getresourceattributes);
-    ADD_VERB(BIGSTRING("\psetresourceattributes"), rezv_setresourceattributes);
+    ADD_VERB(BIGSTRING("\013getresource"), rezv_getresource);
+    ADD_VERB(BIGSTRING("\013putresource"), rezv_putresource);
+    ADD_VERB(BIGSTRING("\020getnamedresource"), rezv_getnamedresource);
+    ADD_VERB(BIGSTRING("\020putnamedresource"), rezv_putnamedresource);
+    ADD_VERB(BIGSTRING("\015countrestypes"), rezv_countrestypes);
+    ADD_VERB(BIGSTRING("\015getnthrestype"), rezv_getnthrestype);
+    ADD_VERB(BIGSTRING("\016countresources"), rezv_countresources);
+    ADD_VERB(BIGSTRING("\016getnthresource"), rezv_getnthresource);
+    ADD_VERB(BIGSTRING("\015getnthresinfo"), rezv_getnthresinfo);
+    ADD_VERB(BIGSTRING("\016resourceexists"), rezv_resourceexists);
+    ADD_VERB(BIGSTRING("\023namedresourceexists"), rezv_namedresourceexists);
+    ADD_VERB(BIGSTRING("\016deleteresource"), rezv_deleteresource);
+    ADD_VERB(BIGSTRING("\023deletenamedresource"), rezv_deletenamedresource);
+    ADD_VERB(BIGSTRING("\025getresourceattributes"), rezv_getresourceattributes);
+    ADD_VERB(BIGSTRING("\025setresourceattributes"), rezv_setresourceattributes);
 
     #undef ADD_VERB
 

--- a/tests/headless_rgb_verbs.c
+++ b/tests/headless_rgb_verbs.c
@@ -89,7 +89,7 @@ boolean rgbinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\prgb"), bsname);
+    copystring(BIGSTRING("\003rgb"), bsname);
 
     if (!newfunctionprocessor(bsname, &rgb_valueproc, false, &htable))
         return false;
@@ -105,8 +105,8 @@ boolean rgbinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), rgbv_get);
-    ADD_VERB(BIGSTRING("\pset"), rgbv_set);
+    ADD_VERB(BIGSTRING("\003get"), rgbv_get);
+    ADD_VERB(BIGSTRING("\003set"), rgbv_set);
 
     #undef ADD_VERB
 

--- a/tests/headless_script_verbs.c
+++ b/tests/headless_script_verbs.c
@@ -83,7 +83,7 @@ static boolean script_getscriptparam(hdltreenode hparam1, short pnum, hdlexterna
         return false;
 
     if (id != idscriptprocessor) {
-        langerrormessage(BIGSTRING("\pnot a script object"));
+        langerrormessage(BIGSTRING("\023not a script object"));
         return false;
     }
 
@@ -248,7 +248,7 @@ static boolean script_setsource(hdltreenode hparam1, tyvaluerecord *vreturned) {
     /* Validate hv before dereferencing */
     if (hv == nil) {
         disposehandle(hsourcetext);
-        langerrormessage(BIGSTRING("\pscript variable is nil"));
+        langerrormessage(BIGSTRING("\026script variable is nil"));
         return false;
     }
 
@@ -257,7 +257,7 @@ static boolean script_setsource(hdltreenode hparam1, tyvaluerecord *vreturned) {
     /* Check if outline is valid */
     if (ho == nil || (**ho).hsummit == nil) {
         disposehandle(hsourcetext);
-        langerrormessage(BIGSTRING("\pscript outline not properly initialized"));
+        langerrormessage(BIGSTRING("\047script outline not properly initialized"));
         return false;
     }
 
@@ -367,13 +367,13 @@ static boolean script_setcode(hdltreenode hparam1, tyvaluerecord *vreturned) {
     /* Look up code value */
     hdlhashnode hnode;
     if (!hashtablelookup(htable, varname, &codeval, &hnode)) {
-        langerrormessage(BIGSTRING("\pcode variable not found"));
+        langerrormessage(BIGSTRING("\027code variable not found"));
         return false;
     }
 
     /* Verify it's binary data */
     if (codeval.valuetype != binaryvaluetype) {
-        langerrormessage(BIGSTRING("\pcode must be binary type"));
+        langerrormessage(BIGSTRING("\030code must be binary type"));
         return false;
     }
 
@@ -387,7 +387,7 @@ static boolean script_setcode(hdltreenode hparam1, tyvaluerecord *vreturned) {
     disposehandle(hpackedcode);
 
     if (!fl) {
-        langerrormessage(BIGSTRING("\pinvalid compiled code"));
+        langerrormessage(BIGSTRING("\025invalid compiled code"));
         return false;
     }
 
@@ -460,7 +460,7 @@ static boolean script_removesource(hdltreenode hparam1, tyvaluerecord *vreturned
 
     flnextparamislast = true;
 
-    langerrormessage(BIGSTRING("\pscript.removeSource is not supported on this platform"));
+    langerrormessage(BIGSTRING("\065script.removeSource is not supported on this platform"));
     return false;
 }
 
@@ -496,47 +496,47 @@ static boolean script_valueproc(short token, hdltreenode hparam1,
         /* See usertalk_scripts/Frontier.root/system/verbs/builtins/script/ */
         case scrv_uncompile:
             /* @SCRIPT_IMPLEMENTED - unCompile.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_getlanguage:
             /* @SCRIPT_IMPLEMENTED - getLanguage.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_setlanguage:
             /* @SCRIPT_IMPLEMENTED - setLanguage.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_makecomment:
             /* @SCRIPT_IMPLEMENTED - makeComment.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_uncomment:
             /* @SCRIPT_IMPLEMENTED - unComment.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_iscomment:
             /* @SCRIPT_IMPLEMENTED - isComment.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_getbreakpoint:
             /* @SCRIPT_IMPLEMENTED - getBreakpoint.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_setbreakpoint:
             /* @SCRIPT_IMPLEMENTED - setBreakpoint.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_clearbreakpoint:
             /* @SCRIPT_IMPLEMENTED - clearBreakpoint.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_startprofile:
             /* @SCRIPT_IMPLEMENTED - startProfile.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case scrv_stopprofile:
             /* @SCRIPT_IMPLEMENTED - stopProfile.ut */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -547,7 +547,7 @@ boolean scriptinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pscript"), bsname);
+    copystring(BIGSTRING("\006script"), bsname);
 
     if (!newfunctionprocessor(bsname, &script_valueproc, false, &htable))
         return false;
@@ -563,25 +563,25 @@ boolean scriptinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pcompile"), scrv_compile);
-    ADD_VERB(BIGSTRING("\prun"), scrv_run);
-    ADD_VERB(BIGSTRING("\pgetcode"), scrv_getcode);
-    ADD_VERB(BIGSTRING("\psetcode"), scrv_setcode);
-    ADD_VERB(BIGSTRING("\pgetsource"), scrv_getsource);
-    ADD_VERB(BIGSTRING("\psetsource"), scrv_setsource);
-    ADD_VERB(BIGSTRING("\perror"), scrv_error);
-    ADD_VERB(BIGSTRING("\premoveSource"), scrv_removesource);
-    ADD_VERB(BIGSTRING("\puncompile"), scrv_uncompile);
-    ADD_VERB(BIGSTRING("\pgetlanguage"), scrv_getlanguage);
-    ADD_VERB(BIGSTRING("\psetlanguage"), scrv_setlanguage);
-    ADD_VERB(BIGSTRING("\pmakecomment"), scrv_makecomment);
-    ADD_VERB(BIGSTRING("\puncomment"), scrv_uncomment);
-    ADD_VERB(BIGSTRING("\piscomment"), scrv_iscomment);
-    ADD_VERB(BIGSTRING("\pgetbreakpoint"), scrv_getbreakpoint);
-    ADD_VERB(BIGSTRING("\psetbreakpoint"), scrv_setbreakpoint);
-    ADD_VERB(BIGSTRING("\pclearbreakpoint"), scrv_clearbreakpoint);
-    ADD_VERB(BIGSTRING("\pstartprofile"), scrv_startprofile);
-    ADD_VERB(BIGSTRING("\pstopprofile"), scrv_stopprofile);
+    ADD_VERB(BIGSTRING("\007compile"), scrv_compile);
+    ADD_VERB(BIGSTRING("\003run"), scrv_run);
+    ADD_VERB(BIGSTRING("\007getcode"), scrv_getcode);
+    ADD_VERB(BIGSTRING("\007setcode"), scrv_setcode);
+    ADD_VERB(BIGSTRING("\011getsource"), scrv_getsource);
+    ADD_VERB(BIGSTRING("\011setsource"), scrv_setsource);
+    ADD_VERB(BIGSTRING("\005error"), scrv_error);
+    ADD_VERB(BIGSTRING("\014removeSource"), scrv_removesource);
+    ADD_VERB(BIGSTRING("\011uncompile"), scrv_uncompile);
+    ADD_VERB(BIGSTRING("\013getlanguage"), scrv_getlanguage);
+    ADD_VERB(BIGSTRING("\013setlanguage"), scrv_setlanguage);
+    ADD_VERB(BIGSTRING("\013makecomment"), scrv_makecomment);
+    ADD_VERB(BIGSTRING("\011uncomment"), scrv_uncomment);
+    ADD_VERB(BIGSTRING("\011iscomment"), scrv_iscomment);
+    ADD_VERB(BIGSTRING("\015getbreakpoint"), scrv_getbreakpoint);
+    ADD_VERB(BIGSTRING("\015setbreakpoint"), scrv_setbreakpoint);
+    ADD_VERB(BIGSTRING("\017clearbreakpoint"), scrv_clearbreakpoint);
+    ADD_VERB(BIGSTRING("\014startprofile"), scrv_startprofile);
+    ADD_VERB(BIGSTRING("\013stopprofile"), scrv_stopprofile);
 
     #undef ADD_VERB
 

--- a/tests/headless_search_verbs.c
+++ b/tests/headless_search_verbs.c
@@ -37,27 +37,27 @@ static boolean search_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case seav_reset:
             /* Verb #0: search.reset - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_findnext:
             /* Verb #1: search.findnext - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_replace:
             /* Verb #2: search.replace - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_replaceall:
             /* Verb #3: search.replaceall - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_findtextdialog:
             /* Verb #4: search.findtextdialog - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_replacetextdialog:
             /* Verb #5: search.replacetextdialog - @SCRIPT_IMPLEMENTED (pure UserTalk) */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -68,7 +68,7 @@ boolean searchinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\psearch"), bsname);
+    copystring(BIGSTRING("\006search"), bsname);
 
     if (!newfunctionprocessor(bsname, &search_valueproc, false, &htable))
         return false;
@@ -84,12 +84,12 @@ boolean searchinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\preset"), seav_reset);
-    ADD_VERB(BIGSTRING("\pfindnext"), seav_findnext);
-    ADD_VERB(BIGSTRING("\preplace"), seav_replace);
-    ADD_VERB(BIGSTRING("\preplaceall"), seav_replaceall);
-    ADD_VERB(BIGSTRING("\pfindtextdialog"), seav_findtextdialog);
-    ADD_VERB(BIGSTRING("\preplacetextdialog"), seav_replacetextdialog);
+    ADD_VERB(BIGSTRING("\005reset"), seav_reset);
+    ADD_VERB(BIGSTRING("\010findnext"), seav_findnext);
+    ADD_VERB(BIGSTRING("\007replace"), seav_replace);
+    ADD_VERB(BIGSTRING("\012replaceall"), seav_replaceall);
+    ADD_VERB(BIGSTRING("\016findtextdialog"), seav_findtextdialog);
+    ADD_VERB(BIGSTRING("\021replacetextdialog"), seav_replacetextdialog);
 
     #undef ADD_VERB
 

--- a/tests/headless_searchengine_verbs.c
+++ b/tests/headless_searchengine_verbs.c
@@ -39,19 +39,19 @@ static boolean searchengine_valueproc(short token, hdltreenode hparam1,
             return stripmarkupverb(hparam1, vreturned);
         case seav_deindexpage:
             /* Verb #1: searchengine.deindexpage - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_indexpage:
             /* Verb #2: searchengine.indexpage - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_cleanindex:
             /* Verb #3: searchengine.cleanindex - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case seav_mergeresults:
             /* Verb #4: searchengine.mergeresults - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -62,7 +62,7 @@ boolean searchengineinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\psearchengine"), bsname);
+    copystring(BIGSTRING("\014searchengine"), bsname);
 
     if (!newfunctionprocessor(bsname, &searchengine_valueproc, false, &htable))
         return false;
@@ -78,11 +78,11 @@ boolean searchengineinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pstripmarkup"), seav_stripmarkup);
-    ADD_VERB(BIGSTRING("\pdeindexpage"), seav_deindexpage);
-    ADD_VERB(BIGSTRING("\pindexpage"), seav_indexpage);
-    ADD_VERB(BIGSTRING("\pcleanindex"), seav_cleanindex);
-    ADD_VERB(BIGSTRING("\pmergeresults"), seav_mergeresults);
+    ADD_VERB(BIGSTRING("\013stripmarkup"), seav_stripmarkup);
+    ADD_VERB(BIGSTRING("\013deindexpage"), seav_deindexpage);
+    ADD_VERB(BIGSTRING("\011indexpage"), seav_indexpage);
+    ADD_VERB(BIGSTRING("\012cleanindex"), seav_cleanindex);
+    ADD_VERB(BIGSTRING("\014mergeresults"), seav_mergeresults);
 
     #undef ADD_VERB
 

--- a/tests/headless_semaphore_verbs.c
+++ b/tests/headless_semaphore_verbs.c
@@ -53,7 +53,7 @@ boolean semaphoreinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\psemaphore"), bsname);
+    copystring(BIGSTRING("\011semaphore"), bsname);
 
     if (!newfunctionprocessor(bsname, &semaphore_valueproc, false, &htable))
         return false;
@@ -69,8 +69,8 @@ boolean semaphoreinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\plock"), semv_lock);
-    ADD_VERB(BIGSTRING("\punlock"), semv_unlock);
+    ADD_VERB(BIGSTRING("\004lock"), semv_lock);
+    ADD_VERB(BIGSTRING("\006unlock"), semv_unlock);
 
     #undef ADD_VERB
 

--- a/tests/headless_speaker_verbs.c
+++ b/tests/headless_speaker_verbs.c
@@ -33,15 +33,15 @@ static boolean speaker_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case spev_beep:
             /* Verb #0: speaker.beep - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case spev_sound:
             /* Verb #1: speaker.sound - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case spev_playnamedsound:
             /* Verb #2: speaker.playnamedsound - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -52,7 +52,7 @@ boolean speakerinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pspeaker"), bsname);
+    copystring(BIGSTRING("\007speaker"), bsname);
 
     if (!newfunctionprocessor(bsname, &speaker_valueproc, false, &htable))
         return false;
@@ -68,9 +68,9 @@ boolean speakerinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pbeep"), spev_beep);
-    ADD_VERB(BIGSTRING("\psound"), spev_sound);
-    ADD_VERB(BIGSTRING("\pplaynamedsound"), spev_playnamedsound);
+    ADD_VERB(BIGSTRING("\004beep"), spev_beep);
+    ADD_VERB(BIGSTRING("\005sound"), spev_sound);
+    ADD_VERB(BIGSTRING("\016playnamedsound"), spev_playnamedsound);
 
     #undef ADD_VERB
 

--- a/tests/headless_sqlite_verbs.c
+++ b/tests/headless_sqlite_verbs.c
@@ -47,71 +47,71 @@ static boolean sqlite_valueproc(short token, hdltreenode hparam1,
     switch(token) {
         case sqlv_open:
             /* Verb #0: sqlite.open - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_compileQuery:
             /* Verb #1: sqlite.compileQuery - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_clearQuery:
             /* Verb #2: sqlite.clearQuery - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_resetQuery:
             /* Verb #3: sqlite.resetQuery - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_stepQuery:
             /* Verb #4: sqlite.stepQuery - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumnCount:
             /* Verb #5: sqlite.getColumnCount - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumnType:
             /* Verb #6: sqlite.getColumnType - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumnInt:
             /* Verb #7: sqlite.getColumnInt - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumnDouble:
             /* Verb #8: sqlite.getColumnDouble - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumnText:
             /* Verb #9: sqlite.getColumnText - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumnName:
             /* Verb #10: sqlite.getColumnName - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getColumn:
             /* Verb #11: sqlite.getColumn - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getRow:
             /* Verb #12: sqlite.getRow - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getErrorMessage:
             /* Verb #13: sqlite.getErrorMessage - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_close:
             /* Verb #14: sqlite.close - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_setColumnBlob:
             /* Verb #15: sqlite.setColumnBlob - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case sqlv_getLastInsertRowId:
             /* Verb #16: sqlite.getLastInsertRowId - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -122,7 +122,7 @@ boolean sqliteinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\psqlite"), bsname);
+    copystring(BIGSTRING("\006sqlite"), bsname);
 
     if (!newfunctionprocessor(bsname, &sqlite_valueproc, false, &htable))
         return false;
@@ -138,23 +138,23 @@ boolean sqliteinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\popen"), sqlv_open);
-    ADD_VERB(BIGSTRING("\pcompileQuery"), sqlv_compileQuery);
-    ADD_VERB(BIGSTRING("\pclearQuery"), sqlv_clearQuery);
-    ADD_VERB(BIGSTRING("\presetQuery"), sqlv_resetQuery);
-    ADD_VERB(BIGSTRING("\pstepQuery"), sqlv_stepQuery);
-    ADD_VERB(BIGSTRING("\pgetColumnCount"), sqlv_getColumnCount);
-    ADD_VERB(BIGSTRING("\pgetColumnType"), sqlv_getColumnType);
-    ADD_VERB(BIGSTRING("\pgetColumnInt"), sqlv_getColumnInt);
-    ADD_VERB(BIGSTRING("\pgetColumnDouble"), sqlv_getColumnDouble);
-    ADD_VERB(BIGSTRING("\pgetColumnText"), sqlv_getColumnText);
-    ADD_VERB(BIGSTRING("\pgetColumnName"), sqlv_getColumnName);
-    ADD_VERB(BIGSTRING("\pgetColumn"), sqlv_getColumn);
-    ADD_VERB(BIGSTRING("\pgetRow"), sqlv_getRow);
-    ADD_VERB(BIGSTRING("\pgetErrorMessage"), sqlv_getErrorMessage);
-    ADD_VERB(BIGSTRING("\pclose"), sqlv_close);
-    ADD_VERB(BIGSTRING("\psetColumnBlob"), sqlv_setColumnBlob);
-    ADD_VERB(BIGSTRING("\pgetLastInsertRowId"), sqlv_getLastInsertRowId);
+    ADD_VERB(BIGSTRING("\004open"), sqlv_open);
+    ADD_VERB(BIGSTRING("\014compileQuery"), sqlv_compileQuery);
+    ADD_VERB(BIGSTRING("\012clearQuery"), sqlv_clearQuery);
+    ADD_VERB(BIGSTRING("\012resetQuery"), sqlv_resetQuery);
+    ADD_VERB(BIGSTRING("\011stepQuery"), sqlv_stepQuery);
+    ADD_VERB(BIGSTRING("\016getColumnCount"), sqlv_getColumnCount);
+    ADD_VERB(BIGSTRING("\015getColumnType"), sqlv_getColumnType);
+    ADD_VERB(BIGSTRING("\014getColumnInt"), sqlv_getColumnInt);
+    ADD_VERB(BIGSTRING("\017getColumnDouble"), sqlv_getColumnDouble);
+    ADD_VERB(BIGSTRING("\015getColumnText"), sqlv_getColumnText);
+    ADD_VERB(BIGSTRING("\015getColumnName"), sqlv_getColumnName);
+    ADD_VERB(BIGSTRING("\011getColumn"), sqlv_getColumn);
+    ADD_VERB(BIGSTRING("\006getRow"), sqlv_getRow);
+    ADD_VERB(BIGSTRING("\017getErrorMessage"), sqlv_getErrorMessage);
+    ADD_VERB(BIGSTRING("\005close"), sqlv_close);
+    ADD_VERB(BIGSTRING("\015setColumnBlob"), sqlv_setColumnBlob);
+    ADD_VERB(BIGSTRING("\022getLastInsertRowId"), sqlv_getLastInsertRowId);
 
     #undef ADD_VERB
 

--- a/tests/headless_statusbar_verbs.c
+++ b/tests/headless_statusbar_verbs.c
@@ -36,27 +36,27 @@ static boolean statusbar_valueproc(short token, hdltreenode hparam1,
         case stav_msg:
             /* statusbar.msg - error stub */
             if (bserror)
-                copystring(BIGSTRING("\pCan't use status bar verbs because GUI is not available in headless mode"), bserror);
+                copystring(BIGSTRING("\110Can't use status bar verbs because GUI is not available in headless mode"), bserror);
             return false;
         case stav_setsections:
             /* statusbar.setsections - error stub */
             if (bserror)
-                copystring(BIGSTRING("\pCan't use status bar verbs because GUI is not available in headless mode"), bserror);
+                copystring(BIGSTRING("\110Can't use status bar verbs because GUI is not available in headless mode"), bserror);
             return false;
         case stav_getsections:
             /* statusbar.getsections - error stub */
             if (bserror)
-                copystring(BIGSTRING("\pCan't use status bar verbs because GUI is not available in headless mode"), bserror);
+                copystring(BIGSTRING("\110Can't use status bar verbs because GUI is not available in headless mode"), bserror);
             return false;
         case stav_getsectionone:
             /* statusbar.getsectionone - error stub */
             if (bserror)
-                copystring(BIGSTRING("\pCan't use status bar verbs because GUI is not available in headless mode"), bserror);
+                copystring(BIGSTRING("\110Can't use status bar verbs because GUI is not available in headless mode"), bserror);
             return false;
         case stav_getmessage:
             /* statusbar.getmessage - error stub */
             if (bserror)
-                copystring(BIGSTRING("\pCan't use status bar verbs because GUI is not available in headless mode"), bserror);
+                copystring(BIGSTRING("\110Can't use status bar verbs because GUI is not available in headless mode"), bserror);
             return false;
         default:
             return false;
@@ -67,7 +67,7 @@ boolean statusbarinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pstatusbar"), bsname);
+    copystring(BIGSTRING("\011statusbar"), bsname);
 
     if (!newfunctionprocessor(bsname, &statusbar_valueproc, false, &htable))
         return false;
@@ -83,11 +83,11 @@ boolean statusbarinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pmsg"), stav_msg);
-    ADD_VERB(BIGSTRING("\psetsections"), stav_setsections);
-    ADD_VERB(BIGSTRING("\pgetsections"), stav_getsections);
-    ADD_VERB(BIGSTRING("\pgetsectionone"), stav_getsectionone);
-    ADD_VERB(BIGSTRING("\pgetmessage"), stav_getmessage);
+    ADD_VERB(BIGSTRING("\003msg"), stav_msg);
+    ADD_VERB(BIGSTRING("\013setsections"), stav_setsections);
+    ADD_VERB(BIGSTRING("\013getsections"), stav_getsections);
+    ADD_VERB(BIGSTRING("\015getsectionone"), stav_getsectionone);
+    ADD_VERB(BIGSTRING("\012getmessage"), stav_getmessage);
 
     #undef ADD_VERB
 

--- a/tests/headless_string_verbs.c
+++ b/tests/headless_string_verbs.c
@@ -214,8 +214,8 @@ boolean stringinitverbs(void) {
 	ADD_VERB(BIGSTRING("\011urlencode"), urlencodefunc);
 	ADD_VERB(BIGSTRING("\015parsehttpargs"), parseargsfunc);
 	ADD_VERB(BIGSTRING("\015iso8859encode"), iso8859encodefunc);
-	ADD_VERB(BIGSTRING("\020getgifheightwidth"), getgifheightwidthfunc);
-	ADD_VERB(BIGSTRING("\021getjpegheightwidth"), getjpegheightwidthfunc);
+	ADD_VERB(BIGSTRING("\021getgifheightwidth"), getgifheightwidthfunc);
+	ADD_VERB(BIGSTRING("\022getjpegheightwidth"), getjpegheightwidthfunc);
 	ADD_VERB(BIGSTRING("\004wrap"), wrapfunc);
 	ADD_VERB(BIGSTRING("\017davenetmassager"), davenetmassagerfunc);
 	ADD_VERB(BIGSTRING("\014parseaddress"), parseaddressfunc);

--- a/tests/headless_string_verbs.c
+++ b/tests/headless_string_verbs.c
@@ -194,7 +194,7 @@ boolean stringinitverbs(void) {
 	ADD_VERB(BIGSTRING("\007nthword"), nthwordfunc);
 	ADD_VERB(BIGSTRING("\012countwords"), countwordsfunc);
 	ADD_VERB(BIGSTRING("\015commentdelete"), commentdeletefunc);
-	ADD_VERB(BIGSTRING("\016firstsentence"), firstsentencefunc);
+	ADD_VERB(BIGSTRING("\015firstsentence"), firstsentencefunc);
 	ADD_VERB(BIGSTRING("\014patternmatch"), patternmatchfunc);
 	ADD_VERB(BIGSTRING("\003hex"), hexfunc);
 	ADD_VERB(BIGSTRING("\012timestring"), timestringfunc);
@@ -208,11 +208,11 @@ boolean stringinitverbs(void) {
 	ADD_VERB(BIGSTRING("\006length"), lengthfunc);
 	ADD_VERB(BIGSTRING("\007isalpha"), isalphafunc);
 	ADD_VERB(BIGSTRING("\011isnumeric"), isnumericfunc);
-	ADD_VERB(BIGSTRING("\016ispunctuation"), ispunctuationfunc);
-	ADD_VERB(BIGSTRING("\020processhtmlmacros"), processmacrosfunc);
+	ADD_VERB(BIGSTRING("\015ispunctuation"), ispunctuationfunc);
+	ADD_VERB(BIGSTRING("\021processhtmlmacros"), processmacrosfunc);
 	ADD_VERB(BIGSTRING("\011urldecode"), urldecodefunc);
 	ADD_VERB(BIGSTRING("\011urlencode"), urlencodefunc);
-	ADD_VERB(BIGSTRING("\016parsehttpargs"), parseargsfunc);
+	ADD_VERB(BIGSTRING("\015parsehttpargs"), parseargsfunc);
 	ADD_VERB(BIGSTRING("\015iso8859encode"), iso8859encodefunc);
 	ADD_VERB(BIGSTRING("\020getgifheightwidth"), getgifheightwidthfunc);
 	ADD_VERB(BIGSTRING("\021getjpegheightwidth"), getjpegheightwidthfunc);
@@ -231,7 +231,7 @@ boolean stringinitverbs(void) {
 	ADD_VERB(BIGSTRING("\012utf8toansi"), utf8toansifunc);
 	ADD_VERB(BIGSTRING("\012ansitoutf8"), ansitoutf8func);
 	ADD_VERB(BIGSTRING("\013ansitoutf16"), ansitoutf16func);
-	ADD_VERB(BIGSTRING("\021multiplereplaceall"), multiplereplaceallfunc);
+	ADD_VERB(BIGSTRING("\022multiplereplaceall"), multiplereplaceallfunc);
 	ADD_VERB(BIGSTRING("\016macromantoutf8"), macromantoutf8func);
 	ADD_VERB(BIGSTRING("\016utf8tomacroman"), utf8tomacromanfunc);
 	ADD_VERB(BIGSTRING("\016convertcharset"), convertcharsetfunc);

--- a/tests/headless_sys_verbs.c
+++ b/tests/headless_sys_verbs.c
@@ -82,7 +82,7 @@ static boolean shellescapestring(bigstring input, Handle *hescaped) {
     for (i = 1; i <= stringlength(input); i++) {
         if (input[i] == '\'') {
             /* Close quote, add escaped quote, reopen quote: '\'' */
-            if (!pushtexthandle(BIGSTRING("\005'\\''"), h)) {
+            if (!pushtexthandle(BIGSTRING("\004'\\''"), h)) {
                 disposehandle(h);
                 return false;
             }

--- a/tests/headless_sys_verbs.c
+++ b/tests/headless_sys_verbs.c
@@ -75,14 +75,14 @@ static boolean shellescapestring(bigstring input, Handle *hescaped) {
     Handle h;
     short i;
 
-    if (!newtexthandle(BIGSTRING("\p'"), &h))
+    if (!newtexthandle(BIGSTRING("\001'"), &h))
         return false;
 
     /* Escape each single quote as '\'' and copy other chars verbatim */
     for (i = 1; i <= stringlength(input); i++) {
         if (input[i] == '\'') {
             /* Close quote, add escaped quote, reopen quote: '\'' */
-            if (!pushtexthandle(BIGSTRING("\p'\\''"), h)) {
+            if (!pushtexthandle(BIGSTRING("\005'\\''"), h)) {
                 disposehandle(h);
                 return false;
             }
@@ -99,7 +99,7 @@ static boolean shellescapestring(bigstring input, Handle *hescaped) {
     }
 
     /* Close final quote */
-    if (!pushtexthandle(BIGSTRING("\p'"), h)) {
+    if (!pushtexthandle(BIGSTRING("\001'"), h)) {
         disposehandle(h);
         return false;
     }
@@ -121,7 +121,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
 
             #ifdef __APPLE__
             /* macOS: Use sw_vers -productVersion */
-            if (!newtexthandle(BIGSTRING("\psw_vers -productVersion"), &hcommand))
+            if (!newtexthandle(BIGSTRING("\027sw_vers -productVersion"), &hcommand))
                 return false;
             #else
             /* Linux: Try to get distribution name and version, fall back to uname -r */
@@ -189,7 +189,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
              * Single quotes prevent all shell interpretation
              * Exit code 0 = process found, non-zero = not found
              */
-            if (!newtexthandle(BIGSTRING("\ppgrep -x "), &hcommand)) {
+            if (!newtexthandle(BIGSTRING("\011pgrep -x "), &hcommand)) {
                 disposehandle(hescaped);
                 return false;
             }
@@ -201,7 +201,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
             }
             disposehandle(hescaped);
 
-            if (!pushtexthandle(BIGSTRING("\p > /dev/null 2>&1"), hcommand)) {
+            if (!pushtexthandle(BIGSTRING("\021 > /dev/null 2>&1"), hcommand)) {
                 disposehandle(hcommand);
                 return false;
             }
@@ -251,7 +251,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
                 return false;
 
             /* Build command: ps aux | tail -n +2 | wc -l (skip header line) */
-            if (!newtexthandle(BIGSTRING("\pps aux | tail -n +2 | wc -l"), &hcommand))
+            if (!newtexthandle(BIGSTRING("\033ps aux | tail -n +2 | wc -l"), &hcommand))
                 return false;
 
             newemptyhandle(&houtput);
@@ -312,7 +312,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
             if (!getstringvalue(hparam1, 1, appname))
                 return false;
 
-            copystring(BIGSTRING("\psys.getAppPath is not implemented on this platform"), bserror);
+            copystring(BIGSTRING("\062sys.getAppPath is not implemented on this platform"), bserror);
 
             return false;
             }
@@ -331,7 +331,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
                 return false;
 
             /* Use uname -m to get machine architecture */
-            if (!newtexthandle(BIGSTRING("\puname -m"), &hcommand))
+            if (!newtexthandle(BIGSTRING("\010uname -m"), &hcommand))
                 return false;
 
             newemptyhandle(&hmachine);
@@ -356,13 +356,13 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
                 return false;
 
             #ifdef __APPLE__
-            return setstringvalue(BIGSTRING("\pMacOS"), vreturned);
+            return setstringvalue(BIGSTRING("\005MacOS"), vreturned);
             #elif defined(_WIN32)
-            return setstringvalue(BIGSTRING("\pWindows"), vreturned);
+            return setstringvalue(BIGSTRING("\007Windows"), vreturned);
             #elif defined(__linux__)
-            return setstringvalue(BIGSTRING("\pLinux"), vreturned);
+            return setstringvalue(BIGSTRING("\005Linux"), vreturned);
             #else
-            return setstringvalue(BIGSTRING("\pUnknown"), vreturned);
+            return setstringvalue(BIGSTRING("\007Unknown"), vreturned);
             #endif
         case sysv_getenvironmentvariable: {
             /* @IMPLEMENTED sys.getenvironmentvariable(name) - Get environment variable value
@@ -446,7 +446,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
             #else
             if (setenv(cvarname, cvarvalue, 1) != 0) {
             #endif
-                langerrormessage(BIGSTRING("\pCan't set environment variable because system call failed"));
+                langerrormessage(BIGSTRING("\071Can't set environment variable because system call failed"));
                 return false;
             }
 
@@ -601,7 +601,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
                 return (setbooleanvalue (true, vreturned));
             }
             else {
-                langparamerror (unimplementedverberror, BIGSTRING("\ptoo many parameters"));
+                langparamerror (unimplementedverberror, BIGSTRING("\023too many parameters"));
                 return (false);
             }
             }
@@ -614,7 +614,7 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
 
             /* Don't dispose hcommand — exempted handles are managed by heap/hashtable */
 
-            copystring(BIGSTRING("\psys.winShellCommand is not implemented on this platform"), bserror);
+            copystring(BIGSTRING("\067sys.winShellCommand is not implemented on this platform"), bserror);
 
             return false;
             }
@@ -627,7 +627,7 @@ boolean sysinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\psys"), bsname);
+    copystring(BIGSTRING("\003sys"), bsname);
 
     if (!newfunctionprocessor(bsname, &sys_valueproc, false, &htable))
         return false;
@@ -643,22 +643,22 @@ boolean sysinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\posversion"), sysv_osversion);
-    ADD_VERB(BIGSTRING("\psystemtask"), sysv_systemtask);
-    ADD_VERB(BIGSTRING("\pbrowsenetwork"), sysv_browsenetwork);
-    ADD_VERB(BIGSTRING("\pappisrunning"), sysv_appisrunning);
-    ADD_VERB(BIGSTRING("\pfrontmostapp"), sysv_frontmostapp);
-    ADD_VERB(BIGSTRING("\pbringapptofront"), sysv_bringapptofront);
-    ADD_VERB(BIGSTRING("\pcountapps"), sysv_countapps);
-    ADD_VERB(BIGSTRING("\pgetnthapp"), sysv_getnthapp);
-    ADD_VERB(BIGSTRING("\pgetapppath"), sysv_getapppath);
-    ADD_VERB(BIGSTRING("\pmemavail"), sysv_memavail);
-    ADD_VERB(BIGSTRING("\pmachine"), sysv_machine);
-    ADD_VERB(BIGSTRING("\pos"), sysv_os);
-    ADD_VERB(BIGSTRING("\pgetenvironmentvariable"), sysv_getenvironmentvariable);
-    ADD_VERB(BIGSTRING("\psetenvironmentvariable"), sysv_setenvironmentvariable);
-    ADD_VERB(BIGSTRING("\punixshellcommand"), sysv_unixshellcommand);
-    ADD_VERB(BIGSTRING("\pwinshellcommand"), sysv_winshellcommand);
+    ADD_VERB(BIGSTRING("\011osversion"), sysv_osversion);
+    ADD_VERB(BIGSTRING("\012systemtask"), sysv_systemtask);
+    ADD_VERB(BIGSTRING("\015browsenetwork"), sysv_browsenetwork);
+    ADD_VERB(BIGSTRING("\014appisrunning"), sysv_appisrunning);
+    ADD_VERB(BIGSTRING("\014frontmostapp"), sysv_frontmostapp);
+    ADD_VERB(BIGSTRING("\017bringapptofront"), sysv_bringapptofront);
+    ADD_VERB(BIGSTRING("\011countapps"), sysv_countapps);
+    ADD_VERB(BIGSTRING("\011getnthapp"), sysv_getnthapp);
+    ADD_VERB(BIGSTRING("\012getapppath"), sysv_getapppath);
+    ADD_VERB(BIGSTRING("\010memavail"), sysv_memavail);
+    ADD_VERB(BIGSTRING("\007machine"), sysv_machine);
+    ADD_VERB(BIGSTRING("\002os"), sysv_os);
+    ADD_VERB(BIGSTRING("\026getenvironmentvariable"), sysv_getenvironmentvariable);
+    ADD_VERB(BIGSTRING("\026setenvironmentvariable"), sysv_setenvironmentvariable);
+    ADD_VERB(BIGSTRING("\020unixshellcommand"), sysv_unixshellcommand);
+    ADD_VERB(BIGSTRING("\017winshellcommand"), sysv_winshellcommand);
 
     #undef ADD_VERB
 

--- a/tests/headless_target_verbs.c
+++ b/tests/headless_target_verbs.c
@@ -48,7 +48,7 @@ boolean targetinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\ptarget"), bsname);
+    copystring(BIGSTRING("\006target"), bsname);
 
     if (!newfunctionprocessor(bsname, &target_valueproc, false, &htable))
         return false;
@@ -64,9 +64,9 @@ boolean targetinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pget"), tarv_get);
-    ADD_VERB(BIGSTRING("\pset"), tarv_set);
-    ADD_VERB(BIGSTRING("\pclear"), tarv_clear);
+    ADD_VERB(BIGSTRING("\003get"), tarv_get);
+    ADD_VERB(BIGSTRING("\003set"), tarv_set);
+    ADD_VERB(BIGSTRING("\005clear"), tarv_clear);
 
     #undef ADD_VERB
 

--- a/tests/headless_tcp_verbs.c
+++ b/tests/headless_tcp_verbs.c
@@ -266,7 +266,7 @@ static boolean tcp_valueproc(short token, hdltreenode hparam1,
 
             /* Extract hash table and script name from address */
             if (!getaddressvalue(vcallback, &callback_htable, callback_name)) {
-                if (bserror) copystring(BIGSTRING("\pCan't resolve callback address"), bserror);
+                if (bserror) copystring(BIGSTRING("\036Can't resolve callback address"), bserror);
                 return false;
             }
 
@@ -573,7 +573,7 @@ boolean tcpinitverbs(void) {
     if (!tcp_init_context())
         return false;
 
-    copystring(BIGSTRING("\ptcp"), bsname);
+    copystring(BIGSTRING("\003tcp"), bsname);
 
     if (!newfunctionprocessor(bsname, &tcp_valueproc, false, &htable))
         return false;
@@ -589,29 +589,29 @@ boolean tcpinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\paddressdecode"), tcpv_addressdecode);
-    ADD_VERB(BIGSTRING("\paddressencode"), tcpv_addressencode);
-    ADD_VERB(BIGSTRING("\paddresstoname"), tcpv_addresstoname);
-    ADD_VERB(BIGSTRING("\pnametoaddress"), tcpv_nametoaddress);
-    ADD_VERB(BIGSTRING("\pmyaddress"), tcpv_myaddress);
-    ADD_VERB(BIGSTRING("\pabortstream"), tcpv_abortstream);
-    ADD_VERB(BIGSTRING("\pclosestream"), tcpv_closestream);
-    ADD_VERB(BIGSTRING("\pcloselisten"), tcpv_closelisten);
-    ADD_VERB(BIGSTRING("\popenaddrstream"), tcpv_openaddrstream);
-    ADD_VERB(BIGSTRING("\popennamestream"), tcpv_opennamestream);
-    ADD_VERB(BIGSTRING("\preadstream"), tcpv_readstream);
-    ADD_VERB(BIGSTRING("\pwritestream"), tcpv_writestream);
-    ADD_VERB(BIGSTRING("\plistenstream"), tcpv_listenstream);
-    ADD_VERB(BIGSTRING("\pstatusstream"), tcpv_statusstream);
-    ADD_VERB(BIGSTRING("\pgetpeeraddress"), tcpv_getpeeraddress);
-    ADD_VERB(BIGSTRING("\pgetpeerport"), tcpv_getpeerport);
-    ADD_VERB(BIGSTRING("\pwritestringtostream"), tcpv_writestringtostream);
-    ADD_VERB(BIGSTRING("\pwritefiletostream"), tcpv_writefiletostream);
-    ADD_VERB(BIGSTRING("\preadstreamuntil"), tcpv_readstreamuntil);
-    ADD_VERB(BIGSTRING("\preadstreambytes"), tcpv_readstreambytes);
-    ADD_VERB(BIGSTRING("\preadstreamuntilclosed"), tcpv_readstreamuntilclosed);
-    ADD_VERB(BIGSTRING("\pgetstats"), tcpv_getstats);
-    ADD_VERB(BIGSTRING("\pcountconnections"), tcpv_countconnections);
+    ADD_VERB(BIGSTRING("\015addressdecode"), tcpv_addressdecode);
+    ADD_VERB(BIGSTRING("\015addressencode"), tcpv_addressencode);
+    ADD_VERB(BIGSTRING("\015addresstoname"), tcpv_addresstoname);
+    ADD_VERB(BIGSTRING("\015nametoaddress"), tcpv_nametoaddress);
+    ADD_VERB(BIGSTRING("\011myaddress"), tcpv_myaddress);
+    ADD_VERB(BIGSTRING("\013abortstream"), tcpv_abortstream);
+    ADD_VERB(BIGSTRING("\013closestream"), tcpv_closestream);
+    ADD_VERB(BIGSTRING("\013closelisten"), tcpv_closelisten);
+    ADD_VERB(BIGSTRING("\016openaddrstream"), tcpv_openaddrstream);
+    ADD_VERB(BIGSTRING("\016opennamestream"), tcpv_opennamestream);
+    ADD_VERB(BIGSTRING("\012readstream"), tcpv_readstream);
+    ADD_VERB(BIGSTRING("\013writestream"), tcpv_writestream);
+    ADD_VERB(BIGSTRING("\014listenstream"), tcpv_listenstream);
+    ADD_VERB(BIGSTRING("\014statusstream"), tcpv_statusstream);
+    ADD_VERB(BIGSTRING("\016getpeeraddress"), tcpv_getpeeraddress);
+    ADD_VERB(BIGSTRING("\013getpeerport"), tcpv_getpeerport);
+    ADD_VERB(BIGSTRING("\023writestringtostream"), tcpv_writestringtostream);
+    ADD_VERB(BIGSTRING("\021writefiletostream"), tcpv_writefiletostream);
+    ADD_VERB(BIGSTRING("\017readstreamuntil"), tcpv_readstreamuntil);
+    ADD_VERB(BIGSTRING("\017readstreambytes"), tcpv_readstreambytes);
+    ADD_VERB(BIGSTRING("\025readstreamuntilclosed"), tcpv_readstreamuntilclosed);
+    ADD_VERB(BIGSTRING("\010getstats"), tcpv_getstats);
+    ADD_VERB(BIGSTRING("\020countconnections"), tcpv_countconnections);
 
     #undef ADD_VERB
 

--- a/tests/headless_thread_verbs.c
+++ b/tests/headless_thread_verbs.c
@@ -600,7 +600,7 @@ static boolean headless_thread_evaluate(bigstring bscode, tyvaluerecord *vreturn
     (**new_hglobals).hcurrenthashtable = currenthashtable;
 
     /* Register in system.compiler.threads (calling thread context) */
-    copystring(BIGSTRING("\panonymous"), bsanon);
+    copystring(BIGSTRING("\011anonymous"), bsanon);
     headless_register_thread(bsanon, threadid);
 
     /* Package launch parameters */
@@ -1020,7 +1020,7 @@ static boolean thread_valueproc(short token, hdltreenode hparam1,
         case thrv_sleep:
             /* Verb #6: thread.sleep - not yet implemented */
             log_warn(LOG_COMP_LANG, "thread.sleep not yet implemented");
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case thrv_sleepfor: {
             /* Verb #7: thread.sleepfor - Sleep for N seconds via registry */
@@ -1136,27 +1136,27 @@ static boolean thread_valueproc(short token, hdltreenode hparam1,
         case thrv_gettimeslice:
             /* Verb #12: thread.gettimeslice - not yet implemented */
             log_warn(LOG_COMP_LANG, "thread.gettimeslice not yet implemented");
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case thrv_settimeslice:
             /* Verb #13: thread.settimeslice - not yet implemented */
             log_warn(LOG_COMP_LANG, "thread.settimeslice not yet implemented");
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case thrv_getdefaulttimeslice:
             /* Verb #14: thread.getdefaulttimeslice - not yet implemented */
             log_warn(LOG_COMP_LANG, "thread.getdefaulttimeslice not yet implemented");
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case thrv_setdefaulttimeslice:
             /* Verb #15: thread.setdefaulttimeslice - not yet implemented */
             log_warn(LOG_COMP_LANG, "thread.setdefaulttimeslice not yet implemented");
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case thrv_getstats:
             /* Verb #16: thread.getstats - not yet implemented */
             log_warn(LOG_COMP_LANG, "thread.getstats not yet implemented");
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -1167,7 +1167,7 @@ boolean threadinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pthread"), bsname);
+    copystring(BIGSTRING("\006thread"), bsname);
 
     if (!newfunctionprocessor(bsname, &thread_valueproc, false, &htable))
         return false;
@@ -1183,23 +1183,23 @@ boolean threadinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pexists"), thrv_exists);
-    ADD_VERB(BIGSTRING("\pevaluate"), thrv_evaluate);
-    ADD_VERB(BIGSTRING("\pcallscript"), thrv_callscript);
-    ADD_VERB(BIGSTRING("\pgetcurrentid"), thrv_getcurrentid);
-    ADD_VERB(BIGSTRING("\pgetcount"), thrv_getcount);
-    ADD_VERB(BIGSTRING("\pgetnthid"), thrv_getnthid);
-    ADD_VERB(BIGSTRING("\psleep"), thrv_sleep);
-    ADD_VERB(BIGSTRING("\psleepfor"), thrv_sleepfor);
-    ADD_VERB(BIGSTRING("\psleepticks"), thrv_sleepticks);
-    ADD_VERB(BIGSTRING("\pissleeping"), thrv_issleeping);
-    ADD_VERB(BIGSTRING("\pwake"), thrv_wake);
-    ADD_VERB(BIGSTRING("\pkill"), thrv_kill);
-    ADD_VERB(BIGSTRING("\pgettimeslice"), thrv_gettimeslice);
-    ADD_VERB(BIGSTRING("\psettimeslice"), thrv_settimeslice);
-    ADD_VERB(BIGSTRING("\pgetdefaulttimeslice"), thrv_getdefaulttimeslice);
-    ADD_VERB(BIGSTRING("\psetdefaulttimeslice"), thrv_setdefaulttimeslice);
-    ADD_VERB(BIGSTRING("\pgetstats"), thrv_getstats);
+    ADD_VERB(BIGSTRING("\006exists"), thrv_exists);
+    ADD_VERB(BIGSTRING("\010evaluate"), thrv_evaluate);
+    ADD_VERB(BIGSTRING("\012callscript"), thrv_callscript);
+    ADD_VERB(BIGSTRING("\014getcurrentid"), thrv_getcurrentid);
+    ADD_VERB(BIGSTRING("\010getcount"), thrv_getcount);
+    ADD_VERB(BIGSTRING("\010getnthid"), thrv_getnthid);
+    ADD_VERB(BIGSTRING("\005sleep"), thrv_sleep);
+    ADD_VERB(BIGSTRING("\010sleepfor"), thrv_sleepfor);
+    ADD_VERB(BIGSTRING("\012sleepticks"), thrv_sleepticks);
+    ADD_VERB(BIGSTRING("\012issleeping"), thrv_issleeping);
+    ADD_VERB(BIGSTRING("\004wake"), thrv_wake);
+    ADD_VERB(BIGSTRING("\004kill"), thrv_kill);
+    ADD_VERB(BIGSTRING("\014gettimeslice"), thrv_gettimeslice);
+    ADD_VERB(BIGSTRING("\014settimeslice"), thrv_settimeslice);
+    ADD_VERB(BIGSTRING("\023getdefaulttimeslice"), thrv_getdefaulttimeslice);
+    ADD_VERB(BIGSTRING("\023setdefaulttimeslice"), thrv_setdefaulttimeslice);
+    ADD_VERB(BIGSTRING("\010getstats"), thrv_getstats);
 
     #undef ADD_VERB
 

--- a/tests/headless_webserver_verbs.c
+++ b/tests/headless_webserver_verbs.c
@@ -116,7 +116,7 @@ static boolean webserver_valueproc(short token, hdltreenode hparam1,
 
             initvalue(&vadrtable, addressvaluetype);
 
-            if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\padrHeaderTable"), &vadrtable))
+            if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\016adrHeaderTable"), &vadrtable))
                 return false;
 
             if (vadrtable.data.addressvalue != nil) {
@@ -136,7 +136,7 @@ static boolean webserver_valueproc(short token, hdltreenode hparam1,
 
             flnextparamislast = true;
 
-            if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\presponseBody"), &vresponse))
+            if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\014responseBody"), &vresponse))
                 return false;
 
             return webserverbuildresponse(bscode, hheadertable, vresponse.data.stringvalue, vreturned);
@@ -179,7 +179,7 @@ boolean webserverinitverbs(void) {
 
     log_debug(LOG_COMP_LANG, "webserverinitverbs: registering webserver EFP");
 
-    copystring(BIGSTRING("\pwebserver"), bsname);
+    copystring(BIGSTRING("\011webserver"), bsname);
 
     if (!newfunctionprocessor(bsname, &webserver_valueproc, false, &htable)) {
         log_error(LOG_COMP_LANG, "webserverinitverbs: newfunctionprocessor failed");
@@ -197,13 +197,13 @@ boolean webserverinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pserver"), webv_server);
-    ADD_VERB(BIGSTRING("\pdispatch"), webv_dispatch);
-    ADD_VERB(BIGSTRING("\pparseheaders"), webv_parseheaders);
-    ADD_VERB(BIGSTRING("\pparsecookies"), webv_parsecookies);
-    ADD_VERB(BIGSTRING("\pbuildresponse"), webv_buildresponse);
-    ADD_VERB(BIGSTRING("\pbuilderrorpage"), webv_builderrorpage);
-    ADD_VERB(BIGSTRING("\pgetserverstring"), webv_getserverstring);
+    ADD_VERB(BIGSTRING("\006server"), webv_server);
+    ADD_VERB(BIGSTRING("\010dispatch"), webv_dispatch);
+    ADD_VERB(BIGSTRING("\014parseheaders"), webv_parseheaders);
+    ADD_VERB(BIGSTRING("\014parsecookies"), webv_parsecookies);
+    ADD_VERB(BIGSTRING("\015buildresponse"), webv_buildresponse);
+    ADD_VERB(BIGSTRING("\016builderrorpage"), webv_builderrorpage);
+    ADD_VERB(BIGSTRING("\017getserverstring"), webv_getserverstring);
 
     #undef ADD_VERB
 

--- a/tests/headless_window_verbs.c
+++ b/tests/headless_window_verbs.c
@@ -259,26 +259,26 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
         }
         case winv_open:
             /* Verb: window.open - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_isfront:
             /* Verb: window.isfront - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_bringtofront:
             /* Verb: window.bringtofront - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_sendtoback:
             /* Verb: window.sendtoback - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_frontmost:
             /* window.frontmost - no-op in headless mode, returns empty string */
             return setstringvalue(BIGSTRING("\x00"), vreturned);
         case winv_next:
             /* Verb: window.next - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_isvisible: {
             /* window.isVisible(title) - always false in headless mode */
@@ -303,7 +303,7 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
         }
         case winv_close:
             /* Verb: window.close - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_update:
             /* window.update - no-op in headless mode (no GUI to update) */
@@ -311,7 +311,7 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
             return true;
         case winv_ismenuscript:
             /* Verb: window.ismenuscript - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_getposition: {
             /* window.getPosition(title, horizAddr, vertAddr)
@@ -395,15 +395,15 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
         }
         case winv_zoom:
             /* Verb: window.zoom - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_runselection:
             /* Verb: window.runselection - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_scroll:
             /* Verb: window.scroll - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_msg:
             /* window.msg - no-op in headless mode (no status bar) */
@@ -412,19 +412,19 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
         case winv_dbstats:
             /* window.dbstats - error stub */
             if (bserror)
-                copystring(BIGSTRING("\pCan't use window verbs because GUI is not available in headless mode"), bserror);
+                copystring(BIGSTRING("\104Can't use window verbs because GUI is not available in headless mode"), bserror);
             return false;
         case winv_quickscript:
             /* Verb: window.quickscript - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_ismodified:
             /* Verb: window.ismodified - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_setmodified:
             /* Verb: window.setmodified - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_gettitle: {
             /* window.getTitle(adr)
@@ -474,15 +474,15 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
             return true;
         case winv_getfile:
             /* Verb: window.getfile - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_isreadonly:
             /* Verb: window.isreadonly - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         case winv_setquickscript:
             /* Verb: window.setquickscript - not yet implemented */
-            if (bserror) copystring(BIGSTRING("\pnot implemented"), bserror);
+            if (bserror) copystring(BIGSTRING("\017not implemented"), bserror);
             return false;
         default:
             return false;
@@ -493,7 +493,7 @@ boolean windowinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pwindow"), bsname);
+    copystring(BIGSTRING("\006window"), bsname);
 
     if (!newfunctionprocessor(bsname, &window_valueproc, false, &htable))
         return false;
@@ -509,37 +509,37 @@ boolean windowinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pisopen"), winv_isopen);
-    ADD_VERB(BIGSTRING("\popen"), winv_open);
-    ADD_VERB(BIGSTRING("\pisfront"), winv_isfront);
-    ADD_VERB(BIGSTRING("\pbringtofront"), winv_bringtofront);
-    ADD_VERB(BIGSTRING("\psendtoback"), winv_sendtoback);
-    ADD_VERB(BIGSTRING("\pfrontmost"), winv_frontmost);
-    ADD_VERB(BIGSTRING("\pnext"), winv_next);
-    ADD_VERB(BIGSTRING("\pisvisible"), winv_isvisible);
-    ADD_VERB(BIGSTRING("\pshow"), winv_show);
-    ADD_VERB(BIGSTRING("\phide"), winv_hide);
-    ADD_VERB(BIGSTRING("\pclose"), winv_close);
-    ADD_VERB(BIGSTRING("\pupdate"), winv_update);
-    ADD_VERB(BIGSTRING("\pismenuscript"), winv_ismenuscript);
-    ADD_VERB(BIGSTRING("\pgetposition"), winv_getposition);
-    ADD_VERB(BIGSTRING("\psetposition"), winv_setposition);
-    ADD_VERB(BIGSTRING("\pgetsize"), winv_getsize);
-    ADD_VERB(BIGSTRING("\psetsize"), winv_setsize);
-    ADD_VERB(BIGSTRING("\pzoom"), winv_zoom);
-    ADD_VERB(BIGSTRING("\prunselection"), winv_runselection);
-    ADD_VERB(BIGSTRING("\pscroll"), winv_scroll);
-    ADD_VERB(BIGSTRING("\pmsg"), winv_msg);
-    ADD_VERB(BIGSTRING("\pdbstats"), winv_dbstats);
-    ADD_VERB(BIGSTRING("\pquickscript"), winv_quickscript);
-    ADD_VERB(BIGSTRING("\pismodified"), winv_ismodified);
-    ADD_VERB(BIGSTRING("\psetmodified"), winv_setmodified);
-    ADD_VERB(BIGSTRING("\pgettitle"), winv_gettitle);
-    ADD_VERB(BIGSTRING("\psettitle"), winv_settitle);
-    ADD_VERB(BIGSTRING("\pabout"), winv_about);
-    ADD_VERB(BIGSTRING("\pgetfile"), winv_getfile);
-    ADD_VERB(BIGSTRING("\pisreadonly"), winv_isreadonly);
-    ADD_VERB(BIGSTRING("\psetquickscript"), winv_setquickscript);
+    ADD_VERB(BIGSTRING("\006isopen"), winv_isopen);
+    ADD_VERB(BIGSTRING("\004open"), winv_open);
+    ADD_VERB(BIGSTRING("\007isfront"), winv_isfront);
+    ADD_VERB(BIGSTRING("\014bringtofront"), winv_bringtofront);
+    ADD_VERB(BIGSTRING("\012sendtoback"), winv_sendtoback);
+    ADD_VERB(BIGSTRING("\011frontmost"), winv_frontmost);
+    ADD_VERB(BIGSTRING("\004next"), winv_next);
+    ADD_VERB(BIGSTRING("\011isvisible"), winv_isvisible);
+    ADD_VERB(BIGSTRING("\004show"), winv_show);
+    ADD_VERB(BIGSTRING("\004hide"), winv_hide);
+    ADD_VERB(BIGSTRING("\005close"), winv_close);
+    ADD_VERB(BIGSTRING("\006update"), winv_update);
+    ADD_VERB(BIGSTRING("\014ismenuscript"), winv_ismenuscript);
+    ADD_VERB(BIGSTRING("\013getposition"), winv_getposition);
+    ADD_VERB(BIGSTRING("\013setposition"), winv_setposition);
+    ADD_VERB(BIGSTRING("\007getsize"), winv_getsize);
+    ADD_VERB(BIGSTRING("\007setsize"), winv_setsize);
+    ADD_VERB(BIGSTRING("\004zoom"), winv_zoom);
+    ADD_VERB(BIGSTRING("\014runselection"), winv_runselection);
+    ADD_VERB(BIGSTRING("\006scroll"), winv_scroll);
+    ADD_VERB(BIGSTRING("\003msg"), winv_msg);
+    ADD_VERB(BIGSTRING("\007dbstats"), winv_dbstats);
+    ADD_VERB(BIGSTRING("\013quickscript"), winv_quickscript);
+    ADD_VERB(BIGSTRING("\012ismodified"), winv_ismodified);
+    ADD_VERB(BIGSTRING("\013setmodified"), winv_setmodified);
+    ADD_VERB(BIGSTRING("\010gettitle"), winv_gettitle);
+    ADD_VERB(BIGSTRING("\010settitle"), winv_settitle);
+    ADD_VERB(BIGSTRING("\005about"), winv_about);
+    ADD_VERB(BIGSTRING("\007getfile"), winv_getfile);
+    ADD_VERB(BIGSTRING("\012isreadonly"), winv_isreadonly);
+    ADD_VERB(BIGSTRING("\016setquickscript"), winv_setquickscript);
 
     #undef ADD_VERB
 

--- a/tests/headless_wp_verbs.c
+++ b/tests/headless_wp_verbs.c
@@ -303,7 +303,7 @@ boolean wpinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pwp"), bsname);
+    copystring(BIGSTRING("\002wp"), bsname);
 
     if (!newfunctionprocessor(bsname, &wp_valueproc, true, &htable))
         return false;
@@ -317,33 +317,33 @@ boolean wpinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\pintextmode"), wpv_intextmode);
-    ADD_VERB(BIGSTRING("\psettextmode"), wpv_settextmode);
-    ADD_VERB(BIGSTRING("\pgettext"), wpv_gettext);
-    ADD_VERB(BIGSTRING("\psettext"), wpv_settext);
-    ADD_VERB(BIGSTRING("\pgetseltext"), wpv_getseltext);
-    ADD_VERB(BIGSTRING("\pgetdisplay"), wpv_getdisplay);
-    ADD_VERB(BIGSTRING("\psetdisplay"), wpv_setdisplay);
-    ADD_VERB(BIGSTRING("\pgetruler"), wpv_getruler);
-    ADD_VERB(BIGSTRING("\psetruler"), wpv_setruler);
-    ADD_VERB(BIGSTRING("\pgetindent"), wpv_getindent);
-    ADD_VERB(BIGSTRING("\psetindent"), wpv_setindent);
-    ADD_VERB(BIGSTRING("\pgetleftmargin"), wpv_getleftmargin);
-    ADD_VERB(BIGSTRING("\psetleftmargin"), wpv_setleftmargin);
-    ADD_VERB(BIGSTRING("\pgetrightmargin"), wpv_getrightmargin);
-    ADD_VERB(BIGSTRING("\psetrightmargin"), wpv_setrightmargin);
-    ADD_VERB(BIGSTRING("\psetspacing"), wpv_setspacing);
-    ADD_VERB(BIGSTRING("\psetjustification"), wpv_setjustification);
-    ADD_VERB(BIGSTRING("\psettab"), wpv_settab);
-    ADD_VERB(BIGSTRING("\pcleartabs"), wpv_cleartabs);
-    ADD_VERB(BIGSTRING("\pgetselect"), wpv_getselection);
-    ADD_VERB(BIGSTRING("\psetselect"), wpv_setselection);
-    ADD_VERB(BIGSTRING("\pinsert"), wpv_insert);
-    ADD_VERB(BIGSTRING("\prulerlength"), wpv_rulerlength);
-    ADD_VERB(BIGSTRING("\pgo"), wpv_go);
-    ADD_VERB(BIGSTRING("\pselectword"), wpv_selectword);
-    ADD_VERB(BIGSTRING("\pselectline"), wpv_selectline);
-    ADD_VERB(BIGSTRING("\pselectparagraph"), wpv_selectparagraph);
+    ADD_VERB(BIGSTRING("\012intextmode"), wpv_intextmode);
+    ADD_VERB(BIGSTRING("\013settextmode"), wpv_settextmode);
+    ADD_VERB(BIGSTRING("\007gettext"), wpv_gettext);
+    ADD_VERB(BIGSTRING("\007settext"), wpv_settext);
+    ADD_VERB(BIGSTRING("\012getseltext"), wpv_getseltext);
+    ADD_VERB(BIGSTRING("\012getdisplay"), wpv_getdisplay);
+    ADD_VERB(BIGSTRING("\012setdisplay"), wpv_setdisplay);
+    ADD_VERB(BIGSTRING("\010getruler"), wpv_getruler);
+    ADD_VERB(BIGSTRING("\010setruler"), wpv_setruler);
+    ADD_VERB(BIGSTRING("\011getindent"), wpv_getindent);
+    ADD_VERB(BIGSTRING("\011setindent"), wpv_setindent);
+    ADD_VERB(BIGSTRING("\015getleftmargin"), wpv_getleftmargin);
+    ADD_VERB(BIGSTRING("\015setleftmargin"), wpv_setleftmargin);
+    ADD_VERB(BIGSTRING("\016getrightmargin"), wpv_getrightmargin);
+    ADD_VERB(BIGSTRING("\016setrightmargin"), wpv_setrightmargin);
+    ADD_VERB(BIGSTRING("\012setspacing"), wpv_setspacing);
+    ADD_VERB(BIGSTRING("\020setjustification"), wpv_setjustification);
+    ADD_VERB(BIGSTRING("\006settab"), wpv_settab);
+    ADD_VERB(BIGSTRING("\011cleartabs"), wpv_cleartabs);
+    ADD_VERB(BIGSTRING("\011getselect"), wpv_getselection);
+    ADD_VERB(BIGSTRING("\011setselect"), wpv_setselection);
+    ADD_VERB(BIGSTRING("\006insert"), wpv_insert);
+    ADD_VERB(BIGSTRING("\013rulerlength"), wpv_rulerlength);
+    ADD_VERB(BIGSTRING("\002go"), wpv_go);
+    ADD_VERB(BIGSTRING("\012selectword"), wpv_selectword);
+    ADD_VERB(BIGSTRING("\012selectline"), wpv_selectline);
+    ADD_VERB(BIGSTRING("\017selectparagraph"), wpv_selectparagraph);
 
     #undef ADD_VERB
 

--- a/tests/headless_xml_verbs.c
+++ b/tests/headless_xml_verbs.c
@@ -363,7 +363,7 @@ static boolean xml_valueproc(short token, hdltreenode hparam1,
                 if (!tablevaltotable(val, &ht, hnode)) {
                     log_error(LOG_COMP_LANG, "xml.getaddresslist: tablevaltotable failed (not a table)");
                     if (!fllangerror) {
-                        copystring(BIGSTRING("\pCan't coerce the value because it's not a table"), bserror);
+                        copystring(BIGSTRING("\057Can't coerce the value because it's not a table"), bserror);
                         langerrormessage(bserror);
                     }
                     return false;
@@ -880,7 +880,7 @@ boolean xmlinitverbs(void) {
     hdlhashtable htable = nil;
     bigstring bsname;
 
-    copystring(BIGSTRING("\pxml"), bsname);
+    copystring(BIGSTRING("\003xml"), bsname);
 
     if (!newfunctionprocessor(bsname, &xml_valueproc, false, &htable))
         return false;
@@ -896,20 +896,20 @@ boolean xmlinitverbs(void) {
         } \
     } while(0)
 
-    ADD_VERB(BIGSTRING("\paddtable"), xmlv_addtable);
-    ADD_VERB(BIGSTRING("\paddvalue"), xmlv_addvalue);
-    ADD_VERB(BIGSTRING("\pcompile"), xmlv_compile);
-    ADD_VERB(BIGSTRING("\pdecompile"), xmlv_decompile);
-    ADD_VERB(BIGSTRING("\pgetaddress"), xmlv_getaddress);
-    ADD_VERB(BIGSTRING("\pgetaddresslist"), xmlv_getaddresslist);
-    ADD_VERB(BIGSTRING("\pgetattribute"), xmlv_getattribute);
-    ADD_VERB(BIGSTRING("\pgetattributevalue"), xmlv_getattributevalue);
-    ADD_VERB(BIGSTRING("\pgetvalue"), xmlv_getvalue);
-    ADD_VERB(BIGSTRING("\pvaltostring"), xmlv_valtostring);
-    ADD_VERB(BIGSTRING("\pfrontiervaluetotaggedtext"), xmlv_frontiervaluetotaggedtext);
-    ADD_VERB(BIGSTRING("\pstructtofrontiervalue"), xmlv_structtofrontiervalue);
-    ADD_VERB(BIGSTRING("\pgetpathaddress"), xmlv_getpathaddress);
-    ADD_VERB(BIGSTRING("\pconverttodisplayname"), xmlv_converttodisplayname);
+    ADD_VERB(BIGSTRING("\010addtable"), xmlv_addtable);
+    ADD_VERB(BIGSTRING("\010addvalue"), xmlv_addvalue);
+    ADD_VERB(BIGSTRING("\007compile"), xmlv_compile);
+    ADD_VERB(BIGSTRING("\011decompile"), xmlv_decompile);
+    ADD_VERB(BIGSTRING("\012getaddress"), xmlv_getaddress);
+    ADD_VERB(BIGSTRING("\016getaddresslist"), xmlv_getaddresslist);
+    ADD_VERB(BIGSTRING("\014getattribute"), xmlv_getattribute);
+    ADD_VERB(BIGSTRING("\021getattributevalue"), xmlv_getattributevalue);
+    ADD_VERB(BIGSTRING("\010getvalue"), xmlv_getvalue);
+    ADD_VERB(BIGSTRING("\013valtostring"), xmlv_valtostring);
+    ADD_VERB(BIGSTRING("\031frontiervaluetotaggedtext"), xmlv_frontiervaluetotaggedtext);
+    ADD_VERB(BIGSTRING("\025structtofrontiervalue"), xmlv_structtofrontiervalue);
+    ADD_VERB(BIGSTRING("\016getpathaddress"), xmlv_getpathaddress);
+    ADD_VERB(BIGSTRING("\024converttodisplayname"), xmlv_converttodisplayname);
 
     #undef ADD_VERB
 

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -133,4 +133,33 @@ if [ -n "$DOC_FILES_CHANGED" ]; then
     echo -e "${GREEN}✓ Documentation validation passed${NC}"
 fi
 
+# ──────────────────────────────────────────────────────────────
+# Verb registration: Check for broken \p prefixes and wrong lengths
+# ──────────────────────────────────────────────────────────────
+
+VERB_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^tests/headless_.*_verbs\.c$' || true)
+
+if [ -n "$VERB_FILES_CHANGED" ]; then
+    echo -e "${YELLOW}Headless verb files changed, checking Pascal string lengths...${NC}"
+
+    # Check for broken \p prefixes (classic Mac, not valid in modern C)
+    if grep -n '\\p[a-z]' $VERB_FILES_CHANGED | grep -q 'BIGSTRING'; then
+        echo -e "${RED}ERROR: Found broken \\p Pascal string prefix in verb registration:${NC}" >&2
+        grep -n '\\p[a-z]' $VERB_FILES_CHANGED | grep 'BIGSTRING' | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "Use octal length bytes instead (e.g., \\006 for 6-char string)." >&2
+        exit 1
+    fi
+
+    # Run the full length verification if available
+    if [ -f "$GIT_ROOT/tools/verify_pascal_string_lengths.py" ]; then
+        cd "$GIT_ROOT"
+        if ! python3 tools/verify_pascal_string_lengths.py; then
+            echo -e "${RED}ERROR: Pascal string length verification failed${NC}" >&2
+            exit 1
+        fi
+        echo -e "${GREEN}Pascal string lengths verified${NC}"
+    fi
+fi
+
 exit 0

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -143,9 +143,9 @@ if [ -n "$VERB_FILES_CHANGED" ]; then
     echo -e "${YELLOW}Headless verb files changed, checking Pascal string lengths...${NC}"
 
     # Check for broken \p prefixes (classic Mac, not valid in modern C)
-    if grep -n '\\p[a-z]' $VERB_FILES_CHANGED | grep -q 'BIGSTRING'; then
+    if echo "$VERB_FILES_CHANGED" | xargs grep -n '\\p[a-zA-Z]' 2>/dev/null | grep -q 'BIGSTRING'; then
         echo -e "${RED}ERROR: Found broken \\p Pascal string prefix in verb registration:${NC}" >&2
-        grep -n '\\p[a-z]' $VERB_FILES_CHANGED | grep 'BIGSTRING' | sed 's/^/  /' >&2
+        echo "$VERB_FILES_CHANGED" | xargs grep -n '\\p[a-zA-Z]' 2>/dev/null | grep 'BIGSTRING' | sed 's/^/  /' >&2
         echo "" >&2
         echo "Use octal length bytes instead (e.g., \\006 for 6-char string)." >&2
         exit 1

--- a/tools/verify_pascal_string_lengths.py
+++ b/tools/verify_pascal_string_lengths.py
@@ -27,7 +27,7 @@ def check_file(filepath):
 
             # Check octal length bytes in ADD_VERB lines only
             # (skip non-verb BIGSTRING usage like shell escape sequences)
-            for m in re.finditer(r'ADD_VERB\(BIGSTRING\("\\(\d{3})([^"]+)"\)', line):
+            for m in re.finditer(r'ADD_VERB\(BIGSTRING\("\\([0-7]{3})([^"]+)"\)', line):
                 octal_str = m.group(1)
                 verb_name = m.group(2)
                 declared_len = int(octal_str, 8)

--- a/tools/verify_pascal_string_lengths.py
+++ b/tools/verify_pascal_string_lengths.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+r"""Verify Pascal string length bytes in headless verb registration files.
+
+Checks all ADD_VERB(BIGSTRING()) macros in tests/headless_*_verbs.c files to
+ensure the octal length byte matches the actual string length. Also checks for
+broken \p prefixes that don't work in modern compilers.
+
+Usage:
+    python3 tools/verify_pascal_string_lengths.py
+
+Exit code 0 if all lengths are correct, 1 if any errors found.
+"""
+
+import re
+import glob
+import sys
+
+
+def check_file(filepath):
+    errors = []
+    with open(filepath, 'r') as f:
+        for lineno, line in enumerate(f, 1):
+            # Check for broken \p prefixes in ADD_VERB lines
+            for m in re.finditer(r'ADD_VERB\(BIGSTRING\("\\p([^"]+)"\)', line):
+                errors.append((filepath, lineno, 'broken_prefix',
+                    f'\\p prefix (not valid in modern C): "\\p{m.group(1)}"'))
+
+            # Check octal length bytes in ADD_VERB lines only
+            # (skip non-verb BIGSTRING usage like shell escape sequences)
+            for m in re.finditer(r'ADD_VERB\(BIGSTRING\("\\(\d{3})([^"]+)"\)', line):
+                octal_str = m.group(1)
+                verb_name = m.group(2)
+                declared_len = int(octal_str, 8)
+                actual_len = len(verb_name)
+                if declared_len != actual_len:
+                    errors.append((filepath, lineno, 'wrong_length',
+                        f'\\{octal_str} ({declared_len}) != "{verb_name}" ({actual_len})'))
+    return errors
+
+
+def main():
+    files = sorted(glob.glob('tests/headless_*_verbs.c'))
+    if not files:
+        print("ERROR: No headless verb files found. Run from repository root.", file=sys.stderr)
+        return 1
+
+    all_errors = []
+    total_checked = 0
+
+    for filepath in files:
+        with open(filepath, 'r') as f:
+            content = f.read()
+        count = len(re.findall(r'ADD_VERB\(BIGSTRING\("\\', content))
+        total_checked += count
+        errors = check_file(filepath)
+        all_errors.extend(errors)
+
+    if all_errors:
+        print(f"FAILED: {len(all_errors)} error(s) found in {len(files)} files:")
+        for filepath, lineno, kind, msg in all_errors:
+            print(f"  {filepath}:{lineno}: [{kind}] {msg}")
+        return 1
+    else:
+        print(f"OK: All {total_checked} Pascal string lengths correct across {len(files)} files.")
+        return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Replace 905 broken `\p` Pascal string prefixes across 48 headless verb files with correct octal length bytes. Modern Clang treats `\p` as literal `p` (ASCII 112), so every verb was registered with a bogus length — making them unfindable by name lookup at runtime.
- Fix 5 additional wrong length bytes in `headless_string_verbs.c` (`multipleReplaceAll`, `firstsentence`, `ispunctuation`, `processhtmlmacros`, `parsehttpargs`)
- Add stale linked-code detection in `langgetnodecode()`: when a script node has pre-compiled v6 code with nil `param1`, force recompilation from source. This fixes `kernel()` directives (e.g., `window.isOpen`) that had stale v6 code trees preventing recompilation.

## Context
After PRs #442 and #443 fixed the TCP callback threading, the webserver could spawn threads and yield the GIL, but page rendering failed because nearly all kernel verbs were silently unregistered. The `\p` prefix is a classic Mac compiler extension for Pascal strings that modern compilers do not support. This was the root cause of `multipleReplaceAll`, `window.isOpen`, and hundreds of other verb lookup failures.

With this fix, the setupFrontier page loads successfully in a browser for the first time in the headless build.

## Test plan
- [x] 284/284 unit tests pass
- [x] 1703/1703 integration tests pass (0 failures)
- [x] Manual verification: setupFrontier page loads and renders correctly
- [x] Verified all 905+ octal length bytes are correct via automated script

Generated with [Claude Code](https://claude.com/claude-code)