### PR TITLE
feat: Eliminate dbpushdatabase/dbpopdatabase from tableverbinmemory_common (Phase 4)

### DIFF
--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -294,16 +294,11 @@ static boolean headless_convert_legacy_table_payload(const unsigned char *payloa
 
 boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvariable, hdlhashnode hnode) {
     /*
-    2025-12-27: Uses dbpushdatabase/dbpopdatabase to temporarily switch to table's database.
-
-    ctx parameter is currently unused but kept for API compatibility. This function was
-    refactored to use the database stack (dbpushdatabase/dbpopdatabase) instead of context
-    guards because the table's database handle ((**hv).hdatabase) is the canonical source
-    of truth for which database to read from. The ctx parameter may be used in a future
-    refactoring as part of the broader mode stack elimination work (see CLAUDE.md -
-    "Architectural Patterns to Avoid" section and MODE_STACK_REFACTOR_PLAN.md).
+    2026-02-25: Phase 4 - Inline save/restore of databasedata global.
+    Replaces dbpushdatabase/dbpopdatabase with a direct inline swap so that
+    dbrefhandle and dbnormalizeaddress read from the correct database.
+    The global is always restored before returning (callee-saves).
     */
-    (void)ctx;  /* unused - see comment above */
 
     register hdltablevariable hv = (hdltablevariable) hvariable;
     Handle hpacked;
@@ -319,6 +314,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
 #if !defined(NDEBUG)
     assert(ctx != NULL && "Issue #347: NULL context passed to tableverbinmemory_common - use db_context_init()");
 #endif
+    (void)ctx;  /* ctx validated above; inline swap uses databasedata directly */
 
     log_trace(LOG_COMP_TABLE, "tableverbinmemory enter hvariable=%p hnode=%p flinmemory=%d",
             (void *) hvariable,
@@ -331,16 +327,20 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     if ((hnode == nil) || (hnode == HNoNode))
         hnode = nil;
 
-    /* Push the table's database onto the stack (only if non-nil) */
-    boolean pushed_database = false;
-    if ((**hv).hdatabase != nil) {
-        if (!dbpushdatabase((**hv).hdatabase)) {
-            log_error(LOG_COMP_TABLE, "tableverbinmemory_common: dbpushdatabase failed");
-            return false;
-        }
-        pushed_database = true;
-    } else {
+    if ((**hv).hdatabase == nil) {
         log_warn(LOG_COMP_TABLE, "tableverbinmemory nil database for variable");
+    }
+
+    /*
+     * Temporarily switch to the table's database for reading.
+     * The old code used dbpushdatabase/dbpopdatabase to accomplish this.
+     * We do the same global swap inline, avoiding the stack-based API.
+     * This is necessary because dbrefhandle and dbnormalizeaddress read from
+     * the global databasedata, and we need them to target the table's DB.
+     */
+    hdldatabaserecord saved_databasedata = databasedata;
+    if ((**hv).hdatabase != nil) {
+        databasedata = (**hv).hdatabase;
     }
 
     adr = (dbaddress) (**hv).variabledata;  /* DISK ADDRESS - format depends on source DB */
@@ -349,9 +349,14 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
             (void*)(**hv).hdatabase,
             (unsigned long long)adr);
     long payload_offset = 0;
-    log_debug(LOG_COMP_TABLE, "tableverbinmemory dbpush database=%p adr=0x%llx",
+    log_debug(LOG_COMP_TABLE, "tableverbinmemory database=%p adr=0x%llx",
             (void *)(**hv).hdatabase, (unsigned long long) adr);
 
+    /*
+     * Normalize the address against the current databasedata (which we
+     * swapped above to (**hv).hdatabase). This is identical to what the
+     * old dbpushdatabase/dbrefhandle path did.
+     */
     {
         dbaddress normalized = adr;
         if (dbnormalizeaddress(&normalized)) {
@@ -373,7 +378,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
         shellinternalerror(idniltableaddress, BIGSTRING ("\x2b" "nil table address.  (Creating empty table.)"));
         fl = false;
     } else {
-        /* Read from the pushed database */
+        /* Read from the (swapped) global databasedata */
         fl = dbrefhandle(adr, &hpacked);
 
         if (!fl) {
@@ -470,8 +475,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     }
 
     if (!fl) {
-        if (pushed_database)
-            dbpopdatabase();
+        databasedata = saved_databasedata;  /* restore before returning */
         return false;
     }
 
@@ -479,13 +483,12 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
 
     (**hv).variabledata = (long) htable; /* link into variable structure */
 
-    /* During migration/repack, clear oldaddress to force new allocation */
-    db_format_mode current_mode = db_format_mode_current();
-    log_debug(LOG_COMP_TABLE, "tableverbinmemory before address assignment: adapter_repack=%d use_64bit=%d databasedata=%p adr=0x%llx",
-            (int)current_mode.adapter_repack, (int)current_mode.use_64bit_format,
+    /* During migration/repack, clear oldaddress to force new allocation. */
+    log_debug(LOG_COMP_TABLE, "tableverbinmemory before address assignment: adapter_repack=%d use_64bit=%d database=%p adr=0x%llx",
+            (int)db_format_mode_current().adapter_repack, (int)db_format_mode_current().use_64bit_format,
             (void*)databasedata, (unsigned long long)adr);
 
-    if (current_mode.adapter_repack && databasedata != nil) {
+    if (db_format_mode_current().adapter_repack && databasedata != nil) {
         (**hv).oldaddress = nildbaddress;
         log_debug(LOG_COMP_TABLE, "tableverbinmemory CLEARED oldaddress (adapter_repack) adr=0x%llx variabledata=0x%llx flinmemory=%d",
                 (unsigned long long)adr, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
@@ -531,8 +534,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
 
     (**htable).thistableshashnode = hnode; /* The var rec is contained in the hashnode... RAB 1/3/00 */
 
-    if (pushed_database)
-        dbpopdatabase();
+    databasedata = saved_databasedata;  /* restore before returning */
 
     return true;
 }

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -484,11 +484,13 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     (**hv).variabledata = (long) htable; /* link into variable structure */
 
     /* During migration/repack, clear oldaddress to force new allocation. */
+    {
+    db_format_mode current_mode = db_format_mode_current();
     log_debug(LOG_COMP_TABLE, "tableverbinmemory before address assignment: adapter_repack=%d use_64bit=%d database=%p adr=0x%llx",
-            (int)db_format_mode_current().adapter_repack, (int)db_format_mode_current().use_64bit_format,
+            (int)current_mode.adapter_repack, (int)current_mode.use_64bit_format,
             (void*)databasedata, (unsigned long long)adr);
 
-    if (db_format_mode_current().adapter_repack && databasedata != nil) {
+    if (current_mode.adapter_repack && databasedata != nil) {
         (**hv).oldaddress = nildbaddress;
         log_debug(LOG_COMP_TABLE, "tableverbinmemory CLEARED oldaddress (adapter_repack) adr=0x%llx variabledata=0x%llx flinmemory=%d",
                 (unsigned long long)adr, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
@@ -496,6 +498,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
         (**hv).oldaddress = adr; /* last place this table was stored */
         log_debug(LOG_COMP_TABLE, "tableverbinmemory SET oldaddress=0x%llx variabledata=0x%llx flinmemory=%d",
                 (unsigned long long)adr, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
+    }
     }
 
     if (log_enabled(LOG_LEVEL_TRACE, LOG_COMP_TABLE)) {

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 287 tests: 287 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 07:56:09 GMT</dateCreated>
+    <title>Frontier Unit Tests - 288 tests: 288 pass (100%)</title>
+    <dateCreated>Wed, 25 Feb 2026 08:46:57 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-25 at 07:56 UTC"/>
-      <outline text="Results: 287 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (287 tests total)"/>
+      <outline text="Run: 2026-02-25 at 08:46 UTC"/>
+      <outline text="Results: 288 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (288 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 21 tests: 21 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 22 tests: 22 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 21 tests: 21 pass (100%)</title>
-    <dateCreated>Tue, 24 Feb 2026 00:43:33 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 22 tests: 22 pass (100%)</title>
+    <dateCreated>Wed, 25 Feb 2026 08:15:21 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -23,6 +23,7 @@
     <outline text="✓ test_verbpack_internal_callee_saves_databasedata"/>
     <outline text="✓ test_db_context_io_primitives_restore_databasedata"/>
     <outline text="✓ test_verbpack_internal_callee_saves_format_mode"/>
+    <outline text="✓ test_tableverbinmemory_common_callee_saves"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -18,6 +18,7 @@
 #include "wpverbs.h"
 #include "pictverbs.h"
 #include "menuverbs.h"
+#include "tableexternal_common.h"
 #include "logging.h"
 #include "test_report.h"
 
@@ -1199,6 +1200,69 @@ static void test_verbpack_internal_callee_saves_format_mode(void) {
     log_info(LOG_COMP_DB, "[TEST] test_verbpack_internal_callee_saves_format_mode COMPLETED");
 }
 
+static void test_tableverbinmemory_common_callee_saves(void) {
+    /*
+     * Phase 4: Verify that tableverbinmemory_common restores databasedata
+     * after its inline save/restore swap. The function temporarily switches
+     * databasedata to (**hv).hdatabase for reading, but must restore the
+     * original value before returning (callee-saves invariant).
+     *
+     * We test the nil-address path (variabledata = nildbaddress) which exercises
+     * the full code path without needing a real database.
+     */
+    hdldatabaserecord baseline_db = databasedata;
+    db_format_mode baseline_mode = db_format_mode_current();
+
+    /* Create two fake database handles: db_A = "system root", db_B = "guest db" */
+    hdldatabaserecord db_A = nil;
+    hdldatabaserecord db_B = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_A));
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &db_B));
+    (**db_A).fnumdatabase = 100;
+    (**db_B).fnumdatabase = 200;
+
+    /* Set databasedata to db_A (simulating "we're saving the system root") */
+    databasedata = db_A;
+
+    /* Build a minimal table external: flinmemory=false, nildbaddress → triggers
+       the "nil table address" error path, but must NOT touch databasedata. */
+    hdlexternalvariable hv = nil;
+    assert(newclearhandle(sizeof(tyexternalvariable), (Handle *)&hv));
+    (**hv).id = idtableprocessor;
+    (**hv).flinmemory = 0;
+    (**hv).variabledata = (long) nildbaddress;
+    (**hv).hdatabase = db_B;  /* points to guest DB */
+
+    /* Create a context pointing to db_B */
+    db_context guest_ctx;
+    db_context_init(&guest_ctx);
+    guest_ctx.database = db_B;
+    guest_ctx.mode.adapter_repack = true;  /* different from default to detect mutation */
+
+    db_format_mode before = db_format_mode_current();
+
+    /* Call — will fail (nil address) but must restore databasedata */
+    boolean ok = tableverbinmemory_common(&guest_ctx, hv, nil);
+    assert(!ok);  /* expected: nil address triggers failure */
+
+    /* THE INVARIANT: databasedata must be restored to db_A */
+    assert(databasedata == db_A);
+
+    /* THE INVARIANT: format mode must be unchanged */
+    db_format_mode after = db_format_mode_current();
+    assert(before.use_64bit_format == after.use_64bit_format);
+    assert(before.adapter_repack == after.adapter_repack);
+
+    /* Cleanup */
+    disposehandle((Handle) hv);
+    databasedata = baseline_db;
+    db_format_mode_apply(&baseline_mode);
+    disposehandle((Handle) db_A);
+    disposehandle((Handle) db_B);
+
+    log_info(LOG_COMP_DB, "[TEST] test_tableverbinmemory_common_callee_saves COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -1223,6 +1287,7 @@ int main(void) {
     TR_RUN(test_verbpack_internal_callee_saves_databasedata);
     TR_RUN(test_db_context_io_primitives_restore_databasedata);
     TR_RUN(test_verbpack_internal_callee_saves_format_mode);
+    TR_RUN(test_tableverbinmemory_common_callee_saves);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/headless_table_stubs.c
+++ b/tests/headless_table_stubs.c
@@ -85,15 +85,16 @@ boolean tableverbgetsize (hdlexternalvariable h, long *size) {
 }
 
 #if !defined(HEADLESS_USE_REAL_TABLEPACK)
-boolean tableverbinmemory (hdlexternalvariable h, hdlhashnode node) {
+boolean tableverbinmemory (const db_context *ctx, hdlexternalvariable h, hdlhashnode node) {
+    (void) ctx;
     (void) h;
     (void) node;
     return true;
 }
 #else
 #include "tableexternal_common.h"
-boolean tableverbinmemory (hdlexternalvariable h, hdlhashnode node) {
-    return tableverbinmemory_common(h, node);
+boolean tableverbinmemory (const db_context *ctx, hdlexternalvariable h, hdlhashnode node) {
+    return tableverbinmemory_common(ctx, h, node);
 }
 #endif
 


### PR DESCRIPTION
## Summary

- Replaces the **last `dbpushdatabase`/`dbpopdatabase` call site** in the codebase with inline save/restore of the `databasedata` global
- Maintains identical read behavior (`dbrefhandle` + `dbnormalizeaddress` against the swapped global) while eliminating the stack-based API dependency
- Updates headless stub signatures and adds a callee-saves unit test

## Context

PR #448 completed Phases 1-3 (pack/save path). This PR completes **Phase 4** (unpack/load path) — the sole remaining target was `tableverbinmemory_common` in `tableexternal_common.c`.

After this change, `dbpushdatabase`/`dbpopdatabase` have **zero call sites** outside their own implementations in `db.c`.

## Design Decision

The original plan called for `dbrefhandle_context(ctx, ...)` to eliminate global mutation entirely. However, `dbrefhandle_context` routes through `dbrefhandle_fnum` which skips `dbnormalizeaddress` and uses a different header size calculation, breaking guest DB migration (10 integration test failures). The inline save/restore approach preserves exact behavioral compatibility.

## Files Changed

| File | Change |
|------|--------|
| `Common/source/tableexternal_common.c` | Inline save/restore of `databasedata` instead of push/pop |
| `tests/headless_table_stubs.c` | Update stub signatures for `db_context` param |
| `tests/db_format_tests.c` | Add callee-saves unit test |

## Test plan

- [x] 288/288 unit tests pass (including new `test_tableverbinmemory_common_callee_saves`)
- [x] 1704/1704 integration tests pass (0 failures)
- [x] `grep -r 'dbpushdatabase\|dbpopdatabase' Common/source/*.c` — only hits in `db.c` (implementations)
- [ ] Manual: `fileMenu.save()` with guest databases open
- [ ] Manual: Open guest DB, navigate tables, verify data loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)