### PR TITLE
fix: Save/restore databasedata during recursive packing

### DIFF
--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1075,6 +1075,8 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	 * Pack with output format mode - children don't change mode
 	 * ================================================================
 	 */
+	hdldatabaserecord saved_databasedata = databasedata;
+
 	switch ((**hv).id) {
 
 		case idoutlineprocessor:
@@ -1102,6 +1104,8 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 			ok = false;
 			break;
 		}
+
+	databasedata = saved_databasedata;
 
 	/* Mode remains in output format - caller will manage further transitions if needed */
 	return (ok);

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1075,7 +1075,7 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	 * Pack with output format mode - children don't change mode
 	 * ================================================================
 	 */
-	hdldatabaserecord saved_databasedata = databasedata;
+	hdldatabaserecord savedatabasedata = databasedata;
 
 	switch ((**hv).id) {
 
@@ -1105,7 +1105,7 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 			break;
 		}
 
-	databasedata = saved_databasedata;
+	databasedata = savedatabasedata;
 
 	/* Mode remains in output format - caller will manage further transitions if needed */
 	return (ok);

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1910 tests: 1721 pass (90%) 189 skip (9%)</title>
-    <dateCreated>Fri, 20 Feb 2026 00:12:03 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1911 tests: 1722 pass (90%) 189 skip (9%)</title>
+    <dateCreated>Mon, 23 Feb 2026 05:46:51 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-20 at 00:11 UTC"/>
-      <outline text="Results: 1703 passed (90%), 189 skipped (10%), 0 failed (0%)"/>
-      <outline text="Duration: 43.5s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 1910 tests (1721 active, 189 marked skip) across 51 categories"/>
+      <outline text="Run: 2026-02-23 at 05:46 UTC"/>
+      <outline text="Results: 1704 passed (90%), 189 skipped (10%), 0 failed (0%)"/>
+      <outline text="Duration: 39.5s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 1911 tests (1722 active, 189 marked skip) across 51 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
@@ -21,7 +21,7 @@
     <outline text="Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs) - 14 tests: 13 pass (92%) 1 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
     <outline text="File Verbs (file_verbs) - 81 tests: 75 pass (92%) 6 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
-    <outline text="Filemenu Verbs (filemenu_verbs) - 33 tests: 30 pass (90%) 3 skip (9%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
+    <outline text="Filemenu Verbs (filemenu_verbs) - 34 tests: 31 pass (91%) 3 skip (8%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
     <outline text="Frontier Verbs (frontier_verbs) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/frontier_verbs.opml"/>
     <outline text="Guest Db Externals (guest_db_externals) - 11 tests: 11 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/guest_db_externals.opml"/>
     <outline text="Html Core Tests (html_core_tests) - 60 tests: 60 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_core_tests.opml"/>

--- a/reports/integration_tests/filemenu_verbs.opml
+++ b/reports/integration_tests/filemenu_verbs.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Filemenu Verbs (filemenu_verbs) - 33 tests: 30 pass (90%) 3 skip (9%)</title>
-    <dateCreated>Mon, 16 Feb 2026 18:41:35 GMT</dateCreated>
+    <title>Filemenu Verbs (filemenu_verbs) - 34 tests: 31 pass (91%) 3 skip (8%)</title>
+    <dateCreated>Mon, 23 Feb 2026 05:46:51 GMT</dateCreated>
   </head>
   <body>
     <outline text="fileMenu.new - create new database - fileMenu.new creates a new empty ODB database and opens it">
@@ -277,6 +277,20 @@
       </outline>
       <outline text="Script">
         <outline text="return fileMenu.save()"/>
+      </outline>
+    </outline>
+    <outline text="fileMenu.save - save system root with guest database open - Regression test: saving the system root while a guest database is open should not corrupt the databasedata global. Previously, recursive packing of system table externals would switch databasedata to the guest database, causing dbread failures on sibling externals (e.g. menus at addresses valid only in the system root).&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;filemenu_save_regression.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="fileMenu.open(dbPath)"/>
+        <outline text="local(result = fileMenu.save())"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return result"/>
       </outline>
     </outline>
     <outline text="fileMenu.save - save guest database by path - Open a guest database, write a value, then save it by path">

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 284 tests: 284 pass (100%)</title>
-    <dateCreated>Thu, 19 Feb 2026 23:52:19 GMT</dateCreated>
+    <dateCreated>Mon, 23 Feb 2026 05:42:50 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-19 at 23:52 UTC"/>
+      <outline text="Run: 2026-02-23 at 05:42 UTC"/>
       <outline text="Results: 284 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (284 tests total)"/>
     </outline>

--- a/tests/integration/test_cases/filemenu_verbs.yaml
+++ b/tests/integration/test_cases/filemenu_verbs.yaml
@@ -307,6 +307,24 @@ tests:
     expected_success: true
     expected_result: "true"
 
+  - name: "fileMenu.save - save system root with guest database open"
+    description: >
+      Regression test: saving the system root while a guest database is open
+      should not corrupt the databasedata global. Previously, recursive packing
+      of system table externals would switch databasedata to the guest database,
+      causing dbread failures on sibling externals (e.g. menus at addresses
+      valid only in the system root).
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "filemenu_save_regression.root7");
+      db.new(dbPath);
+      fileMenu.open(dbPath);
+      local(result = fileMenu.save());
+      fileMenu.closeall();
+      return result
+    expected_success: true
+    expected_result: "true"
+
   # ========================================================================
   # fileMenu.save - Save Guest Database
   # ========================================================================


### PR DESCRIPTION
## Summary

- Fixes `fileMenu.save()` failure caused by `databasedata` global corruption during recursive packing
- During recursive packing of the system table, child `*verbpack_internal` functions set the global `databasedata` from their context but never restore it — when a nested sub-table belonging to a guest database is packed, `databasedata` gets switched to the guest database handle, causing subsequent sibling externals to read from the wrong database file (`dbread read failed fnum=6`)
- Adds save/restore of `databasedata` around the pack dispatch switch in `langexternalpack_internal`, ensuring each external's pack uses the correct database for its own I/O while preserving the caller's global state

## Test plan

- [x] Build: `make -C frontier-cli` — succeeds
- [x] Unit tests: `./tools/run_headless_tests.sh` — 284/284 pass
- [x] Integration tests: `cd tests && make test-integration` — 1703 pass, 189 skipped, 0 failed
- [ ] Manual verification: `./dist/frontier-cli --system-root dist/Frontier.root -e "fileMenu.save()"` — should succeed without dbread errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)