### PR TITLE
feat: Remove dead DB stack, add _fnum variants for thread-safe I/O (Phases 5-6)

### DIFF
--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -198,6 +198,8 @@ extern boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long heade
 
 extern boolean dbread_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
 
+/* hdb: owning database handle, used for the read-only guard.  Pass nil
+   to skip the guard (only when no database handle is available). */
 extern boolean dbwrite_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum, hdldatabaserecord hdb);
 
 extern boolean dbgeteof_fnum(long *eof, hdlfilenum fnum);

--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -198,7 +198,7 @@ extern boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long heade
 
 extern boolean dbread_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
 
-extern boolean dbwrite_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
+extern boolean dbwrite_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum, hdldatabaserecord hdb);
 
 extern boolean dbgeteof_fnum(long *eof, hdlfilenum fnum);
 

--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -196,6 +196,14 @@ extern boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoi
 
 extern boolean dbrefhandle_with_header_size(dbaddress adr, Handle *h, long header_size);
 
+extern boolean dbread_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
+
+extern boolean dbwrite_fnum(dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
+
+extern boolean dbgeteof_fnum(long *eof, hdlfilenum fnum);
+
+extern boolean dbreference_fnum(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size, hdlfilenum fnum);
+
 extern boolean dbrefhandle_fnum(dbaddress adr, Handle *h, long header_size, hdlfilenum fnum);
 
 extern boolean dbassign (dbaddress *, long, ptrvoid);
@@ -217,14 +225,6 @@ extern boolean dbassignheapstring (dbaddress *, hdlstring);
 extern void dbsetview (short, dbaddress);
 
 extern void dbgetview (short, dbaddress *);
-
-extern void dbcurrentdatabase (hdldatabaserecord);
-
-extern void dbgetcurrentdatabase (hdldatabaserecord *);
-
-extern boolean dbpushdatabase (hdldatabaserecord);
-
-extern boolean dbpopdatabase (void);
 
 extern boolean dbflushreleasestack (void);
 

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -9,6 +9,7 @@
 #ifndef FRONTIER_DB_FORMAT_H
 #define FRONTIER_DB_FORMAT_H
 
+#include <assert.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -135,6 +136,7 @@ void db_saveas_state_apply(const db_saveas_state *state);
    don't repeat the dereference chain.
    Precondition: context != NULL && context->database != nil. */
 static inline hdlfilenum db_context_fnum(const db_context *context) {
+    assert(context != NULL && context->database != nil);
     return (hdlfilenum)((**context->database).fnumdatabase);
 }
 

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -130,6 +130,14 @@ void db_format_mode_apply(const db_format_mode *mode);
 void db_saveas_state_snapshot(db_saveas_state *state);
 void db_saveas_state_apply(const db_saveas_state *state);
 
+/* Extract the file number from a context's database handle.
+   Centralises the (hdlfilenum)((**hdb).fnumdatabase) cast so callers
+   don't repeat the dereference chain.
+   Precondition: context != NULL && context->database != nil. */
+static inline hdlfilenum db_context_fnum(const db_context *context) {
+    return (hdlfilenum)((**context->database).fnumdatabase);
+}
+
 /* Context initialization API */
 void db_context_init(db_context *context);
 void db_context_init_with_mode(db_context *context, const db_format_mode *mode);

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -356,11 +356,6 @@ static boolean dbseteof (long eof) {
 #endif
 
 
-#define ctdatabasestack 10
-
-short topdatabasestack = 0;
-
-hdldatabaserecord databasestack [ctdatabasestack];
 static db_context g_default_db_context;
 typedef struct db_context_guard {
     db_format_mode prev_mode;
@@ -461,54 +456,6 @@ static void db_context_guard_exit_with_saveas(const db_context_guard *guard, con
 }
 
 /* odb_guard functions moved to db_format.c where lang.h globals are available */
-
-boolean dbpushdatabase (hdldatabaserecord hdatabase) {
-	/*
-	when you want to temporarily work with a different databaserecord, call this
-	routine, do your stuff and then call dbpopdatabase.
-	*/
-
-	if (topdatabasestack >= ctdatabasestack) {
-
-		DebugStr (STR_database_stack_overflow);
-
-		return (false);
-		}
-
-	databasestack [topdatabasestack++] = databasedata;
-
-#if defined(FRONTIER_HEADLESS)
-	log_trace(LOG_COMP_DB, "dbpushdatabase: old=%p new=%p stack_depth=%d",
-	        (void*)databasedata,
-	        (void*)hdatabase,
-	        topdatabasestack);
-#endif
-
-	databasedata = hdatabase; /*install the new database*/
-	db_sync_use64_to_current_db();
-
-	return (true);
-	} /*dbpushdatabase*/
-
-
-boolean dbpopdatabase (void) {
-
-	if (topdatabasestack <= 0)
-		return (false);
-
-#if defined(FRONTIER_HEADLESS)
-	log_trace(LOG_COMP_DB, "dbpopdatabase: old=%p restored=%p stack_depth=%d",
-	        (void*)databasedata,
-	        (void*)databasestack[topdatabasestack - 1],
-	        topdatabasestack);
-#endif
-
-	databasedata = databasestack [--topdatabasestack];
-	db_sync_use64_to_current_db();
-
-	return (true);
-	} /*dbpopdatabase*/
-
 
 static boolean dbrelease_internal (dbaddress); /*6.2b2: Dropped from db.h and declared static*/
 static boolean dballocate (long databytes, ptrvoid pdata, dbaddress *paddress); /*6.2b14 AR: forward declaration for dbwriteshadowavaillist*/
@@ -836,7 +783,7 @@ static boolean dbflushheader (void) {
 
 
 /* Forward declaration for dbreadheader_core which needs to call dbread_fnum */
-static boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
+boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum);
 
 static boolean dbreadheader_core (dbaddress adr, boolean *flfree, long *ctbytes, tyvariance *variance, long header_size, hdlfilenum fnum) {
 
@@ -928,7 +875,7 @@ boolean dbreadheader (dbaddress adr, boolean *flfree, long *ctbytes, tyvariance 
 	} /*dbreadheader*/
 
 
-static boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum) {
+boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum) {
 
 	if (!filesetposition (fnum, adr))
 		return (false);
@@ -938,6 +885,24 @@ static boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilen
 
 	return (true);
 	} /*dbread_fnum*/
+
+
+boolean dbwrite_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum) {
+
+	if (!filesetposition (fnum, adr))
+		return (false);
+
+	if (!filewrite (fnum, ctbytes, pdata))
+		return (false);
+
+	return (true);
+	} /*dbwrite_fnum*/
+
+
+boolean dbgeteof_fnum (long *eof, hdlfilenum fnum) {
+
+	return (filegeteof (fnum, eof));
+	} /*dbgeteof_fnum*/
 
 
 boolean dbrefhandle_fnum (dbaddress adr, Handle *h, long header_size, hdlfilenum fnum) {
@@ -1750,6 +1715,39 @@ boolean dbreference_with_header_size(dbaddress adr, long maxbytes, ptrvoid pdata
 	}
 
 	return (dbread(adr + header_size, min(maxbytes, ctbytes - (long) variance), pdata));
+}
+
+boolean dbreference_fnum(dbaddress adr, long maxbytes, ptrvoid pdata, long header_size, hdlfilenum fnum) {
+	/*
+	Like dbreference_with_header_size but reads from an explicit file number
+	instead of the global databasedata. This allows context-aware reads without
+	mutating global state.
+
+	header_size: Must be 8 (v6) or 12 (v7).
+	fnum: File number to read from directly.
+	*/
+	long ctbytes;
+	boolean flfree;
+	tyvariance variance;
+
+	if (header_size != 8 && header_size != 12) {
+		log_error(LOG_COMP_DB, "dbreference_fnum: invalid header_size %ld (must be 8 or 12)", header_size);
+		return (false);
+	}
+
+	/* No dbnormalizeaddress: callers must provide block-start addresses.
+	   dbnormalizeaddress uses global databasedata which may point to a
+	   different file than fnum. */
+
+	if (!dbreadheader_core(adr, &flfree, &ctbytes, &variance, header_size, fnum))
+		return (false);
+
+	if (flfree || (ctbytes < 0)) {
+		dberror(dbfreeblockerror);
+		return (false);
+	}
+
+	return (dbread_fnum(adr + header_size, min(maxbytes, ctbytes - (long) variance), pdata, fnum));
 }
 
 boolean dbreference (dbaddress adr, long maxbytes, ptrvoid pdata) {
@@ -3005,19 +3003,6 @@ void dbgetview (short viewnumber, dbaddress *adrtext) {
 	} /*dbgetview*/
 
 
-void dbcurrentdatabase (hdldatabaserecord hdb) {
-	
-	if (hdb != nil)
-		databasedata = hdb; 
-	} /*dbcurrentdatabase*/
-	
-
-void dbgetcurrentdatabase (hdldatabaserecord *hdb) {
-	
-	*hdb = databasedata;
-	} /*dbgetcurrentdatabase*/
-	
-	
 boolean dbfnumchanged (hdlfilenum newfnum) {
 	
 	register hdldatabaserecord hdb = databasedata;

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -903,12 +903,10 @@ boolean dbwrite_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnu
 
 	/* Read-only guard: correctness invariant, enforced in all builds. */
 	if (hdb && (**hdb).u.extensions.flreadonly) {
-#if defined(FRONTIER_HEADLESS)
 		log_error(LOG_COMP_DB, "dbwrite_fnum BLOCKED read-only fnum=%ld adr=0x%llx bytes=%ld",
 			(long) fnum,
 			(unsigned long long) adr,
 			ctbytes);
-#endif
 		return (false);
 	}
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -877,6 +877,12 @@ boolean dbreadheader (dbaddress adr, boolean *flfree, long *ctbytes, tyvariance 
 
 boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum) {
 
+	/*
+	Like dbread but reads from an explicit file number instead of the global
+	databasedata. Bypasses Save As source redirection intentionally: an
+	explicit fnum means "read from this specific database, period."
+	*/
+
 	if (!filesetposition (fnum, adr))
 		return (false);
 
@@ -887,7 +893,25 @@ boolean dbread_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum
 	} /*dbread_fnum*/
 
 
-boolean dbwrite_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum) {
+boolean dbwrite_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnum, hdldatabaserecord hdb) {
+
+	/*
+	Like dbwrite but writes to an explicit file number instead of the global
+	databasedata. Preserves the read-only guard from dbwrite: callers must
+	pass the database handle so we can check flreadonly.
+	*/
+
+#if defined(FRONTIER_HEADLESS)
+	if (hdb && (**hdb).u.extensions.flreadonly) {
+		log_error(LOG_COMP_DB, "dbwrite_fnum BLOCKED read-only fnum=%ld adr=0x%llx bytes=%ld",
+			(long) fnum,
+			(unsigned long long) adr,
+			ctbytes);
+		return (false);
+	}
+#else
+	(void) hdb;
+#endif
 
 	if (!filesetposition (fnum, adr))
 		return (false);

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -901,17 +901,16 @@ boolean dbwrite_fnum (dbaddress adr, long ctbytes, ptrvoid pdata, hdlfilenum fnu
 	pass the database handle so we can check flreadonly.
 	*/
 
-#if defined(FRONTIER_HEADLESS)
+	/* Read-only guard: correctness invariant, enforced in all builds. */
 	if (hdb && (**hdb).u.extensions.flreadonly) {
+#if defined(FRONTIER_HEADLESS)
 		log_error(LOG_COMP_DB, "dbwrite_fnum BLOCKED read-only fnum=%ld adr=0x%llx bytes=%ld",
 			(long) fnum,
 			(unsigned long long) adr,
 			ctbytes);
+#endif
 		return (false);
 	}
-#else
-	(void) hdb;
-#endif
 
 	if (!filesetposition (fnum, adr))
 		return (false);

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2640,8 +2640,7 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
 
         if (context->database != nil) {
             /* Thread fnum explicitly — no databasedata mutation */
-            hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
-            return dbreference_fnum(adr, ctbytes, pdata, header_size, fnum);
+            return dbreference_fnum(adr, ctbytes, pdata, header_size, db_context_fnum(context));
         }
 
         /* Context with nil database: use global databasedata via legacy path */
@@ -2678,8 +2677,7 @@ boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, p
     */
 
     if (context != NULL && context->database != nil) {
-        hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
-        return dbread_fnum(adr, ctbytes, pdata, fnum);
+        return dbread_fnum(adr, ctbytes, pdata, db_context_fnum(context));
     }
 
     return dbread(adr, ctbytes, pdata);
@@ -2693,8 +2691,7 @@ boolean dbwrite_context(const db_context *context, dbaddress adr, long ctbytes, 
     */
 
     if (context != NULL && context->database != nil) {
-        hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
-        return dbwrite_fnum(adr, ctbytes, pdata, fnum);
+        return dbwrite_fnum(adr, ctbytes, pdata, db_context_fnum(context), context->database);
     }
 
     return dbwrite(adr, ctbytes, pdata);
@@ -2731,8 +2728,7 @@ boolean dbgeteof_context(const db_context *context, long *eof) {
     */
 
     if (context != NULL && context->database != nil) {
-        hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
-        return dbgeteof_fnum(eof, fnum);
+        return dbgeteof_fnum(eof, db_context_fnum(context));
     }
 
     return dbgeteof(eof);

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2630,32 +2630,26 @@ boolean dbassign_context(const db_context *context, dbaddress *padr, long newsiz
 
 boolean dbreference_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
     /*
-    Context-aware dbreference. Temporarily applies the context's database
-    handle, calls the appropriate legacy function, and restores.
-    Format mode is not saved/restored: the non-NULL path passes header size
-    explicitly via dbreference_with_header_size (so the global mode is never
-    consulted), and the NULL path reads the current global mode directly
-    without modifying it.
+    Context-aware dbreference. For non-NULL contexts with a database handle,
+    passes fnum explicitly via dbreference_fnum — no global mutation needed.
+    For NULL context, delegates to dbreference_internal (uses global state).
     */
-    hdldatabaserecord savedatabasedata = databasedata;
-    boolean result;
 
     if (context != NULL) {
-        if (context->database != nil)
-            databasedata = context->database;
-
-        /* During migration with mode lock, can't downgrade global mode to v6.
-           Pass explicit header size based on context mode. */
         long header_size = context->mode.use_64bit_format ? sizeheader_v7 : sizeheader_v6;
-        result = dbreference_with_header_size(adr, ctbytes, pdata, header_size);
-    }
-    else {
-        /* NULL context: use current global databasedata and mode as-is */
-        result = dbreference_internal(adr, ctbytes, pdata);
+
+        if (context->database != nil) {
+            /* Thread fnum explicitly — no databasedata mutation */
+            hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
+            return dbreference_fnum(adr, ctbytes, pdata, header_size, fnum);
+        }
+
+        /* Context with nil database: use global databasedata via legacy path */
+        return dbreference_with_header_size(adr, ctbytes, pdata, header_size);
     }
 
-    databasedata = savedatabasedata;
-    return result;
+    /* NULL context: use current global databasedata and mode as-is */
+    return dbreference_internal(adr, ctbytes, pdata);
 }
 
 boolean dbreference_handle_context(const db_context *context, dbaddress adr, Handle *h) {
@@ -2678,39 +2672,32 @@ boolean dbreference_handle_context(const db_context *context, dbaddress adr, Han
 
 boolean dbread_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
     /*
-    Phase 2: Context-aware dbread. Temporarily applies the context's database
-    handle, calls the legacy dbread (which handles Save As source redirection
-    internally), and restores databasedata. Format mode is not saved/restored:
-    raw read is mode-agnostic (header interpretation is the caller's concern).
+    Context-aware dbread. For non-NULL contexts with a database handle,
+    passes fnum explicitly via dbread_fnum — no global mutation needed.
+    For NULL context or nil database, delegates to legacy dbread.
     */
-    hdldatabaserecord savedatabasedata = databasedata;
-    boolean result;
 
-    if (context != NULL && context->database != nil)
-        databasedata = context->database;
+    if (context != NULL && context->database != nil) {
+        hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
+        return dbread_fnum(adr, ctbytes, pdata, fnum);
+    }
 
-    result = dbread(adr, ctbytes, pdata);
-
-    databasedata = savedatabasedata;
-    return result;
+    return dbread(adr, ctbytes, pdata);
 }
 
 boolean dbwrite_context(const db_context *context, dbaddress adr, long ctbytes, ptrvoid pdata) {
     /*
-    Phase 2: Context-aware dbwrite. Temporarily applies the context's database
-    handle, calls the legacy dbwrite, and restores databasedata. Format mode
-    is not saved/restored: raw write is mode-agnostic.
+    Context-aware dbwrite. For non-NULL contexts with a database handle,
+    passes fnum explicitly via dbwrite_fnum — no global mutation needed.
+    For NULL context or nil database, delegates to legacy dbwrite.
     */
-    hdldatabaserecord savedatabasedata = databasedata;
-    boolean result;
 
-    if (context != NULL && context->database != nil)
-        databasedata = context->database;
+    if (context != NULL && context->database != nil) {
+        hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
+        return dbwrite_fnum(adr, ctbytes, pdata, fnum);
+    }
 
-    result = dbwrite(adr, ctbytes, pdata);
-
-    databasedata = savedatabasedata;
-    return result;
+    return dbwrite(adr, ctbytes, pdata);
 }
 
 boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr) {
@@ -2738,18 +2725,15 @@ boolean dbsavehandle_context(const db_context *context, Handle h, dbaddress *adr
 
 boolean dbgeteof_context(const db_context *context, long *eof) {
     /*
-    Phase 2: Context-aware dbgeteof. Temporarily applies the context's
-    database handle and restores. Format mode is not saved/restored:
-    EOF position is mode-agnostic.
+    Context-aware dbgeteof. For non-NULL contexts with a database handle,
+    passes fnum explicitly via dbgeteof_fnum — no global mutation needed.
+    For NULL context or nil database, delegates to legacy dbgeteof.
     */
-    hdldatabaserecord savedatabasedata = databasedata;
-    boolean result;
 
-    if (context != NULL && context->database != nil)
-        databasedata = context->database;
+    if (context != NULL && context->database != nil) {
+        hdlfilenum fnum = (hdlfilenum)((**context->database).fnumdatabase);
+        return dbgeteof_fnum(eof, fnum);
+    }
 
-    result = dbgeteof(eof);
-
-    databasedata = savedatabasedata;
-    return result;
+    return dbgeteof(eof);
 }

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2643,7 +2643,12 @@ boolean dbreference_context(const db_context *context, dbaddress adr, long ctbyt
             return dbreference_fnum(adr, ctbytes, pdata, header_size, db_context_fnum(context));
         }
 
-        /* Context with nil database: use global databasedata via legacy path */
+        /* FALLBACK: non-NULL context with nil database — reads from global
+           databasedata via legacy path.  This case occurs when the caller
+           constructs a context to override mode only (e.g. force v6 header
+           interpretation) while keeping the current database.  It is NOT a
+           thread-safe path; Phase 7+ should require all contexts to carry a
+           non-nil database handle once the allocation subsystem is converted. */
         return dbreference_with_header_size(adr, ctbytes, pdata, header_size);
     }
 

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 288 tests: 288 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 19:34:53 GMT</dateCreated>
+    <title>Frontier Unit Tests - 290 tests: 290 pass (100%)</title>
+    <dateCreated>Wed, 25 Feb 2026 19:50:39 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-25 at 19:34 UTC"/>
-      <outline text="Results: 288 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (288 tests total)"/>
+      <outline text="Run: 2026-02-25 at 19:50 UTC"/>
+      <outline text="Results: 290 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (290 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 22 tests: 22 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 288 tests: 288 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 08:46:57 GMT</dateCreated>
+    <dateCreated>Wed, 25 Feb 2026 19:34:53 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-25 at 08:46 UTC"/>
+      <outline text="Run: 2026-02-25 at 19:34 UTC"/>
       <outline text="Results: 288 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (288 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 290 tests: 290 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 19:50:39 GMT</dateCreated>
+    <title>Frontier Unit Tests - 291 tests: 291 pass (100%)</title>
+    <dateCreated>Thu, 26 Feb 2026 19:14:24 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-25 at 19:50 UTC"/>
-      <outline text="Results: 290 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (290 tests total)"/>
+      <outline text="Run: 2026-02-26 at 19:14 UTC"/>
+      <outline text="Results: 291 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (291 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 25 tests: 25 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 22 tests: 22 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 08:15:21 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 24 tests: 24 pass (100%)</title>
+    <dateCreated>Wed, 25 Feb 2026 19:50:39 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -24,6 +24,8 @@
     <outline text="✓ test_db_context_io_primitives_restore_databasedata"/>
     <outline text="✓ test_verbpack_internal_callee_saves_format_mode"/>
     <outline text="✓ test_tableverbinmemory_common_callee_saves"/>
+    <outline text="✓ test_fnum_variants_reject_invalid_fnum"/>
+    <outline text="✓ test_dbwrite_fnum_readonly_guard"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 24 tests: 24 pass (100%)</title>
-    <dateCreated>Wed, 25 Feb 2026 19:50:39 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 25 tests: 25 pass (100%)</title>
+    <dateCreated>Thu, 26 Feb 2026 19:14:24 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -26,6 +26,7 @@
     <outline text="✓ test_tableverbinmemory_common_callee_saves"/>
     <outline text="✓ test_fnum_variants_reject_invalid_fnum"/>
     <outline text="✓ test_dbwrite_fnum_readonly_guard"/>
+    <outline text="✓ test_fnum_variants_success_path"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -1268,6 +1268,55 @@ static void test_tableverbinmemory_common_callee_saves(void) {
     log_info(LOG_COMP_DB, "[TEST] test_tableverbinmemory_common_callee_saves COMPLETED");
 }
 
+static void test_fnum_variants_reject_invalid_fnum(void) {
+    /*
+     * Verify that the new _fnum functions return false when given an
+     * invalid file number (0 or -1), exercising basic error paths.
+     */
+    char buf[16] = {0};
+    long eof_val = 0;
+    hdlfilenum bad_fnum = (hdlfilenum) 0;
+
+    /* dbread_fnum: seek to invalid fnum should fail */
+    assert(!dbread_fnum((dbaddress) 0x100, sizeof(buf), buf, bad_fnum));
+
+    /* dbwrite_fnum: seek to invalid fnum should fail (nil hdb — no read-only check) */
+    assert(!dbwrite_fnum((dbaddress) 0x100, sizeof(buf), buf, bad_fnum, nil));
+
+    /* dbgeteof_fnum: EOF on invalid fnum should fail */
+    assert(!dbgeteof_fnum(&eof_val, bad_fnum));
+
+    /* dbreference_fnum: header read on invalid fnum should fail */
+    assert(!dbreference_fnum((dbaddress) 0x100, sizeof(buf), buf, 8, bad_fnum));
+
+    log_info(LOG_COMP_DB, "[TEST] test_fnum_variants_reject_invalid_fnum COMPLETED");
+}
+
+static void test_dbwrite_fnum_readonly_guard(void) {
+    /*
+     * Verify that dbwrite_fnum blocks writes to a read-only database,
+     * matching the safety guard in the legacy dbwrite function.
+     */
+    hdldatabaserecord hdb = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &hdb));
+    (**hdb).fnumdatabase = 999;
+    (**hdb).u.extensions.flreadonly = true;
+
+    char buf[16] = {0};
+
+    /* Should be blocked by the read-only guard */
+    assert(!dbwrite_fnum((dbaddress) 0x100, sizeof(buf), buf, (hdlfilenum) 999, hdb));
+
+    /* With flreadonly = false, should fail for a different reason (invalid fnum) */
+    (**hdb).u.extensions.flreadonly = false;
+    /* This will fail at filesetposition, not at the read-only guard */
+    assert(!dbwrite_fnum((dbaddress) 0x100, sizeof(buf), buf, (hdlfilenum) 999, hdb));
+
+    disposehandle((Handle) hdb);
+
+    log_info(LOG_COMP_DB, "[TEST] test_dbwrite_fnum_readonly_guard COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -1293,6 +1342,8 @@ int main(void) {
     TR_RUN(test_db_context_io_primitives_restore_databasedata);
     TR_RUN(test_verbpack_internal_callee_saves_format_mode);
     TR_RUN(test_tableverbinmemory_common_callee_saves);
+    TR_RUN(test_fnum_variants_reject_invalid_fnum);
+    TR_RUN(test_dbwrite_fnum_readonly_guard);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -974,13 +974,18 @@ static void test_verbpack_internal_callee_saves_databasedata(void) {
 
 static void test_db_context_io_primitives_restore_databasedata(void) {
     /*
-     * Verify that all nine _context() wrappers restore databasedata after
+     * Verify that all nine _context() wrappers preserve databasedata after
      * the call, regardless of success or failure:
      *   dbread, dbwrite, dbgeteof, dbsavehandle, dbassign, dbassignhandle,
      *   dbcopy, dbreference, dbreference_handle.
      *
+     * After Phase 6, dbread_context, dbwrite_context, dbgeteof_context, and
+     * dbreference_context pass fnum explicitly via _fnum variants and never
+     * touch databasedata at all (when given a non-nil context database).
+     * The remaining 5 wrappers still use save/swap/restore.
+     *
      * We don't have a real database file open, so the underlying operations
-     * will fail — but the save/restore of databasedata must still work.
+     * will fail — but the callee-saves invariant must still hold.
      */
     hdldatabaserecord baseline_db = databasedata;
 

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "frontier.h"
+#include "file.h"
 #include "db_format.h"
 #include "db_writer_v7.h"
 #include "dbinternal.h"
@@ -1317,6 +1318,83 @@ static void test_dbwrite_fnum_readonly_guard(void) {
     log_info(LOG_COMP_DB, "[TEST] test_dbwrite_fnum_readonly_guard COMPLETED");
 }
 
+static void bs_from_cstr(const char *c, bigstring bs) {
+    size_t n = strlen(c);
+    if (n > 255) n = 255;
+    bs[0] = (unsigned char)n;
+    memcpy(&bs[1], c, n);
+}
+
+static void test_fnum_variants_success_path(void) {
+    /*
+     * Exercise the success path of dbread_fnum, dbwrite_fnum, dbgeteof_fnum,
+     * and dbreference_fnum against a real scratch file opened through the
+     * Frontier file layer (openfile/closefile).
+     */
+    const char *scratch_path = "fnum_scratch_test.db";
+
+    /* Create file via fopen so it exists on disk, then open through Frontier */
+    { FILE *f = fopen(scratch_path, "wb"); assert(f); fclose(f); }
+
+    bigstring bspath; tyfilespec fs; hdlfilenum fnum = 0;
+    bs_from_cstr(scratch_path, bspath);
+    assert(pathtofilespec(bspath, &fs));
+    assert(openfile(&fs, &fnum, false));  /* read-write */
+
+    /* Prepare a database handle for dbwrite_fnum (not read-only) */
+    hdldatabaserecord hdb = nil;
+    assert(newclearhandle(longsizeof(tydatabaserecord), (Handle *) &hdb));
+    (**hdb).fnumdatabase = (short) fnum;
+    (**hdb).u.extensions.flreadonly = false;
+
+    /* dbwrite_fnum: write 8 bytes at offset 0 */
+    char write_buf[8] = { 'F', 'N', 'U', 'M', 'T', 'E', 'S', 'T' };
+    assert(dbwrite_fnum((dbaddress) 0, sizeof(write_buf), write_buf, fnum, hdb));
+
+    /* dbgeteof_fnum: should report 8 bytes */
+    long eof_val = 0;
+    assert(dbgeteof_fnum(&eof_val, fnum));
+    assert(eof_val == 8);
+
+    /* dbread_fnum: read back the 8 bytes */
+    char read_buf[8] = {0};
+    assert(dbread_fnum((dbaddress) 0, sizeof(read_buf), read_buf, fnum));
+    assert(memcmp(read_buf, write_buf, 8) == 0);
+
+    /* dbreference_fnum: write a v6 block header (8 bytes) + 4 bytes of data,
+       then read it back via dbreference_fnum.
+
+       v6 header layout (big-endian):
+         bytes 0-3: sizefreeword (high bit = free flag, rest = size)
+         bytes 4-7: variance (32-bit BE)
+       size = header_size(8) + data_size(4) + variance(0) = 12
+       free flag = 0 */
+    long block_offset = 16;  /* write at offset 16 to avoid the earlier data */
+    unsigned char v6_header[8] = {0};
+    /* size = 12 in big-endian 32-bit, free flag clear */
+    v6_header[0] = 0x00;
+    v6_header[1] = 0x00;
+    v6_header[2] = 0x00;
+    v6_header[3] = 0x0C;  /* 12 */
+    /* variance = 0 */
+
+    assert(dbwrite_fnum((dbaddress) block_offset, 8, v6_header, fnum, hdb));
+    char block_data[4] = { 'D', 'A', 'T', 'A' };
+    assert(dbwrite_fnum((dbaddress)(block_offset + 8), 4, block_data, fnum, hdb));
+
+    /* Now read it back via dbreference_fnum with header_size=8 (v6) */
+    char ref_buf[4] = {0};
+    assert(dbreference_fnum((dbaddress) block_offset, sizeof(ref_buf), ref_buf, 8, fnum));
+    assert(memcmp(ref_buf, block_data, 4) == 0);
+
+    /* Cleanup */
+    disposehandle((Handle) hdb);
+    closefile(fnum);
+    remove(scratch_path);
+
+    log_info(LOG_COMP_DB, "[TEST] test_fnum_variants_success_path COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -1344,6 +1422,7 @@ int main(void) {
     TR_RUN(test_tableverbinmemory_common_callee_saves);
     TR_RUN(test_fnum_variants_reject_invalid_fnum);
     TR_RUN(test_dbwrite_fnum_readonly_guard);
+    TR_RUN(test_fnum_variants_success_path);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/headless_lang_runtime_more_stubs.c
+++ b/tests/headless_lang_runtime_more_stubs.c
@@ -37,8 +37,8 @@ long releasethreadglobals (void) { return 1; }
 #if !defined(HEADLESS_LINKS_REAL_DB)
 boolean dbpushreleasestack (dbaddress adr, long valtype) { (void)adr; (void)valtype; return true; }
 boolean dbrefhandle (dbaddress adr, Handle *h) { (void)adr; if (h) *h = nil; return false; }
-/* dbassignhandle, dbcopy, dbpushdatabase, dbpopdatabase, and fldatabasesaveas
- * are provided by headless_mac_compat.c so the symbol definitions stay centralized.
+/* dbassignhandle, dbcopy, and fldatabasesaveas are provided by
+ * headless_mac_compat.c so the symbol definitions stay centralized.
  * When the real database core is linked (HEADLESS_LINKS_REAL_DB), these stubs are
  * omitted to avoid duplicate symbols.
  */

--- a/tests/headless_mac_compat.c
+++ b/tests/headless_mac_compat.c
@@ -261,8 +261,6 @@ void invalrect (Rect r) { (void)r; }
 
 // DB stubs (disabled when linking the real database core)
 #if !defined(HEADLESS_LINKS_REAL_DB)
-boolean dbpushdatabase (hdldatabaserecord h) { (void)h; return false; }
-boolean dbpopdatabase (void) { return false; }
 boolean dbcopy (dbaddress a, dbaddress *b) { (void)a; if (b) *b=0; return false; }
 boolean dbassignhandle (Handle h, dbaddress *adr) { (void)h; if (adr) *adr=0; return false; }
 #endif


### PR DESCRIPTION
## Summary

- **Phase 5**: Remove `dbpushdatabase`/`dbpopdatabase` and all associated dead code — database stack array, counter, constant, `dbcurrentdatabase`, `dbgetcurrentdatabase`. Zero call sites remain after Phase 4 (#451) eliminated the last caller.
- **Phase 6**: Add `dbread_fnum`, `dbwrite_fnum`, `dbgeteof_fnum`, `dbreference_fnum` that accept explicit file numbers. Convert 4 `_context()` wrappers (`dbread_context`, `dbwrite_context`, `dbgeteof_context`, `dbreference_context`) to use `_fnum` variants, eliminating global `databasedata` mutation from these code paths.
- 5 complex wrappers retain save/swap/restore (Phase 7+ scope).

## Test plan

- [x] `make -C frontier-cli` builds cleanly
- [x] 288 unit tests pass (`./tools/run_headless_tests.sh`)
- [x] 1704 integration tests pass (`cd tests && make test-integration`)
- [x] `grep -rn 'dbpushdatabase\|dbpopdatabase\|dbcurrentdatabase\|dbgetcurrentdatabase' Common/` returns only comments
- [x] Existing callee-saves test (`test_db_context_io_primitives_restore_databasedata`) validates converted wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)