### PR TITLE
feat: Eliminate last runtime databasedata swap (Phase 9)

### DIFF
--- a/Common/headers/tableinternal.h
+++ b/Common/headers/tableinternal.h
@@ -122,6 +122,17 @@ typedef struct tytablevariable {
 
 typedef boolean (*tyfindvariablecallback) (hdlhashtable, hdlhashnode);
 
+/*
+   Phase 9: Refcon wrapper for tablesortedinversesearch.
+   Carries the database handle through the existing refcon parameter
+   so visit callbacks can build a db_context for disk-value reads
+   without mutating the databasedata global.
+*/
+typedef struct tablesortedsearchctx {
+    ptrvoid original_refcon;
+    hdldatabaserecord hdb;
+} tablesortedsearchctx;
+
 
 /*prototypes*/
 

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1078,6 +1078,9 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 		}
 	}
 
+	/* Invariant: all switch branches below must be callee-saves for
+	   databasedata.  Each *verbpack_internal child uses an explicit
+	   db_context and never mutates the global (Phases 1-3). */
 	db_format_mode savedmode = db_format_mode_current();
 
 	switch ((**hv).id) {

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1078,10 +1078,6 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 		}
 	}
 
-	/* Belt-and-suspenders safety net: all children are callee-saves and
-	   context-aware (no databasedata mutations in the pack path), but we
-	   restore here defensively in case a future child loses the invariant. */
-	hdldatabaserecord savedatabasedata = databasedata;
 	db_format_mode savedmode = db_format_mode_current();
 
 	switch ((**hv).id) {
@@ -1112,7 +1108,6 @@ boolean langexternalpack_internal (const db_context *ctx, hdlexternalhandle h, H
 			break;
 		}
 
-	databasedata = savedatabasedata;
 	db_format_mode_apply(&savedmode);
 
 	return (ok);

--- a/Common/source/langipc.c
+++ b/Common/source/langipc.c
@@ -2391,19 +2391,30 @@ boolean langipcapprunning (hdltreenode hparam1, tyvaluerecord *vreturned) {
 static boolean langipcgetparamvisit (bigstring bs, hdlhashnode hnode, tyvaluerecord val, ptrvoid refcon) {
 #pragma unused (hnode)
 
-	hdlverbrecord hv = (hdlverbrecord) refcon;
+	/*
+	Phase 9: unwrap tablesortedsearchctx; use copyvaluerecord_internal
+	to avoid mutating databasedata.
+	*/
+
+	tablesortedsearchctx *sctx = (tablesortedsearchctx *) refcon;
+	hdlverbrecord hv = (hdlverbrecord) sctx->original_refcon;
 	OSType key;
-	
+
 	if (!stringtoostype (bs, &key)) {
-		
+
 		langparamerror (ostypecoerceerror, bs);
-		
+
 		return (true); /*stop visit*/
 		}
-	
-	if (!copyvaluerecord (val, &val))
-		return (false);
-	
+
+	{
+		db_context dbctx;
+		db_context_init (&dbctx);
+		dbctx.database = sctx->hdb;
+		if (!copyvaluerecord_internal (&dbctx, val, &val))
+			return (false);
+	}
+
 	return (!langipcpushparam (&val, key, hv));
 	} /*langipcgetparamvisit*/
 

--- a/Common/source/langipc.c
+++ b/Common/source/langipc.c
@@ -2409,8 +2409,10 @@ static boolean langipcgetparamvisit (bigstring bs, hdlhashnode hnode, tyvaluerec
 
 	{
 		db_context dbctx;
-		db_context_init (&dbctx);
-		dbctx.database = sctx->hdb;
+		if (db_is_v7 (sctx->hdb))
+			db_context_init_v7_read (&dbctx, sctx->hdb);
+		else
+			db_context_init_legacy_read (&dbctx, sctx->hdb);
 		if (!copyvaluerecord_internal (&dbctx, val, &val))
 			return (false);
 	}

--- a/Common/source/legacy/tablepack_legacy.c
+++ b/Common/source/legacy/tablepack_legacy.c
@@ -491,28 +491,36 @@ static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvalu
 
 	/*
 	4.0.2b1 dmb: handle fldiskvals. see comment in hashsortedinversesearch
+
+	Phase 9: unwrap tablesortedsearchctx; use copyvaluerecord_internal
+	for disk values to avoid mutating databasedata.
 	*/
-	
-	Handle htextscrap = (Handle) refcon;
+
+	tablesortedsearchctx *sctx = (tablesortedsearchctx *) refcon;
+	Handle htextscrap = (Handle) sctx->original_refcon;
 	boolean fl;
-	
+
 	pushchar (chtab, bsname);
-	
+
 	if (!pushtexthandle (bsname, htextscrap))
 		return (true); /*abort traversal*/
-	
-	if (val.fldiskval)
-		if (!copyvaluerecord (val, &val))
+
+	if (val.fldiskval) {
+		db_context dbctx;
+		db_context_init (&dbctx);
+		dbctx.database = sctx->hdb;
+		if (!copyvaluerecord_internal (&dbctx, val, &val))
 			return (true);
-	
+	}
+
 	fl = langvaluetotextscrap (val, htextscrap);
-	
+
 	if (exemptfromtmpstack (&val))
 		disposevaluerecord (val, false);
-	
+
 	if (!fl)
 		return (true);
-	
+
 	return (false); /*keep going*/
 	} /*tablepacktotextvisit*/
 

--- a/Common/source/legacy/tablepack_legacy.c
+++ b/Common/source/legacy/tablepack_legacy.c
@@ -507,8 +507,10 @@ static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvalu
 
 	if (val.fldiskval) {
 		db_context dbctx;
-		db_context_init (&dbctx);
-		dbctx.database = sctx->hdb;
+		if (db_is_v7 (sctx->hdb))
+			db_context_init_v7_read (&dbctx, sctx->hdb);
+		else
+			db_context_init_legacy_read (&dbctx, sctx->hdb);
 		if (!copyvaluerecord_internal (&dbctx, val, &val))
 			return (true);
 	}

--- a/Common/source/tablefind.c
+++ b/Common/source/tablefind.c
@@ -266,6 +266,8 @@ static boolean tablefindvisit (bigstring bsname, hdlhashnode hnode, tyvaluerecor
 
 		if (val.valuetype != externalvaluetype) {
 
+			boolean flresolveddisk = false;
+
 			if (val.fldiskval) {
 				db_context dbctx;
 				if (db_is_v7 (sctx->hdb))
@@ -274,10 +276,19 @@ static boolean tablefindvisit (bigstring bsname, hdlhashnode hnode, tyvaluerecor
 					db_context_init_legacy_read (&dbctx, sctx->hdb);
 				if (!copyvaluerecord_internal (&dbctx, val, &val))
 					return (true);
+				flresolveddisk = true;
 			}
 
-			if (tablesearchcellvalue (hnode, bsname, val))
+			if (tablesearchcellvalue (hnode, bsname, val)) {
+				if (flresolveddisk)
+					if (exemptfromtmpstack (&val))
+						disposevaluerecord (val, false);
 				return (true);
+			}
+
+			if (flresolveddisk)
+				if (exemptfromtmpstack (&val))
+					disposevaluerecord (val, false);
 			}
 		}
 

--- a/Common/source/tablefind.c
+++ b/Common/source/tablefind.c
@@ -213,85 +213,96 @@ static boolean tablesearchcellvalue (hdlhashnode hnode, bigstring bscell, tyvalu
 
 
 static boolean tablefindvisit (bigstring bsname, hdlhashnode hnode, tyvaluerecord val, ptrvoid refcon) {
-#pragma unused (refcon)
 
 	/*
-	7/4/91 dmb: langexternalzoom now takes table/name pair instead 
+	7/4/91 dmb: langexternalzoom now takes table/name pair instead
 	of full path.
-	
-	7/29/91 dmb: handle activate events after zooming so deferred visiing 
+
+	7/29/91 dmb: handle activate events after zooming so deferred visiing
 	takes place
-	
+
 	9/12/91 dmb: new marker logic to handle wraparound search
+
+	Phase 9: unwrap tablesortedsearchctx; resolve disk values via
+	copyvaluerecord_internal before tablesearchcellvalue.
 	*/
-	
+
+	tablesortedsearchctx *sctx = (tablesortedsearchctx *) refcon;
 	boolean flzoom;
 	boolean flsearchcell = true;
 	boolean flsearchvalue = true;
-	
+
 	if (!isemptystring (bssearchmarker)) { /*we've haven't passed the marked entry*/
-		
+
 		if (!equalstrings (bsname, bssearchmarker)) { /*we haven't reached the marked entry*/
-			
+
 			flsearchcell = false;
-			
+
 			flsearchvalue = false;
 			}
 		else { /*we're at the marked cell*/
-			
+
 			setemptystring (bssearchmarker);
-			
+
 			flsearchcell = false;
-			
+
 			flsearchvalue = flsearchundermarker;
 			}
 		}
-	
+
 	if (flsearchwrapped) { /*if the search has wrapped, we search *before* the marker, not after*/
-		
+
 		flsearchcell = !flsearchcell;
-		
+
 		flsearchvalue = !flsearchvalue;
 		}
-	
+
 	if (flsearchcell) {
-		
+
 		rollbeachball ();
-		
+
 		if (tablesearchcellname (hnode, bsname))
 			return (true);
-		
+
 		if (val.valuetype != externalvaluetype) {
-			
+
+			if (val.fldiskval) {
+				db_context dbctx;
+				db_context_init (&dbctx);
+				dbctx.database = sctx->hdb;
+				if (!copyvaluerecord_internal (&dbctx, val, &val))
+					return (true);
+			}
+
 			if (tablesearchcellvalue (hnode, bsname, val))
 				return (true);
 			}
 		}
-	
+
 	if (searchparams.flonelevel || !flsearchvalue)
 		return (false);
-	
+
 	if (keyboardescape ()) /*user pressed cmd-period -- stop visiting*/
 		return (true);
-	
+
 	if (!langexternalsearch (val, &flzoom))
 		return (false);
-	
+
 	if (searchparams.flreplaceall) /*keep going*/
 		return (false);
-	
+
 	if (flzoom && searchparams.flzoomfound) {
-		
+
 		hdlwindowinfo hinfo;
-		
+
 		langexternalzoom (val, hsearchtable, bsname);
-		
+
 		if (getfrontwindowinfo (&hinfo))
 			(**hinfo).flopenedforfind = searchparams.flwindowzoomed;
-		
+
 		shellpartialeventloop (activMask); /*handle pending activate events*/
 		}
-	
+
 	return (true);
 	} /*tablefindvisit*/
 

--- a/Common/source/tablefind.c
+++ b/Common/source/tablefind.c
@@ -268,8 +268,10 @@ static boolean tablefindvisit (bigstring bsname, hdlhashnode hnode, tyvaluerecor
 
 			if (val.fldiskval) {
 				db_context dbctx;
-				db_context_init (&dbctx);
-				dbctx.database = sctx->hdb;
+				if (db_is_v7 (sctx->hdb))
+					db_context_init_v7_read (&dbctx, sctx->hdb);
+				else
+					db_context_init_legacy_read (&dbctx, sctx->hdb);
 				if (!copyvaluerecord_internal (&dbctx, val, &val))
 					return (true);
 			}

--- a/Common/source/tableops.c
+++ b/Common/source/tableops.c
@@ -344,25 +344,20 @@ hdldatabaserecord tablegetdatabase (hdlhashtable ht) {
 
 
 boolean tablesortedinversesearch (hdlhashtable htable, langsortedinversesearchcallback visit, ptrvoid refcon) {
-	
+
 	/*
-	like the langhash version, but we push the table's database in case 
-	a disk value must be resolved
+	Phase 9: thread the table's database handle through the refcon
+	wrapper instead of mutating the databasedata global.  Visit
+	callbacks unwrap the context and use copyvaluerecord_internal
+	for disk-value reads.
 	*/
-	
-	hdldatabaserecord hdb = tablegetdatabase (htable);
-	hdldatabaserecord hdbsave = databasedata;
-	boolean fl;
-	
-	if (hdb)
-		databasedata = hdb;
-	
-	fl = hashsortedinversesearch (htable, visit, refcon);
-	
-	if (hdb)
-		databasedata = hdbsave;
-	
-	return (fl);
+
+	tablesortedsearchctx ctx;
+
+	ctx.original_refcon = refcon;
+	ctx.hdb = tablegetdatabase (htable);
+
+	return (hashsortedinversesearch (htable, visit, (ptrvoid) &ctx));
 	} /*tablesortedinversesearch*/
 
 

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -593,8 +593,10 @@ static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvalu
 
 	if (val.fldiskval) {
 		db_context dbctx;
-		db_context_init (&dbctx);
-		dbctx.database = sctx->hdb;
+		if (db_is_v7 (sctx->hdb))
+			db_context_init_v7_read (&dbctx, sctx->hdb);
+		else
+			db_context_init_legacy_read (&dbctx, sctx->hdb);
 		if (!copyvaluerecord_internal (&dbctx, val, &val))
 			return (true);
 	}

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -577,28 +577,36 @@ static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvalu
 
 	/*
 	4.0.2b1 dmb: handle fldiskvals. see comment in hashsortedinversesearch
+
+	Phase 9: unwrap tablesortedsearchctx; use copyvaluerecord_internal
+	for disk values to avoid mutating databasedata.
 	*/
-	
-	Handle htextscrap = (Handle) refcon;
+
+	tablesortedsearchctx *sctx = (tablesortedsearchctx *) refcon;
+	Handle htextscrap = (Handle) sctx->original_refcon;
 	boolean fl;
-	
+
 	pushchar (chtab, bsname);
-	
+
 	if (!pushtexthandle (bsname, htextscrap))
 		return (true); /*abort traversal*/
-	
-	if (val.fldiskval)
-		if (!copyvaluerecord (val, &val))
+
+	if (val.fldiskval) {
+		db_context dbctx;
+		db_context_init (&dbctx);
+		dbctx.database = sctx->hdb;
+		if (!copyvaluerecord_internal (&dbctx, val, &val))
 			return (true);
-	
+	}
+
 	fl = langvaluetotextscrap (val, htextscrap);
-	
+
 	if (exemptfromtmpstack (&val))
 		disposevaluerecord (val, false);
-	
+
 	if (!fl)
 		return (true);
-	
+
 	return (false); /*keep going*/
 	} /*tablepacktotextvisit*/
 

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Unit Tests - 300 tests: 300 pass (100%)</title>
-    <dateCreated>Sat, 28 Feb 2026 00:54:07 GMT</dateCreated>
+    <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
+    <dateCreated>Sat, 28 Feb 2026 01:44:49 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-28 at 00:54 UTC"/>
-      <outline text="Results: 300 passed (100%), 0 failed (0%)"/>
-      <outline text="Executables: 30 (300 tests total)"/>
+      <outline text="Run: 2026-02-28 at 01:40 UTC"/>
+      <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
+      <outline text="Executables: 30 (302 tests total)"/>
     </outline>
     <outline text="Cli Runtime Tests (cli_runtime_tests) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/cli_runtime_tests.opml"/>
     <outline text="Core Tests (core_tests) - 3 tests: 3 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/core_tests.opml"/>
-    <outline text="Db Format Tests (db_format_tests) - 34 tests: 34 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
+    <outline text="Db Format Tests (db_format_tests) - 36 tests: 36 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/db_format_tests.opml"/>
     <outline text="File Portable Tests (file_portable_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_portable_tests.opml"/>
     <outline text="File Readline Tests (file_readline_tests) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_readline_tests.opml"/>
     <outline text="File Verb Tests (file_verb_tests) - 0 tests" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/unit_tests/file_verb_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Sat, 28 Feb 2026 01:44:49 GMT</dateCreated>
+    <dateCreated>Sat, 28 Feb 2026 02:08:28 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-28 at 01:40 UTC"/>
+      <outline text="Run: 2026-02-28 at 02:08 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/reports/unit_tests/db_format_tests.opml
+++ b/reports/unit_tests/db_format_tests.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Db Format Tests (db_format_tests) - 34 tests: 34 pass (100%)</title>
-    <dateCreated>Fri, 27 Feb 2026 21:19:05 GMT</dateCreated>
+    <title>Db Format Tests (db_format_tests) - 36 tests: 36 pass (100%)</title>
+    <dateCreated>Sat, 28 Feb 2026 01:44:49 GMT</dateCreated>
   </head>
   <body>
     <outline text="✓ test_legacy_adapter_widen_to_v7_bytes"/>
@@ -36,6 +36,8 @@
     <outline text="✓ test_dbnormalizeaddress_hdb_callee_saves"/>
     <outline text="✓ test_dbnormalizeaddress_hdb_roundtrip"/>
     <outline text="✓ test_dbclearshadowavaillist_no_global_swap"/>
+    <outline text="✓ test_tablesortedinversesearch_no_global_swap"/>
+    <outline text="✓ test_copyvaluerecord_internal_reads_from_context"/>
     <outline text="✓ test_header_version_and_loader_switch"/>
     <outline text="✓ test_legacy_table_repack_forces_be64_address"/>
     <outline text="✓ test_legacy_record_reference_repacked_to_be64"/>

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -21,6 +21,7 @@
 #include "pictverbs.h"
 #include "menuverbs.h"
 #include "tableexternal_common.h"
+#include "tableinternal.h"
 #include "logging.h"
 #include "test_report.h"
 
@@ -1737,6 +1738,96 @@ static void test_dbclearshadowavaillist_no_global_swap(void) {
     log_info(LOG_COMP_DB, "[TEST] test_dbclearshadowavaillist_no_global_swap COMPLETED");
 }
 
+/* Phase 9: tablesortedinversesearch callee-saves test */
+
+static void test_tablesortedinversesearch_no_global_swap (void) {
+    /*
+     * Phase 9: Create a scratch v7 DB and an empty in-memory hash table.
+     * Point the table's database at the scratch DB (via the external
+     * variable refcon path that tablegetdatabase follows).  Call
+     * tablesortedinversesearch and verify that databasedata is NOT
+     * mutated.
+     *
+     * The table is empty so no visit callback fires; the point is to
+     * confirm that the function no longer saves/swaps/restores the global.
+     */
+    hdb_test_ctx tctx;
+    assert (open_scratch_v7_db (&tctx, "tsearch"));
+
+    hdlhashtable ht;
+    assert (newhashtable (&ht));
+
+    hdldatabaserecord before = databasedata;
+
+    /* With an empty sorted list (hfirstsort == nil from newhashtable),
+       hashsortedinversesearch returns false immediately. */
+    boolean fl = tablesortedinversesearch (ht, NULL, NULL);
+
+    /* Verify databasedata was NOT mutated */
+    assert (databasedata == before);
+    assert (!fl);
+
+    close_scratch_v7_db (&tctx);
+    log_info (LOG_COMP_DB, "[TEST] test_tablesortedinversesearch_no_global_swap COMPLETED");
+}
+
+static void test_copyvaluerecord_internal_reads_from_context (void) {
+    /*
+     * Phase 9: Allocate a string as a disk value in a scratch DB via
+     * dbsavehandle_hdb, build a db_context pointing to that DB,
+     * construct a tyvaluerecord with fldiskval=1 pointing to the
+     * saved address, call copyvaluerecord_internal(ctx, ...).
+     * Verify it reads the correct data without touching databasedata.
+     */
+    hdb_test_ctx tctx;
+    assert (open_scratch_v7_db (&tctx, "cvri"));
+
+    /* Store "PHASE9" as a handle in the scratch DB */
+    char payload[6] = "PHASE9";
+    Handle hsrc = nil;
+    assert (newfilledhandle (payload, sizeof(payload), &hsrc));
+
+    dbaddress adr = nildbaddress;
+    assert (dbsavehandle_hdb (hsrc, &adr, tctx.hdb));
+    assert (adr != nildbaddress);
+    disposehandle (hsrc);
+
+    /* Build a tyvaluerecord that looks like a disk value */
+    tyvaluerecord diskval;
+    initvalue (&diskval, stringvaluetype);
+    diskval.fldiskval = 1;
+    diskval.data.diskvalue = adr;
+
+    /* Build a db_context pointing to the scratch DB (v7 format) */
+    db_context dbctx;
+    db_context_init_v7_read (&dbctx, tctx.hdb);
+
+    hdldatabaserecord before = databasedata;
+
+    tyvaluerecord result;
+    initvalue (&result, novaluetype);
+    boolean ok = copyvaluerecord_internal (&dbctx, diskval, &result);
+    assert (ok);
+
+    /* Verify databasedata was NOT mutated */
+    assert (databasedata == before);
+
+    /* Verify the resolved value contains the correct string */
+    assert (result.valuetype == stringvaluetype);
+    assert (!result.fldiskval);
+    assert (result.data.stringvalue != nil);
+    assert (GetHandleSize (result.data.stringvalue) == sizeof(payload));
+    lockhandle (result.data.stringvalue);
+    assert (memcmp (*result.data.stringvalue, payload, sizeof(payload)) == 0);
+    unlockhandle (result.data.stringvalue);
+
+    if (exemptfromtmpstack (&result))
+        disposevaluerecord (result, false);
+
+    close_scratch_v7_db (&tctx);
+    log_info (LOG_COMP_DB, "[TEST] test_copyvaluerecord_internal_reads_from_context COMPLETED");
+}
+
 int main(void) {
     TR_INIT("db_format_tests");
 
@@ -1780,6 +1871,10 @@ int main(void) {
     TR_RUN(test_dbnormalizeaddress_hdb_roundtrip);
 #endif
     TR_RUN(test_dbclearshadowavaillist_no_global_swap);
+
+    /* Phase 9: tablesortedinversesearch callee-saves */
+    TR_RUN(test_tablesortedinversesearch_no_global_swap);
+    TR_RUN(test_copyvaluerecord_internal_reads_from_context);
 
     /* Phase 3: Tests that lock mode - MUST run LAST (mode lock is never reset) */
     TR_RUN(test_header_version_and_loader_switch);

--- a/tests/db_format_tests.c
+++ b/tests/db_format_tests.c
@@ -1740,16 +1740,21 @@ static void test_dbclearshadowavaillist_no_global_swap(void) {
 
 /* Phase 9: tablesortedinversesearch callee-saves test */
 
+static boolean phase9_unreachable_visit (bigstring bsname, hdlhashnode hnode, tyvaluerecord val, ptrvoid refcon) {
+#pragma unused (bsname, hnode, val, refcon)
+    assert (false && "phase9_unreachable_visit: should never be called on empty table");
+    return (false);
+}
+
 static void test_tablesortedinversesearch_no_global_swap (void) {
     /*
      * Phase 9: Create a scratch v7 DB and an empty in-memory hash table.
-     * Point the table's database at the scratch DB (via the external
-     * variable refcon path that tablegetdatabase follows).  Call
-     * tablesortedinversesearch and verify that databasedata is NOT
+     * Call tablesortedinversesearch and verify that databasedata is NOT
      * mutated.
      *
-     * The table is empty so no visit callback fires; the point is to
-     * confirm that the function no longer saves/swaps/restores the global.
+     * The table is empty (hfirstsort == nil) so the visit callback should
+     * never fire. We pass a stub that asserts-false to catch regressions
+     * in hashsortedinversesearch's iteration logic.
      */
     hdb_test_ctx tctx;
     assert (open_scratch_v7_db (&tctx, "tsearch"));
@@ -1759,9 +1764,7 @@ static void test_tablesortedinversesearch_no_global_swap (void) {
 
     hdldatabaserecord before = databasedata;
 
-    /* With an empty sorted list (hfirstsort == nil from newhashtable),
-       hashsortedinversesearch returns false immediately. */
-    boolean fl = tablesortedinversesearch (ht, NULL, NULL);
+    boolean fl = tablesortedinversesearch (ht, &phase9_unreachable_visit, NULL);
 
     /* Verify databasedata was NOT mutated */
     assert (databasedata == before);


### PR DESCRIPTION
## Summary

- Eliminate the last structural runtime `databasedata` save/swap/restore in `tablesortedinversesearch` by threading the database handle through a refcon wrapper struct (`tablesortedsearchctx`)
- Convert all 4 visit callbacks (`tablepacktotextvisit` x2, `langipcgetparamvisit`, `tablefindvisit`) to unwrap the context and use `copyvaluerecord_internal` for disk-value reads
- Remove the now-unnecessary belt-and-suspenders `databasedata` restore from `langexternalpack_internal`
- Add 2 Phase 9 unit tests (302 total, all passing)

After this PR, **zero runtime code paths** do save/swap/restore of `databasedata`. The global remains but is never mutated at runtime.

## Files Changed (8)

| File | Changes |
|------|---------|
| `Common/headers/tableinternal.h` | Add `tablesortedsearchctx` typedef |
| `Common/source/tableops.c` | Convert `tablesortedinversesearch` — refcon wrapper, no global swap |
| `Common/source/tablepack.c` | Convert `tablepacktotextvisit` — unwrap ctx, use `copyvaluerecord_internal` |
| `Common/source/legacy/tablepack_legacy.c` | Same conversion for legacy copy |
| `Common/source/tablefind.c` | Convert `tablefindvisit` — resolve disk values before `tablesearchcellvalue` |
| `Common/source/langipc.c` | Convert `langipcgetparamvisit` — unwrap ctx |
| `Common/source/langexternal.c` | Remove defensive `databasedata` save/restore from `langexternalpack_internal` |
| `tests/db_format_tests.c` | 2 new Phase 9 tests |

## Test plan

- [x] `make -C frontier-cli` builds cleanly
- [x] `./tools/run_headless_tests.sh` — 302/302 unit tests pass
- [x] `cd tests && make test-integration` — 1698/1893 pass (6 failures are pre-existing on develop, same tests, same errors)
- [x] Grep confirms no runtime save/swap/restore of `databasedata` in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)