### PR TITLE
fix: Thread explicit hdb through unpack chain for guest DB externals

### DIFF
--- a/Common/headers/langexternal.h
+++ b/Common/headers/langexternal.h
@@ -226,7 +226,7 @@ extern boolean langexternalsetdirty (hdlexternalhandle, boolean);
 
 extern boolean langexternalpack (hdlexternalhandle, Handle *, boolean *);
 
-extern boolean langexternalunpack (Handle, hdlexternalhandle *);
+extern boolean langexternalunpack (Handle, hdlexternalhandle *, hdldatabaserecord);
 
 /* Context-aware internal version (used by db_format layer) */
 struct db_context; /* forward declaration */
@@ -240,7 +240,7 @@ extern boolean langexternalunpack_legacy (Handle, hdlexternalhandle *);
 
 extern boolean langexternalmemorypack (hdlexternalhandle, Handle *, hdlhashnode);
 
-extern boolean langexternalmemoryunpack (Handle, hdlexternalhandle *);
+extern boolean langexternalmemoryunpack (Handle, hdlexternalhandle *, hdldatabaserecord);
 
 extern boolean langexternalcopyvalue (const tyvaluerecord *, tyvaluerecord *);
 
@@ -280,7 +280,7 @@ extern boolean langexternalvaltocode (tyvaluerecord, hdltreenode *);
 
 extern boolean langexternalgetvalsize (tyvaluerecord, long *);
 
-extern boolean langnewexternalvariable (boolean, long, hdlexternalvariable *);
+extern boolean langnewexternalvariable (boolean, long, hdlexternalvariable *, hdldatabaserecord);
 
 /* Single-point state transition functions (MODE_SINGLE_DECISION_POINT pattern) */
 extern boolean external_set_ondisk (hdlexternalvariable, dbaddress);

--- a/Common/headers/menuverbs.h
+++ b/Common/headers/menuverbs.h
@@ -59,7 +59,7 @@ extern boolean menuverbpack (hdlexternalvariable, Handle *, boolean *);
 
 extern boolean menuverbpack_internal (const db_context *, hdlexternalvariable, Handle *, boolean *);
 
-extern boolean menuverbunpack (Handle, long *, hdlexternalvariable *);
+extern boolean menuverbunpack (Handle, long *, hdlexternalvariable *, hdldatabaserecord);
 
 extern boolean menuverbinmemory_context (const db_context *, hdlexternalvariable);
 

--- a/Common/headers/opverbs.h
+++ b/Common/headers/opverbs.h
@@ -62,13 +62,13 @@ extern boolean opverbinmemory (const struct db_context *, hdlexternalvariable);
 
 extern boolean opverbpack (hdlexternalvariable, Handle *, boolean *);
 
-extern boolean opverbunpack (Handle, long *, hdlexternalvariable *);
+extern boolean opverbunpack (Handle, long *, hdlexternalvariable *, hdldatabaserecord);
 
 /* Context-aware internal version (used by langexternal layer) */
 struct db_context; /* forward declaration */
 extern boolean opverbpack_internal (const struct db_context *, hdlexternalvariable, Handle *, boolean *);
 
-extern boolean opverbscriptunpack (Handle, long *, hdlexternalvariable *);
+extern boolean opverbscriptunpack (Handle, long *, hdlexternalvariable *, hdldatabaserecord);
 
 extern boolean opverbpacktotext (hdlexternalvariable, Handle);
 

--- a/Common/headers/pictverbs.h
+++ b/Common/headers/pictverbs.h
@@ -51,7 +51,7 @@ extern boolean pictverbpack_internal (const db_context *, hdlexternalvariable, H
 
 extern boolean pictverbpack (hdlexternalvariable, Handle *, boolean *);
 
-extern boolean pictverbunpack (Handle, long *, hdlexternalvariable *);
+extern boolean pictverbunpack (Handle, long *, hdlexternalvariable *, hdldatabaserecord);
 
 extern boolean pictverbpacktotext (hdlexternalvariable, Handle);
 

--- a/Common/headers/tableinternal.h
+++ b/Common/headers/tableinternal.h
@@ -181,7 +181,7 @@ extern boolean istablevariable (hdlexternalvariable);
 
 extern boolean gettablevariable (tyvaluerecord, hdltablevariable *, short *);
 
-extern boolean newtablevariable (boolean, long, hdltablevariable *, boolean);
+extern boolean newtablevariable (boolean, long, hdltablevariable *, boolean, hdldatabaserecord);
 
 extern boolean tablenewtablevalue (hdlhashtable *, tyvaluerecord *);
 
@@ -225,6 +225,9 @@ extern boolean tablegetstringlist (short, bigstring);
 extern boolean tablepacktable (hdlhashtable, boolean, Handle *, boolean *); /*tablepack.c*/
 
 extern boolean tableunpacktable (Handle, boolean, hdlhashtable *);
+
+/* Context-aware internal version — threads guest DB handle to child externals */
+extern boolean tableunpacktable_internal (const struct db_context *, Handle, boolean, hdlhashtable *);
 
 /* Legacy (32-bit) pack/unpack entry points used during migration. */
 extern boolean tablepacktable_legacy (hdlhashtable, boolean, Handle *, boolean *);

--- a/Common/headers/tableverbs.h
+++ b/Common/headers/tableverbs.h
@@ -62,7 +62,7 @@ extern boolean tableverbmemoryunpack (Handle, long *, hdlexternalvariable *, boo
 
 extern boolean tableverbpack (hdlexternalvariable, Handle *, boolean *);
 
-extern boolean tableverbunpack (Handle, long *, hdlexternalvariable *, boolean);
+extern boolean tableverbunpack (Handle, long *, hdlexternalvariable *, boolean, hdldatabaserecord);
 
 /* Context-aware internal versions (used by langexternal layer) */
 struct db_context; /* forward declaration */

--- a/Common/headers/wpverbs.h
+++ b/Common/headers/wpverbs.h
@@ -48,7 +48,7 @@ extern boolean wpverbmemoryunpack (Handle, long *, hdlexternalvariable *);
 
 extern boolean wpverbpack (hdlexternalvariable, Handle *, boolean *);
 
-extern boolean wpverbunpack (Handle, long *, hdlexternalvariable *);
+extern boolean wpverbunpack (Handle, long *, hdlexternalvariable *, hdldatabaserecord);
 
 /* Context-aware internal version (used by langexternal layer) */
 struct db_context; /* forward declaration */

--- a/Common/source/langexternal.c
+++ b/Common/source/langexternal.c
@@ -1123,29 +1123,29 @@ boolean langexternalpack (hdlexternalhandle h, Handle *hpacked, boolean *flnewdb
 }
 	
 	
-boolean langexternalunpack (Handle hpacked, hdlexternalhandle *h) {
-	
+boolean langexternalunpack (Handle hpacked, hdlexternalhandle *h, hdldatabaserecord hdb) {
+
 	hdlexternalvariable hdata;
 	long ixload = 0;
 	tydiskexternalhandle rec;
 	tyexternalid id;
-	
+
 	*h = nil;
-	
+
 	if (hpacked == nil)
 		return (false);
-	
+
 #if !defined(FRONTIER_HEADLESS)
 	assert (sizeof (tyexternalvariable) == 16L);
 #else
 	assert (sizeof (tyexternalvariable) >= 16L); /* 2025-10-27 Codex: 64-bit headless builds use wider pointers */
 #endif
-	
+
 	rollbeachball ();
-	
+
 	if (!loadfromhandle (hpacked, &ixload, sizeof (rec), &rec))
 		goto cantunpack;
-	
+
 	disktomemshort (rec.versionnumber);
 //	disktomemshort (rec.id);
 
@@ -1158,41 +1158,41 @@ boolean langexternalunpack (Handle hpacked, hdlexternalhandle *h) {
 
 
 	switch (id) {
-		
+
 		case idoutlineprocessor:
-			if (!opverbunpack (hpacked, &ixload, &hdata))
+			if (!opverbunpack (hpacked, &ixload, &hdata, hdb))
 				goto error;
-				
+
 			break;
-		
+
 		case idscriptprocessor:
-			if (!opverbscriptunpack (hpacked, &ixload, &hdata))
+			if (!opverbscriptunpack (hpacked, &ixload, &hdata, hdb))
 				goto error;
-				
+
 			break;
-			
+
 		case idwordprocessor:
-			if (!wpverbunpack (hpacked, &ixload, &hdata))
+			if (!wpverbunpack (hpacked, &ixload, &hdata, hdb))
 				goto error;
-				
+
 			break;
-		
+
 		case idtableprocessor:
-			if (!tableverbunpack (hpacked, &ixload, &hdata, false))
+			if (!tableverbunpack (hpacked, &ixload, &hdata, false, hdb))
 				goto error;
-				
+
 			break;
-		
+
 		case idmenuprocessor:
-			if (!menuverbunpack (hpacked, &ixload, &hdata))
+			if (!menuverbunpack (hpacked, &ixload, &hdata, hdb))
 				goto error;
-			
+
 			break;
-			
+
 		case idpictprocessor:
-			if (!pictverbunpack (hpacked, &ixload, &hdata))
+			if (!pictverbunpack (hpacked, &ixload, &hdata, hdb))
 				goto error;
-			
+
 			break;
 		
 		
@@ -1265,19 +1265,21 @@ boolean langexternalmemorypack (hdlexternalhandle h, Handle *hpacked, hdlhashnod
 	} /*langexternalmemorypack*/
 
 
-boolean langexternalmemoryunpack (Handle hpacked, hdlexternalhandle *h) {
-	
+boolean langexternalmemoryunpack (Handle hpacked, hdlexternalhandle *h, hdldatabaserecord hdb) {
+
 	/*
 	see comment at head of langexternalmemorypack.
 	*/
-	
+
 	hdlexternalvariable hdata;
 	long ixload = 0;
 	tydiskexternalhandle rec;
 	tyexternalid id;
-	
+
+	(void) hdb; /*memory unpack always creates in-memory objects; hdb unused*/
+
 	*h = nil;
-	
+
 	if (hpacked == nil)
 		return (false);
 	
@@ -2901,7 +2903,7 @@ boolean langexternalgetvalsize (tyvaluerecord val, long *size) {
 	} /*langexternalgetvalsize*/
 
 
-boolean langnewexternalvariable (boolean flinmemory, long variabledata, hdlexternalvariable *h) {
+boolean langnewexternalvariable (boolean flinmemory, long variabledata, hdlexternalvariable *h, hdldatabaserecord hdb) {
 
 	tyexternalvariable item;
 
@@ -2919,15 +2921,20 @@ boolean langnewexternalvariable (boolean flinmemory, long variabledata, hdlexter
 	 * Background: The 1987-era design captured databasedata globally for all new objects,
 	 * which caused corruption when creating new in-memory tables with a system root loaded.
 	 * This aligns with the intent documented in langexternalsetdatabase() (see line 280).
+	 *
+	 * 2026-02: hdb parameter replaces implicit databasedata capture. Callers in the
+	 * unpack path pass the explicit hdb threaded from the database layer; callers
+	 * creating new objects pass databasedata (or nil for in-memory).
 	 */
-	item.hdatabase = flinmemory ? nil : databasedata;
+	item.hdatabase = flinmemory ? nil : hdb;
 
 	item.oldaddress = nildbaddress; // 2025-12-28: Explicit init to prevent garbage values
 
-	log_trace(LOG_COMP_EXTERNAL, "langnewexternalvariable: flinmemory=%d variabledata=0x%llx hdatabase=%p (current_db=%p)",
+	log_trace(LOG_COMP_EXTERNAL, "langnewexternalvariable: flinmemory=%d variabledata=0x%llx hdatabase=%p (hdb=%p current_db=%p)",
 	        (int)flinmemory,
 	        (unsigned long long)variabledata,
 	        (void *)item.hdatabase,
+	        (void *)hdb,
 	        (void *)databasedata);
 
 	/* New in-memory objects should have hdatabase=nil at creation time;

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2775,7 +2775,7 @@ static boolean hashpackexternal (handlestream *s, hdlexternalvariable h, int32_t
 	} /*hashpackexternal*/
 
 
-static boolean hashunpackexternal (Handle hget, boolean flmemory, hdlexternalhandle *h, int32_t ix) {
+static boolean hashunpackexternal (Handle hget, boolean flmemory, hdlexternalhandle *h, int32_t ix, hdldatabaserecord hdb) {
 	Handle hpacked;
 	boolean fl;
 	long lix = (long) ix;
@@ -2815,7 +2815,7 @@ static boolean hashunpackexternal (Handle hget, boolean flmemory, hdlexternalhan
 	if (!loadfromhandletohandle (hget, &lix, ctbytes, true, &hpacked))
 		return (false);
 
-	fl = flmemory ? langexternalmemoryunpack (hpacked, h) : langexternalunpack (hpacked, h);
+	fl = flmemory ? langexternalmemoryunpack (hpacked, h, hdb) : langexternalunpack (hpacked, h, hdb);
 
 	disposehandle (hpacked);
 
@@ -4478,7 +4478,7 @@ log_trace(LOG_COMP_HASH, "opunpacklist returned false path=%s", (langhash_materi
 				case externalvaluetype: {
 					hdlexternalhandle h;
 
-					if (!hashunpackexternal (hstrings, flmemory, &h, ixstrings))
+					if (!hashunpackexternal (hstrings, flmemory, &h, ixstrings, ctx ? ctx->database : nil))
 						goto L1;
 
 					val.data.externalvalue = (Handle) h;

--- a/Common/source/langpack.c
+++ b/Common/source/langpack.c
@@ -474,7 +474,7 @@ static boolean langunpackexternal (hdlexternalhandle *hexternal, hdlpackedvalue 
 	
 	initbeachball (right);
 	
-	fl = langexternalmemoryunpack (hpacked, hexternal);
+	fl = langexternalmemoryunpack (hpacked, hexternal, nil);
 	
 	disposehandle (hpacked);
 	

--- a/Common/source/legacy/langexternal_legacy.c
+++ b/Common/source/legacy/langexternal_legacy.c
@@ -10,7 +10,7 @@ boolean langexternalpack_legacy (hdlexternalhandle h, Handle *hpacked, boolean *
 }
 
 boolean langexternalunpack_legacy (Handle hpacked, hdlexternalhandle *h) {
-    return langexternalunpack(hpacked, h);
+    return langexternalunpack(hpacked, h, databasedata);
 }
 
 boolean langexternalpacktotext_legacy (hdlexternalhandle h, Handle htext) {

--- a/Common/source/legacy/opverbs_legacy.c
+++ b/Common/source/legacy/opverbs_legacy.c
@@ -27,11 +27,11 @@ boolean opverbpack_legacy (hdlexternalvariable h, Handle *hpacked, boolean *flne
 }
 
 boolean opverbunpack_legacy (Handle hpacked, long *ixload, hdlexternalvariable *h) {
-    return opverbunpack(hpacked, ixload, h);
+    return opverbunpack(hpacked, ixload, h, databasedata);
 }
 
 boolean opverbscriptunpack_legacy (Handle hpacked, long *ixload, hdlexternalvariable *h) {
-    return opverbscriptunpack(hpacked, ixload, h);
+    return opverbscriptunpack(hpacked, ixload, h, databasedata);
 }
 
 boolean opverbpacktotext_legacy (hdlexternalvariable h, Handle htext) {

--- a/Common/source/legacy/tablepack_legacy.c
+++ b/Common/source/legacy/tablepack_legacy.c
@@ -268,10 +268,10 @@ boolean tableverbmemoryunpack_legacy (Handle hpacked, long *ixload, hdlexternalv
 	
 	ht = htable; /*move into register*/
 	
-	if (!newtablevariable (true, (long) ht, (hdltablevariable *) h, flxml)) {
-		
+	if (!newtablevariable (true, (long) ht, (hdltablevariable *) h, flxml, nil)) { /*in-memory: hdb=nil*/
+
 		tabledisposetable (ht, false);
-		
+
 		return (false);
 		}
 	
@@ -482,7 +482,7 @@ boolean tableverbunpack_legacy (Handle hpacked, long *ixload, hdlexternalvariabl
 		}
 	}
 
-	return (newtablevariable (false, rawadr, (hdltablevariable *) h, flxml));
+	return (newtablevariable (false, rawadr, (hdltablevariable *) h, flxml, databasedata));
 	} /*tableverbunpack_legacy*/
 
 

--- a/Common/source/legacy/wpverbs_legacy.c
+++ b/Common/source/legacy/wpverbs_legacy.c
@@ -18,7 +18,7 @@ boolean wpverbpack_legacy (hdlexternalvariable h, Handle *hpacked, boolean *flne
 }
 
 boolean wpverbunpack_legacy (Handle hpacked, long *ixload, hdlexternalvariable *h) {
-    return wpverbunpack(hpacked, ixload, h);
+    return wpverbunpack(hpacked, ixload, h, databasedata);
 }
 
 boolean wpverbpacktotext_legacy (hdlexternalvariable h, Handle htext) {

--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -133,9 +133,9 @@ boolean menuverbgettypestring (hdlexternalvariable hvariable, bigstring bs) {
 	} /*menuverbgettypestring*/
 	
 
-static boolean newmenuvariable (boolean flinmemory, long variabledata, hdlmenuvariable *h) {
+static boolean newmenuvariable (boolean flinmemory, long variabledata, hdlmenuvariable *h, hdldatabaserecord hdb) {
 
-	return (langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h));
+	return (langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h, hdb));
 	} /*newmenuvariable*/
 
 
@@ -365,15 +365,15 @@ boolean menuverbmemoryunpack (Handle hpacked, long *ixload, hdlexternalvariable 
 	
 	hm = hmenurecord; /*move into register*/
 	
-	if (!newmenuvariable (true, (long) hm, (hdlmenuvariable *) h)) {
-		
+	if (!newmenuvariable (true, (long) hm, (hdlmenuvariable *) h, nil)) { /*in-memory: hdb=nil*/
+
 		medisposemenurecord (hm, false);
-		
+
 		return (false);
 		}
-	
+
 	(**hm).menurefcon = (long) *h; /*point back to variable*/
-	
+
 	(**hm).fldirty = true;
 	
 	return (true);
@@ -492,14 +492,14 @@ boolean menuverbpack (hdlexternalvariable hvariable, Handle *hpacked, boolean *f
 	} /*menuverbpack*/
 
 
-boolean menuverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean menuverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
 
 	long rawadr = 0;
 
 	if (!loadlongfromdiskhandle (hpacked, ixload, &rawadr))
 		return (false);
 
-	return (newmenuvariable (false, (dbaddress) rawadr, (hdlmenuvariable *) h));
+	return (newmenuvariable (false, (dbaddress) rawadr, (hdlmenuvariable *) h, hdb));
 	} /*menuverbunpack*/
 
 
@@ -724,13 +724,13 @@ boolean menunewmenubar (hdlhashtable htable, bigstring bs, hdlmenurecord *hnewre
 		
 	hm = *hnewrecord; /*copy into register*/
 		
-	if (!newmenuvariable (true, (long) hm, &hv)) {
-		
+	if (!newmenuvariable (true, (long) hm, &hv, databasedata)) { /*creating new object*/
+
 		medisposemenurecord (hm, false);
-		
+
 		return (false);
 		}
-		
+
 	(**hv).variabledata = (long) hm; /*link the menu rec into the variable rec*/
 	
 	(**hm).menurefcon = (long) hv; /*the pointing is mutual*/
@@ -1002,13 +1002,13 @@ boolean menuverbnew (Handle hdata, hdlexternalvariable *hvariable) {
 	
 	hm = hnewrecord; /*copy into register*/
 	
-	if (!newmenuvariable (true, (long) hm, (hdlmenuvariable *) hvariable)) {
-		
+	if (!newmenuvariable (true, (long) hm, (hdlmenuvariable *) hvariable, databasedata)) { /*creating new object*/
+
 		medisposemenurecord (hm, false);
-		
+
 		return (false);
 		}
-	
+
 	hv = (hdlmenuvariable) *hvariable; /*copy into register*/
 	
 	if (hdata != nil) {
@@ -1512,7 +1512,7 @@ static boolean getsubmenuvalue (hdltreenode hfirst, short pnum, hdlheadrecord *h
 	if (!langexternalmemorypack ((hdlexternalvariable) hv, &hpacked, HNoNode))
 		return (false);
 	
-	fl = langexternalmemoryunpack (hpacked, (hdlexternalvariable *) &hv);
+	fl = langexternalmemoryunpack (hpacked, (hdlexternalvariable *) &hv, nil);
 	
 	disposehandle (hpacked);
 	

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -353,7 +353,7 @@ boolean opverbdispose (hdlexternalvariable hvariable, boolean fldisk) {
 	} /*opverbdispose*/
 
 
-static boolean newoutlinevariable (boolean flinmemory, long variabledata, hdloutlinevariable *h) {
+static boolean newoutlinevariable (boolean flinmemory, long variabledata, hdloutlinevariable *h, hdldatabaserecord hdb) {
 
 	tyoutlinevariable item;
 
@@ -363,13 +363,14 @@ static boolean newoutlinevariable (boolean flinmemory, long variabledata, hdlout
 
 	item.variabledata = variabledata;
 
-	item.hdatabase = databasedata; // 5.0a18 dmb
+	item.hdatabase = flinmemory ? nil : hdb; // 2026-02: explicit hdb replaces databasedata capture; guard with flinmemory
 
 #if defined(FRONTIER_HEADLESS)
-	log_debug(LOG_COMP_OP, "newoutlinevariable: flinmemory=%d variabledata=0x%llx captured_db=%p (current=%p)",
+	log_debug(LOG_COMP_OP, "newoutlinevariable: flinmemory=%d variabledata=0x%llx captured_db=%p (hdb=%p current=%p)",
 	        (int)flinmemory,
 	        (unsigned long long)variabledata,
 	        (void*)item.hdatabase,
+	        (void*)hdb,
 	        (void*)databasedata);
 #endif
 
@@ -823,7 +824,7 @@ boolean opverbmemoryunpack (Handle hpacked, long *ixload, hdlexternalvariable *h
 	if (!fl)
 		return (false);
 	
-	if (!newoutlinevariable (true, (long) ho, h)) {
+	if (!newoutlinevariable (true, (long) ho, h, nil)) { /*in-memory: hdb=nil*/
 		
 		opdisposeoutline (ho, false);
 		
@@ -1009,7 +1010,7 @@ boolean opverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddr
 }
 	
 	
-boolean opverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariable) {
+boolean opverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariable, hdldatabaserecord hdb) {
 
 	long rawadr = 0;
 
@@ -1018,21 +1019,21 @@ boolean opverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariab
 
 	log_trace(LOG_COMP_MIGRATION, "opverbunpack: rawadr=0x%lx (32-bit long), casting to dbaddress", (unsigned long)rawadr);
 
-	return (newoutlinevariable (false, (dbaddress) rawadr, (hdloutlinevariable *) hvariable));
+	return (newoutlinevariable (false, (dbaddress) rawadr, (hdloutlinevariable *) hvariable, hdb));
 	} /*opverbunpack*/
 
 
-boolean opverbscriptunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariable) {
-	
+boolean opverbscriptunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariable, hdldatabaserecord hdb) {
+
 	register hdloutlinevariable hv;
-	
-	if (!opverbunpack (hpacked, ixload, hvariable))
+
+	if (!opverbunpack (hpacked, ixload, hvariable, hdb))
 		return (false);
-	
+
 	hv = (hdloutlinevariable) *hvariable;
-	
+
 	(**hv).flscript = true;
-	
+
 	return (true);
 	} /*opverbscriptunpack*/
 
@@ -1302,7 +1303,7 @@ boolean opverbnew (short id, Handle hdata, hdlexternalvariable *hvariable) {
 	hdlheadrecord hsummit = nil;
 	hdloutlinerecord houtline;
 	
-	if (!newoutlinevariable (true, 0L, (hdloutlinevariable *) hvariable))
+	if (!newoutlinevariable (true, 0L, (hdloutlinevariable *) hvariable, databasedata)) /*creating new object*/
 		return (false);
 	
 	hv = (hdloutlinevariable) *hvariable; /*copy into register*/

--- a/Common/source/osacomponent.c
+++ b/Common/source/osacomponent.c
@@ -2609,7 +2609,7 @@ osaCoerceFromDesc (
     
     copydatahandle (&desc, &h);
     
-    fl = langexternalmemoryunpack (h, (hdlexternalhandle *) &val.data.externalvalue);
+    fl = langexternalmemoryunpack (h, (hdlexternalhandle *) &val.data.externalvalue, nil);
     
     disposehandle (h);
     }

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -98,9 +98,9 @@ static short errornum = 0;
 
 
 
-static boolean newpictvariable (boolean flinmemory, long variabledata, hdlpictvariable *h) {
+static boolean newpictvariable (boolean flinmemory, long variabledata, hdlpictvariable *h, hdldatabaserecord hdb) {
 
-	return (langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h));
+	return (langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h, hdb));
 	} /*newpictvariable*/
 	
 
@@ -141,10 +141,10 @@ boolean pictverbnew (Handle hdata, hdlexternalvariable *hvariable) {
 	
 	hp = pictdata; /*copy into register*/
 	
-	if (!newpictvariable (true, (long) hp, (hdlpictvariable *) hvariable)) {
-		
+	if (!newpictvariable (true, (long) hp, (hdlpictvariable *) hvariable, databasedata)) { /*creating new object*/
+
 		pictdisposerecord (hp);
-		
+
 		return (false);
 		}
 	
@@ -338,10 +338,10 @@ boolean pictverbmemoryunpack (Handle hpacked, long *ixload, hdlexternalvariable 
 	if (!fl)
 		return (false);
 	
-	if (!newpictvariable (true, (long) hpict, (hdlpictvariable *) h)) {
-		
+	if (!newpictvariable (true, (long) hpict, (hdlpictvariable *) h, nil)) { /*in-memory: hdb=nil*/
+
 		pictdisposerecord (hpict);
-		
+
 		return (false);
 		}
 	
@@ -483,14 +483,14 @@ boolean pictverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdbad
 	} /*pictverbpack*/
 
 
-boolean pictverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariable) {
+boolean pictverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hvariable, hdldatabaserecord hdb) {
 
 	long rawadr = 0;
-	
-	if (!loadlongfromdiskhandle (hpacked, ixload, &rawadr)) 
+
+	if (!loadlongfromdiskhandle (hpacked, ixload, &rawadr))
 		return (false);
-		
-	return (newpictvariable (false, (dbaddress) rawadr, (hdlpictvariable *) hvariable));
+
+	return (newpictvariable (false, (dbaddress) rawadr, (hdlpictvariable *) hvariable, hdb));
 	} /*pictverbunpack*/
 
 

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -424,10 +424,18 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
 
             langtraperrors(bsunpackerror, &savecallback, &saverefcon);
 
-            log_trace(LOG_COMP_TABLE, "tableunpacktable enter path=%s adr=0x%llx",
+            log_trace(LOG_COMP_TABLE, "tableunpacktable enter path=%s adr=0x%llx hdb=%p",
                     (langhash_materialize_current_path != NULL) ? langhash_materialize_current_path : "<nil>",
-                    (unsigned long long) adr);
-            fl = tableunpacktable(hpacked, false, &htable); /* always disposes of hpackedtable */
+                    (unsigned long long) adr, (void *)hdb);
+            {
+                /* Build a db_context with the table's own database handle so that
+                   child externals unpacked from this table get the correct hdatabase
+                   instead of the system root (databasedata global). */
+                db_context unpack_ctx;
+                db_context_init(&unpack_ctx);
+                unpack_ctx.database = hdb;
+                fl = tableunpacktable_internal(&unpack_ctx, hpacked, false, &htable);
+            }
 
             languntraperrors(savecallback, saverefcon, !fl);
 

--- a/Common/source/tableops.c
+++ b/Common/source/tableops.c
@@ -249,22 +249,22 @@ boolean findnamedtable (hdlhashtable htable, bigstring bs, hdlhashtable *hnamedt
 	} /*findnamedtable*/
 
 
-boolean newtablevariable (boolean flinmemory, long variabledata, hdltablevariable *h, boolean flxml) {
+boolean newtablevariable (boolean flinmemory, long variabledata, hdltablevariable *h, boolean flxml, hdldatabaserecord hdb) {
 #pragma unused (flxml)
 
 	/*
 	tytablevariable item;
-	
+
 	clearbytes ((ptrchar) &item, longsizeof (item));
-	
+
 	item.flinmemory = flinmemory;
-	
+
 	item.variabledata = variabledata;
-	
+
 	return (newfilledhandle ((ptrchar) &item, longsizeof (item), (Handle *) h));
 	*/
-	
-	if (!langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h))
+
+	if (!langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h, hdb))
 		return (false);
 
 	#ifdef xmlfeatures

--- a/Common/source/tablepack.c
+++ b/Common/source/tablepack.c
@@ -309,13 +309,13 @@ boolean tableverbmemoryunpack (Handle hpacked, long *ixload, hdlexternalvariable
 	
 	ht = htable; /*move into register*/
 	
-	if (!newtablevariable (true, (long) ht, (hdltablevariable *) h, flxml)) {
-		
+	if (!newtablevariable (true, (long) ht, (hdltablevariable *) h, flxml, nil)) { /*in-memory: hdb=nil*/
+
 		tabledisposetable (ht, false);
-		
+
 		return (false);
 		}
-	
+
 	(**ht).hashtablerefcon = (long) *h; /*we can get from hashtable to variable rec*/
 	
 	(**ht).fldirty = true;
@@ -562,14 +562,24 @@ boolean tableverbunpack_internal (const db_context *ctx, Handle hpacked, long *i
 		}
 	}
 
-	return (newtablevariable (false, rawadr, (hdltablevariable *) h, flxml));
+	return (newtablevariable (false, rawadr, (hdltablevariable *) h, flxml, ctx ? ctx->database : databasedata));
 	} /*tableverbunpack_internal*/
 
 
-boolean tableverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, boolean flxml) {
-	/* Wrapper for backward compatibility - uses global mode state */
+boolean tableverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, boolean flxml, hdldatabaserecord hdb) {
+
+	if (hdb != nil) {
+		db_context ctx;
+
+		db_context_init (&ctx);
+
+		ctx.database = hdb;
+
+		return tableverbunpack_internal (&ctx, hpacked, ixload, h, flxml);
+		}
+
 	return tableverbunpack_internal (NULL, hpacked, ixload, h, flxml);
-}
+	}
 
 
 static boolean tablepacktotextvisit (bigstring bsname, hdlhashnode hnode, tyvaluerecord val, ptrvoid refcon) {

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -814,7 +814,7 @@ boolean tablenewtable (hdltablevariable *hvariable, hdlhashtable *htable) {
 	register hdltablevariable hv;
 	register hdlhashtable ht;
 	
-	if (!newtablevariable (true, 0L, hvariable, false))
+	if (!newtablevariable (true, 0L, hvariable, false, databasedata)) /*creating new object*/
 		return (false);
 	
 	hv = *hvariable; /*copy into register*/
@@ -960,7 +960,7 @@ boolean tableloadsystemtable (dbaddress adr, Handle *hvariable, hdlhashtable *ht
 		}
 	else {
 
-		if (!newtablevariable (false, adr, (hdltablevariable *) hvariable, false))
+		if (!newtablevariable (false, adr, (hdltablevariable *) hvariable, false, databasedata)) /*loading from disk*/
 			return (false);
 
 		hv = (hdlexternalvariable) *hvariable;

--- a/Common/source/wpverbs.c
+++ b/Common/source/wpverbs.c
@@ -326,9 +326,9 @@ boolean wpverbgettypestring (hdlexternalvariable hvariable, bigstring bs) {
 
 
 
-static boolean newwpvariable (boolean flinmemory, boolean flpacked, long variabledata, hdlwpvariable *h) {
+static boolean newwpvariable (boolean flinmemory, boolean flpacked, long variabledata, hdlwpvariable *h, hdldatabaserecord hdb) {
 
-	if (!langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h))
+	if (!langnewexternalvariable (flinmemory, variabledata, (hdlexternalvariable *) h, hdb))
 		return (false);
 	
 	(***h).flpacked = flpacked;
@@ -450,7 +450,7 @@ boolean wpverbnew (Handle hdata, hdlexternalvariable *hvariable) {
 	hdlwprecord hwp;
 	Rect r;
 	
-	if (!newwpvariable (true, false, 0L, (hdlwpvariable *) hvariable))
+	if (!newwpvariable (true, false, 0L, (hdlwpvariable *) hvariable, databasedata)) /*creating new object*/
 		return (false);
 	
 	hv = (hdlwpvariable) *hvariable; /*copy into register*/
@@ -566,7 +566,7 @@ boolean wpverbmemoryunpack (Handle hpacked, long *ixload, hdlexternalvariable *h
 	if (!loadhandleremains (*ixload, hpacked, &hpackedwp))
 		return (false);
 	
-	return (newwpvariable (true, true, (long) hpackedwp, (hdlwpvariable *) h));	
+	return (newwpvariable (true, true, (long) hpackedwp, (hdlwpvariable *) h, nil));	/*in-memory: hdb=nil*/
 	} /*wpverbmemoryunpack*/
 
 
@@ -747,14 +747,14 @@ boolean wpverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddr
 	} /*wpverbpack*/
 
 
-boolean wpverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean wpverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
 
 	long rawadr = 0;
-	
-	if (!loadlongfromdiskhandle (hpacked, ixload, &rawadr)) 
+
+	if (!loadlongfromdiskhandle (hpacked, ixload, &rawadr))
 		return (false);
 
-	return (newwpvariable (false, false, (dbaddress) rawadr, (hdlwpvariable *) h));
+	return (newwpvariable (false, false, (dbaddress) rawadr, (hdlwpvariable *) h, hdb));
 	} /*wpverbunpack*/
 
 

--- a/portable/wptext_runtime.c
+++ b/portable/wptext_runtime.c
@@ -439,7 +439,7 @@ boolean wpverbnew(Handle h, hdlexternalvariable *hv) {
     if (state == NULL)
         return false;
 
-    if (!langnewexternalvariable(true, 0, hv)) {
+    if (!langnewexternalvariable(true, 0, hv, nil)) { /*in-memory*/
         wp_portable_state_free(state);
         return false;
     }
@@ -506,7 +506,7 @@ boolean wpverbmemoryunpack(Handle hpacked, long *ixload, hdlexternalvariable *h)
     }
 
     hdlexternalvariable hv = nil;
-    if (!langnewexternalvariable(true, (long)(intptr_t)state, &hv)) {
+    if (!langnewexternalvariable(true, (long)(intptr_t)state, &hv, nil)) { /*in-memory*/
         wp_portable_state_free(state);
         disposehandle(hdata);
         return false;
@@ -599,8 +599,10 @@ boolean wpverbpack_internal(const db_context *ctx, hdlexternalvariable h, Handle
     return pushlongondiskhandle((long) adr, *hpacked);
 }
 
-boolean wpverbunpack(Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean wpverbunpack(Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
     long rawadr = 0;
+
+    (void) hdb; /*portable wp runtime always creates in-memory objects*/
 
     if (!loadlongfromdiskhandle(hpacked, ixload, &rawadr))
         return false;
@@ -610,7 +612,7 @@ boolean wpverbunpack(Handle hpacked, long *ixload, hdlexternalvariable *h) {
         return false;
 
     hdlexternalvariable hv = nil;
-    if (!langnewexternalvariable(true, (long)(intptr_t)state, &hv)) {
+    if (!langnewexternalvariable(true, (long)(intptr_t)state, &hv, nil)) { /*in-memory*/
         wp_portable_state_free(state);
         return false;
     }

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Sat, 28 Feb 2026 02:08:28 GMT</dateCreated>
+    <dateCreated>Sat, 28 Feb 2026 06:16:05 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-28 at 02:08 UTC"/>
+      <outline text="Run: 2026-02-28 at 06:16 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/headless_menu_stubs.c
+++ b/tests/headless_menu_stubs.c
@@ -552,11 +552,11 @@ boolean menuverbpack (hdlexternalvariable h, Handle *hp, boolean *flnew) {
     return menuverbpack_internal(NULL, h, hp, flnew);
 }
 
-boolean menuverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean menuverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
     long rawadr = 0;
     if (!loadlongfromdiskhandle(hpacked, ixload, &rawadr))
         return false;
-    return langnewexternalvariable(false, rawadr, h);
+    return langnewexternalvariable(false, rawadr, h, hdb);
 }
 
 boolean menuverbpacktotext (hdlexternalvariable h, Handle htext) {

--- a/tests/headless_op_stubs.c
+++ b/tests/headless_op_stubs.c
@@ -158,17 +158,19 @@ boolean opverbpackunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) 
     return false;
 }
 
-boolean opverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean opverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
     (void) hpacked;
     (void) ixload;
     (void) h;
+    (void) hdb;
     return false;
 }
 
-boolean opverbscriptunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean opverbscriptunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
     (void) hpacked;
     (void) ixload;
     (void) h;
+    (void) hdb;
     return false;
 }
 

--- a/tests/headless_pict_stubs.c
+++ b/tests/headless_pict_stubs.c
@@ -121,11 +121,11 @@ boolean pictverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdbad
     return pictverbpack_internal(NULL, h, hpacked, flnewdbaddress);
 }
 
-boolean pictverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hv) {
+boolean pictverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *hv, hdldatabaserecord hdb) {
     long rawadr = 0;
     if (!loadlongfromdiskhandle(hpacked, ixload, &rawadr))
         return false;
-    return langnewexternalvariable(false, rawadr, hv);
+    return langnewexternalvariable(false, rawadr, hv, hdb);
 }
 
 boolean pictverbpacktotext (hdlexternalvariable h, Handle htext) {

--- a/tests/headless_table_stubs.c
+++ b/tests/headless_table_stubs.c
@@ -118,7 +118,7 @@ boolean tableverbdispose (hdlexternalvariable h, boolean fldisk) {
 boolean tableverbnew (hdlexternalvariable *hvariable) {
     hdltablevariable hv;
     hdlhashtable ht;
-    if (!langnewexternalvariable(true, 0L, (hdlexternalvariable *)&hv))
+    if (!langnewexternalvariable(true, 0L, (hdlexternalvariable *)&hv, nil)) /*in-memory*/
         return false;
     if (!newhashtable(&ht)) {
         disposehandle((Handle)hv);
@@ -151,11 +151,12 @@ boolean tableverbpacktotext (hdlexternalvariable h, Handle htext) {
 #endif /* !HEADLESS_USE_REAL_TABLEPACK */
 
 #if !defined(HEADLESS_USE_REAL_TABLEPACK)
-boolean tableverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, boolean fldisk) {
+boolean tableverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, boolean fldisk, hdldatabaserecord hdb) {
     (void) hpacked;
     (void) ixload;
     (void) h;
     (void) fldisk;
+    (void) hdb;
     return false;
 }
 #endif /* !HEADLESS_USE_REAL_TABLEPACK */

--- a/tests/headless_wp_stubs.c
+++ b/tests/headless_wp_stubs.c
@@ -91,10 +91,11 @@ boolean wpverbpack (hdlexternalvariable h, Handle *hpacked, boolean *flnewdbaddr
     return false;
 }
 
-boolean wpverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h) {
+boolean wpverbunpack (Handle hpacked, long *ixload, hdlexternalvariable *h, hdldatabaserecord hdb) {
     (void) hpacked;
     (void) ixload;
     (void) h;
+    (void) hdb;
     return false;
 }
 


### PR DESCRIPTION
## Summary

- Thread `hdldatabaserecord hdb` parameter through the entire unpack chain (`hashunpacktable_internal` → `hashunpackexternal` → `langexternalunpack` → `verb*unpack` → `new*variable` → `langnewexternalvariable`) so guest DB externals get the correct `hdatabase` instead of the system root
- Fix `tableverbinmemory_common` to call `tableunpacktable_internal` with a `db_context` containing the table's own database handle, instead of `tableunpacktable` (which passed NULL ctx)
- Fix `newoutlinevariable` unconditional `databasedata` capture — now guards with `flinmemory` check like `langnewexternalvariable`
- Non-unpack callers pass `databasedata` (preserving existing behavior); in-memory callers pass `nil`

## Root Cause

`hashunpackexternal` (static in langhash.c) dropped the `db_context` that `hashunpacktable_internal` had, so `langnewexternalvariable` and `newoutlinevariable` read the `databasedata` global (system root) instead of the guest DB handle.

## Test plan

- [x] `make -C frontier-cli` — builds cleanly (universal binary)
- [x] `./tools/run_headless_tests.sh` — 302/302 unit tests pass
- [x] `cd tests && make test-integration` — 1704/1704 pass, 0 failures (6 previously-failing guest DB tests now pass)
- [x] Grep confirms no new reads of `databasedata` in the unpack path

### Previously failing tests now passing:
1. guest db externals - script text readable from StartupTasks
2. guest db externals - script text readable from mainResponder
3. guest db externals - outline text typeof from mainResponder
4. guest db externals - outline text readable from mainResponder
5. guest db externals - deep table access in mainResponder
6. cross-db external pack - copy script from guest db, save system root

🤖 Generated with [Claude Code](https://claude.com/claude-code)