### PR TITLE
feat: Explicit DB context for pack/save path (Phases 1-3)

### DIFF
--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -144,6 +144,8 @@ boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *a
 boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h);
 boolean dbcopy_context(const db_context *context, dbaddress src, dbaddress *dest);
 boolean dbassign_context(const db_context *context, dbaddress *padr, long newsize, ptrvoid pdata);
+/* Note: unlike other _context() wrappers, dbreference_context does NOT
+   save/restore db_format_mode — it passes header_size explicitly. */
 boolean dbreference_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata);
 boolean dballocate_context(const db_context *context, long databytes, ptrvoid pdata, dbaddress *paddress);
 boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h);

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -161,7 +161,8 @@ boolean dbreference_internal(dbaddress adr, long maxbytes, ptrvoid pdata);
 
 /* Phase 2: Context-aware wrappers for core DB I/O primitives.
    These temporarily apply the context's database, call the legacy function,
-   and restore databasedata. Stepping stones toward eliminating the global. */
+   and restore databasedata. Stepping stones toward eliminating the global.
+   Intended callers: Phase 3+ pack/save/unpack paths replacing direct dbread/dbwrite. */
 boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata);
 boolean dbwrite_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata);
 boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr);

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -159,6 +159,14 @@ boolean dbassign_internal(dbaddress *padr, long newsize, ptrvoid pdata);
 boolean dbcopy_internal(dbaddress adrorig, dbaddress *adrcopy);
 boolean dbreference_internal(dbaddress adr, long maxbytes, ptrvoid pdata);
 
+/* Phase 2: Context-aware wrappers for core DB I/O primitives.
+   These temporarily apply the context's database, call the legacy function,
+   and restore databasedata. Stepping stones toward eliminating the global. */
+boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata);
+boolean dbwrite_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata);
+boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr);
+boolean dbgeteof_context(const db_context *context, long *eof);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/Common/headers/menueditor.h
+++ b/Common/headers/menueditor.h
@@ -231,7 +231,7 @@ extern boolean meloadoutline (dbaddress, hdloutlinerecord *); /*menueditor.c*/
 
 extern boolean mepackoutline (hdloutlinerecord, Handle *);
 
-extern boolean mesaveoutline (hdloutlinerecord, dbaddress *);
+extern boolean mesaveoutline (const db_context *, hdloutlinerecord, dbaddress *);
 
 extern boolean meloadscriptoutline (hdlmenurecord, hdlheadrecord, hdloutlinerecord *, boolean *);
 

--- a/Common/headers/menuinternal.h
+++ b/Common/headers/menuinternal.h
@@ -59,7 +59,7 @@ extern boolean mereleaserefconroutine (hdlheadrecord, boolean);
 
 extern boolean mepackmenustructure (tysavedmenuinfo *, Handle *);
 
-extern boolean mesavemenurecord (hdlmenurecord, boolean, boolean, dbaddress *, Handle *);
+extern boolean mesavemenurecord (const db_context *, hdlmenurecord, boolean, boolean, dbaddress *, Handle *);
 
 extern boolean mesetupmenurecord (tysavedmenuinfo *, hdloutlinerecord, hdlmenurecord *);
 

--- a/Common/headers/wpverbs.h
+++ b/Common/headers/wpverbs.h
@@ -54,6 +54,8 @@ extern boolean wpverbunpack (Handle, long *, hdlexternalvariable *);
 struct db_context; /* forward declaration */
 extern boolean wpverbpack_internal (const struct db_context *, hdlexternalvariable, Handle *, boolean *);
 
+/* ctx parameter is forward-looking (Phase 4: unpack/load path will use it
+   to read from the correct database). All callers currently pass NULL. */
 extern boolean wpverbinmemory (const struct db_context *, hdlexternalvariable);
 
 extern boolean wpverbpacktotext (hdlexternalvariable, Handle);

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2638,7 +2638,9 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
         databasedata = savedatabasedata;
         return result;
     }
-    return dbreference_internal(adr, ctbytes, pdata);
+    boolean result = dbreference_internal(adr, ctbytes, pdata);
+    databasedata = savedatabasedata;
+    return result;
 }
 
 boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h) {

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2631,6 +2631,8 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
     /*
     Context-aware dbreference. Temporarily applies the context's database
     handle, calls the legacy function with explicit header size, and restores.
+    Format mode is not saved/restored here: header size is passed explicitly
+    via dbreference_with_header_size, so the global mode is never consulted.
     */
     hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2631,14 +2631,15 @@ boolean dbassign_context(const db_context *context, dbaddress *padr, long newsiz
 boolean dbreference_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
     /*
     Context-aware dbreference. Temporarily applies the context's database
-    handle, calls the legacy function with explicit header size, and restores.
-    Format mode is not saved/restored on the non-NULL path: header size is
-    passed explicitly via dbreference_with_header_size, so the global mode
-    is never consulted. On the NULL path, dbreference_internal reads the
-    current global mode directly; we don't modify it, so no save/restore
-    is needed.
+    handle, calls the appropriate legacy function, and restores.
+    Format mode is not saved/restored: the non-NULL path passes header size
+    explicitly via dbreference_with_header_size (so the global mode is never
+    consulted), and the NULL path reads the current global mode directly
+    without modifying it.
     */
     hdldatabaserecord savedatabasedata = databasedata;
+    boolean result;
+
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
@@ -2646,12 +2647,13 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
         /* During migration with mode lock, can't downgrade global mode to v6.
            Pass explicit header size based on context mode. */
         long header_size = context->mode.use_64bit_format ? sizeheader_v7 : sizeheader_v6;
-        boolean result = dbreference_with_header_size(adr, ctbytes, pdata, header_size);
-        databasedata = savedatabasedata;
-        return result;
+        result = dbreference_with_header_size(adr, ctbytes, pdata, header_size);
     }
-    /* NULL context: use current global databasedata and mode as-is */
-    boolean result = dbreference_internal(adr, ctbytes, pdata);
+    else {
+        /* NULL context: use current global databasedata and mode as-is */
+        result = dbreference_internal(adr, ctbytes, pdata);
+    }
+
     databasedata = savedatabasedata;
     return result;
 }

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2544,9 +2544,10 @@ boolean hashunpacktable_context(const db_context *context, Handle hpacked, boole
 boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *adr) {
     /*
     Context-aware dbassignhandle. Temporarily applies the context's database
-    handle and format mode, calls the legacy function, and restores.
+    handle and format mode, calls the legacy function, and restores both.
     */
     hdldatabaserecord savedatabasedata = databasedata;
+    db_format_mode savedmode = db_format_mode_current();
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
@@ -2554,6 +2555,7 @@ boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *a
     }
     boolean result = dbassignhandle(h, adr);
     databasedata = savedatabasedata;
+    db_format_mode_apply(&savedmode);
     return result;
 }
 
@@ -2592,9 +2594,10 @@ boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h)
 boolean dbcopy_context(const db_context *context, dbaddress src, dbaddress *dest) {
     /*
     Context-aware dbcopy. Temporarily applies the context's database
-    handle and format mode, calls the legacy function, and restores.
+    handle and format mode, calls the legacy function, and restores both.
     */
     hdldatabaserecord savedatabasedata = databasedata;
+    db_format_mode savedmode = db_format_mode_current();
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
@@ -2602,15 +2605,17 @@ boolean dbcopy_context(const db_context *context, dbaddress src, dbaddress *dest
     }
     boolean result = dbcopy_internal(src, dest);
     databasedata = savedatabasedata;
+    db_format_mode_apply(&savedmode);
     return result;
 }
 
 boolean dbassign_context(const db_context *context, dbaddress *padr, long newsize, ptrvoid pdata) {
     /*
     Context-aware dbassign. Temporarily applies the context's database
-    handle and format mode, calls the legacy function, and restores.
+    handle and format mode, calls the legacy function, and restores both.
     */
     hdldatabaserecord savedatabasedata = databasedata;
+    db_format_mode savedmode = db_format_mode_current();
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
@@ -2618,6 +2623,7 @@ boolean dbassign_context(const db_context *context, dbaddress *padr, long newsiz
     }
     boolean result = dbassign_internal(padr, newsize, pdata);
     databasedata = savedatabasedata;
+    db_format_mode_apply(&savedmode);
     return result;
 }
 
@@ -2646,9 +2652,10 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
 boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h) {
     /*
     Context-aware dbrefhandle. Temporarily applies the context's database
-    handle and format mode, calls the legacy function, and restores.
+    handle and format mode, calls the legacy function, and restores both.
     */
     hdldatabaserecord savedatabasedata = databasedata;
+    db_format_mode savedmode = db_format_mode_current();
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
@@ -2656,6 +2663,7 @@ boolean dbreference_handle_context(const db_context *context, dbaddress adr, Han
     }
     boolean result = dbrefhandle(adr, h);
     databasedata = savedatabasedata;
+    db_format_mode_apply(&savedmode);
     return result;
 }
 
@@ -2698,9 +2706,10 @@ boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr
     /*
     Phase 2: Context-aware dbsavehandle. Temporarily applies the context's
     database handle and format mode, calls the legacy dbsavehandle (which
-    internally calls dballocate/dbassign using databasedata), and restores.
+    internally calls dballocate/dbassign using databasedata), and restores both.
     */
     hdldatabaserecord savedatabasedata = databasedata;
+    db_format_mode savedmode = db_format_mode_current();
     boolean result;
 
     if (context != NULL) {
@@ -2712,6 +2721,7 @@ boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr
     result = dbsavehandle(h, adr);
 
     databasedata = savedatabasedata;
+    db_format_mode_apply(&savedmode);
     return result;
 }
 

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2543,16 +2543,18 @@ boolean hashunpacktable_context(const db_context *context, Handle hpacked, boole
 
 boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *adr) {
     /*
-    2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
-    Set mode directly from context, call function, done.
-    Caller ensures correct database is active.
+    Context-aware dbassignhandle. Temporarily applies the context's database
+    handle and format mode, calls the legacy function, and restores.
     */
+    hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
         db_format_mode_apply(&context->mode);
     }
-    return dbassignhandle(h, adr);
+    boolean result = dbassignhandle(h, adr);
+    databasedata = savedatabasedata;
+    return result;
 }
 
 boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h) {
@@ -2589,41 +2591,42 @@ boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h)
 
 boolean dbcopy_context(const db_context *context, dbaddress src, dbaddress *dest) {
     /*
-    2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
-    Set mode directly from context, call function, done.
-    Caller ensures correct database is active.
+    Context-aware dbcopy. Temporarily applies the context's database
+    handle and format mode, calls the legacy function, and restores.
     */
+    hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
         db_format_mode_apply(&context->mode);
     }
-    return dbcopy_internal(src, dest);
+    boolean result = dbcopy_internal(src, dest);
+    databasedata = savedatabasedata;
+    return result;
 }
 
 boolean dbassign_context(const db_context *context, dbaddress *padr, long newsize, ptrvoid pdata) {
     /*
-    2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
-    Set mode directly from context, call function, done.
-    Caller ensures correct database is active.
+    Context-aware dbassign. Temporarily applies the context's database
+    handle and format mode, calls the legacy function, and restores.
     */
+    hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
         db_format_mode_apply(&context->mode);
     }
-    return dbassign_internal(padr, newsize, pdata);
+    boolean result = dbassign_internal(padr, newsize, pdata);
+    databasedata = savedatabasedata;
+    return result;
 }
 
 boolean dbreference_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
     /*
-    2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
-    Set mode directly from context, call function, done.
-    Caller ensures correct database is active.
-
-    2026-02-03: During migration, global mode may be locked to v7.
-    Use explicit header size from context instead of global mode.
+    Context-aware dbreference. Temporarily applies the context's database
+    handle, calls the legacy function with explicit header size, and restores.
     */
+    hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
@@ -2631,23 +2634,27 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
         /* During migration with mode lock, can't downgrade global mode to v6.
            Pass explicit header size based on context mode. */
         long header_size = context->mode.use_64bit_format ? sizeheader_v7 : sizeheader_v6;
-        return dbreference_with_header_size(adr, ctbytes, pdata, header_size);
+        boolean result = dbreference_with_header_size(adr, ctbytes, pdata, header_size);
+        databasedata = savedatabasedata;
+        return result;
     }
     return dbreference_internal(adr, ctbytes, pdata);
 }
 
 boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h) {
     /*
-    2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
-    Set mode directly from context, call function, done.
-    Caller ensures correct database is active.
+    Context-aware dbrefhandle. Temporarily applies the context's database
+    handle and format mode, calls the legacy function, and restores.
     */
+    hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {
         if (context->database != nil)
             databasedata = context->database;
         db_format_mode_apply(&context->mode);
     }
-    return dbrefhandle(adr, h);
+    boolean result = dbrefhandle(adr, h);
+    databasedata = savedatabasedata;
+    return result;
 }
 
 boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2631,8 +2631,11 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
     /*
     Context-aware dbreference. Temporarily applies the context's database
     handle, calls the legacy function with explicit header size, and restores.
-    Format mode is not saved/restored here: header size is passed explicitly
-    via dbreference_with_header_size, so the global mode is never consulted.
+    Format mode is not saved/restored on the non-NULL path: header size is
+    passed explicitly via dbreference_with_header_size, so the global mode
+    is never consulted. On the NULL path, dbreference_internal reads the
+    current global mode directly; we don't modify it, so no save/restore
+    is needed.
     */
     hdldatabaserecord savedatabasedata = databasedata;
     if (context != NULL) {
@@ -2646,6 +2649,7 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
         databasedata = savedatabasedata;
         return result;
     }
+    /* NULL context: use current global databasedata and mode as-is */
     boolean result = dbreference_internal(adr, ctbytes, pdata);
     databasedata = savedatabasedata;
     return result;

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2649,3 +2649,76 @@ boolean dbreference_handle_context(const db_context *context, dbaddress adr, Han
     }
     return dbrefhandle(adr, h);
 }
+
+boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
+    /*
+    Phase 2: Context-aware dbread. Temporarily applies the context's database
+    handle, calls the legacy dbread (which handles Save As source redirection
+    internally), and restores databasedata.
+    */
+    hdldatabaserecord savedatabasedata = databasedata;
+    boolean result;
+
+    if (context != NULL && context->database != nil)
+        databasedata = context->database;
+
+    result = dbread(adr, ctbytes, pdata);
+
+    databasedata = savedatabasedata;
+    return result;
+}
+
+boolean dbwrite_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
+    /*
+    Phase 2: Context-aware dbwrite. Temporarily applies the context's database
+    handle, calls the legacy dbwrite, and restores databasedata.
+    */
+    hdldatabaserecord savedatabasedata = databasedata;
+    boolean result;
+
+    if (context != NULL && context->database != nil)
+        databasedata = context->database;
+
+    result = dbwrite(adr, ctbytes, pdata);
+
+    databasedata = savedatabasedata;
+    return result;
+}
+
+boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr) {
+    /*
+    Phase 2: Context-aware dbsavehandle. Temporarily applies the context's
+    database handle and format mode, calls the legacy dbsavehandle (which
+    internally calls dballocate/dbassign using databasedata), and restores.
+    */
+    hdldatabaserecord savedatabasedata = databasedata;
+    boolean result;
+
+    if (context != NULL) {
+        if (context->database != nil)
+            databasedata = context->database;
+        db_format_mode_apply(&context->mode);
+    }
+
+    result = dbsavehandle(h, adr);
+
+    databasedata = savedatabasedata;
+    return result;
+}
+
+boolean dbgeteof_context(const db_context *context, long *eof) {
+    /*
+    Phase 2: Context-aware dbgeteof. Temporarily applies the context's
+    database handle and restores.
+    */
+    hdldatabaserecord savedatabasedata = databasedata;
+    boolean result;
+
+    if (context != NULL && context->database != nil)
+        databasedata = context->database;
+
+    result = dbgeteof(eof);
+
+    databasedata = savedatabasedata;
+    return result;
+}

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2677,7 +2677,8 @@ boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, p
     /*
     Phase 2: Context-aware dbread. Temporarily applies the context's database
     handle, calls the legacy dbread (which handles Save As source redirection
-    internally), and restores databasedata.
+    internally), and restores databasedata. Format mode is not saved/restored:
+    raw read is mode-agnostic (header interpretation is the caller's concern).
     */
     hdldatabaserecord savedatabasedata = databasedata;
     boolean result;
@@ -2694,7 +2695,8 @@ boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, p
 boolean dbwrite_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
     /*
     Phase 2: Context-aware dbwrite. Temporarily applies the context's database
-    handle, calls the legacy dbwrite, and restores databasedata.
+    handle, calls the legacy dbwrite, and restores databasedata. Format mode
+    is not saved/restored: raw write is mode-agnostic.
     */
     hdldatabaserecord savedatabasedata = databasedata;
     boolean result;
@@ -2734,7 +2736,8 @@ boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr
 boolean dbgeteof_context(const db_context *context, long *eof) {
     /*
     Phase 2: Context-aware dbgeteof. Temporarily applies the context's
-    database handle and restores.
+    database handle and restores. Format mode is not saved/restored:
+    EOF position is mode-agnostic.
     */
     hdldatabaserecord savedatabasedata = databasedata;
     boolean result;

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2561,9 +2561,10 @@ boolean dbassignhandle_context(const db_context *context, Handle h, dbaddress *a
 
 boolean dbrefhandle_context(const db_context *context, dbaddress adr, Handle *h) {
     /*
-    2025-12-20: Explicit context - NO GUARDS, NO SAVE/RESTORE
-    Set mode directly from context, call function, done.
-    Caller ensures correct database is active.
+    Explicit context — no global mutation at all. Threads file number and
+    header size directly from context, bypassing databasedata entirely.
+    No save/restore needed (unlike sibling _context() functions that
+    temporarily mutate and restore the global).
 
     2026-02-03: During migration, global mode may be locked to v7.
     Use explicit header size from context instead of global mode.

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -962,12 +962,14 @@ boolean ensure_external_in_memory (const db_context *ctx, hdlexternalvariable hv
 boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, Handle *hpacked, boolean *flnewdbaddress) {
 
 	/*
-	2025-12-20: THE ONLY FUNCTION THAT MANAGES MODE FOR EXTERNAL PACKING
+	2025-12-20: MODE MANAGEMENT FOR EXTERNAL PACKING
 
-	Single Decision Point Pattern:
-	  - This function decides when to use v6 read mode vs v7 write mode
-	  - Child pack functions are pure operations - they don't manage mode
-	  - Mode transitions happen in ONE place (here) for entire operation
+	This function decides when to use v6 read mode vs v7 write mode,
+	sets the appropriate mode context, and dispatches to child pack functions.
+	Child pack functions are callee-saves: each saves/restores both
+	databasedata and db_format_mode around its own body. The outer
+	save/restore below is a safety net in case a future child loses
+	the callee-saves invariant.
 	*/
 
 	tydiskexternalhandle rec;
@@ -1071,10 +1073,8 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 		}
 	}
 
-	/* ================================================================
-	 * Pack with output format mode - children don't change mode
-	 * ================================================================
-	 */
+	/* Belt-and-suspenders: children are callee-saves but we restore here
+	   as a safety net in case a future child loses the invariant. */
 	hdldatabaserecord savedatabasedata = databasedata;
 	db_format_mode savedmode = db_format_mode_current();
 

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1076,6 +1076,7 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	 * ================================================================
 	 */
 	hdldatabaserecord savedatabasedata = databasedata;
+	db_format_mode savedmode = db_format_mode_current();
 
 	switch ((**hv).id) {
 
@@ -1106,8 +1107,8 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 		}
 
 	databasedata = savedatabasedata;
+	db_format_mode_apply(&savedmode);
 
-	/* Mode remains in output format - caller will manage further transitions if needed */
 	return (ok);
 	} /*langexternalpack_internal*/
 

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -970,6 +970,11 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 	databasedata and db_format_mode around its own body. The outer
 	save/restore below is a safety net in case a future child loses
 	the callee-saves invariant.
+
+	2026-02-23: The _context() wrappers were changed from caller-saves to
+	callee-saves. All callers were audited: none depend on the side-effect
+	of the global being left set after the call (confirmed by 287 unit +
+	1704 integration tests passing).
 	*/
 
 	tydiskexternalhandle rec;

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1078,8 +1078,9 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 		}
 	}
 
-	/* Belt-and-suspenders: children are callee-saves but we restore here
-	   as a safety net in case a future child loses the invariant. */
+	/* Belt-and-suspenders safety net: all children are callee-saves and
+	   context-aware (no databasedata mutations in the pack path), but we
+	   restore here defensively in case a future child loses the invariant. */
 	hdldatabaserecord savedatabasedata = databasedata;
 	db_format_mode savedmode = db_format_mode_current();
 

--- a/Common/source/menueditor.c
+++ b/Common/source/menueditor.c
@@ -47,6 +47,7 @@
 #include "windowlayout.h"
 #include "zoom.h"
 #include "db.h"
+#include "db_format.h"
 #include "tablestructure.h"
 #include "shell.h"
 #include "shellprivate.h"
@@ -474,31 +475,31 @@ boolean meloadoutline (dbaddress adr, hdloutlinerecord *houtline) {
 } /*meloadoutline*/
 
 
-boolean mesaveoutline (hdloutlinerecord ho, dbaddress *adr) {
-	
+boolean mesaveoutline (const db_context *ctx, hdloutlinerecord ho, dbaddress *adr) {
+
 	/*
 	save an outline in the database, and return the address of the database
 	memory that was allocated.
 	*/
-	
+
 	register boolean fl;
 	Handle hpackedoutline;
-	
+
 	hpackedoutline = nil; /*allocate a new handle for packing*/
-	
+
 	if (!oppackoutline (ho, &hpackedoutline))
 		return (false);
-	
-	fl = dbsavehandle (hpackedoutline, adr);
-	
+
+	fl = dbsavehandle_context (ctx, hpackedoutline, adr);
+
 	disposehandle (hpackedoutline);
-	
+
 	if (!fl)
 		return (false);
-	
+
 	if (!fldatabasesaveas)
 		(**ho).fldirty = false;
-	
+
 	return (true);
 	} /*mesaveoutline*/
 

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -225,90 +225,89 @@ typedef struct typackinfo {
 
 
 static boolean mesavescriptvisit (hdlheadrecord hnode, ptrvoid refcon) {
-#pragma unused (refcon)
 
+	const db_context *ctx = (const db_context *) refcon;
 	register hdlheadrecord h = hnode;
-	//ptrpackinfo packinfo = (ptrpackinfo) refcon;
 	register hdloutlinerecord ho;
 	tymenuiteminfo item;
-	
+
 	rollbeachball ();
-	
+
 	assert (menudata != nil);
-	
+
 	if (!megetmenuiteminfo (h, &item)) /*nothing linked, keep visiting*/
 		return (true);
-	
+
 	ho = item.linkedscript.houtline; /*copy into register*/
-	
+
 	if (ho == nil) /*if nil, nothing to worry about saving*/
 		return (true);
-	
+
 	if ((**ho).fldirty) { /*needs saving*/
-		
-		if (!mesaveoutline (ho, &item.linkedscript.adrlink)) /*memory or disk error, stop visiting*/
+
+		if (!mesaveoutline (ctx, ho, &item.linkedscript.adrlink)) /*memory or disk error, stop visiting*/
 			return (false);
 		}
-	
+
 	if (ho != (**menudata).scriptoutline) { /*don't reclaim the active script'*/
-		
+
 		opdisposeoutline (ho, false); /*reclaim the script*/
-	
+
 		item.linkedscript.houtline = nil; /*force us to look to disk*/
 		}
-		
+
 	else { /*'just clear its madechanges bit*/
-		
+
 		windowsetchanges ((**menudata).scriptwindow, false);
-		
+
 		(**ho).fldirty = false;
 		}
-	
+
 	return (mesetmenuiteminfo (h, &item));
 	} /*mesavescriptvisit*/
 	
 
 static boolean mesaveasscriptvisit (hdlheadrecord hnode, ptrvoid refcon) {
-#pragma unused (refcon)
 
 	/*
-	for save as, we need to write a packed version of every script to 
-	the new file.  db.c takes care of redirecting reads & writes as 
+	for save as, we need to write a packed version of every script to
+	the new file.  db.c takes care of redirecting reads & writes as
 	necessary
 	*/
-	
+
+	const db_context *ctx = (const db_context *) refcon;
 	register hdlheadrecord h = hnode;
 	hdloutlinerecord ho;
 	tymenuiteminfo item;
 	dbaddress adr;
 	boolean fltempload = false;
-	
+
 	rollbeachball ();
-	
+
 	if (!megetmenuiteminfo (h, &item)) /*nothing linked, keep visiting*/
 		return (true);
-	
+
 	ho = item.linkedscript.houtline; /*copy into register*/
-	
+
 	if (flconvertingolddatabase)
 		if (!meloadscriptoutline (menudata, h, &ho, &fltempload)) /*error loading script*/
 			return (false);
-	
+
 	if (ho != nil) {
-	
-		if (!mesaveoutline (ho, &adr)) /*memory or disk error, stop visiting*/
+
+		if (!mesaveoutline (ctx, ho, &adr)) /*memory or disk error, stop visiting*/
 			return (false);
 		}
 	else {
-		if (!dbcopy (item.linkedscript.adrlink, &adr)) /*copy packed version to new file*/
+		if (!dbcopy_context (ctx, item.linkedscript.adrlink, &adr)) /*copy packed version to new file*/
 			return (false);
 		}
-	
+
 	if (fltempload)
 		opdisposeoutline (ho, false);
-	
+
 	item.linkedscript.adrlink = adr; /*link in current database will be restored by caller*/
-	
+
 	return (mesetmenuiteminfo (h, &item));
 	} /*mesaveasscriptvisit*/
 
@@ -365,7 +364,7 @@ typedef struct tysavedmenuinfo_v7 {
 _Static_assert(sizeof(tysavedmenuinfo_v7) == 1056, "v7 menu struct must be exactly 1056 bytes");
 
 
-static boolean mesavemenustructure_legacy (hdlmenurecord hm, dbaddress *adr) {
+static boolean mesavemenustructure_legacy (const db_context *ctx, hdlmenurecord hm, dbaddress *adr) {
 
 	/*
 	Legacy (v6) save path: save the menu structure with 32-bit BE addresses.
@@ -386,9 +385,9 @@ static boolean mesavemenustructure_legacy (hdlmenurecord hm, dbaddress *adr) {
 	opoutermostsummit (&hsummit);
 
 	if (fldatabasesaveas)
-		fl = opsiblingvisiter (hsummit, false, &mesaveasscriptvisit, nil);
+		fl = opsiblingvisiter (hsummit, false, &mesaveasscriptvisit, (ptrvoid) ctx);
 	else
-		fl = opsiblingvisiter (hsummit, false, &mesavescriptvisit, nil);
+		fl = opsiblingvisiter (hsummit, false, &mesavescriptvisit, (ptrvoid) ctx);
 
 	assert (opvalidate (op_get_outlinedata()));
 
@@ -403,7 +402,7 @@ static boolean mesavemenustructure_legacy (hdlmenurecord hm, dbaddress *adr) {
 
 	info.adroutline = (**hm).adroutline;
 
-	if (!mesaveoutline (op_get_outlinedata(), &info.adroutline))
+	if (!mesaveoutline (ctx, op_get_outlinedata(), &info.adroutline))
 		return (false);
 
 	/* Capture the updated host-order address before BE32 conversion */
@@ -411,7 +410,7 @@ static boolean mesavemenustructure_legacy (hdlmenurecord hm, dbaddress *adr) {
 
 	db_format_write_be32(&info.adroutline, (uint32_t) info.adroutline);
 
-	fl = dbassign (adr, sizeof (tysavedmenuinfo), &info);
+	fl = dbassign_context (ctx, adr, sizeof (tysavedmenuinfo), &info);
 
 	/* Update in-memory address with new outline address.
 	   During Save As, preserve the original address so the source DB stays valid. */
@@ -422,7 +421,7 @@ static boolean mesavemenustructure_legacy (hdlmenurecord hm, dbaddress *adr) {
 	} /*mesavemenustructure_legacy*/
 
 
-static boolean mesavemenustructure_v7 (hdlmenurecord hm, dbaddress *adr) {
+static boolean mesavemenustructure_v7 (const db_context *ctx, hdlmenurecord hm, dbaddress *adr) {
 
 	/*
 	V7 save path: save the menu structure with 64-bit BE addresses.
@@ -437,9 +436,9 @@ static boolean mesavemenustructure_v7 (hdlmenurecord hm, dbaddress *adr) {
 	opoutermostsummit (&hsummit);
 
 	if (fldatabasesaveas)
-		fl = opsiblingvisiter (hsummit, false, &mesaveasscriptvisit, nil);
+		fl = opsiblingvisiter (hsummit, false, &mesaveasscriptvisit, (ptrvoid) ctx);
 	else
-		fl = opsiblingvisiter (hsummit, false, &mesavescriptvisit, nil);
+		fl = opsiblingvisiter (hsummit, false, &mesavescriptvisit, (ptrvoid) ctx);
 
 	assert (opvalidate (op_get_outlinedata()));
 
@@ -448,7 +447,7 @@ static boolean mesavemenustructure_v7 (hdlmenurecord hm, dbaddress *adr) {
 
 	outline_adr = (**hm).adroutline;
 
-	if (!mesaveoutline (op_get_outlinedata(), &outline_adr))
+	if (!mesaveoutline (ctx, op_get_outlinedata(), &outline_adr))
 		return (false);
 
 	clearbytes (&v7info, sizeof (v7info));
@@ -459,7 +458,7 @@ static boolean mesavemenustructure_v7 (hdlmenurecord hm, dbaddress *adr) {
 	v7info.flags = host_to_disk_uint32 ((uint32_t) ((**hm).flautosmash ? flautosmash_mask : 0));
 	v7info.menuactiveitem = host_to_disk_uint32 ((uint32_t) (**hm).menuactiveitem);
 
-	fl = dbassign (adr, sizeof (tysavedmenuinfo_v7), &v7info);
+	fl = dbassign_context (ctx, adr, sizeof (tysavedmenuinfo_v7), &v7info);
 
 	/* During Save As, preserve the original address so the source DB stays valid. */
 	if (fl && !fldatabasesaveas)
@@ -469,12 +468,12 @@ static boolean mesavemenustructure_v7 (hdlmenurecord hm, dbaddress *adr) {
 	} /*mesavemenustructure_v7*/
 
 
-static boolean mesavemenustructure (hdlmenurecord hm, dbaddress *adr) {
+static boolean mesavemenustructure (const db_context *ctx, hdlmenurecord hm, dbaddress *adr) {
 
 	if (db_format_mode_current().use_64bit_format)
-		return mesavemenustructure_v7 (hm, adr);
+		return mesavemenustructure_v7 (ctx, hm, adr);
 	else
-		return mesavemenustructure_legacy (hm, adr);
+		return mesavemenustructure_legacy (ctx, hm, adr);
 	} /*mesavemenustructure*/
 
 
@@ -526,16 +525,19 @@ static boolean mepackmenustructure_legacy (tysavedmenuinfo *info, Handle *hpacke
 	} /*mepackmenustructure_legacy*/
 
 
-boolean mesavemenurecord (hdlmenurecord hmenurecord, boolean flpreservelinks, boolean flmemory, dbaddress *adr, Handle *hpacked) {
-	
+boolean mesavemenurecord (const db_context *ctx, hdlmenurecord hmenurecord, boolean flpreservelinks, boolean flmemory, dbaddress *adr, Handle *hpacked) {
+
 	/*
 	save the menu record handle in the database.
-	
+
 	dmb 9/21/90:  unfortunately, menudata global is heavily entrenched, set it at the
 	beginning of the routine.
-	
-	dmb 10/23/90: the new flmemory parameter determines whether we're saving to disk 
+
+	dmb 10/23/90: the new flmemory parameter determines whether we're saving to disk
 	(using adr), or packing to memory (using hpacked)
+
+	2026-02-23: ctx parameter threads database context through the save chain,
+	eliminating databasedata mutation in the menu pack path.
 	*/
 	
 	register hdlmenurecord hm = hmenurecord;
@@ -637,7 +639,7 @@ boolean mesavemenurecord (hdlmenurecord hmenurecord, boolean flpreservelinks, bo
 			fl = mepackmenustructure (&info, hpacked);
 			}
 		else {
-			fl = mesavemenustructure (hm, adr);
+			fl = mesavemenustructure (ctx, hm, adr);
 			}
 		}
 	

--- a/Common/source/menupack.c
+++ b/Common/source/menupack.c
@@ -470,7 +470,12 @@ static boolean mesavemenustructure_v7 (const db_context *ctx, hdlmenurecord hm, 
 
 static boolean mesavemenustructure (const db_context *ctx, hdlmenurecord hm, dbaddress *adr) {
 
-	if (db_format_mode_current().use_64bit_format)
+	/* Dispatch on ctx->mode, not the global, so this function is safe to
+	   call even if the caller hasn't pre-applied the mode to the global. */
+	boolean use_v7 = (ctx != NULL) ? ctx->mode.use_64bit_format
+	                                : db_format_mode_current().use_64bit_format;
+
+	if (use_v7)
 		return mesavemenustructure_v7 (ctx, hm, adr);
 	else
 		return mesavemenustructure_legacy (ctx, hm, adr);

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -470,8 +470,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 		shellsetwindowchanges (hinfo, false);
 
 pushaddress:
-	/* NO mode management - uses whatever mode is currently set by caller */
-
+	/* Restore mode before returning (callee-saves invariant) */
 	db_format_mode_apply(&savedmode);
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*menuverbpack_internal*/

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -401,18 +401,13 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	boolean flpreservelinks;
 	hdlwindowinfo hinfo;
 
-	/* Callee-saves: protect databasedata from corruption by nested pack operations */
-	hdldatabaserecord savedatabasedata = databasedata;
-
 	/*
-	2025-12-24: Set mode from context before any database I/O
-	This ensures writes use the correct format (v7 during migration)
+	Phase 3: mesavemenurecord is not yet context-aware, so we must
+	temporarily set databasedata for its benefit. Use scoped save/restore
+	around that call only.
 	*/
-	if (ctx != NULL) {
-		if (ctx->database != nil)
-			databasedata = ctx->database;
+	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
-	}
 
 	const boolean adapter_repack = db_format_adapter_force_repack();
 
@@ -425,7 +420,6 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
 		log_error(LOG_COMP_OP, "menuverbpack_internal: FAIL - flinmemory=0, caller should have loaded it");
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -436,20 +430,26 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	if (adapter_repack) {
 		(*flnewdbaddress) = true;
 		(**hm).fldirty = true;
-		/* Mode already set by caller via db_format_mode_apply above - no push/pop! */
 	}
 
 	flpreservelinks = fldatabasesaveas && !fltempload;
 
-	fl = mesavemenurecord (hm, flpreservelinks, false, &adr, nil);
+	{
+		/* Scoped databasedata for mesavemenurecord (not yet context-aware) */
+		hdldatabaserecord savedatabasedata = databasedata;
+		if (ctx != NULL && ctx->database != nil)
+			databasedata = ctx->database;
+
+		fl = mesavemenurecord (hm, flpreservelinks, false, &adr, nil);
+
+		databasedata = savedatabasedata;
+	}
 
 	if (fltempload)
 		menuverbunload ((hdlexternalvariable) hv);
 
-	if (!fl) {
-		databasedata = savedatabasedata;
+	if (!fl)
 		return (false);
-	}
 
 	if (fldatabasesaveas)
 		goto pushaddress;
@@ -466,7 +466,6 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 pushaddress:
 	/* NO mode management - uses whatever mode is currently set by caller */
 
-	databasedata = savedatabasedata;
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*menuverbpack_internal*/
 

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -405,6 +405,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	Phase 3: mesavemenurecord is not yet context-aware, so we must
 	temporarily set databasedata for its benefit. Use scoped save/restore
 	around that call only.
+	TODO: Make mesavemenurecord context-aware (Phase 3 follow-up).
 	*/
 	db_format_mode savedmode = db_format_mode_current();
 

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -406,6 +406,8 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	temporarily set databasedata for its benefit. Use scoped save/restore
 	around that call only.
 	*/
+	db_format_mode savedmode = db_format_mode_current();
+
 	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
 
@@ -420,6 +422,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
 		log_error(LOG_COMP_OP, "menuverbpack_internal: FAIL - flinmemory=0, caller should have loaded it");
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -448,8 +451,10 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	if (fltempload)
 		menuverbunload ((hdlexternalvariable) hv);
 
-	if (!fl)
+	if (!fl) {
+		db_format_mode_apply(&savedmode);
 		return (false);
+	}
 
 	if (fldatabasesaveas)
 		goto pushaddress;
@@ -466,6 +471,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 pushaddress:
 	/* NO mode management - uses whatever mode is currently set by caller */
 
+	db_format_mode_apply(&savedmode);
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*menuverbpack_internal*/
 

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -401,6 +401,9 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	boolean flpreservelinks;
 	hdlwindowinfo hinfo;
 
+	/* Callee-saves: protect databasedata from corruption by nested pack operations */
+	hdldatabaserecord savedatabasedata = databasedata;
+
 	/*
 	2025-12-24: Set mode from context before any database I/O
 	This ensures writes use the correct format (v7 during migration)
@@ -422,6 +425,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
 		log_error(LOG_COMP_OP, "menuverbpack_internal: FAIL - flinmemory=0, caller should have loaded it");
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -442,8 +446,10 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	if (fltempload)
 		menuverbunload ((hdlexternalvariable) hv);
 
-	if (!fl)
+	if (!fl) {
+		databasedata = savedatabasedata;
 		return (false);
+	}
 
 	if (fldatabasesaveas)
 		goto pushaddress;
@@ -460,6 +466,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 pushaddress:
 	/* NO mode management - uses whatever mode is currently set by caller */
 
+	databasedata = savedatabasedata;
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*menuverbpack_internal*/
 

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -328,7 +328,7 @@ boolean menuverbmemorypack (hdlexternalvariable hvariable, Handle *hpacked) {
 	
 	hm = (hdlmenurecord) (**hv).variabledata;
 	
-	fl = mesavemenurecord (hm, false, true, nil, &hpush);
+	fl = mesavemenurecord (NULL, hm, false, true, nil, &hpush);
 	
 	if (fltempload)
 		menuverbunload ((hdlexternalvariable) hv);
@@ -402,10 +402,9 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	hdlwindowinfo hinfo;
 
 	/*
-	Phase 3: mesavemenurecord is not yet context-aware, so we must
-	temporarily set databasedata for its benefit. Use scoped save/restore
-	around that call only.
-	TODO: Make mesavemenurecord context-aware (Phase 3 follow-up).
+	Phase 3: mesavemenurecord and its call chain are now fully
+	context-aware — ctx threads through to all DB I/O calls.
+	Mode save/restore is still callee-saves for menuverbpack_internal.
 	*/
 	db_format_mode savedmode = db_format_mode_current();
 
@@ -438,16 +437,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 
 	flpreservelinks = fldatabasesaveas && !fltempload;
 
-	{
-		/* Scoped databasedata for mesavemenurecord (not yet context-aware) */
-		hdldatabaserecord savedatabasedata = databasedata;
-		if (ctx != NULL && ctx->database != nil)
-			databasedata = ctx->database;
-
-		fl = mesavemenurecord (hm, flpreservelinks, false, &adr, nil);
-
-		databasedata = savedatabasedata;
-	}
+	fl = mesavemenurecord (ctx, hm, flpreservelinks, false, &adr, nil);
 
 	if (fltempload)
 		menuverbunload ((hdlexternalvariable) hv);

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -328,6 +328,7 @@ boolean menuverbmemorypack (hdlexternalvariable hvariable, Handle *hpacked) {
 	
 	hm = (hdlmenurecord) (**hv).variabledata;
 	
+	/* NULL ctx: memory-only pack, operates on current databasedata global */
 	fl = mesavemenurecord (NULL, hm, false, true, nil, &hpush);
 	
 	if (fltempload)

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -895,25 +895,18 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	boolean fltempload = false;
 	boolean adapter_repack;
 
-	/* Callee-saves: protect databasedata from corruption by nested pack operations */
-	hdldatabaserecord savedatabasedata = databasedata;
-
 	/*
-	2025-12-20: Set mode from context before any database I/O
-	This ensures writes use the correct format (v7 during migration)
+	Phase 3: No direct databasedata mutation. All DB I/O goes through
+	_context() wrappers. Apply mode from context for mode-dependent logic.
 	*/
-	if (ctx != NULL) {
-		if (ctx->database != nil)
-			databasedata = ctx->database;
+	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
-	}
 
 	adapter_repack = db_format_adapter_force_repack();
 
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -948,12 +941,11 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		log_error(LOG_COMP_OP, "opverbpackoutline failed for outline at adr=0x%llx",
 		        (unsigned long long) (**hv).oldaddress);
 #endif
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
-	/* During migration, dbassignhandle will use the global v7 write mode set by caller */
-	fl = dbassignhandle (hpackedoutline, &adr);
+	/* Use context-aware wrapper — no direct databasedata mutation */
+	fl = dbassignhandle_context (ctx, hpackedoutline, &adr);
 
 #if defined(FRONTIER_HEADLESS)
 	db_format_mode check_mode = db_format_mode_current();
@@ -968,7 +960,6 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		log_error(LOG_COMP_OP, "dbassignhandle failed for outline adr=0x%llx",
 		        (unsigned long long) (**hv).oldaddress);
 #endif
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -1002,7 +993,6 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	else
 		*flnewdbaddress = true;
 
-	databasedata = savedatabasedata;
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*opverbpack_internal*/
 

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -895,6 +895,9 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	boolean fltempload = false;
 	boolean adapter_repack;
 
+	/* Callee-saves: protect databasedata from corruption by nested pack operations */
+	hdldatabaserecord savedatabasedata = databasedata;
+
 	/*
 	2025-12-20: Set mode from context before any database I/O
 	This ensures writes use the correct format (v7 during migration)
@@ -910,6 +913,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -944,6 +948,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		log_error(LOG_COMP_OP, "opverbpackoutline failed for outline at adr=0x%llx",
 		        (unsigned long long) (**hv).oldaddress);
 #endif
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -963,6 +968,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		log_error(LOG_COMP_OP, "dbassignhandle failed for outline adr=0x%llx",
 		        (unsigned long long) (**hv).oldaddress);
 #endif
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -996,6 +1002,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	else
 		*flnewdbaddress = true;
 
+	databasedata = savedatabasedata;
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*opverbpack_internal*/
 

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -987,7 +987,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		}
 
 	pushaddress:
-	/* NO mode management - uses whatever mode is currently set */
+	/* pushlongondiskhandle is mode-agnostic; restore mode before returning */
 
 	if (!fldatabasesaveas) {
 

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -899,6 +899,8 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	Phase 3: No direct databasedata mutation. All DB I/O goes through
 	_context() wrappers. Apply mode from context for mode-dependent logic.
 	*/
+	db_format_mode savedmode = db_format_mode_current();
+
 	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
 
@@ -907,6 +909,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -941,6 +944,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		log_error(LOG_COMP_OP, "opverbpackoutline failed for outline at adr=0x%llx",
 		        (unsigned long long) (**hv).oldaddress);
 #endif
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -960,6 +964,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		log_error(LOG_COMP_OP, "dbassignhandle failed for outline adr=0x%llx",
 		        (unsigned long long) (**hv).oldaddress);
 #endif
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -993,6 +998,7 @@ boolean opverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	else
 		*flnewdbaddress = true;
 
+	db_format_mode_apply(&savedmode);
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*opverbpack_internal*/
 

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -377,6 +377,9 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	boolean fltempload = false;
 	boolean adapter_repack;
 
+	/* Callee-saves: protect databasedata from corruption by nested pack operations */
+	hdldatabaserecord savedatabasedata = databasedata;
+
 	/*
 	2025-12-23: Set mode from context before any database I/O
 	This ensures writes use the correct format (v7 during migration)
@@ -400,6 +403,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -419,16 +423,20 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 
 	hpackedpict = nil; /*force a new handle to be allocated*/
 
-	if (!pictpack (hp, &hpackedpict))
+	if (!pictpack (hp, &hpackedpict)) {
+		databasedata = savedatabasedata;
 		return (false);
+	}
 
 	/* During migration, dbassignhandle will use the global v7 write mode set by caller */
 	fl = dbassignhandle (hpackedpict, &adr);
 
 	disposehandle (hpackedpict);
 
-	if (!fl)
+	if (!fl) {
+		databasedata = savedatabasedata;
 		return (false);
+	}
 
 	if (fldatabasesaveas && !fltempload)
 		goto pushaddress;
@@ -444,6 +452,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 		if (!external_set_ondisk((hdlexternalvariable) hv, adr)) {
 			log_error(LOG_COMP_PICT, "pictverbpack_internal: failed to transition to on-disk state (adr=0x%llx)",
 					(unsigned long long)adr);
+			databasedata = savedatabasedata;
 			return false;
 			}
 		}
@@ -466,6 +475,7 @@ pushaddress:
 	else
 		*flnewdbaddress = true;
 
+	databasedata = savedatabasedata;
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*pictverbpack_internal*/
 

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -461,7 +461,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 		}
 
 pushaddress:
-	/* NO mode management - uses whatever mode is currently set */
+	/* Restore mode before returning (callee-saves invariant) */
 
 	if (!fldatabasesaveas) {
 

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -377,16 +377,11 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	boolean fltempload = false;
 	boolean adapter_repack;
 
-	/* Callee-saves: protect databasedata from corruption by nested pack operations */
-	hdldatabaserecord savedatabasedata = databasedata;
-
 	/*
-	2025-12-23: Set mode from context before any database I/O
-	This ensures writes use the correct format (v7 during migration)
+	Phase 3: No direct databasedata mutation. All DB I/O goes through
+	_context() wrappers. Apply mode from context for mode-dependent logic.
 	*/
 	if (ctx != NULL) {
-		if (ctx->database != nil)
-			databasedata = ctx->database;
 #if defined(FRONTIER_HEADLESS)
 		log_debug(LOG_COMP_OP, "pictverbpack_internal: applying mode use_64bit=%d adapter_repack=%d",
 		        (int) ctx->mode.use_64bit_format, (int) ctx->mode.adapter_repack);
@@ -403,7 +398,6 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -423,20 +417,16 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 
 	hpackedpict = nil; /*force a new handle to be allocated*/
 
-	if (!pictpack (hp, &hpackedpict)) {
-		databasedata = savedatabasedata;
+	if (!pictpack (hp, &hpackedpict))
 		return (false);
-	}
 
-	/* During migration, dbassignhandle will use the global v7 write mode set by caller */
-	fl = dbassignhandle (hpackedpict, &adr);
+	/* Use context-aware wrapper — no direct databasedata mutation */
+	fl = dbassignhandle_context (ctx, hpackedpict, &adr);
 
 	disposehandle (hpackedpict);
 
-	if (!fl) {
-		databasedata = savedatabasedata;
+	if (!fl)
 		return (false);
-	}
 
 	if (fldatabasesaveas && !fltempload)
 		goto pushaddress;
@@ -452,7 +442,6 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 		if (!external_set_ondisk((hdlexternalvariable) hv, adr)) {
 			log_error(LOG_COMP_PICT, "pictverbpack_internal: failed to transition to on-disk state (adr=0x%llx)",
 					(unsigned long long)adr);
-			databasedata = savedatabasedata;
 			return false;
 			}
 		}
@@ -475,7 +464,6 @@ pushaddress:
 	else
 		*flnewdbaddress = true;
 
-	databasedata = savedatabasedata;
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*pictverbpack_internal*/
 

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -381,6 +381,8 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	Phase 3: No direct databasedata mutation. All DB I/O goes through
 	_context() wrappers. Apply mode from context for mode-dependent logic.
 	*/
+	db_format_mode savedmode = db_format_mode_current();
+
 	if (ctx != NULL) {
 #if defined(FRONTIER_HEADLESS)
 		log_debug(LOG_COMP_OP, "pictverbpack_internal: applying mode use_64bit=%d adapter_repack=%d",
@@ -398,6 +400,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -417,16 +420,20 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 
 	hpackedpict = nil; /*force a new handle to be allocated*/
 
-	if (!pictpack (hp, &hpackedpict))
+	if (!pictpack (hp, &hpackedpict)) {
+		db_format_mode_apply(&savedmode);
 		return (false);
+	}
 
 	/* Use context-aware wrapper — no direct databasedata mutation */
 	fl = dbassignhandle_context (ctx, hpackedpict, &adr);
 
 	disposehandle (hpackedpict);
 
-	if (!fl)
+	if (!fl) {
+		db_format_mode_apply(&savedmode);
 		return (false);
+	}
 
 	if (fldatabasesaveas && !fltempload)
 		goto pushaddress;
@@ -442,6 +449,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
 		if (!external_set_ondisk((hdlexternalvariable) hv, adr)) {
 			log_error(LOG_COMP_PICT, "pictverbpack_internal: failed to transition to on-disk state (adr=0x%llx)",
 					(unsigned long long)adr);
+			db_format_mode_apply(&savedmode);
 			return false;
 			}
 		}
@@ -464,6 +472,7 @@ pushaddress:
 	else
 		*flnewdbaddress = true;
 
+	db_format_mode_apply(&savedmode);
 	return (pushlongondiskhandle (adr, *hpacked));
 	} /*pictverbpack_internal*/
 

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -362,6 +362,7 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 	apply mode from context for mode-dependent logic.
 	*/
 	hdldatabaserecord activedb = (ctx != NULL && ctx->database != nil) ? ctx->database : databasedata;
+	db_format_mode savedmode = db_format_mode_current();
 
 	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
@@ -376,6 +377,7 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -462,8 +464,10 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 	if (fltempload)
 		tableverbunload (hv);
 
-	if (!fl)
+	if (!fl) {
+		db_format_mode_apply(&savedmode);
 		return (false);
+	}
 
 	unsigned char adrbuffer[sizeof (dbaddress)];
 	long adrsize;
@@ -490,9 +494,11 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 
 	if (!enlargehandle (*hpacked, adrsize, (ptrchar) adrbuffer)) {
 		log_error(LOG_COMP_TABLE, "enlargehandle failed while packing table");
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
+	db_format_mode_apply(&savedmode);
 	return (true);
 	} /*tableverbpack_internal*/
 

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -356,32 +356,26 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
     boolean mode64_for_save = false;
 	db_format_mode current_mode;
 
-	/* Callee-saves: protect databasedata from corruption by nested pack operations.
-	   During recursive table packing, child operations may set databasedata to a
-	   different database, which would corrupt sibling operations if not restored. */
-	hdldatabaserecord savedatabasedata = databasedata;
-
 	/*
-	2025-12-20: Set mode from context before any database I/O
-	This ensures writes use the correct format (v7 during migration)
+	Phase 3: No direct databasedata mutation. All DB I/O goes through
+	_context() wrappers. We derive a local activedb for nil checks and
+	apply mode from context for mode-dependent logic.
 	*/
-	if (ctx != NULL) {
-		if (ctx->database != nil)
-			databasedata = ctx->database;
-		db_format_mode_apply(&ctx->mode);
-	}
+	hdldatabaserecord activedb = (ctx != NULL && ctx->database != nil) ? ctx->database : databasedata;
 
-	adapter_repack = db_format_adapter_force_repack() && (databasedata != nil);
+	if (ctx != NULL)
+		db_format_mode_apply(&ctx->mode);
+
+	adapter_repack = db_format_adapter_force_repack() && (activedb != nil);
 
 	/* Trace table packing with context info for debugging nested tables */
-	log_debug(LOG_COMP_TABLE, "tableverbpack_internal start flinmemory=%d adapter_repack=%d databasedata=%p ctx=%p ctx.use_64bit=%d",
-	        (int) (**hv).flinmemory, (int) adapter_repack, (void *) databasedata,
+	log_debug(LOG_COMP_TABLE, "tableverbpack_internal start flinmemory=%d adapter_repack=%d activedb=%p ctx=%p ctx.use_64bit=%d",
+	        (int) (**hv).flinmemory, (int) adapter_repack, (void *) activedb,
 	        (void *) ctx, (ctx != NULL) ? (int)ctx->mode.use_64bit_format : -1);
 
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -424,10 +418,10 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 
 	if (fldatabasesaveas || (**ht).fldirty || flmustsave) {
 		dbaddress adr_before = adr;
-		if (databasedata != nil)
-			fl = dbsavehandle (hpackedtable, &adr);
+		if (activedb != nil)
+			fl = dbsavehandle_context (ctx, hpackedtable, &adr);
 		else {
-			log_debug(LOG_COMP_TABLE, "tableverbpack skipping dbsavehandle; databasedata is nil");
+			log_debug(LOG_COMP_TABLE, "tableverbpack skipping dbsavehandle; no active database");
 			fl = true;
 			adr = 0;
 		}
@@ -468,10 +462,8 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 	if (fltempload)
 		tableverbunload (hv);
 
-	if (!fl) {
-		databasedata = savedatabasedata;
+	if (!fl)
 		return (false);
-	}
 
 	unsigned char adrbuffer[sizeof (dbaddress)];
 	long adrsize;
@@ -498,11 +490,9 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 
 	if (!enlargehandle (*hpacked, adrsize, (ptrchar) adrbuffer)) {
 		log_error(LOG_COMP_TABLE, "enlargehandle failed while packing table");
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
-	databasedata = savedatabasedata;
 	return (true);
 	} /*tableverbpack_internal*/
 

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -356,6 +356,11 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
     boolean mode64_for_save = false;
 	db_format_mode current_mode;
 
+	/* Callee-saves: protect databasedata from corruption by nested pack operations.
+	   During recursive table packing, child operations may set databasedata to a
+	   different database, which would corrupt sibling operations if not restored. */
+	hdldatabaserecord savedatabasedata = databasedata;
+
 	/*
 	2025-12-20: Set mode from context before any database I/O
 	This ensures writes use the correct format (v7 during migration)
@@ -376,6 +381,7 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -462,8 +468,10 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 	if (fltempload)
 		tableverbunload (hv);
 
-	if (!fl)
+	if (!fl) {
+		databasedata = savedatabasedata;
 		return (false);
+	}
 
 	unsigned char adrbuffer[sizeof (dbaddress)];
 	long adrsize;
@@ -490,9 +498,11 @@ boolean tableverbpack_internal (const db_context *ctx, hdlexternalvariable h, Ha
 
 	if (!enlargehandle (*hpacked, adrsize, (ptrchar) adrbuffer)) {
 		log_error(LOG_COMP_TABLE, "enlargehandle failed while packing table");
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
+	databasedata = savedatabasedata;
 	return (true);
 	} /*tableverbpack_internal*/
 

--- a/Common/source/tablescrap.c
+++ b/Common/source/tablescrap.c
@@ -246,7 +246,7 @@ static boolean tableexportwpscrap (const tyvaluerecord *scrapval, Handle *hexpor
 	
 	hv = (hdlexternalvariable) val.data.externalvalue;
 	
-	fl = wpverbinmemory (hv);
+	fl = wpverbinmemory (NULL, hv);
 	
 	if (fl) {
 		

--- a/Common/source/wpverbs.c
+++ b/Common/source/wpverbs.c
@@ -632,6 +632,9 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	boolean fltempload = false;
 	const boolean adapter_repack = db_format_adapter_force_repack();
 
+	/* Callee-saves: protect databasedata from corruption by nested pack operations */
+	hdldatabaserecord savedatabasedata = databasedata;
+
 	/*
 	2025-12-20: Set mode from context before any database I/O
 	This ensures writes use the correct format (v7 during migration)
@@ -645,6 +648,7 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -656,8 +660,10 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 
 		hpackedwp = (Handle) (**hv).variabledata;
 
-		if (!dbassignhandle (hpackedwp, &adr))
+		if (!dbassignhandle (hpackedwp, &adr)) {
+			databasedata = savedatabasedata;
 			return (false);
+		}
 
 		if (fldatabasesaveas)
 			goto pushaddress;
@@ -684,15 +690,19 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	if (!fldatabasesaveas && !(**hwp).fldirty && !(**hwp).fldirtyview) /*don't need to update the db version of the wpdoc*/
 		goto pushaddress;
 
-	if (!wpverbpackrecord (hwp, &hpackedwp))
+	if (!wpverbpackrecord (hwp, &hpackedwp)) {
+		databasedata = savedatabasedata;
 		return (false);
+	}
 
 	fl = dbassignhandle (hpackedwp, &adr);
 
 	disposehandle (hpackedwp);
 
-	if (!fl)
+	if (!fl) {
+		databasedata = savedatabasedata;
 		return (false);
+	}
 
 	if (fldatabasesaveas)
 		goto pushaddress;
@@ -726,6 +736,7 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		else
 			*flnewdbaddress = true;
 
+		databasedata = savedatabasedata;
 		return (pushlongondiskhandle (adr, *hpacked));
 		} /*wpverbpack_internal*/
 

--- a/Common/source/wpverbs.c
+++ b/Common/source/wpverbs.c
@@ -632,23 +632,16 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	boolean fltempload = false;
 	const boolean adapter_repack = db_format_adapter_force_repack();
 
-	/* Callee-saves: protect databasedata from corruption by nested pack operations */
-	hdldatabaserecord savedatabasedata = databasedata;
-
 	/*
-	2025-12-20: Set mode from context before any database I/O
-	This ensures writes use the correct format (v7 during migration)
+	Phase 3: No direct databasedata mutation. All DB I/O goes through
+	_context() wrappers. Apply mode from context for mode-dependent logic.
 	*/
-	if (ctx != NULL) {
-		if (ctx->database != nil)
-			databasedata = ctx->database;
+	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
-	}
 
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
-		databasedata = savedatabasedata;
 		return (false);
 	}
 
@@ -660,10 +653,8 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 
 		hpackedwp = (Handle) (**hv).variabledata;
 
-		if (!dbassignhandle (hpackedwp, &adr)) {
-			databasedata = savedatabasedata;
+		if (!dbassignhandle_context (ctx, hpackedwp, &adr))
 			return (false);
-		}
 
 		if (fldatabasesaveas)
 			goto pushaddress;
@@ -690,19 +681,15 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	if (!fldatabasesaveas && !(**hwp).fldirty && !(**hwp).fldirtyview) /*don't need to update the db version of the wpdoc*/
 		goto pushaddress;
 
-	if (!wpverbpackrecord (hwp, &hpackedwp)) {
-		databasedata = savedatabasedata;
+	if (!wpverbpackrecord (hwp, &hpackedwp))
 		return (false);
-	}
 
-	fl = dbassignhandle (hpackedwp, &adr);
+	fl = dbassignhandle_context (ctx, hpackedwp, &adr);
 
 	disposehandle (hpackedwp);
 
-	if (!fl) {
-		databasedata = savedatabasedata;
+	if (!fl)
 		return (false);
-	}
 
 	if (fldatabasesaveas)
 		goto pushaddress;
@@ -736,7 +723,6 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		else
 			*flnewdbaddress = true;
 
-		databasedata = savedatabasedata;
 		return (pushlongondiskhandle (adr, *hpacked));
 		} /*wpverbpack_internal*/
 

--- a/Common/source/wpverbs.c
+++ b/Common/source/wpverbs.c
@@ -102,7 +102,7 @@ static boolean wp_headless_get_target_record (hdlwprecord *hout, hdlwpvariable *
     if (*hvout == nil)
         return false;
 
-    if (!wpverbinmemory ((hdlexternalvariable) *hvout))
+    if (!wpverbinmemory (NULL, (hdlexternalvariable) *hvout))
         return false;
 
     *hout = (hdlwprecord) (**(*hvout)).variabledata;
@@ -417,7 +417,7 @@ boolean wpverbsetdirty (hdlexternalvariable hvariable, boolean fldirty) {
 	register hdlwpvariable hv = (hdlwpvariable) hvariable;
 	register hdlwprecord hwp;
 	
-	if (!wpverbinmemory ((hdlexternalvariable) hv))
+	if (!wpverbinmemory (NULL, (hdlexternalvariable) hv))
 		return (false);
 	
 	hwp = (hdlwprecord) (**hv).variabledata;
@@ -831,7 +831,7 @@ boolean wpverbgetsize (hdlexternalvariable hvariable, long *size) {
 		
 	else {
 		
-		if (!wpverbinmemory ((hdlexternalvariable) hv))
+		if (!wpverbinmemory (NULL, (hdlexternalvariable) hv))
 			return (false);
 		
 		wppushdata ((hdlwprecord) (**hv).variabledata);
@@ -875,7 +875,7 @@ boolean wpverbpacktotext (hdlexternalvariable h, Handle htext) {
 	Handle hwptext;
 	boolean fltempload = !(**hv).flinmemory;
 	
-	if (!wpverbinmemory ((hdlexternalvariable) hv))
+	if (!wpverbinmemory (NULL, (hdlexternalvariable) hv))
 		return (false);
 	
 	hwp = (hdlwprecord) (**hv).variabledata;
@@ -903,7 +903,7 @@ boolean wpverbgettimes (hdlexternalvariable h, int64_t *timecreated, int64_t *ti
 	register hdlexternalvariable hv = h;
 	register hdlwprecord hwp;
 	
-	if (!wpverbinmemory (hv))
+	if (!wpverbinmemory (NULL, hv))
 		return (false);
 	
 	hwp = (hdlwprecord) (**hv).variabledata;
@@ -921,7 +921,7 @@ boolean wpverbsettimes (hdlexternalvariable h, int64_t timecreated, int64_t time
 	register hdlexternalvariable hv = h;
 	register hdlwprecord hwp;
 	
-	if (!wpverbinmemory (hv))
+	if (!wpverbinmemory (NULL, hv))
 		return (false);
 	
 	hwp = (hdlwprecord) (**hv).variabledata;
@@ -988,7 +988,7 @@ boolean wpedit (hdlexternalvariable hvariable, hdlwindowinfo hparent, ptrfilespe
 	WindowPtr w;
 	hdlwindowinfo hi;
 	
-	if (!wpverbinmemory ((hdlexternalvariable) hv)) // couldn't swap it into memory
+	if (!wpverbinmemory (NULL, (hdlexternalvariable) hv)) // couldn't swap it into memory
 		return (false);
 	
 	hwp = (hdlwprecord) (**hv).variabledata; // it's in memory
@@ -1938,7 +1938,7 @@ boolean wpverbfind (hdlexternalvariable hvariable, boolean *flzoom) {
 	
 	fltempload = !(**hv).flinmemory;
 	
-	if (!wpverbinmemory ((hdlexternalvariable) hv))
+	if (!wpverbinmemory (NULL, (hdlexternalvariable) hv))
 		return (false);
 	
 	hwp = (hdlwprecord) (**hv).variabledata;

--- a/Common/source/wpverbs.c
+++ b/Common/source/wpverbs.c
@@ -636,12 +636,15 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	Phase 3: No direct databasedata mutation. All DB I/O goes through
 	_context() wrappers. Apply mode from context for mode-dependent logic.
 	*/
+	db_format_mode savedmode = db_format_mode_current();
+
 	if (ctx != NULL)
 		db_format_mode_apply(&ctx->mode);
 
 	/* Precondition: external must be in memory */
 	if (!(**hv).flinmemory) {
 		/* This is a programming error - caller should have loaded it */
+		db_format_mode_apply(&savedmode);
 		return (false);
 	}
 
@@ -653,8 +656,10 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 
 		hpackedwp = (Handle) (**hv).variabledata;
 
-		if (!dbassignhandle_context (ctx, hpackedwp, &adr))
+		if (!dbassignhandle_context (ctx, hpackedwp, &adr)) {
+			db_format_mode_apply(&savedmode);
 			return (false);
+		}
 
 		if (fldatabasesaveas)
 			goto pushaddress;
@@ -681,15 +686,19 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 	if (!fldatabasesaveas && !(**hwp).fldirty && !(**hwp).fldirtyview) /*don't need to update the db version of the wpdoc*/
 		goto pushaddress;
 
-	if (!wpverbpackrecord (hwp, &hpackedwp))
+	if (!wpverbpackrecord (hwp, &hpackedwp)) {
+		db_format_mode_apply(&savedmode);
 		return (false);
+	}
 
 	fl = dbassignhandle_context (ctx, hpackedwp, &adr);
 
 	disposehandle (hpackedwp);
 
-	if (!fl)
+	if (!fl) {
+		db_format_mode_apply(&savedmode);
 		return (false);
+	}
 
 	if (fldatabasesaveas)
 		goto pushaddress;
@@ -723,6 +732,7 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 		else
 			*flnewdbaddress = true;
 
+		db_format_mode_apply(&savedmode);
 		return (pushlongondiskhandle (adr, *hpacked));
 		} /*wpverbpack_internal*/
 

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -572,17 +572,26 @@ boolean wpverbpack(hdlexternalvariable hv, Handle *hpacked, boolean *flnewdbaddr
 }
 
 boolean wpverbpack_internal(const db_context *ctx, hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddress) {
-    /* Portable WP pack: context is unused because we only read oldaddress
-       (no DB I/O), so no save/restore of databasedata or mode is needed. */
-    (void) ctx;
+    /* WP pack is read-only (only reads oldaddress, no DB I/O), but we
+       apply the callee-saves pattern for structural consistency with the
+       other four verbpack_internal functions. */
 
     if ((h == nil) || (hpacked == nil))
         return false;
 
-    if (!(**h).flinmemory)
+    db_format_mode savedmode = db_format_mode_current();
+
+    if (ctx != NULL)
+        db_format_mode_apply(&ctx->mode);
+
+    if (!(**h).flinmemory) {
+        db_format_mode_apply(&savedmode);
         return false;
+    }
 
     dbaddress adr = (**h).oldaddress;
+
+    db_format_mode_apply(&savedmode);
 
     if (flnewdbaddress != NULL)
         *flnewdbaddress = false;

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -572,25 +572,17 @@ boolean wpverbpack(hdlexternalvariable hv, Handle *hpacked, boolean *flnewdbaddr
 }
 
 boolean wpverbpack_internal(const db_context *ctx, hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddress) {
+    /* Portable WP pack: context is unused because we only read oldaddress
+       (no DB I/O), so no save/restore of databasedata or mode is needed. */
+    (void) ctx;
+
     if ((h == nil) || (hpacked == nil))
         return false;
 
     if (!(**h).flinmemory)
         return false;
 
-    hdldatabaserecord savedatabasedata = databasedata;
-    db_format_mode savedmode = db_format_mode_current();
-
-    if (ctx != NULL) {
-        if (ctx->database != nil)
-            databasedata = ctx->database;
-        db_format_mode_apply(&ctx->mode);
-    }
-
     dbaddress adr = (**h).oldaddress;
-
-    databasedata = savedatabasedata;
-    db_format_mode_apply(&savedmode);
 
     if (flnewdbaddress != NULL)
         *flnewdbaddress = false;

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -589,7 +589,6 @@ boolean wpverbpack_internal(const db_context *ctx, hdlexternalvariable h, Handle
 
     dbaddress adr = (**h).oldaddress;
 
-    (**h).oldaddress = adr;
     databasedata = savedatabasedata;
     db_format_mode_apply(&savedmode);
 

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -571,6 +571,34 @@ boolean wpverbpack(hdlexternalvariable hv, Handle *hpacked, boolean *flnewdbaddr
     return pushlongondiskhandle((long)adr, *hpacked);
 }
 
+boolean wpverbpack_internal(const db_context *ctx, hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddress) {
+    if ((h == nil) || (hpacked == nil))
+        return false;
+
+    if (!(**h).flinmemory)
+        return false;
+
+    hdldatabaserecord savedatabasedata = databasedata;
+    db_format_mode savedmode = db_format_mode_current();
+
+    if (ctx != NULL) {
+        if (ctx->database != nil)
+            databasedata = ctx->database;
+        db_format_mode_apply(&ctx->mode);
+    }
+
+    dbaddress adr = (**h).oldaddress;
+
+    (**h).oldaddress = adr;
+    databasedata = savedatabasedata;
+    db_format_mode_apply(&savedmode);
+
+    if (flnewdbaddress != NULL)
+        *flnewdbaddress = false;
+
+    return pushlongondiskhandle((long) adr, *hpacked);
+}
+
 boolean wpverbunpack(Handle hpacked, long *ixload, hdlexternalvariable *h) {
     long rawadr = 0;
 

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 05:22:30 GMT</dateCreated>
+    <dateCreated>Tue, 24 Feb 2026 05:35:46 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-24 at 05:22 UTC"/>
+      <outline text="Run: 2026-02-24 at 05:35 UTC"/>
       <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (287 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 05:11:56 GMT</dateCreated>
+    <dateCreated>Tue, 24 Feb 2026 05:22:30 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-24 at 05:11 UTC"/>
+      <outline text="Run: 2026-02-24 at 05:22 UTC"/>
       <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (287 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 286 tests: 286 pass (100%)</title>
-    <dateCreated>Mon, 23 Feb 2026 08:03:20 GMT</dateCreated>
+    <dateCreated>Mon, 23 Feb 2026 21:01:30 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-23 at 08:03 UTC"/>
+      <outline text="Run: 2026-02-23 at 21:01 UTC"/>
       <outline text="Results: 286 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (286 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 286 tests: 286 pass (100%)</title>
-    <dateCreated>Mon, 23 Feb 2026 21:01:30 GMT</dateCreated>
+    <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
+    <dateCreated>Tue, 24 Feb 2026 00:43:33 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-23 at 21:01 UTC"/>
-      <outline text="Results: 286 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (286 tests total)"/>
+      <outline text="Run: 2026-02-24 at 00:43 UTC"/>
+      <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (287 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 20 tests: 20 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 21 tests: 21 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 284 tests: 284 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 07:03:25 GMT</dateCreated>
+    <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
+    <dateCreated>Wed, 25 Feb 2026 07:41:32 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-24 at 07:03 UTC"/>
-      <outline text="Results: 284 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (284 tests total)"/>
+      <outline text="Run: 2026-02-25 at 07:41 UTC"/>
+      <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (287 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 06:35:18 GMT</dateCreated>
+    <dateCreated>Tue, 24 Feb 2026 07:03:36 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-24 at 06:35 UTC"/>
+      <outline text="Run: 2026-02-24 at 07:03 UTC"/>
       <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (287 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 284 tests: 284 pass (100%)</title>
-    <dateCreated>Mon, 23 Feb 2026 05:42:50 GMT</dateCreated>
+    <title>Frontier Unit Tests - 286 tests: 286 pass (100%)</title>
+    <dateCreated>Mon, 23 Feb 2026 07:47:54 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-23 at 05:42 UTC"/>
-      <outline text="Results: 284 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (284 tests total)"/>
+      <outline text="Run: 2026-02-23 at 07:47 UTC"/>
+      <outline text="Results: 286 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (286 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 18 tests: 18 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 20 tests: 20 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 05:35:46 GMT</dateCreated>
+    <dateCreated>Tue, 24 Feb 2026 06:35:18 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-24 at 05:35 UTC"/>
+      <outline text="Run: 2026-02-24 at 06:35 UTC"/>
       <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (287 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 00:43:33 GMT</dateCreated>
+    <dateCreated>Tue, 24 Feb 2026 05:11:56 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-24 at 00:43 UTC"/>
+      <outline text="Run: 2026-02-24 at 05:11 UTC"/>
       <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (287 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 07:41:32 GMT</dateCreated>
+    <dateCreated>Wed, 25 Feb 2026 07:56:09 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-25 at 07:41 UTC"/>
+      <outline text="Run: 2026-02-25 at 07:56 UTC"/>
       <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (287 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 286 tests: 286 pass (100%)</title>
-    <dateCreated>Mon, 23 Feb 2026 07:47:54 GMT</dateCreated>
+    <dateCreated>Mon, 23 Feb 2026 08:03:20 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-23 at 07:47 UTC"/>
+      <outline text="Run: 2026-02-23 at 08:03 UTC"/>
       <outline text="Results: 286 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (286 tests total)"/>
     </outline>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 18 tests: 18 pass (100%)</title>
-    <dateCreated>Wed, 18 Feb 2026 21:49:56 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 20 tests: 20 pass (100%)</title>
+    <dateCreated>Mon, 23 Feb 2026 07:47:54 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -20,6 +20,8 @@
     <outline text="✓ test_procedural_v7_golden_header_and_avail"/>
     <outline text="✓ test_db_context_database_swap"/>
     <outline text="✓ test_dbswapglobals_context_scoped"/>
+    <outline text="✓ test_verbpack_internal_callee_saves_databasedata"/>
+    <outline text="✓ test_db_context_io_primitives_restore_databasedata"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 20 tests: 20 pass (100%)</title>
-    <dateCreated>Mon, 23 Feb 2026 07:47:54 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 21 tests: 21 pass (100%)</title>
+    <dateCreated>Tue, 24 Feb 2026 00:43:33 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -22,6 +22,7 @@
     <outline text="✓ test_dbswapglobals_context_scoped"/>
     <outline text="✓ test_verbpack_internal_callee_saves_databasedata"/>
     <outline text="✓ test_db_context_io_primitives_restore_databasedata"/>
+    <outline text="✓ test_verbpack_internal_callee_saves_format_mode"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -870,15 +870,12 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     /* Set databasedata to db_A (simulating "we're saving the system root") */
     databasedata = db_A;
 
-    /* Build a minimal in-memory table external */
-    hdlhashtable htable = nil;
-    assert(newhashtable(&htable));
-
+    /* Build a minimal table external with flinmemory=0 to force early return,
+       consistent with the other four verb types below. */
     hdlexternalvariable hv = nil;
     assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
     (**hv).id = idtableprocessor;
-    (**hv).flinmemory = 1;
-    (**hv).variabledata = (long) htable;
+    (**hv).flinmemory = 0;
     (**hv).oldaddress = (dbaddress) 0x1000;
 
     Handle hpacked = nil;
@@ -889,9 +886,9 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     db_context_init(&guest_ctx);
     guest_ctx.database = db_B;
 
-    /* Pack using the guest context — this sets databasedata = db_B internally */
+    /* Pack using the guest context — early return, but databasedata must be restored */
     boolean flnew = false;
-    boolean ok = tableverbpack_internal(&guest_ctx, hv, &hpacked, &flnew);
+    (void) tableverbpack_internal(&guest_ctx, hv, &hpacked, &flnew);
 
     /* THE INVARIANT: databasedata must be restored to db_A after the call */
     assert(databasedata == db_A);
@@ -949,6 +946,8 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     Handle hpacked_menu = nil;
     assert(newclearhandle(0, &hpacked_menu));
     boolean flnew_menu = false;
+    /* menuverbpack_internal threads ctx to callees — never mutates databasedata
+       directly in Phase 3, so this assertion is a structural sanity check. */
     (void) menuverbpack_internal(&guest_ctx, hv_menu, &hpacked_menu, &flnew_menu);
     assert(databasedata == db_A);
 
@@ -958,14 +957,11 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     disposehandle(hpacked_wp);
     disposehandle(hpacked_pict);
     disposehandle(hpacked_menu);
-    (**hv).variabledata = 0;
     disposehandle((Handle) hv);
     disposehandle((Handle) hv_op);
     disposehandle((Handle) hv_wp);
     disposehandle((Handle) hv_pict);
     disposehandle((Handle) hv_menu);
-    (void)htable;  /* intentional leak: hash table dispose requires full runtime; expected under ASAN */
-    (void)ok;  /* return value unchecked: may succeed or fail depending on runtime state; we only assert databasedata restore */
 
     databasedata = baseline_db;
     db_format_mode_apply(&baseline_mode);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -920,8 +920,8 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     (**hv).variabledata = 0;
     disposehandle((Handle) hv);
     disposehandle((Handle) hv_op);
-    (void)htable;  /* skip hash table dispose — requires full runtime */
-    (void)ok;
+    (void)htable;  /* intentional leak: hash table dispose requires full runtime; expected under ASAN */
+    (void)ok;  /* return value unchecked: may succeed or fail depending on runtime state; we only assert databasedata restore */
 
     databasedata = baseline_db;
     db_format_mode_apply(&baseline_mode);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -928,6 +928,68 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     log_info(LOG_COMP_DB, "[TEST] test_verbpack_internal_callee_saves_databasedata COMPLETED");
 }
 
+static void test_db_context_io_primitives_restore_databasedata(void) {
+    /*
+     * Verify that the Phase 2 _context() wrappers (dbread_context,
+     * dbwrite_context, dbsavehandle_context, dbgeteof_context) restore
+     * databasedata after the call, regardless of success or failure.
+     *
+     * We don't have a real database file open, so the underlying operations
+     * will fail — but the save/restore of databasedata must still work.
+     */
+    hdldatabaserecord baseline_db = databasedata;
+
+    hdldatabaserecord db_A = nil;
+    hdldatabaserecord db_B = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_A));
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_B));
+    (**db_A).fnumdatabase = 300;
+    (**db_B).fnumdatabase = 400;
+
+    db_context ctx_B;
+    db_context_init(&ctx_B);
+    ctx_B.database = db_B;
+
+    char buf[16];
+
+    /* dbread_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    (void) dbread_context(&ctx_B, (dbaddress) 0x100, sizeof(buf), buf);
+    assert(databasedata == db_A);
+
+    /* dbwrite_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    (void) dbwrite_context(&ctx_B, (dbaddress) 0x100, sizeof(buf), buf);
+    assert(databasedata == db_A);
+
+    /* dbgeteof_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    long eof_val = 0;
+    (void) dbgeteof_context(&ctx_B, &eof_val);
+    assert(databasedata == db_A);
+
+    /* dbsavehandle_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    Handle hsave = nil;
+    assert(newclearhandle(8, &hsave));
+    dbaddress save_adr = nildbaddress;
+    (void) dbsavehandle_context(&ctx_B, hsave, &save_adr);
+    assert(databasedata == db_A);
+    disposehandle(hsave);
+
+    /* Also verify NULL context is a no-op for databasedata */
+    databasedata = db_A;
+    (void) dbread_context(NULL, (dbaddress) 0x100, sizeof(buf), buf);
+    assert(databasedata == db_A);
+
+    /* Cleanup */
+    databasedata = baseline_db;
+    disposehandle((Handle) db_A);
+    disposehandle((Handle) db_B);
+
+    log_info(LOG_COMP_DB, "[TEST] test_db_context_io_primitives_restore_databasedata COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -950,6 +1012,7 @@ int main(void) {
     TR_RUN(test_db_context_database_swap);
     TR_RUN(test_dbswapglobals_context_scoped);
     TR_RUN(test_verbpack_internal_callee_saves_databasedata);
+    TR_RUN(test_db_context_io_primitives_restore_databasedata);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -914,12 +914,56 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
     assert(!ok_op);  /* expected failure: not in memory */
     assert(databasedata == db_A);  /* invariant must hold even on error paths */
 
+    /* Verify databasedata callee-saves for wp (early return: not in memory) */
+    databasedata = db_A;
+    hdlexternalvariable hv_wp = nil;
+    assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv_wp));
+    (**hv_wp).id = idwordprocessor;
+    (**hv_wp).flinmemory = 0;
+    Handle hpacked_wp = nil;
+    assert(newclearhandle(0, &hpacked_wp));
+    boolean flnew_wp = false;
+    boolean ok_wp = wpverbpack_internal(&guest_ctx, hv_wp, &hpacked_wp, &flnew_wp);
+    assert(!ok_wp);
+    assert(databasedata == db_A);
+
+    /* Verify databasedata callee-saves for pict (early return: not in memory) */
+    databasedata = db_A;
+    hdlexternalvariable hv_pict = nil;
+    assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv_pict));
+    (**hv_pict).id = idpictprocessor;
+    (**hv_pict).flinmemory = 0;
+    Handle hpacked_pict = nil;
+    assert(newclearhandle(0, &hpacked_pict));
+    boolean flnew_pict = false;
+    boolean ok_pict = pictverbpack_internal(&guest_ctx, hv_pict, &hpacked_pict, &flnew_pict);
+    assert(!ok_pict);
+    assert(databasedata == db_A);
+
+    /* Verify databasedata callee-saves for menu (early return: not in memory) */
+    databasedata = db_A;
+    hdlexternalvariable hv_menu = nil;
+    assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv_menu));
+    (**hv_menu).id = idmenuprocessor;
+    (**hv_menu).flinmemory = 0;
+    Handle hpacked_menu = nil;
+    assert(newclearhandle(0, &hpacked_menu));
+    boolean flnew_menu = false;
+    (void) menuverbpack_internal(&guest_ctx, hv_menu, &hpacked_menu, &flnew_menu);
+    assert(databasedata == db_A);
+
     /* Cleanup */
     disposehandle(hpacked);
     disposehandle(hpacked_op);
+    disposehandle(hpacked_wp);
+    disposehandle(hpacked_pict);
+    disposehandle(hpacked_menu);
     (**hv).variabledata = 0;
     disposehandle((Handle) hv);
     disposehandle((Handle) hv_op);
+    disposehandle((Handle) hv_wp);
+    disposehandle((Handle) hv_pict);
+    disposehandle((Handle) hv_menu);
     (void)htable;  /* intentional leak: hash table dispose requires full runtime; expected under ASAN */
     (void)ok;  /* return value unchecked: may succeed or fail depending on runtime state; we only assert databasedata restore */
 

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -14,6 +14,7 @@
 #include "dbinternal.h"
 #include "langexternal.h"
 #include "tableverbs.h"
+#include "opverbs.h"
 #include "logging.h"
 #include "test_report.h"
 
@@ -841,6 +842,92 @@ static void test_dbswapglobals_context_scoped(void) {
     disposehandle((Handle) hsrc);
     disposehandle((Handle) hdst);
 }
+
+static void test_verbpack_internal_callee_saves_databasedata(void) {
+    /*
+     * Verify the callee-saves invariant: each *verbpack_internal function must
+     * restore databasedata to its original value before returning, even when
+     * the context points to a different database.
+     *
+     * This prevents the bug where packing a child external belonging to
+     * database B corrupts databasedata for the next sibling that expects
+     * database A.
+     */
+    hdldatabaserecord baseline_db = databasedata;
+    db_format_mode baseline_mode = db_format_mode_current();
+
+    /* Create two fake database handles: db_A = "system root", db_B = "guest db" */
+    hdldatabaserecord db_A = nil;
+    hdldatabaserecord db_B = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_A));
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_B));
+    (**db_A).fnumdatabase = 100;
+    (**db_B).fnumdatabase = 200;
+
+    /* Set databasedata to db_A (simulating "we're saving the system root") */
+    databasedata = db_A;
+
+    /* Build a minimal in-memory table external */
+    hdlhashtable htable = nil;
+    assert(newhashtable(&htable));
+
+    hdlexternalvariable hv = nil;
+    assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+    (**hv).id = idtableprocessor;
+    (**hv).flinmemory = 1;
+    (**hv).variabledata = (long) htable;
+    (**hv).oldaddress = (dbaddress) 0x1000;
+
+    Handle hpacked = nil;
+    assert(newclearhandle(0, &hpacked));
+
+    /* Create a context pointing to db_B (the "guest database") */
+    db_context guest_ctx;
+    db_context_init(&guest_ctx);
+    guest_ctx.database = db_B;
+
+    /* Pack using the guest context — this sets databasedata = db_B internally */
+    boolean flnew = false;
+    boolean ok = tableverbpack_internal(&guest_ctx, hv, &hpacked, &flnew);
+
+    /* THE INVARIANT: databasedata must be restored to db_A after the call */
+    assert(databasedata == db_A);
+
+    /* Verify for opverbpack_internal too — create a minimal outline external */
+    databasedata = db_A;  /* reset in case the test above somehow changed it */
+
+    hdlexternalvariable hv_op = nil;
+    assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv_op));
+    (**hv_op).id = idoutlineprocessor;
+    (**hv_op).flinmemory = 0;  /* not in memory — early return path */
+    (**hv_op).oldaddress = (dbaddress) 0x2000;
+
+    Handle hpacked_op = nil;
+    assert(newclearhandle(0, &hpacked_op));
+
+    /* This should fail (not in memory) but STILL restore databasedata */
+    boolean flnew_op = false;
+    boolean ok_op = opverbpack_internal(&guest_ctx, hv_op, &hpacked_op, &flnew_op);
+    assert(!ok_op);  /* expected failure: not in memory */
+    assert(databasedata == db_A);  /* invariant must hold even on error paths */
+
+    /* Cleanup */
+    disposehandle(hpacked);
+    disposehandle(hpacked_op);
+    (**hv).variabledata = 0;
+    disposehandle((Handle) hv);
+    disposehandle((Handle) hv_op);
+    (void)htable;  /* skip hash table dispose — requires full runtime */
+    (void)ok;
+
+    databasedata = baseline_db;
+    db_format_mode_apply(&baseline_mode);
+    disposehandle((Handle) db_A);
+    disposehandle((Handle) db_B);
+
+    log_info(LOG_COMP_DB, "[TEST] test_verbpack_internal_callee_saves_databasedata COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -862,6 +949,7 @@ int main(void) {
     TR_RUN(test_procedural_v7_golden_header_and_avail);
     TR_RUN(test_db_context_database_swap);
     TR_RUN(test_dbswapglobals_context_scoped);
+    TR_RUN(test_verbpack_internal_callee_saves_databasedata);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -15,6 +15,9 @@
 #include "langexternal.h"
 #include "tableverbs.h"
 #include "opverbs.h"
+#include "wpverbs.h"
+#include "pictverbs.h"
+#include "menuverbs.h"
 #include "logging.h"
 #include "test_report.h"
 
@@ -1006,6 +1009,134 @@ static void test_db_context_io_primitives_restore_databasedata(void) {
     log_info(LOG_COMP_DB, "[TEST] test_db_context_io_primitives_restore_databasedata COMPLETED");
 }
 
+static void test_verbpack_internal_callee_saves_format_mode(void) {
+    /*
+     * Verify that all five *verbpack_internal functions restore the global
+     * format mode after the call, even on error paths. This is the mode-state
+     * counterpart to test_verbpack_internal_callee_saves_databasedata.
+     *
+     * We test each function on its early-return (not-in-memory) path, which
+     * exercises the mode apply + restore without needing a real database.
+     */
+    hdldatabaserecord baseline_db = databasedata;
+    db_format_mode baseline_mode = db_format_mode_current();
+
+    hdldatabaserecord db_dummy = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_dummy));
+    (**db_dummy).fnumdatabase = 999;
+
+    /* Create a context with v7 mode (different from default) */
+    db_context ctx;
+    db_context_init(&ctx);
+    ctx.database = db_dummy;
+    ctx.mode.use_64bit_format = true;
+    ctx.mode.adapter_repack = true;
+
+    Handle hpacked = nil;
+    boolean flnew = false;
+
+    /* --- tableverbpack_internal (early return: not in memory) --- */
+    {
+        hdlexternalvariable hv = nil;
+        assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+        (**hv).id = idtableprocessor;
+        (**hv).flinmemory = 0;  /* triggers early return */
+        (**hv).oldaddress = (dbaddress) 0x1000;
+
+        assert(newclearhandle(0, &hpacked));
+        db_format_mode before = db_format_mode_current();
+        boolean ok = tableverbpack_internal(&ctx, hv, &hpacked, &flnew);
+        db_format_mode after = db_format_mode_current();
+        assert(!ok);
+        assert(before.use_64bit_format == after.use_64bit_format);
+        assert(before.adapter_repack == after.adapter_repack);
+        disposehandle(hpacked); hpacked = nil;
+        disposehandle((Handle) hv);
+    }
+
+    /* --- opverbpack_internal (early return: not in memory) --- */
+    {
+        hdlexternalvariable hv = nil;
+        assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+        (**hv).id = idoutlineprocessor;
+        (**hv).flinmemory = 0;
+        (**hv).oldaddress = (dbaddress) 0x2000;
+
+        assert(newclearhandle(0, &hpacked));
+        db_format_mode before = db_format_mode_current();
+        boolean ok = opverbpack_internal(&ctx, hv, &hpacked, &flnew);
+        db_format_mode after = db_format_mode_current();
+        assert(!ok);
+        assert(before.use_64bit_format == after.use_64bit_format);
+        assert(before.adapter_repack == after.adapter_repack);
+        disposehandle(hpacked); hpacked = nil;
+        disposehandle((Handle) hv);
+    }
+
+    /* --- wpverbpack_internal (early return: not in memory) --- */
+    {
+        hdlexternalvariable hv = nil;
+        assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+        (**hv).id = idwordprocessor;
+        (**hv).flinmemory = 0;
+        (**hv).oldaddress = (dbaddress) 0x3000;
+
+        assert(newclearhandle(0, &hpacked));
+        db_format_mode before = db_format_mode_current();
+        boolean ok = wpverbpack_internal(&ctx, hv, &hpacked, &flnew);
+        db_format_mode after = db_format_mode_current();
+        assert(!ok);
+        assert(before.use_64bit_format == after.use_64bit_format);
+        assert(before.adapter_repack == after.adapter_repack);
+        disposehandle(hpacked); hpacked = nil;
+        disposehandle((Handle) hv);
+    }
+
+    /* --- pictverbpack_internal (early return: not in memory) --- */
+    {
+        hdlexternalvariable hv = nil;
+        assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+        (**hv).id = idpictprocessor;
+        (**hv).flinmemory = 0;
+        (**hv).oldaddress = (dbaddress) 0x4000;
+
+        assert(newclearhandle(0, &hpacked));
+        db_format_mode before = db_format_mode_current();
+        boolean ok = pictverbpack_internal(&ctx, hv, &hpacked, &flnew);
+        db_format_mode after = db_format_mode_current();
+        assert(!ok);
+        assert(before.use_64bit_format == after.use_64bit_format);
+        assert(before.adapter_repack == after.adapter_repack);
+        disposehandle(hpacked); hpacked = nil;
+        disposehandle((Handle) hv);
+    }
+
+    /* --- menuverbpack_internal (early return: not in memory) --- */
+    {
+        hdlexternalvariable hv = nil;
+        assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+        (**hv).id = idmenuprocessor;
+        (**hv).flinmemory = 0;
+        (**hv).oldaddress = (dbaddress) 0x5000;
+
+        assert(newclearhandle(0, &hpacked));
+        db_format_mode before = db_format_mode_current();
+        (void) menuverbpack_internal(&ctx, hv, &hpacked, &flnew);
+        db_format_mode after = db_format_mode_current();
+        assert(before.use_64bit_format == after.use_64bit_format);
+        assert(before.adapter_repack == after.adapter_repack);
+        disposehandle(hpacked); hpacked = nil;
+        disposehandle((Handle) hv);
+    }
+
+    /* Cleanup */
+    databasedata = baseline_db;
+    db_format_mode_apply(&baseline_mode);
+    disposehandle((Handle) db_dummy);
+
+    log_info(LOG_COMP_DB, "[TEST] test_verbpack_internal_callee_saves_format_mode COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -1029,6 +1160,7 @@ int main(void) {
     TR_RUN(test_dbswapglobals_context_scoped);
     TR_RUN(test_verbpack_internal_callee_saves_databasedata);
     TR_RUN(test_db_context_io_primitives_restore_databasedata);
+    TR_RUN(test_verbpack_internal_callee_saves_format_mode);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -977,6 +977,22 @@ static void test_db_context_io_primitives_restore_databasedata(void) {
     assert(databasedata == db_A);
     disposehandle(hsave);
 
+    /* dbreference_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    (void) dbreference_context(&ctx_B, (dbaddress) 0x100, sizeof(buf), buf);
+    assert(databasedata == db_A);
+
+    /* dbreference_context with NULL context: should still restore */
+    databasedata = db_A;
+    (void) dbreference_context(NULL, (dbaddress) 0x100, sizeof(buf), buf);
+    assert(databasedata == db_A);
+
+    /* dbreference_handle_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    Handle href = nil;
+    (void) dbreference_handle_context(&ctx_B, (dbaddress) 0x100, &href);
+    assert(databasedata == db_A);
+
     /* Also verify NULL context is a no-op for databasedata */
     databasedata = db_A;
     (void) dbread_context(NULL, (dbaddress) 0x100, sizeof(buf), buf);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -977,9 +977,10 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
 
 static void test_db_context_io_primitives_restore_databasedata(void) {
     /*
-     * Verify that the Phase 2 _context() wrappers (dbread_context,
-     * dbwrite_context, dbsavehandle_context, dbgeteof_context) restore
-     * databasedata after the call, regardless of success or failure.
+     * Verify that all nine _context() wrappers restore databasedata after
+     * the call, regardless of success or failure:
+     *   dbread, dbwrite, dbgeteof, dbsavehandle, dbassign, dbassignhandle,
+     *   dbcopy, dbreference, dbreference_handle.
      *
      * We don't have a real database file open, so the underlying operations
      * will fail — but the save/restore of databasedata must still work.
@@ -1023,6 +1024,27 @@ static void test_db_context_io_primitives_restore_databasedata(void) {
     (void) dbsavehandle_context(&ctx_B, hsave, &save_adr);
     assert(databasedata == db_A);
     disposehandle(hsave);
+
+    /* dbassign_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    dbaddress assign_adr = nildbaddress;
+    (void) dbassign_context(&ctx_B, &assign_adr, sizeof(buf), buf);
+    assert(databasedata == db_A);
+
+    /* dbassignhandle_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    Handle hassign = nil;
+    assert(newclearhandle(8, &hassign));
+    dbaddress assignh_adr = nildbaddress;
+    (void) dbassignhandle_context(&ctx_B, hassign, &assignh_adr);
+    assert(databasedata == db_A);
+    disposehandle(hassign);
+
+    /* dbcopy_context: should restore databasedata even on failure */
+    databasedata = db_A;
+    dbaddress copy_dest = nildbaddress;
+    (void) dbcopy_context(&ctx_B, (dbaddress) 0x100, &copy_dest);
+    assert(databasedata == db_A);
 
     /* dbreference_context: should restore databasedata even on failure */
     databasedata = db_A;

--- a/tests/headless_menu_stubs.c
+++ b/tests/headless_menu_stubs.c
@@ -400,7 +400,7 @@ boolean meloadoutline (dbaddress adr, hdloutlinerecord *houtline) {
     return meloadoutline_internal (nil, adr, houtline);
 }
 
-boolean mesaveoutline (hdloutlinerecord ho, dbaddress *adr) {
+boolean mesaveoutline (const db_context *ctx, hdloutlinerecord ho, dbaddress *adr) {
     /*
      * Save menu outline to database.
      */
@@ -409,7 +409,7 @@ boolean mesaveoutline (hdloutlinerecord ho, dbaddress *adr) {
     if (!oppackoutline (ho, &hpackedoutline))
         return (false);
 
-    boolean fl = dbsavehandle (hpackedoutline, adr);
+    boolean fl = dbsavehandle_context (ctx, hpackedoutline, adr);
 
     disposehandle (hpackedoutline);
 

--- a/tests/headless_menu_stubs.c
+++ b/tests/headless_menu_stubs.c
@@ -520,10 +520,13 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
      * During headless migration, menu externals are preserved as database references
      * without materializing their data. We just pack the v6 address as-is.
      */
-    (void) ctx;  /* Context not needed for address passthrough */
-
     if ((h == nil) || (hp == nil))
         return false;
+
+    db_format_mode savedmode = db_format_mode_current();
+
+    if (ctx != NULL)
+        db_format_mode_apply(&ctx->mode);
 
     dbaddress adr = (**h).oldaddress;
     if (adr == nildbaddress)
@@ -531,6 +534,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
     if (adr == nildbaddress) {
         if (flnew)
             *flnew = false;
+        db_format_mode_apply(&savedmode);
         return false;
     }
 
@@ -539,6 +543,7 @@ boolean menuverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
         *flnew = true;
 
     (**h).oldaddress = adr;
+    db_format_mode_apply(&savedmode);
     return pushlongondiskhandle((long) adr, *hp);
 }
 

--- a/tests/headless_pict_stubs.c
+++ b/tests/headless_pict_stubs.c
@@ -91,13 +91,8 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
         return false;
     }
 
-    /* Callee-saves: protect databasedata from corruption by nested pack operations */
-    hdldatabaserecord savedatabasedata = databasedata;
-
     /* Apply context mode if provided (for migration: sets v7 format flags) */
     if (ctx != NULL) {
-        if (ctx->database != nil)
-            databasedata = ctx->database;
         db_format_mode_apply(&ctx->mode);
     }
 
@@ -115,7 +110,6 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
     }
 
     (**h).oldaddress = adr;
-    databasedata = savedatabasedata;
     return pushlongondiskhandle((long) adr, *hpacked);
 }
 

--- a/tests/headless_pict_stubs.c
+++ b/tests/headless_pict_stubs.c
@@ -91,6 +91,8 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
         return false;
     }
 
+    db_format_mode savedmode = db_format_mode_current();
+
     /* Apply context mode if provided (for migration: sets v7 format flags) */
     if (ctx != NULL) {
         db_format_mode_apply(&ctx->mode);
@@ -110,6 +112,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
     }
 
     (**h).oldaddress = adr;
+    db_format_mode_apply(&savedmode);
     return pushlongondiskhandle((long) adr, *hpacked);
 }
 

--- a/tests/headless_pict_stubs.c
+++ b/tests/headless_pict_stubs.c
@@ -91,6 +91,9 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
         return false;
     }
 
+    /* Callee-saves: protect databasedata from corruption by nested pack operations */
+    hdldatabaserecord savedatabasedata = databasedata;
+
     /* Apply context mode if provided (for migration: sets v7 format flags) */
     if (ctx != NULL) {
         if (ctx->database != nil)
@@ -112,6 +115,7 @@ boolean pictverbpack_internal (const db_context *ctx, hdlexternalvariable h, Han
     }
 
     (**h).oldaddress = adr;
+    databasedata = savedatabasedata;
     return pushlongondiskhandle((long) adr, *hpacked);
 }
 

--- a/tests/headless_wp_stubs.c
+++ b/tests/headless_wp_stubs.c
@@ -73,7 +73,6 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
 
     dbaddress adr = (**h).oldaddress;
 
-    (**h).oldaddress = adr;
     db_format_mode_apply(&savedmode);
     return pushlongondiskhandle((long) adr, *hpacked);
 }

--- a/tests/headless_wp_stubs.c
+++ b/tests/headless_wp_stubs.c
@@ -62,14 +62,15 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
     if ((h == nil) || (hpacked == nil))
         return false;
 
-    if (!(**h).flinmemory)  {
-        return false;
-    }
-
     db_format_mode savedmode = db_format_mode_current();
 
     if (ctx != NULL)
         db_format_mode_apply(&ctx->mode);
+
+    if (!(**h).flinmemory)  {
+        db_format_mode_apply(&savedmode);
+        return false;
+    }
 
     dbaddress adr = (**h).oldaddress;
 

--- a/tests/headless_wp_stubs.c
+++ b/tests/headless_wp_stubs.c
@@ -74,6 +74,10 @@ boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handl
     dbaddress adr = (**h).oldaddress;
 
     db_format_mode_apply(&savedmode);
+
+    if (flnewdbaddress != NULL)
+        *flnewdbaddress = false;
+
     return pushlongondiskhandle((long) adr, *hpacked);
 }
 

--- a/tests/headless_wp_stubs.c
+++ b/tests/headless_wp_stubs.c
@@ -4,6 +4,8 @@
 #include "wpengine.h"
 #include "wpverbs.h"
 #include "strings.h"
+#include "db.h"
+#include "db_format.h"
 #include "processinternal.h"  /* wp_sel_start/wp_sel_end macros (thread-local via GIL) */
 
 #ifdef FRONTIER_HEADLESS
@@ -56,6 +58,26 @@ boolean wpverbmemoryunpack (Handle hpacked, long *ixload, hdlexternalvariable *h
     return false;
 }
 
+boolean wpverbpack_internal (const db_context *ctx, hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddress) {
+    if ((h == nil) || (hpacked == nil))
+        return false;
+
+    if (!(**h).flinmemory)  {
+        return false;
+    }
+
+    db_format_mode savedmode = db_format_mode_current();
+
+    if (ctx != NULL)
+        db_format_mode_apply(&ctx->mode);
+
+    dbaddress adr = (**h).oldaddress;
+
+    (**h).oldaddress = adr;
+    db_format_mode_apply(&savedmode);
+    return pushlongondiskhandle((long) adr, *hpacked);
+}
+
 boolean wpverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddress) {
     (void) h;
     if (hpacked)
@@ -72,7 +94,8 @@ boolean wpverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
     return false;
 }
 
-boolean wpverbinmemory (hdlexternalvariable h) {
+boolean wpverbinmemory (const db_context *ctx, hdlexternalvariable h) {
+    (void) ctx;
     (void) h;
     return true;
 }


### PR DESCRIPTION
## Summary

- **Phase 1**: Add callee-saves `databasedata` and `db_format_mode` protection to all five `*verbpack_internal` functions, preventing recursive packing from corrupting the global database handle (fixes `fileMenu.save()` failure with guest databases open)
- **Phase 2**: Add `_context()` wrappers for core DB I/O primitives (`dbread_context`, `dbwrite_context`, `dbsavehandle_context`, `dbgeteof_context`, `dbassign_context`, `dbassignhandle_context`, `dbcopy_context`, `dbreference_context`, `dbrefhandle_context`) that internally save/restore `databasedata` and `db_format_mode`
- **Phase 3**: Replace direct `databasedata` mutation in `*verbpack_internal` with `_context()` primitives — all five functions are fully context-aware and no longer touch the global. `mesavemenurecord` and its entire call chain (`mesavemenustructure`, `mesavescriptvisit`, `mesaveasscriptvisit`, `mesaveoutline`) thread `const db_context *ctx` to all DB I/O calls.

Net result: the pack/save path no longer corrupts `databasedata` during recursive table packing. All five verb types, all visitor callbacks, and all DB I/O in the menu save chain use explicit context passing.

## Test plan

- [x] New unit test `test_verbpack_internal_callee_saves_databasedata` — verifies `databasedata` is preserved after all five `*verbpack_internal` calls (table, op, wp, pict, menu)
- [x] New unit test `test_verbpack_internal_callee_saves_format_mode` — verifies `db_format_mode` is preserved after all five `*verbpack_internal` calls
- [x] New unit test `test_db_context_io_primitives_restore_databasedata` — verifies all `_context()` wrappers (dbread, dbwrite, dbsavehandle, dbgeteof, dbreference, dbrefhandle) restore `databasedata` even on failure
- [x] 287 unit tests pass (0 failures)
- [x] 1704 integration tests pass (0 failures)
- [x] Full migration of all guest databases succeeds during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)