### PR TITLE
feat: Save system root database on CLI exit for state persistence

### DIFF
--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -1292,6 +1292,12 @@ static void save_system_root_on_exit(void) {
         return;
     }
 
+    /* Skip save if the database header has not been dirtied this session */
+    if (!((**databasedata).flags & dbdirtymask)) {
+        cli_log_info("System root not dirty, skipping save");
+        return;
+    }
+
     cli_log_info("Saving system root database before exit");
 
     /* Save the root table using v7 format */
@@ -1312,13 +1318,11 @@ static void save_system_root_on_exit(void) {
     db_context_init(&ctx);
     dbflushreleasestack_context(&ctx);
 
-    /* Update views[0] to point to the saved root table */
+    /* Update views[0] to point to the saved root table;
+     * dbsetview already flushes the header to disk. */
     dbsetview(cancoonview, root_adr);
 
-    /* Flush to disk */
-    if (!dbclose()) {
-        cli_log_warn("save_system_root_on_exit: dbclose (flush) failed");
-    }
+    cli_log_info("System root database saved successfully");
 }
 
 /* Unloads the system root database and clears all global table structures. */

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -1316,7 +1316,9 @@ static void save_system_root_on_exit(void) {
 
     /* Flush release stack */
     db_context_init(&ctx);
-    dbflushreleasestack_context(&ctx);
+
+    if (!dbflushreleasestack_context(&ctx))
+        cli_log_warn("save_system_root_on_exit: dbflushreleasestack_context failed");
 
     /* Update views[0] to point to the saved root table;
      * dbsetview already flushes the header to disk. */

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -1281,6 +1281,46 @@ static boolean load_system_root_database(const char* path) {
     return load_system_root_database_internal(path, true);
 }
 
+/* Saves the system root database to disk before unloading.
+ * Called during cleanup to persist any changes made during script execution
+ * (e.g., user.databases entries created by finishInstall during first-run). */
+static void save_system_root_on_exit(void) {
+    dbaddress root_adr;
+    db_context ctx;
+
+    if (databasedata == nil || rootvariable == nil) {
+        return;
+    }
+
+    cli_log_info("Saving system root database before exit");
+
+    /* Save the root table using v7 format */
+    {
+        db_format_mode mode = {true, false, false};  /* 64-bit, no adapter_repack, no drop_cancoon */
+        db_format_mode_push(&mode);
+
+        if (!tablesavesystemtable(rootvariable, &root_adr)) {
+            db_format_mode_pop();
+            cli_log_warn("save_system_root_on_exit: tablesavesystemtable failed");
+            return;
+        }
+
+        db_format_mode_pop();
+    }
+
+    /* Flush release stack */
+    db_context_init(&ctx);
+    dbflushreleasestack_context(&ctx);
+
+    /* Update views[0] to point to the saved root table */
+    dbsetview(cancoonview, root_adr);
+
+    /* Flush to disk */
+    if (!dbclose()) {
+        cli_log_warn("save_system_root_on_exit: dbclose (flush) failed");
+    }
+}
+
 /* Unloads the system root database and clears all global table structures. */
 static void unload_system_root_database(void) {
     if (!g_system_root_loaded) {
@@ -1289,6 +1329,9 @@ static void unload_system_root_database(void) {
 
     const char* path = (g_system_root_path[0] != '\0') ? g_system_root_path : "(unknown)";
     cli_log_info("Unloading system root database: %s", path);
+
+    /* Save any changes made during this session before tearing down */
+    save_system_root_on_exit();
 
     if (systemtable != nil) {
         if (!unlinksystemtablestructure()) {

--- a/usertalk_scripts/Frontier.root/system/startup/startupScript.ut
+++ b/usertalk_scripts/Frontier.root/system/startup/startupScript.ut
@@ -201,6 +201,7 @@ if user.prefs.firstRootRun { //license agreement, finish cleanup on user's machi
 			if user.prefs.serialNumber != "" and not (string.lower (user.prefs.serialNumber) contains "trial") {
 				rootUpdates.init ();
 				rootUpdates.getCurrent ("Frontier")}}}};
+	fileMenu.save ()}; «save after finishInstall so user.databases entries persist
 
 system.menus.buildMenuBar ();
 system.menus.buildSuitesSubmenu (); //5.0


### PR DESCRIPTION
## Summary

- Add `save_system_root_on_exit()` to persist the system root database before CLI process exit
- Ensures changes made during script execution (like guest DB registrations from `finishInstall()`) survive across restarts
- Add `fileMenu.save()` after the firstRootRun block in the startup script reference copy

## Context

During the first-run startup flow, `finishInstall()` installs mainResponder.root and manila.root as guest databases, adding entries to `user.databases`. However, the explicit `fileMenu.save()` in the startup script runs **before** `finishInstall()`, so these entries were never persisted to disk. On subsequent runs, `user.databases` was empty and guest DBs were not reopened.

The C-layer save-on-exit fix addresses this specific bug and also aligns with the broader design goal of automatic database persistence — the CLI should persist dirty state on exit rather than silently discarding changes.

## Test plan

- [x] 302/302 unit tests pass
- [x] 1703/1704 integration tests pass (1 pre-existing REPL /list crash)
- [x] Fresh dist: first run installs guest DBs, second run reopens them from persisted `user.databases`
- [x] Guest DB save round-trip verified: write value → save → restart → value persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)