### PR TITLE
fix: Handle trailing path separators in portable_filefrompath

### DIFF
--- a/Common/source/file_portable_posix.c
+++ b/Common/source/file_portable_posix.c
@@ -94,9 +94,21 @@ boolean portable_filefrompath(const bigstring bspath, bigstring bsfile) {
 	/*
 	 * Extract filename portion from path by finding last path separator
 	 * and returning everything after it.
+	 *
+	 * For directory paths (ending with separator), strips the trailing
+	 * separator, extracts the directory name, then re-appends the separator.
+	 * This matches legacy Frontier behavior where file.fileFromPath on a
+	 * folder path returns the folder name with a trailing separator.
+	 *
+	 * Examples:
+	 *   "/path/to/file.txt" -> "file.txt"
+	 *   "/path/to/folder/"  -> "folder/"
+	 *   "/path/to/folder"   -> "folder"
 	 */
 
 	short pathlen = stringlength(bspath);
+	short effectivelen;
+	boolean flfolder = false;
 	short i;
 	short lastsep = 0;
 
@@ -106,34 +118,43 @@ boolean portable_filefrompath(const bigstring bspath, bigstring bsfile) {
 		return true;
 	}
 
-	/* Find last path separator */
-	for (i = pathlen; i >= 1; i--) {
+	effectivelen = pathlen;
+
+	/* If path ends with separator, strip it and remember it's a folder */
+	if (bspath[pathlen] == PATH_SEP) {
+		flfolder = true;
+		effectivelen = pathlen - 1;
+	}
+
+	/* Find last path separator in the effective path */
+	for (i = effectivelen; i >= 1; i--) {
 		if (bspath[i] == PATH_SEP) {
 			lastsep = i;
 			break;
 		}
 	}
 
-	/* Path ends with separator - no filename */
-	if (lastsep == pathlen) {
-		setemptystring(bsfile);
-		return true;
-	}
-
 	/* Copy everything after last separator */
 	if (lastsep > 0) {
-		short filelen = pathlen - lastsep;
+		short filelen = effectivelen - lastsep;
 		short j;
 
 		setstringlength(bsfile, filelen);
 		for (j = 1; j <= filelen; j++) {
 			bsfile[j] = bspath[lastsep + j];
 		}
-		return true;
+	}
+	else {
+		/* No separator - entire (effective) path is filename */
+		copystring(bspath, bsfile);
+		if (flfolder)
+			setstringlength(bsfile, effectivelen);
 	}
 
-	/* No separator - entire path is filename */
-	copystring(bspath, bsfile);
+	/* Re-add trailing separator for folder paths */
+	if (flfolder)
+		pushchar(PATH_SEP, bsfile);
+
 	return true;
 }
 

--- a/tests/integration/test_cases/file_verbs.yaml
+++ b/tests/integration/test_cases/file_verbs.yaml
@@ -28,6 +28,27 @@ tests:
     expected_success: true
     expected_result: "test.txt"
 
+  - name: "file.fileFromPath - directory path with trailing separator"
+    description: "Trailing separator preserved in returned name (POSIX directory paths)"
+    script: |
+      return file.fileFromPath("/path/to/users/")
+    expected_success: true
+    expected_result: "users/"
+
+  - name: "file.fileFromPath - directory path without trailing separator"
+    description: "No trailing separator returns plain name"
+    script: |
+      return file.fileFromPath("/path/to/users")
+    expected_success: true
+    expected_result: "users"
+
+  - name: "file.fileFromPath - root path"
+    description: "Root path returns separator"
+    script: |
+      return file.fileFromPath("/")
+    expected_success: true
+    expected_result: "/"
+
   - name: "file.exists - nonexistent file"
     description: "Check that nonexistent file returns false"
     script: |


### PR DESCRIPTION
## Summary
- Fix `portable_filefrompath` to handle directory paths ending with `/` (e.g., `/path/users/`), matching legacy Frontier behavior
- Previously returned empty string for such paths, causing `radioCommunityServerSuite.init` to fail during startup with "illegal name" error when constructing `config.mainresponder.sites` entries from directory names
- Now strips trailing separator before extracting directory name, then re-appends it (e.g., `file.fileFromPath("/path/folder/")` returns `"folder/"`)

## Root Cause
On POSIX systems, directory paths end with `/`. The UserTalk script in `radioCommunityServerSuite.init` calls:
```usertalk
local (siteName = string.popTrailing(file.fileFromPath(adrdata^.prefs.userFolder), file.getPathChar()))
```
With `userFolder = "/path/to/users/"`, `file.fileFromPath` returned `""` instead of `"users/"`, making `siteName` empty and causing the illegal name error when creating `config.mainresponder.sites.[siteName]`.

## Test plan
- [x] 302/302 unit tests pass
- [x] Integration tests pass at same rate as develop baseline (flaky `op.*` tests unrelated)
- [x] `file.fileFromPath("/path/users/")` returns `"users/"` (was `""`)
- [x] `file.fileFromPath("/path/users")` returns `"users"` (unchanged)
- [x] Fresh dist startup completes with zero errors (radioCommunityServer.init no longer fails)
- [x] Pre-existing REPL SIGSEGV is the only consistent failure (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)