### PR TITLE
fix: Always save system root on exit to persist in-memory changes

### DIFF
--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -1292,11 +1292,16 @@ static void save_system_root_on_exit(void) {
         return;
     }
 
-    /* Skip save if the database header has not been dirtied this session */
-    if (!((**databasedata).flags & dbdirtymask)) {
-        cli_log_info("System root not dirty, skipping save");
-        return;
-    }
+    /* Note: We intentionally do NOT check dbdirtymask here.
+     *
+     * The dbdirtymask flag tracks disk-level allocation changes (new blocks
+     * allocated/released), but in-memory table modifications (e.g., new entries
+     * added via hashinsert) set fldirty on hash tables WITHOUT setting dbdirtymask.
+     * This means in-memory changes can exist that dbdirtymask doesn't reflect.
+     *
+     * tablesavesystemtable() is efficient when nothing is dirty — it walks the
+     * in-memory tree checking fldirty/flsubsdirty and no-ops for clean tables.
+     * The cost of an unnecessary walk is minimal compared to losing data. */
 
     cli_log_info("Saving system root database before exit");
 

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Sun, 01 Mar 2026 07:19:01 GMT</dateCreated>
+    <dateCreated>Mon, 02 Mar 2026 07:19:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-01 at 07:19 UTC"/>
+      <outline text="Run: 2026-03-02 at 07:19 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>


### PR DESCRIPTION
## Summary

- Remove the `dbdirtymask` shortcut from `save_system_root_on_exit` that was causing in-memory table modifications to be silently lost on exit
- This fixes the P1 bug where `user.databases` entries (created by `installApp` during first-run) were lost between sessions, preventing mainResponder and manila from being mounted on subsequent runs

## Root Cause

The `save_system_root_on_exit` function checked `dbdirtymask` on the database header to decide whether to save. This flag only tracks disk-level allocation changes (via `dbheaderdirty`), but in-memory table modifications — like entries added via `hashinsert` during `finishInstall()` — set `fldirty` on hash tables WITHOUT setting `dbdirtymask`.

The startup flow exposed this:
1. First `fileMenu.save()` (startup line 179) saved and cleared `dbdirtymask`
2. `finishInstall()` added `user.databases` entries (only set in-memory `fldirty`)
3. Second `fileMenu.save()` (startup line 204) never executed due to brace-matching in the legacy script
4. On exit, `dbdirtymask` was clear → save skipped → changes lost

## Fix

Remove the `dbdirtymask` check entirely. `tablesavesystemtable()` is efficient when nothing is dirty — it walks the in-memory tree checking `fldirty`/`flsubsdirty` and no-ops for clean tables. The cost of an unnecessary walk is minimal compared to losing data.

## Test plan

- [x] 302 unit tests pass
- [x] 1703/1893 integration tests pass (1 pre-existing SIGSEGV in REPL `/list`)
- [x] First run: `sizeOf(user.databases)` = 2 (installApp creates entries)
- [x] Second run: `sizeOf(user.databases)` = 2 (entries persist!)
- [x] Third run: startup script opens mainResponder.root and manila.root from user.databases
- [x] Guest DB startup scripts execute (mainResponder, manilaSuite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)