### PR TITLE
feat: Eliminate runtime save/swap/restore of databasedata (Phase 8)

### DIFF
--- a/Common/headers/db.h
+++ b/Common/headers/db.h
@@ -161,7 +161,11 @@ extern boolean db_test_is_saveas_active(void);
 
 #if defined(FRONTIER_HEADLESS)
 extern boolean dbnormalizeaddress(dbaddress *adr);
+extern boolean dbnormalizeaddress_hdb(dbaddress *adr, hdldatabaserecord hdb);
 #endif
+
+/* Phase 8: Push to release stack of explicit database handle. */
+extern boolean dbpushreleasestack_hdb(dbaddress adr, long valtype, hdldatabaserecord hdb);
 
 
 #ifdef DATABASE_DEBUG

--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -136,7 +136,10 @@ void db_saveas_state_apply(const db_saveas_state *state);
    don't repeat the dereference chain.
    Precondition: context != NULL && context->database != nil. */
 static inline hdlfilenum db_context_fnum(const db_context *context) {
-    assert(context != NULL && context->database != nil);
+    if (context == NULL || context->database == nil) {
+        assert(false && "db_context_fnum: NULL context or nil database");
+        return (hdlfilenum) -1;
+    }
     return (hdlfilenum)((**context->database).fnumdatabase);
 }
 

--- a/Common/headers/dbinternal.h
+++ b/Common/headers/dbinternal.h
@@ -116,6 +116,26 @@ typedef struct tytrailer64 {
 #define sizeheader (db_format_mode_current().use_64bit_format ? sizeheader_v7 : sizeheader_v6)
 #define sizetrailer (db_format_mode_current().use_64bit_format ? sizetrailer_v7 : sizetrailer_v6)
 
+/* Explicit-handle format detection helpers — do NOT read global format mode.
+   Used by _hdb/_fnum functions throughout db.c and callers like tableexternal. */
+
+static inline boolean db_hdb_use64 (hdldatabaserecord hdb) {
+	return (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+}
+
+static inline long db_hdb_header_size (hdldatabaserecord hdb) {
+	return db_hdb_use64(hdb) ? sizeheader_v7 : sizeheader_v6;
+}
+
+static inline long db_hdb_trailer_size (hdldatabaserecord hdb) {
+	return db_hdb_use64(hdb) ? sizetrailer_v7 : sizetrailer_v6;
+}
+
+static inline hdlfilenum db_hdb_fnum (hdldatabaserecord hdb) {
+	if (hdb == nil) return (hdlfilenum) -1;
+	return (hdlfilenum)((**hdb).fnumdatabase);
+}
+
 
 #define dbshadow
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -201,7 +201,7 @@ static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, l
 	hdlfilenum fnum = (hdlfilenum)((**hdb).fnumdatabase);
 
 	long min_address = firstphysicaladdress;
-	if (hdb != nil && (**hdb).headerLength > 0) {
+	if ((**hdb).headerLength > 0) { /* hdb provably non-nil after early return above */
 		min_address = (**hdb).headerLength;
 	}
 
@@ -231,7 +231,7 @@ static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, l
 		dbaddress data_start = candidate + header_size;
 		dbaddress data_end = data_start + (node_size - node_variance);
 
-		if (adr < candidate || adr >= data_end)
+		if (adr >= data_end) /* candidate <= adr by loop invariant */
 			continue;
 
 		boolean trailer_free = false;

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -183,27 +183,7 @@ boolean dbnormalizeaddress(dbaddress *adr) {
    section but dbfindblockforaddress_hdb needs it here. */
 static boolean dbreadtrailer_hdb(dbaddress adr, boolean *flfree, long *ctbytes, hdlfilenum fnum, hdldatabaserecord hdb);
 
-/*
- * db_hdb_* helpers — centralised format detection for explicit-handle functions.
- * Defined early so that all _hdb/_fnum functions can use them.
- * (Originally in the Layer 3+ section; moved here for Phase 8.)
- */
-
-static inline boolean db_hdb_use64 (hdldatabaserecord hdb) {
-	return (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
-}
-
-static inline long db_hdb_header_size (hdldatabaserecord hdb) {
-	return db_hdb_use64(hdb) ? sizeheader_v7 : sizeheader_v6;
-}
-
-static inline long db_hdb_trailer_size (hdldatabaserecord hdb) {
-	return db_hdb_use64(hdb) ? sizetrailer_v7 : sizetrailer_v6;
-}
-
-static inline hdlfilenum db_hdb_fnum (hdldatabaserecord hdb) {
-	return (hdlfilenum)((**hdb).fnumdatabase);
-}
+/* db_hdb_* helpers now live in dbinternal.h (available to all includers). */
 
 static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, long *nodebytes, tyvariance *variance, boolean *flfree, hdldatabaserecord hdb) {
 
@@ -3334,8 +3314,7 @@ boolean dbsavehandle (Handle hsave, dbaddress *adr) {
  *     databasedata for callers not yet converted.
  *============================================================================*/
 
-/* db_hdb_* helpers moved to top of file (before dbfindblockforaddress_hdb)
-   so all _hdb/_fnum functions can use them. */
+/* db_hdb_* helpers now live in dbinternal.h. */
 
 static boolean dbwriteheaderandtrailer_hdb (dbaddress adr, boolean flfree, long ctbytes, tyvariance variance, hdlfilenum fnum, hdldatabaserecord hdb) {
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -191,7 +191,12 @@ static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, l
 	*/
 
 	long eof = 0;
-	boolean use64 = (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+	boolean use64;
+
+	if (hdb == nil)
+		return (false);
+
+	use64 = ((**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
 	const long header_size = use64 ? sizeheader_v7 : sizeheader_v6;
 	hdlfilenum fnum = (hdlfilenum)((**hdb).fnumdatabase);
 
@@ -275,6 +280,9 @@ boolean dbnormalizeaddress_hdb(dbaddress *adr, hdldatabaserecord hdb) {
 
 	if (adr == NULL || *adr == nildbaddress)
 		return true;
+
+	if (hdb == nil)
+		return false;
 
 	dbaddress resolved = nildbaddress;
 	if (!dbfindblockforaddress_hdb(*adr, &resolved, NULL, NULL, NULL, hdb))

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -183,6 +183,28 @@ boolean dbnormalizeaddress(dbaddress *adr) {
    section but dbfindblockforaddress_hdb needs it here. */
 static boolean dbreadtrailer_hdb(dbaddress adr, boolean *flfree, long *ctbytes, hdlfilenum fnum, hdldatabaserecord hdb);
 
+/*
+ * db_hdb_* helpers — centralised format detection for explicit-handle functions.
+ * Defined early so that all _hdb/_fnum functions can use them.
+ * (Originally in the Layer 3+ section; moved here for Phase 8.)
+ */
+
+static inline boolean db_hdb_use64 (hdldatabaserecord hdb) {
+	return (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+}
+
+static inline long db_hdb_header_size (hdldatabaserecord hdb) {
+	return db_hdb_use64(hdb) ? sizeheader_v7 : sizeheader_v6;
+}
+
+static inline long db_hdb_trailer_size (hdldatabaserecord hdb) {
+	return db_hdb_use64(hdb) ? sizetrailer_v7 : sizetrailer_v6;
+}
+
+static inline hdlfilenum db_hdb_fnum (hdldatabaserecord hdb) {
+	return (hdlfilenum)((**hdb).fnumdatabase);
+}
+
 static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, long *nodebytes, tyvariance *variance, boolean *flfree, hdldatabaserecord hdb) {
 
 	/*
@@ -191,17 +213,15 @@ static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, l
 	*/
 
 	long eof = 0;
-	boolean use64;
 
 	if (hdb == nil)
 		return (false);
 
-	use64 = ((**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
-	const long header_size = use64 ? sizeheader_v7 : sizeheader_v6;
-	hdlfilenum fnum = (hdlfilenum)((**hdb).fnumdatabase);
+	const long header_size = db_hdb_header_size(hdb);
+	hdlfilenum fnum = db_hdb_fnum(hdb);
 
 	long min_address = firstphysicaladdress;
-	if ((**hdb).headerLength > 0) { /* hdb provably non-nil after early return above */
+	if ((**hdb).headerLength > 0) {
 		min_address = (**hdb).headerLength;
 	}
 
@@ -903,16 +923,19 @@ static boolean dbflushheader_hdb (hdldatabaserecord hdb) {
 	the header of a specific database without mutating the global.
 	*/
 
+	/*
+	Based on dbflushheader() — must be kept in sync with any changes there.
+	Key difference: reads hdb directly instead of databasedata global.
+	*/
+
 	boolean fl;
 	tydatabaserecord diskrec;
-	hdlfilenum fnum;
-	boolean use64log;
 
 	if (hdb == nil)
 		return (false);
 
-	fnum = (hdlfilenum)((**hdb).fnumdatabase);
-	use64log = ((**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+	hdlfilenum fnum = db_hdb_fnum(hdb);
+	boolean use64log = db_hdb_use64(hdb);
 
 	assert (sizeof (diskrec.u.growthspace) >= sizeof (diskrec.u.extensions));
 
@@ -1173,8 +1196,7 @@ boolean dbwriteheader_fnum (dbaddress adr, boolean flfree, long ctbytes, tyvaria
 	all I/O goes through fnum.
 	*/
 
-	/* Same logic as db_hdb_use64() defined below in Layer 3+ helpers section */
-	boolean use64 = (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+	boolean use64 = db_hdb_use64(hdb);
 
 	if (use64) {
 		uint64_t raw_size = (uint64_t) ctbytes;
@@ -1213,8 +1235,7 @@ boolean dbwritetrailer_fnum (dbaddress adr, boolean flfree, long ctbytes, hdlfil
 	all I/O goes through fnum.
 	*/
 
-	/* Same logic as db_hdb_use64() defined below in Layer 3+ helpers section */
-	boolean use64 = (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+	boolean use64 = db_hdb_use64(hdb);
 
 	if (use64) {
 		uint64_t raw_size = (uint64_t) ctbytes;
@@ -3313,26 +3334,8 @@ boolean dbsavehandle (Handle hsave, dbaddress *adr) {
  *     databasedata for callers not yet converted.
  *============================================================================*/
 
-/* Helper: determine whether hdb is v7 format (64-bit headers). */
-static inline boolean db_hdb_use64 (hdldatabaserecord hdb) {
-	return (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
-}
-
-/* Helper: header size in bytes for the given database. */
-static inline long db_hdb_header_size (hdldatabaserecord hdb) {
-	return db_hdb_use64(hdb) ? sizeheader_v7 : sizeheader_v6;
-}
-
-/* Helper: trailer size in bytes for the given database. */
-static inline long db_hdb_trailer_size (hdldatabaserecord hdb) {
-	return db_hdb_use64(hdb) ? sizetrailer_v7 : sizetrailer_v6;
-}
-
-/* Helper: extract file number from database handle. */
-static inline hdlfilenum db_hdb_fnum (hdldatabaserecord hdb) {
-	return (hdlfilenum)((**hdb).fnumdatabase);
-}
-
+/* db_hdb_* helpers moved to top of file (before dbfindblockforaddress_hdb)
+   so all _hdb/_fnum functions can use them. */
 
 static boolean dbwriteheaderandtrailer_hdb (dbaddress adr, boolean flfree, long ctbytes, tyvariance variance, hdlfilenum fnum, hdldatabaserecord hdb) {
 

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -178,6 +178,111 @@ boolean dbnormalizeaddress(dbaddress *adr) {
 	*adr = resolved;
 	return true;
 }
+
+/* Phase 8 forward declaration — dbreadtrailer_hdb is defined in the Layer 3+
+   section but dbfindblockforaddress_hdb needs it here. */
+static boolean dbreadtrailer_hdb(dbaddress adr, boolean *flfree, long *ctbytes, hdlfilenum fnum, hdldatabaserecord hdb);
+
+static boolean dbfindblockforaddress_hdb(dbaddress adr, dbaddress *blockstart, long *nodebytes, tyvariance *variance, boolean *flfree, hdldatabaserecord hdb) {
+
+	/*
+	Phase 8: Like dbfindblockforaddress but reads from explicit hdb instead
+	of databasedata.  Uses _fnum variants for all I/O.
+	*/
+
+	long eof = 0;
+	boolean use64 = (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+	const long header_size = use64 ? sizeheader_v7 : sizeheader_v6;
+	hdlfilenum fnum = (hdlfilenum)((**hdb).fnumdatabase);
+
+	long min_address = firstphysicaladdress;
+	if (hdb != nil && (**hdb).headerLength > 0) {
+		min_address = (**hdb).headerLength;
+	}
+
+	if (adr == nildbaddress)
+		return false;
+
+	if (!dbgeteof_fnum(&eof, fnum))
+		return false;
+
+	if (adr < min_address || adr >= (dbaddress) eof)
+		return false;
+
+	for (dbaddress candidate = adr; candidate >= min_address && (adr - candidate) <= 0x100000; --candidate) {
+		boolean freeflag = false;
+		long node_size = 0;
+		tyvariance node_variance = 0;
+
+		if (!dbreadheader_fnum(candidate, &freeflag, &node_size, &node_variance, header_size, fnum))
+			continue;
+
+		if (node_size <= 0 || node_size > eof)
+			continue;
+
+		if ((node_variance < 0) || (node_variance > node_size))
+			continue;
+
+		dbaddress data_start = candidate + header_size;
+		dbaddress data_end = data_start + (node_size - node_variance);
+
+		if (adr < candidate || adr >= data_end)
+			continue;
+
+		boolean trailer_free = false;
+		long trailer_size = 0;
+		dbaddress trailer_pos = candidate + header_size + node_size;
+
+		if (trailer_pos >= (dbaddress) eof) {
+			log_trace(LOG_COMP_DB,
+				"dbfindblockforaddress_hdb candidate=0x%llx size=%ld variance=%ld eof=%ld trailer=0x%llx",
+				(unsigned long long) candidate,
+				node_size,
+				(long) node_variance,
+				eof,
+				(unsigned long long) trailer_pos);
+			continue;
+		}
+
+		if (!dbreadtrailer_hdb(trailer_pos, &trailer_free, &trailer_size, fnum, hdb))
+			continue;
+
+		if (trailer_size != node_size)
+			continue;
+
+		if (trailer_free != freeflag)
+			continue;
+
+		if (blockstart != NULL)
+			*blockstart = candidate;
+		if (nodebytes != NULL)
+			*nodebytes = node_size;
+		if (variance != NULL)
+			*variance = node_variance;
+		if (flfree != NULL)
+			*flfree = freeflag;
+		return true;
+	}
+
+	return false;
+}
+
+boolean dbnormalizeaddress_hdb(dbaddress *adr, hdldatabaserecord hdb) {
+
+	/*
+	Phase 8: Like dbnormalizeaddress but uses explicit hdb for all I/O.
+	*/
+
+	if (adr == NULL || *adr == nildbaddress)
+		return true;
+
+	dbaddress resolved = nildbaddress;
+	if (!dbfindblockforaddress_hdb(*adr, &resolved, NULL, NULL, NULL, hdb))
+		return false;
+
+	*adr = resolved;
+	return true;
+}
 #endif /* FRONTIER_HEADLESS */
 
 typedef enum {
@@ -780,6 +885,93 @@ static boolean dbflushheader (void) {
 		
 	return (true);
 	} /*dbflushheader*/
+
+
+static boolean dbflushheader_hdb (hdldatabaserecord hdb) {
+
+	/*
+	Phase 8: Like dbflushheader but operates on explicit hdb instead of
+	reading databasedata.  Used by dbclearshadowavaillist_hdb to flush
+	the header of a specific database without mutating the global.
+	*/
+
+	boolean fl;
+	tydatabaserecord diskrec;
+	hdlfilenum fnum = (hdlfilenum)((**hdb).fnumdatabase);
+	boolean use64log = (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+
+	assert (sizeof (diskrec.u.growthspace) >= sizeof (diskrec.u.extensions));
+
+#if defined(FRONTIER_HEADLESS)
+	log_trace(LOG_COMP_DB, "dbflushheader_hdb enter hdb=%p fnum=%ld dirty=%d use64=%d",
+	        (void *) hdb,
+	        hdb ? (long) (**hdb).fnumdatabase : -1L,
+	        hdb ? (int) isdirty(hdb) : 0,
+	        (int) use64log);
+#endif
+
+	db_format_adapter_enable_wide_writes(NULL);
+
+	if (hdb && (**hdb).u.extensions.flreadonly) {
+#if defined(FRONTIER_HEADLESS)
+		log_trace(LOG_COMP_DB, "dbflushheader_hdb skip write (read-only) fnum=%ld dirty=%d",
+		        (long) (**hdb).fnumdatabase,
+		        (int) isdirty(hdb));
+#endif
+		return (true);
+	}
+
+	if (isdirty (hdb)) {
+
+		cleardirty (hdb);
+
+		diskrec = **hdb;
+
+		#ifdef SMART_DB_OPENING
+			clearbytes (&diskrec.u.extensions.availlistshadow, sizeof (diskrec.u.extensions.availlistshadow));
+			clearbytes (&diskrec.u.extensions.flreadonly, sizeof (diskrec.u.extensions.flreadonly));
+		#else
+			clearbytes (&diskrec.u.growthspace, sizeof (diskrec.u.growthspace));
+		#endif
+
+		{
+			unsigned char diskheader[sizeof (tydatabaserecord_64)];
+
+			if (!db_write_v7_header(&diskrec, diskheader, sizeof (diskheader))) {
+#if defined(FRONTIER_HEADLESS)
+				log_error(LOG_COMP_DB, "dbflushheader_hdb db_write_v7_header failed");
+#endif
+				return (false);
+			}
+
+			fl = dbwrite_fnum ((dbaddress) 0, (long) sizeof (diskheader), diskheader, fnum, hdb);
+
+#if defined(FRONTIER_HEADLESS)
+			if (!fl) {
+				log_error(LOG_COMP_DB, "dbflushheader_hdb dbwrite failed fnum=%ld len=%zu",
+				        hdb ? (long) (**hdb).fnumdatabase : -1L,
+				        sizeof (diskheader));
+			}
+#endif
+		}
+
+		#ifndef FRONTIER_HEADLESS
+		/*flush file buffers*/ {
+			IOParam pb;
+
+			clearbytes (&pb, sizeof (pb));
+
+			pb.ioRefNum = (hdlfilenum)((**hdb).fnumdatabase);
+
+			PBFlushFile ((ParmBlkPtr) &pb, false);
+			}
+		#endif
+
+		return (fl);
+		}
+
+	return (true);
+	} /*dbflushheader_hdb*/
 
 
 /* Forward declaration for dbreadheader_core which needs to call dbread_fnum */
@@ -3385,21 +3577,11 @@ static boolean dbmove_hdb (ptrvoid pdata, long ctbytes, dbaddress adr, hdlfilenu
 static void dbclearshadowavaillist_hdb (hdldatabaserecord hdb) {
 
 	/*
-	Phase 7 variant: Clear shadow avail list using explicit hdb instead of
+	Phase 7/8 variant: Clear shadow avail list using explicit hdb instead of
 	databasedata.  Only used by dballocate_hdb / dbrelease_hdb.
 
-	Unlike the legacy dbclearshadowavaillist which uses context guards, this
-	version operates directly on hdb.  Note: when there is a shadow availlist
-	block to release, we still need to use dbrelease_internal (which uses
-	databasedata).  For now, if the shadow block exists and we aren't in
-	Save As, we must temporarily swap databasedata.
-
-	TODO(Phase 8): Convert dbflushheader and dbrelease_internal to _hdb
-	so this function no longer needs to touch databasedata.
-	Safe under GIL: no yield points between save and restore of databasedata.
-	Verified: dbflushheader does only dbwrite (file I/O); dbrelease_internal
-	does header reads/writes and avail list manipulation.  Neither calls
-	langbackgroundtask() or thread.sleepTicks() (the only GIL yield points).
+	Phase 8: Uses dbflushheader_hdb and dbrelease_hdb directly — no
+	databasedata mutation required.
 	*/
 
 #ifdef SMART_DB_OPENING
@@ -3413,25 +3595,9 @@ static void dbclearshadowavaillist_hdb (hdldatabaserecord hdb) {
 
 			setdirty (hdb);
 
-			/* Flush the header — this is the one place where _hdb still touches
-			   the global, because dbflushheader() reads databasedata.  We swap
-			   briefly to keep the flush correct.  The header dirty flag was already
-			   set on hdb above. */
-			{
-				hdldatabaserecord savedatabasedata = databasedata;
-				databasedata = hdb;
-				dbflushheader ();
-				databasedata = savedatabasedata;
-			}
+			dbflushheader_hdb (hdb);
 
-			/* Release the old shadow block.  dbrelease_internal uses databasedata,
-			   so swap temporarily. */
-			{
-				hdldatabaserecord savedatabasedata = databasedata;
-				databasedata = hdb;
-				dbrelease_internal (adrblock);
-				databasedata = savedatabasedata;
-			}
+			dbrelease_hdb (adrblock, hdb);
 			}
 		}
 #endif
@@ -3561,12 +3727,19 @@ static boolean dbmergeleft_hdb (boolean flmerged, dbaddress adr, boolean *ptrflm
 	dbaddress nextavail, prevavail;
 	long ixshadow;
 
+	/* Phase 8 fix: Use hdb's headerLength instead of the compile-time
+	   constant firstphysicaladdress.  v7 databases have headerLength=90
+	   but firstphysicaladdress=118 (sizeof tydatabaserecord on 64-bit). */
+	long first_data_address = (**hdb).headerLength;
+	if (first_data_address <= 0)
+		first_data_address = firstphysicaladdress;
+
 	*ptrflmergedleft = false;
 
-	if (adr == firstphysicaladdress)
+	if (adr == (dbaddress) first_data_address)
 		return (true);
 
-	if (adr < firstphysicaladdress) {
+	if (adr < (dbaddress) first_data_address) {
 
 		dblogerror (dbmergeinvalidblockerror);
 
@@ -4320,6 +4493,33 @@ boolean dbflushreleasestack (void) {
 	} /*dbflushreleasestack*/
 
 #endif
+
+boolean dbpushreleasestack_hdb (dbaddress adr, long valtype, hdldatabaserecord hdb) {
+#pragma unused(valtype)
+
+	/*
+	Phase 8: Like dbpushreleasestack but pushes onto hdb's release stack
+	directly, without mutating databasedata.  Used by langexternaldisposevariable.
+	*/
+
+	Handle hstack;
+
+	if (adr == nildbaddress)
+		return (true);
+
+	hstack = (**hdb).releasestack;
+
+	if (hstack == nil) {
+
+		if (!newclearhandle (0L, &hstack))
+			return (false);
+
+		(**hdb).releasestack = hstack;
+		}
+
+	return (enlargehandle (hstack, sizeof (adr), &adr));
+	} /*dbpushreleasestack_hdb*/
+
 
 boolean dbflushreleasestack_context(const db_context *context) {
     db_context_guard guard;

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -897,8 +897,14 @@ static boolean dbflushheader_hdb (hdldatabaserecord hdb) {
 
 	boolean fl;
 	tydatabaserecord diskrec;
-	hdlfilenum fnum = (hdlfilenum)((**hdb).fnumdatabase);
-	boolean use64log = (hdb != nil && (**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
+	hdlfilenum fnum;
+	boolean use64log;
+
+	if (hdb == nil)
+		return (false);
+
+	fnum = (hdlfilenum)((**hdb).fnumdatabase);
+	use64log = ((**hdb).headerLength == (long) sizeof (tydatabaserecord_64));
 
 	assert (sizeof (diskrec.u.growthspace) >= sizeof (diskrec.u.extensions));
 
@@ -4506,6 +4512,9 @@ boolean dbpushreleasestack_hdb (dbaddress adr, long valtype, hdldatabaserecord h
 
 	if (adr == nildbaddress)
 		return (true);
+
+	if (hdb == nil)
+		return (false);
 
 	hstack = (**hdb).releasestack;
 

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -2587,25 +2587,22 @@ boolean langexternaldisposevariable (hdlexternalvariable hvariable, boolean fldi
 	hdlwindowinfo hinfo;
 	dbaddress adr;
 	boolean flwindowopen;
-	hdldatabaserecord savedatabasedata = databasedata;
-	
+
 	flwindowopen = langexternalvariablewindowopen (hv, &hinfo);
-	
+
 	if (hinfo != nil) {
-		
+
 		langexternalunregisterwindow (hinfo);
-		
+
 		if (flwindowopen) {
-			
+
 			flinhibitclosedialogs = true;
-			
+
 			shellclosewindow ((**hinfo).macwindow);
-			
+
 			flinhibitclosedialogs = false;
 			}
 		}
-	
-	databasedata = (**hv).hdatabase;
 
 	if ((**hv).flinmemory) {
 
@@ -2617,14 +2614,13 @@ boolean langexternaldisposevariable (hdlexternalvariable hvariable, boolean fldi
 		adr = (dbaddress) (**hv).variabledata;
 
 	/* Only push to release stack if there's a valid database context.
-	   In-memory tables created with lang.new() have hdatabase=NULL. */
-	if (fldisk && databasedata != NULL)
-		dbpushreleasestack (adr, (long) (outlinevaluetype + (**hv).id));
-	
-	databasedata = savedatabasedata;
-	
+	   In-memory tables created with lang.new() have hdatabase=NULL.
+	   Phase 8: use _hdb variant — no databasedata mutation needed. */
+	if (fldisk && (**hv).hdatabase != NULL)
+		dbpushreleasestack_hdb (adr, (long) (outlinevaluetype + (**hv).id), (**hv).hdatabase);
+
 	disposehandle ((Handle) hv);
-	
+
 	return (true);
 	} /*langexternaldisposevariable*/
 

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -353,7 +353,8 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
         dbaddress normalized = adr;
         if (dbnormalizeaddress_hdb(&normalized, hdb)) {
             if (normalized != adr) {
-                dbaddress data_start = normalized + sizeheader;
+                long hs = ((**hdb).headerLength == (long)sizeof(tydatabaserecord_64)) ? sizeheader_v7 : sizeheader_v6;
+                dbaddress data_start = normalized + hs;
                 if (adr > data_start)
                     payload_offset = (long) (adr - data_start);
                 adr = normalized;

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -348,12 +348,15 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     /*
      * Normalize the address against the table's database handle.
      * Phase 8: uses _hdb variant — no global swap needed.
+     * dbnormalizeaddress_hdb is FRONTIER_HEADLESS only; the only current
+     * build target defines FRONTIER_HEADLESS.
      */
+#if defined(FRONTIER_HEADLESS)
     {
         dbaddress normalized = adr;
         if (dbnormalizeaddress_hdb(&normalized, hdb)) { /* returns false for nil hdb, so hdb is non-nil here */
             if (normalized != adr) {
-                long hs = ((**hdb).headerLength == (long)sizeof(tydatabaserecord_64)) ? sizeheader_v7 : sizeheader_v6;
+                long hs = db_hdb_header_size(hdb);
                 dbaddress data_start = normalized + hs;
                 if (adr > data_start)
                     payload_offset = (long) (adr - data_start);
@@ -365,6 +368,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
                     (unsigned long long) (**hv).oldaddress, (int)(**hv).flinmemory);
         }
     }
+#endif /* FRONTIER_HEADLESS */
 
     if (adr == nildbaddress) { /* table has never been allocated */
         log_warn(LOG_COMP_TABLE, "tableverbinmemory nil table address (never saved)");

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -351,7 +351,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
      */
     {
         dbaddress normalized = adr;
-        if (dbnormalizeaddress_hdb(&normalized, hdb)) {
+        if (dbnormalizeaddress_hdb(&normalized, hdb)) { /* returns false for nil hdb, so hdb is non-nil here */
             if (normalized != adr) {
                 long hs = ((**hdb).headerLength == (long)sizeof(tydatabaserecord_64)) ? sizeheader_v7 : sizeheader_v6;
                 dbaddress data_start = normalized + hs;

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -294,10 +294,9 @@ static boolean headless_convert_legacy_table_payload(const unsigned char *payloa
 
 boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvariable, hdlhashnode hnode) {
     /*
-    2026-02-25: Phase 4 - Inline save/restore of databasedata global.
-    Replaces dbpushdatabase/dbpopdatabase with a direct inline swap so that
-    dbrefhandle and dbnormalizeaddress read from the correct database.
-    The global is always restored before returning (callee-saves).
+    Phase 8: Uses explicit _hdb variants for all database I/O.
+    No databasedata mutation — reads via dbnormalizeaddress_hdb and
+    dbrefhandle_hdb using (**hv).hdatabase directly.
     */
 
     register hdltablevariable hv = (hdltablevariable) hvariable;
@@ -314,7 +313,7 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
 #if !defined(NDEBUG)
     assert(ctx != NULL && "Issue #347: NULL context passed to tableverbinmemory_common - use db_context_init()");
 #endif
-    (void)ctx;  /* ctx validated above; inline swap uses databasedata directly */
+    (void)ctx;  /* ctx validated above; Phase 8 uses hdb directly */
 
     log_trace(LOG_COMP_TABLE, "tableverbinmemory enter hvariable=%p hnode=%p flinmemory=%d",
             (void *) hvariable,
@@ -332,16 +331,10 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     }
 
     /*
-     * Temporarily switch to the table's database for reading.
-     * The old code used dbpushdatabase/dbpopdatabase to accomplish this.
-     * We do the same global swap inline, avoiding the stack-based API.
-     * This is necessary because dbrefhandle and dbnormalizeaddress read from
-     * the global databasedata, and we need them to target the table's DB.
+     * Phase 8: Use the table's database handle directly via _hdb variants.
+     * No databasedata mutation needed.
      */
-    hdldatabaserecord saved_databasedata = databasedata;
-    if ((**hv).hdatabase != nil) {
-        databasedata = (**hv).hdatabase;
-    }
+    hdldatabaserecord hdb = (**hv).hdatabase;
 
     adr = (dbaddress) (**hv).variabledata;  /* DISK ADDRESS - format depends on source DB */
 
@@ -353,13 +346,12 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
             (void *)(**hv).hdatabase, (unsigned long long) adr);
 
     /*
-     * Normalize the address against the current databasedata (which we
-     * swapped above to (**hv).hdatabase). This is identical to what the
-     * old dbpushdatabase/dbrefhandle path did.
+     * Normalize the address against the table's database handle.
+     * Phase 8: uses _hdb variant — no global swap needed.
      */
     {
         dbaddress normalized = adr;
-        if (dbnormalizeaddress(&normalized)) {
+        if (dbnormalizeaddress_hdb(&normalized, hdb)) {
             if (normalized != adr) {
                 dbaddress data_start = normalized + sizeheader;
                 if (adr > data_start)
@@ -378,8 +370,8 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
         shellinternalerror(idniltableaddress, BIGSTRING ("\x2b" "nil table address.  (Creating empty table.)"));
         fl = false;
     } else {
-        /* Read from the (swapped) global databasedata */
-        fl = dbrefhandle(adr, &hpacked);
+        /* Phase 8: read from explicit hdb */
+        fl = dbrefhandle_hdb(adr, &hpacked, hdb);
 
         if (!fl) {
             log_error(LOG_COMP_TABLE, "dbrefhandle failed adr=0x%llx", (unsigned long long)adr);
@@ -475,7 +467,6 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     }
 
     if (!fl) {
-        databasedata = saved_databasedata;  /* restore before returning */
         return false;
     }
 
@@ -488,9 +479,9 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     db_format_mode current_mode = db_format_mode_current();
     log_debug(LOG_COMP_TABLE, "tableverbinmemory before address assignment: adapter_repack=%d use_64bit=%d database=%p adr=0x%llx",
             (int)current_mode.adapter_repack, (int)current_mode.use_64bit_format,
-            (void*)databasedata, (unsigned long long)adr);
+            (void*)hdb, (unsigned long long)adr);
 
-    if (current_mode.adapter_repack && databasedata != nil) {
+    if (current_mode.adapter_repack && hdb != nil) {
         (**hv).oldaddress = nildbaddress;
         log_debug(LOG_COMP_TABLE, "tableverbinmemory CLEARED oldaddress (adapter_repack) adr=0x%llx variabledata=0x%llx flinmemory=%d",
                 (unsigned long long)adr, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
@@ -536,8 +527,6 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
     (**htable).hashtablerefcon = (long) hv; /* we can get from hashtable to variable rec */
 
     (**htable).thistableshashnode = hnode; /* The var rec is contained in the hashnode... RAB 1/3/00 */
-
-    databasedata = saved_databasedata;  /* restore before returning */
 
     return true;
 }

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 295 tests: 295 pass (100%)</title>
-    <dateCreated>Fri, 27 Feb 2026 09:14:31 GMT</dateCreated>
+    <title>Frontier Unit Tests - 300 tests: 300 pass (100%)</title>
+    <dateCreated>Fri, 27 Feb 2026 21:19:05 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-27 at 09:14 UTC"/>
-      <outline text="Results: 295 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (295 tests total)"/>
+      <outline text="Run: 2026-02-27 at 21:19 UTC"/>
+      <outline text="Results: 300 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (300 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 34 tests: 34 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 300 tests: 300 pass (100%)</title>
-    <dateCreated>Fri, 27 Feb 2026 21:19:05 GMT</dateCreated>
+    <dateCreated>Sat, 28 Feb 2026 00:54:07 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-27 at 21:19 UTC"/>
+      <outline text="Run: 2026-02-28 at 00:54 UTC"/>
       <outline text="Results: 300 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (300 tests total)"/>
     </outline>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 29 tests: 29 pass (100%)</title>
-    <dateCreated>Fri, 27 Feb 2026 07:13:40 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 34 tests: 34 pass (100%)</title>
+    <dateCreated>Fri, 27 Feb 2026 21:19:05 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -31,6 +31,11 @@
     <outline text="✓ test_hdb_assign_roundtrip"/>
     <outline text="✓ test_hdb_savehandle_roundtrip"/>
     <outline text="✓ test_hdb_copy_roundtrip"/>
+    <outline text="✓ test_dbpushreleasestack_hdb_callee_saves"/>
+    <outline text="✓ test_dbpushreleasestack_hdb_targets_correct_db"/>
+    <outline text="✓ test_dbnormalizeaddress_hdb_callee_saves"/>
+    <outline text="✓ test_dbnormalizeaddress_hdb_roundtrip"/>
+    <outline text="✓ test_dbclearshadowavaillist_no_global_swap"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -1587,6 +1587,161 @@ cleanup:
     log_info(LOG_COMP_DB, "[TEST] test_hdb_copy_roundtrip COMPLETED");
 }
 
+/* ============================================================================
+ * Phase 8: Callee-saves and behavioral tests for databasedata elimination
+ * ============================================================================*/
+
+static void test_dbpushreleasestack_hdb_callee_saves(void) {
+    /*
+     * Phase 8: Verify dbpushreleasestack_hdb does not mutate databasedata.
+     */
+    hdb_test_ctx ctx;
+    assert(open_scratch_v7_db(&ctx, "pushrel"));
+
+    /* Allocate a block so we have a real address to push */
+    char payload[4] = { 'P', 'U', 'S', 'H' };
+    dbaddress adr = nildbaddress;
+    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+
+    hdldatabaserecord before = databasedata;
+    boolean ok = dbpushreleasestack_hdb(adr, 42L, ctx.hdb);
+    assert(ok);
+    assert(databasedata == before);
+
+cleanup:
+    close_scratch_v7_db(&ctx);
+    log_info(LOG_COMP_DB, "[TEST] test_dbpushreleasestack_hdb_callee_saves COMPLETED");
+}
+
+static void test_dbpushreleasestack_hdb_targets_correct_db(void) {
+    /*
+     * Phase 8: Create two scratch databases. Push an address to one.
+     * Verify only that one's releasestack is non-nil afterwards.
+     */
+    hdb_test_ctx ctx1, ctx2;
+    assert(open_scratch_v7_db(&ctx1, "pushA"));
+    assert(open_scratch_v7_db(&ctx2, "pushB"));
+
+    /* Allocate a block in ctx1 */
+    char payload[4] = { 'T', 'G', 'T', '!' };
+    dbaddress adr = nildbaddress;
+    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx1.hdb)) goto cleanup;
+
+    /* Confirm both releasestacks start nil */
+    assert((**ctx1.hdb).releasestack == nil);
+    assert((**ctx2.hdb).releasestack == nil);
+
+    /* Push to ctx1 only */
+    boolean ok = dbpushreleasestack_hdb(adr, 99L, ctx1.hdb);
+    assert(ok);
+
+    /* ctx1's releasestack should be non-nil now */
+    assert((**ctx1.hdb).releasestack != nil);
+
+    /* ctx2's releasestack should still be nil */
+    assert((**ctx2.hdb).releasestack == nil);
+
+    assert(databasedata == ctx1.saved_db);
+
+cleanup:
+    close_scratch_v7_db(&ctx2);
+    close_scratch_v7_db(&ctx1);
+    log_info(LOG_COMP_DB, "[TEST] test_dbpushreleasestack_hdb_targets_correct_db COMPLETED");
+}
+
+#if defined(FRONTIER_HEADLESS)
+static void test_dbnormalizeaddress_hdb_callee_saves(void) {
+    /*
+     * Phase 8: Verify dbnormalizeaddress_hdb does not mutate databasedata.
+     */
+    hdb_test_ctx ctx;
+    assert(open_scratch_v7_db(&ctx, "norm"));
+
+    /* Allocate a block so we have a real address */
+    char payload[8] = "NORMADR!";
+    dbaddress adr = nildbaddress;
+    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+
+    hdldatabaserecord before = databasedata;
+    dbaddress normalized = adr;
+    boolean ok = dbnormalizeaddress_hdb(&normalized, ctx.hdb);
+    assert(ok);
+    assert(databasedata == before);
+
+cleanup:
+    close_scratch_v7_db(&ctx);
+    log_info(LOG_COMP_DB, "[TEST] test_dbnormalizeaddress_hdb_callee_saves COMPLETED");
+}
+
+static void test_dbnormalizeaddress_hdb_roundtrip(void) {
+    /*
+     * Phase 8: Allocate a block via dballocate_hdb, normalize its address,
+     * verify it resolves to the block start.
+     */
+    hdb_test_ctx ctx;
+    assert(open_scratch_v7_db(&ctx, "normrt"));
+
+    char payload[16] = "NORMALIZE_RT_OK";
+    dbaddress adr = nildbaddress;
+    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+
+    /* adr should already be the block start, so normalize should be a no-op */
+    dbaddress normalized = adr;
+    boolean ok = dbnormalizeaddress_hdb(&normalized, ctx.hdb);
+    assert(ok);
+    assert(normalized == adr);
+
+    /* Read back through the normalized address to confirm it's valid */
+    Handle href = nil;
+    if (!dbrefhandle_hdb(normalized, &href, ctx.hdb)) goto cleanup;
+    assert(href != nil);
+    assert(GetHandleSize(href) == sizeof(payload));
+    lockhandle(href);
+    assert(memcmp(*href, payload, sizeof(payload)) == 0);
+    unlockhandle(href);
+    disposehandle(href);
+
+    assert(databasedata == ctx.saved_db);
+
+cleanup:
+    close_scratch_v7_db(&ctx);
+    log_info(LOG_COMP_DB, "[TEST] test_dbnormalizeaddress_hdb_roundtrip COMPLETED");
+}
+#endif /* FRONTIER_HEADLESS */
+
+static void test_dbclearshadowavaillist_no_global_swap(void) {
+    /*
+     * Phase 8: Exercise dballocate_hdb / dbrelease_hdb (which internally
+     * call dbclearshadowavaillist_hdb) and verify databasedata is untouched.
+     */
+    hdb_test_ctx ctx;
+    assert(open_scratch_v7_db(&ctx, "shadow"));
+
+    /* Allocate a block */
+    char payload[8] = "SHADOW!!";
+    dbaddress adr = nildbaddress;
+    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+    assert(adr != nildbaddress);
+
+    hdldatabaserecord before = databasedata;
+
+    /* Release it — this triggers dbclearshadowavaillist_hdb internally */
+    boolean ok = dbrelease_hdb(adr, ctx.hdb);
+    assert(ok);
+    assert(databasedata == before);
+
+    /* Allocate again to exercise the free-list reuse path */
+    dbaddress adr2 = nildbaddress;
+    ok = dballocate_hdb(sizeof(payload), payload, &adr2, ctx.hdb);
+    assert(ok);
+    assert(adr2 != nildbaddress);
+    assert(databasedata == before);
+
+cleanup:
+    close_scratch_v7_db(&ctx);
+    log_info(LOG_COMP_DB, "[TEST] test_dbclearshadowavaillist_no_global_swap COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -1621,6 +1776,15 @@ int main(void) {
     TR_RUN(test_hdb_assign_roundtrip);
     TR_RUN(test_hdb_savehandle_roundtrip);
     TR_RUN(test_hdb_copy_roundtrip);
+
+    /* Phase 8: Callee-saves and behavioral tests for databasedata elimination */
+    TR_RUN(test_dbpushreleasestack_hdb_callee_saves);
+    TR_RUN(test_dbpushreleasestack_hdb_targets_correct_db);
+#if defined(FRONTIER_HEADLESS)
+    TR_RUN(test_dbnormalizeaddress_hdb_callee_saves);
+    TR_RUN(test_dbnormalizeaddress_hdb_roundtrip);
+#endif
+    TR_RUN(test_dbclearshadowavaillist_no_global_swap);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -1601,14 +1601,13 @@ static void test_dbpushreleasestack_hdb_callee_saves(void) {
     /* Allocate a block so we have a real address to push */
     char payload[4] = { 'P', 'U', 'S', 'H' };
     dbaddress adr = nildbaddress;
-    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+    assert(dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb));
 
     hdldatabaserecord before = databasedata;
     boolean ok = dbpushreleasestack_hdb(adr, 42L, ctx.hdb);
     assert(ok);
     assert(databasedata == before);
 
-cleanup:
     close_scratch_v7_db(&ctx);
     log_info(LOG_COMP_DB, "[TEST] test_dbpushreleasestack_hdb_callee_saves COMPLETED");
 }
@@ -1625,7 +1624,7 @@ static void test_dbpushreleasestack_hdb_targets_correct_db(void) {
     /* Allocate a block in ctx1 */
     char payload[4] = { 'T', 'G', 'T', '!' };
     dbaddress adr = nildbaddress;
-    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx1.hdb)) goto cleanup;
+    assert(dballocate_hdb(sizeof(payload), payload, &adr, ctx1.hdb));
 
     /* Confirm both releasestacks start nil */
     assert((**ctx1.hdb).releasestack == nil);
@@ -1643,7 +1642,6 @@ static void test_dbpushreleasestack_hdb_targets_correct_db(void) {
 
     assert(databasedata == ctx1.saved_db);
 
-cleanup:
     close_scratch_v7_db(&ctx2);
     close_scratch_v7_db(&ctx1);
     log_info(LOG_COMP_DB, "[TEST] test_dbpushreleasestack_hdb_targets_correct_db COMPLETED");
@@ -1660,7 +1658,7 @@ static void test_dbnormalizeaddress_hdb_callee_saves(void) {
     /* Allocate a block so we have a real address */
     char payload[8] = "NORMADR!";
     dbaddress adr = nildbaddress;
-    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+    assert(dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb));
 
     hdldatabaserecord before = databasedata;
     dbaddress normalized = adr;
@@ -1668,7 +1666,6 @@ static void test_dbnormalizeaddress_hdb_callee_saves(void) {
     assert(ok);
     assert(databasedata == before);
 
-cleanup:
     close_scratch_v7_db(&ctx);
     log_info(LOG_COMP_DB, "[TEST] test_dbnormalizeaddress_hdb_callee_saves COMPLETED");
 }
@@ -1683,7 +1680,7 @@ static void test_dbnormalizeaddress_hdb_roundtrip(void) {
 
     char payload[16] = "NORMALIZE_RT_OK";
     dbaddress adr = nildbaddress;
-    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+    assert(dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb));
 
     /* adr should already be the block start, so normalize should be a no-op */
     dbaddress normalized = adr;
@@ -1693,7 +1690,7 @@ static void test_dbnormalizeaddress_hdb_roundtrip(void) {
 
     /* Read back through the normalized address to confirm it's valid */
     Handle href = nil;
-    if (!dbrefhandle_hdb(normalized, &href, ctx.hdb)) goto cleanup;
+    assert(dbrefhandle_hdb(normalized, &href, ctx.hdb));
     assert(href != nil);
     assert(GetHandleSize(href) == sizeof(payload));
     lockhandle(href);
@@ -1703,7 +1700,6 @@ static void test_dbnormalizeaddress_hdb_roundtrip(void) {
 
     assert(databasedata == ctx.saved_db);
 
-cleanup:
     close_scratch_v7_db(&ctx);
     log_info(LOG_COMP_DB, "[TEST] test_dbnormalizeaddress_hdb_roundtrip COMPLETED");
 }
@@ -1720,7 +1716,7 @@ static void test_dbclearshadowavaillist_no_global_swap(void) {
     /* Allocate a block */
     char payload[8] = "SHADOW!!";
     dbaddress adr = nildbaddress;
-    if (!dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb)) goto cleanup;
+    assert(dballocate_hdb(sizeof(payload), payload, &adr, ctx.hdb));
     assert(adr != nildbaddress);
 
     hdldatabaserecord before = databasedata;
@@ -1737,7 +1733,6 @@ static void test_dbclearshadowavaillist_no_global_swap(void) {
     assert(adr2 != nildbaddress);
     assert(databasedata == before);
 
-cleanup:
     close_scratch_v7_db(&ctx);
     log_info(LOG_COMP_DB, "[TEST] test_dbclearshadowavaillist_no_global_swap COMPLETED");
 }


### PR DESCRIPTION
## Summary

- Eliminates all remaining runtime save/swap/restore of the `databasedata` global from three call sites:
  - `dbclearshadowavaillist_hdb` (db.c) — now uses `dbflushheader_hdb` + `dbrelease_hdb`
  - `langexternaldisposevariable` (langexternal.c) — now uses `dbpushreleasestack_hdb`
  - `tableverbinmemory_common` (tableexternal_common.c) — now uses `dbnormalizeaddress_hdb` + `dbrefhandle_hdb`
- Adds 4 new functions: `dbflushheader_hdb` (static), `dbfindblockforaddress_hdb` (static), `dbnormalizeaddress_hdb`, `dbpushreleasestack_hdb`
- Fixes `dbmergeleft_hdb` to use `(**hdb).headerLength` instead of compile-time `firstphysicaladdress` (118 vs 90 for v7 databases)
- Adds production guard to `db_context_fnum` for nil database handles
- 5 new unit tests (300 total pass), no integration test regressions

## Test plan

- [x] 300/300 unit tests pass (5 new Phase 8 tests)
- [x] Integration tests: only pre-existing failures (6 guest DB + 1 flaky math)
- [x] Migration test: `rm -f databases/Frontier.root7 && ./frontier-cli/frontier-cli --system-root databases/Frontier.root -e "1"` succeeds
- [x] `grep -rn 'savedatabasedata\|saved_databasedata' Common/source/db.c Common/source/langexternal.c Common/source/tableexternal_common.c` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)