### PR TITLE
feat: Enable GIL yielding in blocking REPL mode

### DIFF
--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -1942,30 +1942,66 @@ static boolean process_line(const char *line, boolean *running) {
 
 /* Blocking REPL loop for non-TTY input (fallback mode).
  * Used when stdin is not a terminal (e.g., piped input).
+ *
+ * Uses poll()-based input loop that yields the GIL between input checks,
+ * mirroring the event loop mode's yield pattern. This allows background
+ * threads (TCP callbacks, agents) to run while waiting for input.
  */
 static int repl_main_blocking(void) {
     boolean running = true;
     boolean force_interactive = (getenv("FRONTIER_FORCE_INTERACTIVE") != NULL);
+    char line_buf[MAX_COMMAND_LEN];
 
     while (running) {
-        // In force-interactive mode (testing), manually output the prompt
-        // since linenoise may suppress it when stdin isn't a real TTY
+        // Print prompt
         if (force_interactive) {
             fputs(g_repl_prompt, stderr);
             fflush(stderr);
+        } else {
+            fputs(g_repl_prompt, stdout);
+            fflush(stdout);
         }
 
-        // Read line with blocking linenoise
-        char *line = linenoise(force_interactive ? "" : g_repl_prompt);
+        // Poll-based input loop: yield GIL while waiting for input
+        char *line = NULL;
 
-        if (line == NULL) {
-            // EOF (Ctrl-D) or error
-            break;
+        while (1) {
+            struct pollfd pfd = {STDIN_FILENO, POLLIN, 0};
+            int ready = poll(&pfd, 1, POLL_TIMEOUT_MS);
+
+            if (ready > 0 && (pfd.revents & POLLIN)) {
+                line = fgets(line_buf, sizeof(line_buf), stdin);
+                break;
+            }
+
+            if (ready < 0 && errno != EINTR) {
+                // Unrecoverable poll() error
+                log_error(LOG_COMP_GENERAL, "poll() failed in blocking REPL: %s", strerror(errno));
+                return 1;
+            }
+
+            // No input ready — yield GIL so background threads can run
+            tcp_process_callbacks();
+            headless_backgroundtask(true);
+
+            if (agentsenabled())
+                agentscheduler_tick();
         }
+
+        if (line == NULL)
+            break;  // EOF or read error
+
+        // Strip trailing newline
+        size_t len = strlen(line_buf);
+        if (len > 0 && line_buf[len - 1] == '\n')
+            line_buf[len - 1] = '\0';
+
+        // Add non-empty lines to history
+        if (line_buf[0] != '\0')
+            linenoiseHistoryAdd(line_buf);
 
         // Process the line
-        process_line(line, &running);
-        linenoiseFree(line);
+        process_line(line_buf, &running);
 
         // Process callbacks after each command
         tcp_process_callbacks();

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -1949,18 +1949,12 @@ static boolean process_line(const char *line, boolean *running) {
  */
 static int repl_main_blocking(void) {
     boolean running = true;
-    boolean force_interactive = (getenv("FRONTIER_FORCE_INTERACTIVE") != NULL);
     char line_buf[MAX_COMMAND_LEN];
 
     while (running) {
-        // Print prompt
-        if (force_interactive) {
-            fputs(g_repl_prompt, stderr);
-            fflush(stderr);
-        } else {
-            fputs(g_repl_prompt, stdout);
-            fflush(stdout);
-        }
+        // Print prompt to stderr to avoid corrupting captured stdout in piped mode
+        fputs(g_repl_prompt, stderr);
+        fflush(stderr);
 
         // Poll-based input loop: yield GIL while waiting for input
         char *line = NULL;
@@ -1969,7 +1963,8 @@ static int repl_main_blocking(void) {
             struct pollfd pfd = {STDIN_FILENO, POLLIN, 0};
             int ready = poll(&pfd, 1, POLL_TIMEOUT_MS);
 
-            if (ready > 0 && (pfd.revents & POLLIN)) {
+            if (ready > 0 && (pfd.revents & (POLLIN | POLLHUP | POLLERR))) {
+                // Input available, EOF, or error — fgets handles all cases
                 line = fgets(line_buf, sizeof(line_buf), stdin);
                 break;
             }
@@ -1984,23 +1979,24 @@ static int repl_main_blocking(void) {
             tcp_process_callbacks();
             headless_backgroundtask(true);
 
-            if (agentsenabled())
+            if (agentsenabled()) {
                 agentscheduler_tick();
+            }
         }
 
-        if (line == NULL)
-            break;  // EOF or read error
+        if (line == NULL) {
+            if (ferror(stdin)) {
+                log_error(LOG_COMP_GENERAL, "stdin read error in blocking REPL: %s", strerror(errno));
+            }
+            break;
+        }
 
         // Strip trailing newline
         size_t len = strlen(line_buf);
         if (len > 0 && line_buf[len - 1] == '\n')
             line_buf[len - 1] = '\0';
 
-        // Add non-empty lines to history
-        if (line_buf[0] != '\0')
-            linenoiseHistoryAdd(line_buf);
-
-        // Process the line
+        // Process the line (process_line handles history via linenoiseHistoryAdd)
         process_line(line_buf, &running);
 
         // Process callbacks after each command


### PR DESCRIPTION
## Summary

- Replace blocking `linenoise()` call in `repl_main_blocking()` with a `poll()`-based input loop that yields the GIL every 10ms
- Mirrors the event loop mode's yield pattern (`tcp_process_callbacks` → `headless_backgroundtask` → `agentscheduler_tick`)
- Background threads and TCP callbacks (HTTP server) now run while the blocking REPL waits for input
- Uses `fgets()` for line reading (appropriate for non-TTY stdin) with linenoise history preserved

Previously, `FRONTIER_PLAIN_REPL` and piped-input scenarios held the GIL indefinitely, starving background threads and preventing HTTP callback dispatch until each command completed.

## Test plan

- [x] Build: `make -C frontier-cli` — clean
- [x] Unit tests: 302/302 pass
- [x] Integration tests: 1688/1896 pass (19 failures all pre-existing on develop)
- [ ] Manual: HTTP serving during `thread.sleepFor()` in blocking REPL mode
- [ ] Manual: TTY REPL still works interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
