### PR TITLE
fix: Resolve 19 consistently-failing integration tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,11 @@ Agents must verify fixes work end-to-end, not just fix one piece. Test the compl
 Cross-agent UserTalk invariants and integration-test parser constraints now live in `docs/AI_SHARED_GUIDELINES.md`.
 Use those rules as mandatory baseline guidance.
 
+**Key gotchas (see shared guidelines for full details):**
+- Double quotes for strings — UserTalk uses `"string"` not `'string'`
+- typeof() returns OSType codes (e.g. `'TEXT'`) not descriptive strings
+- Absolute paths required — UserTalk table paths must be fully qualified (e.g. `@workspace.foo`)
+
 ---
 
 ## Critical Testing Constraints

--- a/Common/headers/lang.h
+++ b/Common/headers/lang.h
@@ -379,6 +379,13 @@ typedef union tyvaluedata {
 	} tyvaluedata;
 
 
+/* Minimum valid heap pointer address. The first 4096 bytes of virtual address
+ * space are intentionally unmapped (PROT_NONE) on macOS/Linux. Any non-NULL
+ * pointer below this threshold indicates corruption, not a valid allocation.
+ * Used by corrupt-handle guards in langhash.c and langvalue.c. */
+#define kMinValidPointer ((uintptr_t)0x1000)
+
+
 typedef struct tyvaluerecord {
 	
 	tyvaluetype valuetype;

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2864,6 +2864,58 @@ typedef struct typackinforecord {
 #pragma options align=reset
 
 
+/* Guard against corrupt string/address/binary handles that could SIGSEGV during pack.
+ * Only checks live (non-disk) values — fldiskval entries hold raw disk addresses and
+ * are handled correctly by hashpackscalar without dereferencing.
+ *
+ * The 0x1000 threshold works because the first 4096 bytes of virtual address space
+ * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000.
+ * NULL (*hdata == NULL) is valid — it represents a zero-length handle (NewHandle(0) sets
+ * the master pointer to NULL), which packs correctly as a 0-length field.
+ *
+ * codevaluetype and externalvaluetype are also handle-bearing but are NOT included here —
+ * they have their own packing paths (langpacktree / hashpackexternal) with separate error
+ * handling, and their handles point to structures, not raw data.
+ *
+ * Note: setting fldontsave is permanent for the session — the node stays skipped on all
+ * subsequent pack calls even if later assigned a valid value. This is acceptable since the
+ * guard only fires on corruption, not on transient states.
+ *
+ * Returns true if corruption was detected (caller should skip this entry). */
+
+static boolean hashpackguard_corrupt_handle(tyvaluerecord val, hdlhashnode hnode,
+		bigstring bsname, const char *visitor_name) {
+
+	if (val.fldiskval)
+		return (false);
+
+	if (hnode == nil)  /* legacy visitor checks this; v7 relies on earlier fldontsave deref */
+		return (false);
+
+	if (val.valuetype != addressvaluetype && val.valuetype != stringvaluetype &&
+		val.valuetype != passwordvaluetype && val.valuetype != oldstringvaluetype &&
+		val.valuetype != binaryvaluetype)
+		return (false);
+
+	Handle hdata = (Handle) val.data.binaryvalue;
+
+	if (hdata == nil)
+		return (false);
+
+	char *p = *hdata;
+
+	if (p != NULL && (uintptr_t)p < 0x1000) {
+		log_error(LOG_COMP_HASH, "%s: corrupt handle data ptr=%p handle=%p type=%d name='%.*s'",
+			visitor_name, (void *)p, (void *)hdata, (int)val.valuetype,
+			(int)bsname[0], (char *)&bsname[1]);
+		(**hnode).fldontsave = true;
+		return (true);
+	}
+
+	return (false);
+} /*hashpackguard_corrupt_handle*/
+
+
 /* Legacy pack visitor (v<=6) */
 static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvaluerecord val, ptrvoid refcon);
 
@@ -2949,28 +3001,8 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 	if (hnode != nil && (**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
 		return (false);
 
-	/* Guard against corrupt string/address/binary handles that could SIGSEGV during pack.
-	 * Only check live (non-disk) values — fldiskval entries are handled by hashpackscalar.
-	 * The 0x1000 threshold works because the first 4096 bytes of virtual address space
-	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000.
-	 * Note: codevaluetype and externalvaluetype are also handle-bearing but are NOT included
-	 * here — they have their own packing paths (langpacktree / hashpackexternal) with
-	 * separate error handling, and their handles point to structures, not raw data. */
-	if (!val.fldiskval && hnode != nil &&
-		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
-		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype ||
-		 val.valuetype == binaryvaluetype)) {
-		Handle hdata = (Handle) val.data.binaryvalue;
-		if (hdata != nil) {
-			char *p = *hdata;
-			if (p != NULL && (uintptr_t)p < 0x1000) {
-				log_error(LOG_COMP_HASH, "hashpackvisit_legacy: corrupt handle data ptr=%p handle=%p type=%d name='%.*s'",
-					(void *)p, (void *)hdata, (int)val.valuetype, (int)bsname[0], (char *)&bsname[1]);
-				(**hnode).fldontsave = true;
-				return (false);
-			}
-		}
-	}
+	if (hashpackguard_corrupt_handle(val, hnode, bsname, "hashpackvisit_legacy"))
+		return (false);
 
 	langtraperrors (bspackerror, &savecallback, &saverefcon);
 
@@ -3370,31 +3402,8 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 	if ((**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
 		return (false);
 
-	/* Guard against corrupt string/address/binary handles that could SIGSEGV during pack.
-	 * Only check live (non-disk) values — fldiskval entries hold raw disk addresses
-	 * and are handled correctly by hashpackscalar without dereferencing.
-	 * Check both the handle pointer and its data pointer (the "master pointer")
-	 * since heap corruption can leave the handle valid but its data pointer invalid.
-	 * The 0x1000 threshold works because the first 4096 bytes of virtual address space
-	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000.
-	 * Note: codevaluetype and externalvaluetype are also handle-bearing but are NOT included
-	 * here — they have their own packing paths (langpacktree / hashpackexternal) with
-	 * separate error handling, and their handles point to structures, not raw data. */
-	if (!val.fldiskval &&
-		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
-		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype ||
-		 val.valuetype == binaryvaluetype)) {
-		Handle hdata = (Handle) val.data.binaryvalue;
-		if (hdata != nil) {
-			char *p = *hdata;  /* master pointer / data pointer */
-			if (p != NULL && (uintptr_t)p < 0x1000) {
-				log_error(LOG_COMP_HASH, "hashpackvisit_v7: corrupt handle data ptr=%p handle=%p type=%d name='%.*s'",
-					(void *)p, (void *)hdata, (int)val.valuetype, (int)bsname[0], (char *)&bsname[1]);
-				(**hnode).fldontsave = true;
-				return (false); /* skip corrupt entry, continue traversal */
-			}
-		}
-	}
+	if (hashpackguard_corrupt_handle(val, hnode, bsname, "hashpackvisit_v7"))
+		return (false);
 
 	langtraperrors (bspackerror, &savecallback, &saverefcon);
 

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2868,8 +2868,7 @@ typedef struct typackinforecord {
  * Only checks live (non-disk) values — fldiskval entries hold raw disk addresses and
  * are handled correctly by hashpackscalar without dereferencing.
  *
- * The 0x1000 threshold works because the first 4096 bytes of virtual address space
- * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000.
+ * Uses kMinValidPointer (0x1000) threshold — see lang.h for rationale.
  * NULL (*hdata == NULL) is valid — it represents a zero-length handle (NewHandle(0) sets
  * the master pointer to NULL), which packs correctly as a 0-length field.
  *
@@ -2904,7 +2903,7 @@ static boolean hashpackguard_corrupt_handle(tyvaluerecord val, hdlhashnode hnode
 
 	char *p = *hdata;
 
-	if (p != NULL && (uintptr_t)p < 0x1000) {
+	if (p != NULL && (uintptr_t)p < kMinValidPointer) {
 		log_error(LOG_COMP_HASH, "%s: corrupt handle data ptr=%p handle=%p type=%d name='%.*s'",
 			visitor_name, (void *)p, (void *)hdata, (int)val.valuetype,
 			(int)bsname[0], (char *)&bsname[1]);
@@ -2998,8 +2997,11 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 	ccmsg (bsname, false);
 	*/
 
-	if (hnode != nil && (**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
+	if (hnode != nil && (**hnode).fldontsave && !flexternalmemorypack) { /*keep traversing the table*/
+		log_trace(LOG_COMP_HASH, "hashpackvisit_legacy: skipping fldontsave node name='%.*s'",
+			(int)bsname[0], (char *)&bsname[1]);
 		return (false);
+	}
 
 	if (hashpackguard_corrupt_handle(val, hnode, bsname, "hashpackvisit_legacy"))
 		return (false);
@@ -3399,8 +3401,11 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 	int32_t name_index = 0;
 	int32_t data_index = 0;
 
-	if ((**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
+	if ((**hnode).fldontsave && !flexternalmemorypack) { /*keep traversing the table*/
+		log_trace(LOG_COMP_HASH, "hashpackvisit_v7: skipping fldontsave node name='%.*s'",
+			(int)bsname[0], (char *)&bsname[1]);
 		return (false);
+	}
 
 	if (hashpackguard_corrupt_handle(val, hnode, bsname, "hashpackvisit_v7"))
 		return (false);

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2952,7 +2952,10 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 	/* Guard against corrupt string/address/binary handles that could SIGSEGV during pack.
 	 * Only check live (non-disk) values — fldiskval entries are handled by hashpackscalar.
 	 * The 0x1000 threshold works because the first 4096 bytes of virtual address space
-	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000. */
+	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000.
+	 * Note: codevaluetype and externalvaluetype are also handle-bearing but are NOT included
+	 * here — they have their own packing paths (langpacktree / hashpackexternal) with
+	 * separate error handling, and their handles point to structures, not raw data. */
 	if (!val.fldiskval && hnode != nil &&
 		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
 		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype ||
@@ -3373,7 +3376,10 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 	 * Check both the handle pointer and its data pointer (the "master pointer")
 	 * since heap corruption can leave the handle valid but its data pointer invalid.
 	 * The 0x1000 threshold works because the first 4096 bytes of virtual address space
-	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000. */
+	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000.
+	 * Note: codevaluetype and externalvaluetype are also handle-bearing but are NOT included
+	 * here — they have their own packing paths (langpacktree / hashpackexternal) with
+	 * separate error handling, and their handles point to structures, not raw data. */
 	if (!val.fldiskval &&
 		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
 		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype ||

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2949,6 +2949,23 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 	if (hnode != nil && (**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
 		return (false);
 
+	/* Guard against corrupt string/address handles (see v7 visitor for rationale).
+	 * Only check live (non-disk) values — fldiskval entries are handled by hashpackscalar. */
+	if (!val.fldiskval && hnode != nil &&
+		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
+		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype)) {
+		Handle hdata = (Handle) val.data.binaryvalue;
+		if (hdata != nil) {
+			char *p = *hdata;
+			if (p != NULL && (uintptr_t)p < 0x1000) {
+				log_error(LOG_COMP_HASH, "hashpackvisit_legacy: corrupt handle data ptr=%p handle=%p type=%d name='%.*s'",
+					(void *)p, (void *)hdata, (int)val.valuetype, (int)bsname[0], (char *)&bsname[1]);
+				(**hnode).fldontsave = true;
+				return (false);
+			}
+		}
+	}
+
 	langtraperrors (bspackerror, &savecallback, &saverefcon);
 
 	clearbytes (&rec, sizeof (rec));
@@ -3346,6 +3363,26 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 
 	if ((**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
 		return (false);
+
+	/* Guard against corrupt string/address handles that could SIGSEGV during pack.
+	 * Only check live (non-disk) values — fldiskval entries hold raw disk addresses
+	 * and are handled correctly by hashpackscalar without dereferencing.
+	 * Check both the handle pointer and its data pointer (the "master pointer")
+	 * since heap corruption can leave the handle valid but its data pointer invalid. */
+	if (!val.fldiskval &&
+		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
+		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype)) {
+		Handle hdata = (Handle) val.data.binaryvalue;
+		if (hdata != nil) {
+			char *p = *hdata;  /* master pointer / data pointer */
+			if (p != NULL && (uintptr_t)p < 0x1000) {
+				log_error(LOG_COMP_HASH, "hashpackvisit_v7: corrupt handle data ptr=%p handle=%p type=%d name='%.*s'",
+					(void *)p, (void *)hdata, (int)val.valuetype, (int)bsname[0], (char *)&bsname[1]);
+				(**hnode).fldontsave = true;
+				return (false); /* skip corrupt entry, continue traversal */
+			}
+		}
+	}
 
 	langtraperrors (bspackerror, &savecallback, &saverefcon);
 

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2949,11 +2949,14 @@ static boolean hashpackvisit_legacy (bigstring bsname, hdlhashnode hnode, tyvalu
 	if (hnode != nil && (**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
 		return (false);
 
-	/* Guard against corrupt string/address handles (see v7 visitor for rationale).
-	 * Only check live (non-disk) values — fldiskval entries are handled by hashpackscalar. */
+	/* Guard against corrupt string/address/binary handles that could SIGSEGV during pack.
+	 * Only check live (non-disk) values — fldiskval entries are handled by hashpackscalar.
+	 * The 0x1000 threshold works because the first 4096 bytes of virtual address space
+	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000. */
 	if (!val.fldiskval && hnode != nil &&
 		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
-		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype)) {
+		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype ||
+		 val.valuetype == binaryvaluetype)) {
 		Handle hdata = (Handle) val.data.binaryvalue;
 		if (hdata != nil) {
 			char *p = *hdata;
@@ -3364,14 +3367,17 @@ static boolean hashpackvisit_v7 (bigstring bsname, hdlhashnode hnode, tyvaluerec
 	if ((**hnode).fldontsave && !flexternalmemorypack) /*keep traversing the table*/
 		return (false);
 
-	/* Guard against corrupt string/address handles that could SIGSEGV during pack.
+	/* Guard against corrupt string/address/binary handles that could SIGSEGV during pack.
 	 * Only check live (non-disk) values — fldiskval entries hold raw disk addresses
 	 * and are handled correctly by hashpackscalar without dereferencing.
 	 * Check both the handle pointer and its data pointer (the "master pointer")
-	 * since heap corruption can leave the handle valid but its data pointer invalid. */
+	 * since heap corruption can leave the handle valid but its data pointer invalid.
+	 * The 0x1000 threshold works because the first 4096 bytes of virtual address space
+	 * are intentionally unmapped (PROT_NONE) on macOS/Linux, so any valid heap pointer >= 0x1000. */
 	if (!val.fldiskval &&
 		(val.valuetype == addressvaluetype || val.valuetype == stringvaluetype ||
-		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype)) {
+		 val.valuetype == passwordvaluetype || val.valuetype == oldstringvaluetype ||
+		 val.valuetype == binaryvaluetype)) {
 		Handle hdata = (Handle) val.data.binaryvalue;
 		if (hdata != nil) {
 			char *p = *hdata;  /* master pointer / data pointer */

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -400,7 +400,7 @@ static boolean getaddressparts (const tyvaluerecord *val, hdlhashtable *htable, 
 		return (false);
 	}
 
-	if (*hstring == NULL || (uintptr_t) *hstring < 0x1000) {
+	if ((uintptr_t) *hstring < 0x1000) {
 		/* Handle is valid but its data pointer is corrupt (NULL or low address).
 		 * This can happen with stale entries from prior sessions. */
 		setemptystring(bs);

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -403,6 +403,8 @@ static boolean getaddressparts (const tyvaluerecord *val, hdlhashtable *htable, 
 	if ((uintptr_t) *hstring < 0x1000) {
 		/* Handle is valid but its data pointer is corrupt (NULL or low address).
 		 * This can happen with stale entries from prior sessions. */
+		log_error(LOG_COMP_LANG, "getaddressparts: corrupt address handle data ptr=%p handle=%p",
+			(void *)*hstring, (void *)hstring);
 		setemptystring(bs);
 		*htable = nil;
 		return (false);

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -392,7 +392,7 @@ static boolean getaddressparts (const tyvaluerecord *val, hdlhashtable *htable, 
 	hdlstring hstring = (*val).data.addressvalue;
 	long ixtable;
 
-	if (hstring == nil || (uintptr_t) hstring < 0x1000) {
+	if (hstring == nil || (uintptr_t) hstring < kMinValidPointer) {
 		/* Handle pointer is nil or suspiciously small (likely a raw disk address
 		 * rather than a valid heap handle). Avoid dereferencing. */
 		setemptystring(bs);
@@ -400,9 +400,12 @@ static boolean getaddressparts (const tyvaluerecord *val, hdlhashtable *htable, 
 		return (false);
 	}
 
-	if ((uintptr_t) *hstring < 0x1000) {
+	if ((uintptr_t) *hstring < kMinValidPointer) {
 		/* Handle is valid but its data pointer is corrupt (NULL or low address).
-		 * This can happen with stale entries from prior sessions. */
+		 * This can happen with stale entries from prior sessions.
+		 * Note: unlike the pack guards in langhash.c, NULL is NOT valid here —
+		 * address values must hold a non-empty path string, so a zero-length
+		 * handle is always corrupt for this type. */
 		log_error(LOG_COMP_LANG, "getaddressparts: corrupt address handle data ptr=%p handle=%p",
 			(void *)*hstring, (void *)hstring);
 		setemptystring(bs);

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -391,11 +391,27 @@ static boolean getaddressparts (const tyvaluerecord *val, hdlhashtable *htable, 
 	
 	hdlstring hstring = (*val).data.addressvalue;
 	long ixtable;
-	
+
+	if (hstring == nil || (uintptr_t) hstring < 0x1000) {
+		/* Handle pointer is nil or suspiciously small (likely a raw disk address
+		 * rather than a valid heap handle). Avoid dereferencing. */
+		setemptystring(bs);
+		*htable = nil;
+		return (false);
+	}
+
+	if (*hstring == NULL || (uintptr_t) *hstring < 0x1000) {
+		/* Handle is valid but its data pointer is corrupt (NULL or low address).
+		 * This can happen with stale entries from prior sessions. */
+		setemptystring(bs);
+		*htable = nil;
+		return (false);
+	}
+
 	copyheapstring (hstring, bs);
-	
+
 	ixtable = stringlength (bs) + 1;
-	
+
 	if (!loadfromhandle ((Handle) hstring, &ixtable, sizeof (hdlhashtable), htable))
 		*htable = nil;
 

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -70,7 +70,7 @@ Minimum expectations:
 - Do not place inline `//` comments inside UserTalk `{ ... }` blocks.
 - Keep indentation consistent inside blocks; avoid stray blank lines with mismatched indentation.
 - Isolate test state under `system.temp.*`, never by mutating `system.*` tables directly.
-- Always clean up temporary test objects (for example `delete(@system.temp.someTestTable)`).
+- Cleanup of `system.temp` objects is unnecessary (the table is non-persistent and recreated fresh each run), but acceptable for clarity.
 
 ## Migration and Data-Safety Invariants
 

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -71,6 +71,7 @@ Minimum expectations:
 - Keep indentation consistent inside blocks; avoid stray blank lines with mismatched indentation.
 - Isolate test state under `system.temp.*`, never by mutating `system.*` tables directly.
 - Cleanup of `system.temp` objects is unnecessary (the table is non-persistent and recreated fresh each run), but acceptable for clarity.
+- **NEVER use `new(tableType, @workspace)` or `new(tableType, @workspace.something)`** — this creates persistent tables in workspace that pollute the database across test runs and cause flaky tests. Always use `new(tableType, @system.temp.something)` instead.
 
 ## Migration and Data-Safety Invariants
 

--- a/docs/DEBUGGING_GUIDE.md
+++ b/docs/DEBUGGING_GUIDE.md
@@ -164,6 +164,19 @@ rm -f databases/Frontier.root7
 2. Verify external loading happened
 3. Trace through `langexternalgettable()` or similar
 
+### Corrupt Handle Guards During Save
+
+**Symptom**: Entries silently missing from saved database, or SIGSEGV during save-on-exit
+
+**Cause**: `hashpackvisit_legacy` and `hashpackvisit_v7` guard against corrupt handles (data pointer < 0x1000) for string/address/password/binary value types. When detected, the entry's `fldontsave` flag is set and it is skipped — the save completes successfully but the entry is silently dropped.
+
+**How to Diagnose**:
+- Check stderr/logs for `"corrupt handle data ptr="` messages from `hashpackvisit_legacy` or `hashpackvisit_v7`
+- The log includes the handle pointer, data pointer, value type, and node name
+- `getaddressparts` in `langvalue.c` also logs corrupt address handles as warnings
+
+**What's covered**: `addressvaluetype`, `stringvaluetype`, `passwordvaluetype`, `oldstringvaluetype`, `binaryvaluetype`. Other handle-bearing types (`codevaluetype`, `externalvaluetype`) have their own packing paths with separate error handling.
+
 ### Verb Resolution Failures
 
 **Symptom**: "Can't call X" or verb not found

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -260,6 +260,39 @@ tests:
 
 ---
 
+## Database State Isolation (system.temp Rule)
+
+**CRITICAL: Integration tests must NEVER mutate anything outside `system.temp` in Frontier.root or any other .root file.**
+
+- Use `system.temp.*` for all temporary test fixtures (outlines, tables, menus, scripts, etc.)
+- `system.temp` is cleared on each process startup, preventing cross-test pollution
+- NEVER use `workspace.*` for test fixtures -- workspace persists to disk via save_on_exit
+- NEVER use `lang.new()` to create/overwrite top-level tables like `@workspace` -- this destroys pre-existing data
+- Even if a test calls `delete()` to clean up, use `system.temp` anyway for safety
+
+### Example Patterns
+
+```usertalk
+// GOOD -- uses system.temp
+lang.new(outlineType, @system.temp.myOutline);
+target.set(@system.temp.myOutline);
+
+// BAD -- mutates workspace (persists to disk)
+lang.new(outlineType, @workspace.myOutline);
+target.set(@workspace.myOutline);
+
+// VERY BAD -- overwrites the entire workspace table!
+lang.new(tableType, @workspace);
+```
+
+### Applies To
+
+- All YAML test files under `tests/integration/test_cases/`
+- Any test that creates temporary database objects
+- Both protocol-mode and per-process tests
+
+---
+
 ## Temporary Files in Tests
 
 ### Temporary File Locations

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -387,7 +387,7 @@ static boolean resolve_indexed_node(hdlhashtable htable, hdlhashnode hnode, long
     if (!hashresolvevalue(htable, hnode)) {
         if (error_msg && error_bufsize > 0)
             snprintf(error_msg, error_bufsize, "failed to resolve value at index %ld ('%s') in '%s'",
-                     index, cname, context_name ? context_name : "?");
+                     index, cname[0] ? cname : "?", context_name ? context_name : "?");
         return false;
     }
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -386,7 +386,8 @@ static boolean resolve_indexed_node(hdlhashtable htable, hdlhashnode hnode, long
      * SIGSEGV when langexternalvaltotable dereferences the stale handle. */
     if (!hashresolvevalue(htable, hnode)) {
         if (error_msg && error_bufsize > 0)
-            snprintf(error_msg, error_bufsize, "failed to resolve value at index %ld", index);
+            snprintf(error_msg, error_bufsize, "failed to resolve value at index %ld in '%s'",
+                     index, context_name ? context_name : "?");
         return false;
     }
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -386,8 +386,8 @@ static boolean resolve_indexed_node(hdlhashtable htable, hdlhashnode hnode, long
      * SIGSEGV when langexternalvaltotable dereferences the stale handle. */
     if (!hashresolvevalue(htable, hnode)) {
         if (error_msg && error_bufsize > 0)
-            snprintf(error_msg, error_bufsize, "failed to resolve value at index %ld in '%s'",
-                     index, context_name ? context_name : "?");
+            snprintf(error_msg, error_bufsize, "failed to resolve value at index %ld ('%s') in '%s'",
+                     index, cname, context_name ? context_name : "?");
         return false;
     }
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -362,7 +362,7 @@ static boolean apply_index_to_table(hdlhashtable htable, long index,
  *
  * Returns true on success.
  */
-static boolean resolve_indexed_node(hdlhashnode hnode, long index,
+static boolean resolve_indexed_node(hdlhashtable htable, hdlhashnode hnode, long index,
                                      const char *context_name,
                                      boolean is_last,
                                      typathlookupresult *result,
@@ -380,6 +380,15 @@ static boolean resolve_indexed_node(hdlhashnode hnode, long index,
     /* apply_index_to_table() guarantees hnode != nil && *hnode != nil on success.
      * Assert this contract rather than silently handling a violation. */
     assert(hnode != nil && *hnode != nil);
+
+    /* Resolve on-disk values before reading. Without this, nodes with
+     * unresolved external handles (e.g. when using --skip-startup) cause
+     * SIGSEGV when langexternalvaltotable dereferences the stale handle. */
+    if (!hashresolvevalue(htable, hnode)) {
+        if (error_msg && error_bufsize > 0)
+            snprintf(error_msg, error_bufsize, "failed to resolve value at index %ld", index);
+        return false;
+    }
 
     tyvaluerecord nodeval = (**hnode).val;
 
@@ -494,7 +503,7 @@ static boolean apply_and_resolve_index(hdlhashtable htable, long index,
     if (!apply_index_to_table(htable, index, context_name, &hnode, error_msg, error_bufsize))
         return false;
 
-    if (!resolve_indexed_node(hnode, index, context_name, is_last, result, out_table,
+    if (!resolve_indexed_node(htable, hnode, index, context_name, is_last, result, out_table,
                                name_path, name_path_bufsize, name_path_len,
                                resolved_name_path, resolved_bufsize,
                                error_msg, error_bufsize))

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1911 tests: 1722 pass (90%) 189 skip (9%)</title>
-    <dateCreated>Wed, 25 Feb 2026 06:50:06 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1914 tests: 1725 pass (90%) 189 skip (9%)</title>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-02-25 at 06:49 UTC"/>
-      <outline text="Results: 1703 passed (90%), 189 skipped (10%), 1 failed (0%)"/>
-      <outline text="Duration: 31.3s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 1911 tests (1722 active, 189 marked skip) across 51 categories"/>
+      <outline text="Run: 2026-03-05 at 19:10 UTC"/>
+      <outline text="Results: 1706 passed (90%), 189 skipped (10%), 1 failed (0%)"/>
+      <outline text="Duration: 46.0s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 1914 tests (1725 active, 189 marked skip) across 51 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
@@ -20,7 +20,7 @@
     <outline text="Dist Stability (dist_stability) - 7 tests: 7 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dist_stability.opml"/>
     <outline text="Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs) - 14 tests: 13 pass (92%) 1 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
-    <outline text="File Verbs (file_verbs) - 81 tests: 75 pass (92%) 6 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
+    <outline text="File Verbs (file_verbs) - 84 tests: 78 pass (92%) 6 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
     <outline text="Filemenu Verbs (filemenu_verbs) - 34 tests: 31 pass (91%) 3 skip (8%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
     <outline text="Frontier Verbs (frontier_verbs) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/frontier_verbs.opml"/>
     <outline text="Guest Db Externals (guest_db_externals) - 11 tests: 11 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/guest_db_externals.opml"/>

--- a/reports/integration_tests/file_verbs.opml
+++ b/reports/integration_tests/file_verbs.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>File Verbs (file_verbs) - 81 tests: 75 pass (92%) 6 skip (7%)</title>
-    <dateCreated>Fri, 20 Feb 2026 00:12:03 GMT</dateCreated>
+    <title>File Verbs (file_verbs) - 84 tests: 78 pass (92%) 6 skip (7%)</title>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="file.fileFromPath - extract filename from path - Extract filename component from path string (like basename)">
@@ -14,6 +14,30 @@
         <outline text="local(fullPath = tmpDir + &quot;/&quot; + &quot;test.txt&quot;)"/>
         <outline text="local(filename = file.fileFromPath(fullPath))"/>
         <outline text="return filename"/>
+      </outline>
+    </outline>
+    <outline text="file.fileFromPath - directory path with trailing separator - Trailing separator preserved in returned name (POSIX directory paths)">
+      <outline text="Metadata">
+        <outline text="expected_result: users/"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.fileFromPath(&quot;/path/to/users/&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="file.fileFromPath - directory path without trailing separator - No trailing separator returns plain name">
+      <outline text="Metadata">
+        <outline text="expected_result: users"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.fileFromPath(&quot;/path/to/users&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="file.fileFromPath - root path - Root path returns separator">
+      <outline text="Metadata">
+        <outline text="expected_result: /"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.fileFromPath(&quot;/&quot;)"/>
       </outline>
     </outline>
     <outline text="file.exists - nonexistent file - Check that nonexistent file returns false">

--- a/reports/integration_tests/filemenu_verbs.opml
+++ b/reports/integration_tests/filemenu_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Filemenu Verbs (filemenu_verbs) - 34 tests: 31 pass (91%) 3 skip (8%)</title>
-    <dateCreated>Mon, 23 Feb 2026 05:46:51 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="fileMenu.new - create new database - fileMenu.new creates a new empty ODB database and opens it">
@@ -139,8 +139,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.notADb)"/>
-        <outline text="target.set(@workspace.notADb)"/>
+        <outline text="lang.new(tableType, @system.temp.notADb)"/>
+        <outline text="target.set(@system.temp.notADb)"/>
         <outline text="local(result = fileMenu.close())"/>
         <outline text="target.clear()"/>
         <outline text="return result"/>

--- a/reports/integration_tests/menu_data_verbs.opml
+++ b/reports/integration_tests/menu_data_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Menu Data Verbs (menu_data_verbs) - 49 tests: 29 pass (59%) 20 skip (40%)</title>
-    <dateCreated>Fri, 06 Feb 2026 08:23:43 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="menu.addMenuCommand - create new menu and add item - Add a command to a new menubar, creating the menu if it doesn't exist">
@@ -12,9 +12,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;dialog.alert(\&quot;New!\&quot;)&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;dialog.alert(\&quot;New!\&quot;)&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -25,11 +25,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;edit.cut()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;edit.copy()&quot;)"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Paste&quot;, &quot;edit.paste()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;edit.cut()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;edit.copy()&quot;)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Paste&quot;, &quot;edit.paste()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -40,12 +40,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add initial item"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;oldScript()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;oldScript()&quot;)"/>
         <outline text="# Replace with new script"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;newScript()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;newScript()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -56,11 +56,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;file.new()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;edit.undo()&quot;)"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;Help&quot;, &quot;About&quot;, &quot;help.about()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;file.new()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;edit.undo()&quot;)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;Help&quot;, &quot;About&quot;, &quot;help.about()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -71,10 +71,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;ToDelete&quot;, &quot;script()&quot;)"/>
-        <outline text="local(ok = menu.deleteMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;ToDelete&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;ToDelete&quot;, &quot;script()&quot;)"/>
+        <outline text="local(ok = menu.deleteMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;ToDelete&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -85,10 +85,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Try to delete item that doesn't exist"/>
-        <outline text="local(ok = menu.deleteMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;DoesNotExist&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.deleteMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;DoesNotExist&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -99,10 +99,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Try to delete from menu that doesn't exist"/>
-        <outline text="local(ok = menu.deleteMenuCommand(@workspace.testMenu, &quot;NoSuchMenu&quot;, &quot;Item&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.deleteMenuCommand(@system.temp.testMenu, &quot;NoSuchMenu&quot;, &quot;Item&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -113,13 +113,13 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add, delete, then add again with different script"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;original()&quot;)"/>
-        <outline text="menu.deleteMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;original()&quot;)"/>
+        <outline text="menu.deleteMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;)"/>
         <outline text="# Should succeed - item was deleted"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;replacement()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;replacement()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -130,19 +130,19 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add a command with a known script"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Test&quot;, &quot;MyItem&quot;, &quot;dialog.alert(\&quot;Hello\&quot;)&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Test&quot;, &quot;MyItem&quot;, &quot;dialog.alert(\&quot;Hello\&quot;)&quot;)"/>
         <outline text="# Set target to the menubar and navigate to item"/>
         <outline text="# NOTE: This may require op.find() or similar to locate the item"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Get the script into a scratch location"/>
-        <outline text="local(ok = menu.getScript(@workspace.retrievedScript))"/>
+        <outline text="local(ok = menu.getScript(@system.temp.retrievedScript))"/>
         <outline text="# Verify the script was retrieved"/>
-        <outline text="local(result = defined(workspace.retrievedScript))"/>
+        <outline text="local(result = defined(system.temp.retrievedScript))"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.testMenu)"/>
-        <outline text="try {delete(@workspace.retrievedScript)}"/>
+        <outline text="delete(@system.temp.testMenu)"/>
+        <outline text="try {delete(@system.temp.retrievedScript)}"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -153,18 +153,18 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add initial command"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Test&quot;, &quot;MyItem&quot;, &quot;original()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Test&quot;, &quot;MyItem&quot;, &quot;original()&quot;)"/>
         <outline text="# Create a new script to set"/>
-        <outline text="workspace.newScript = &quot;replacement()&quot;"/>
+        <outline text="system.temp.newScript = &quot;replacement()&quot;"/>
         <outline text="# Set target and change the script"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Set the script from our stored value"/>
-        <outline text="local(ok = menu.setScript(@workspace.newScript))"/>
+        <outline text="local(ok = menu.setScript(@system.temp.newScript))"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.testMenu)"/>
-        <outline text="delete(@workspace.newScript)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
+        <outline text="delete(@system.temp.newScript)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -175,19 +175,19 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add a command"/>
         <outline text="local(originalScript = &quot;dialog.notify(\&quot;test\&quot;)&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, originalScript)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, originalScript)"/>
         <outline text="# Set target"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Get the script back"/>
-        <outline text="menu.getScript(@workspace.retrieved)"/>
+        <outline text="menu.getScript(@system.temp.retrieved)"/>
         <outline text="# Compare"/>
-        <outline text="local(match = (workspace.retrieved == originalScript))"/>
+        <outline text="local(match = (system.temp.retrieved == originalScript))"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.testMenu)"/>
-        <outline text="try {delete(@workspace.retrieved)}"/>
+        <outline text="delete(@system.temp.testMenu)"/>
+        <outline text="try {delete(@system.temp.retrieved)}"/>
         <outline text="return match"/>
       </outline>
     </outline>
@@ -198,14 +198,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add a command"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;file.save()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;file.save()&quot;)"/>
         <outline text="# Set target to the menubar"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Set command key to 'S'"/>
         <outline text="local(ok = menu.setCommandKey(&quot;S&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -216,16 +216,16 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add a command and set its shortcut"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;file.open()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;file.open()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="menu.setCommandKey(&quot;O&quot;)"/>
         <outline text="# Now retrieve it"/>
         <outline text="local(key = menu.getCommandKey())"/>
         <outline text="# Should contain &quot;O&quot; (exact format may vary: &quot;O&quot;, &quot;Cmd+O&quot;, &quot;Ctrl+O&quot;)"/>
         <outline text="local(hasKey = string.contains(key, &quot;O&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return hasKey"/>
       </outline>
     </outline>
@@ -236,17 +236,17 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add command with shortcut"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="menu.setCommandKey(&quot;T&quot;)"/>
         <outline text="# Now clear it"/>
         <outline text="menu.setCommandKey(&quot;&quot;)"/>
         <outline text="# Verify it's cleared"/>
         <outline text="local(key = menu.getCommandKey())"/>
         <outline text="local(cleared = (key == &quot;&quot;) or (sizeof(key) == 0))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return cleared"/>
       </outline>
     </outline>
@@ -257,16 +257,16 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Find&quot;, &quot;edit.find()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Find&quot;, &quot;edit.find()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Set key"/>
         <outline text="menu.setCommandKey(&quot;F&quot;)"/>
         <outline text="# Get key back"/>
         <outline text="local(key = menu.getCommandKey())"/>
         <outline text="# Should contain F"/>
         <outline text="local(match = string.contains(key, &quot;F&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return match"/>
       </outline>
     </outline>
@@ -277,10 +277,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Empty menu name - behavior may vary"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;&quot;, &quot;Item&quot;, &quot;script()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;&quot;, &quot;Item&quot;, &quot;script()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -291,10 +291,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Empty item name - may fail or create separator"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;&quot;, &quot;script()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;&quot;, &quot;script()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -305,10 +305,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Test with special characters"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save As...&quot;, &quot;file.saveAs()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save As...&quot;, &quot;file.saveAs()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -319,10 +319,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Dash often indicates separator in menus"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;-&quot;, &quot;&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;-&quot;, &quot;&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -333,10 +333,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="local(multilineScript = &quot;local(x = 1);\nlocal(y = 2);\nreturn(x + y)&quot;)"/>
-        <outline text="local(ok = menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Calculate&quot;, multilineScript))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.addMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Calculate&quot;, multilineScript))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -347,11 +347,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;test()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;test()&quot;)"/>
         <outline text="# buildMenuBar installs menus in OS - no-op in headless"/>
         <outline text="local(result = menu.buildMenuBar())"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -362,12 +362,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Custom&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Custom&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
         <outline text="# install() adds menu to OS menu bar - no-op in headless"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="local(result = menu.install())"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -378,10 +378,10 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# isInstalled checks if menu is in OS menu bar - always false headless"/>
-        <outline text="local(result = menu.isInstalled(@workspace.testMenu))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(result = menu.isInstalled(@system.temp.testMenu))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -392,24 +392,24 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Build File menu"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open...&quot;, &quot;fileOpen()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;fileSave()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save As...&quot;, &quot;fileSaveAs()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;-&quot;, &quot;&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Quit&quot;, &quot;fileQuit()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open...&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;fileSave()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save As...&quot;, &quot;fileSaveAs()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;-&quot;, &quot;&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Quit&quot;, &quot;fileQuit()&quot;)"/>
         <outline text="# Build Edit menu"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;-&quot;, &quot;&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;editCut()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;editCopy()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Paste&quot;, &quot;editPaste()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;-&quot;, &quot;&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;editCut()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;editCopy()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Paste&quot;, &quot;editPaste()&quot;)"/>
         <outline text="# Set some shortcuts"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Note: Would need to navigate to specific items to set shortcuts"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return true"/>
       </outline>
     </outline>
@@ -420,18 +420,18 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Initial items"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item1&quot;, &quot;script1()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item2&quot;, &quot;script2()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item3&quot;, &quot;script3()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Item1&quot;, &quot;script1()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Item2&quot;, &quot;script2()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Item3&quot;, &quot;script3()&quot;)"/>
         <outline text="# Delete middle item"/>
-        <outline text="menu.deleteMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item2&quot;)"/>
+        <outline text="menu.deleteMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Item2&quot;)"/>
         <outline text="# Add new item (should go at end)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item4&quot;, &quot;script4()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Item4&quot;, &quot;script4()&quot;)"/>
         <outline text="# Modify first item's script"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Tools&quot;, &quot;Item1&quot;, &quot;modifiedScript1()&quot;)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Tools&quot;, &quot;Item1&quot;, &quot;modifiedScript1()&quot;)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return true"/>
       </outline>
     </outline>
@@ -443,17 +443,17 @@
       </outline>
       <outline text="Script">
         <outline text="# Create the parent menubar"/>
-        <outline text="new(menubarType, @workspace.parentMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.parentMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.parentMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.parentMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
         <outline text="# Create the submenu menubar"/>
-        <outline text="new(menubarType, @workspace.subMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;File1.txt&quot;, &quot;openRecent(1)&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;File2.txt&quot;, &quot;openRecent(2)&quot;)"/>
+        <outline text="new(menubarType, @system.temp.subMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.subMenu, &quot;Recent&quot;, &quot;File1.txt&quot;, &quot;openRecent(1)&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.subMenu, &quot;Recent&quot;, &quot;File2.txt&quot;, &quot;openRecent(2)&quot;)"/>
         <outline text="# Add submenu to File menu"/>
-        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;File&quot;, @workspace.subMenu))"/>
+        <outline text="local(ok = menu.addSubMenu(@system.temp.parentMenu, &quot;File&quot;, @system.temp.subMenu))"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.parentMenu)"/>
-        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="delete(@system.temp.parentMenu)"/>
+        <outline text="delete(@system.temp.subMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -464,14 +464,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="new(menubarType, @system.temp.parentMenu)"/>
         <outline text="# Create submenu"/>
-        <outline text="new(menubarType, @workspace.subMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Tools&quot;, &quot;Calculator&quot;, &quot;calc()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.subMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.subMenu, &quot;Tools&quot;, &quot;Calculator&quot;, &quot;calc()&quot;)"/>
         <outline text="# Add as top-level (empty menuName)"/>
-        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;&quot;, @workspace.subMenu))"/>
-        <outline text="delete(@workspace.parentMenu)"/>
-        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="local(ok = menu.addSubMenu(@system.temp.parentMenu, &quot;&quot;, @system.temp.subMenu))"/>
+        <outline text="delete(@system.temp.parentMenu)"/>
+        <outline text="delete(@system.temp.subMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -482,14 +482,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="new(menubarType, @system.temp.parentMenu)"/>
         <outline text="# parentMenu is empty - no &quot;Custom&quot; menu exists yet"/>
-        <outline text="new(menubarType, @workspace.subMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Sub&quot;, &quot;Item&quot;, &quot;doIt()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.subMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.subMenu, &quot;Sub&quot;, &quot;Item&quot;, &quot;doIt()&quot;)"/>
         <outline text="# This should create &quot;Custom&quot; menu and add submenu to it"/>
-        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;Custom&quot;, @workspace.subMenu))"/>
-        <outline text="delete(@workspace.parentMenu)"/>
-        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="local(ok = menu.addSubMenu(@system.temp.parentMenu, &quot;Custom&quot;, @system.temp.subMenu))"/>
+        <outline text="delete(@system.temp.parentMenu)"/>
+        <outline text="delete(@system.temp.subMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -500,10 +500,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.parentMenu)"/>
+        <outline text="new(menubarType, @system.temp.parentMenu)"/>
         <outline text="# In headless mode, addSubMenu is a no-op that returns true"/>
-        <outline text="local(ok = menu.addSubMenu(@workspace.parentMenu, &quot;File&quot;, @workspace.doesNotExist))"/>
-        <outline text="delete(@workspace.parentMenu)"/>
+        <outline text="local(ok = menu.addSubMenu(@system.temp.parentMenu, &quot;File&quot;, @system.temp.doesNotExist))"/>
+        <outline text="delete(@system.temp.parentMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -514,14 +514,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add some menus"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Help&quot;, &quot;About&quot;, &quot;helpAbout()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Help&quot;, &quot;About&quot;, &quot;helpAbout()&quot;)"/>
         <outline text="# Delete the Edit menu"/>
-        <outline text="local(ok = menu.deleteSubMenu(@workspace.testMenu, &quot;Edit&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.deleteSubMenu(@system.temp.testMenu, &quot;Edit&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -532,11 +532,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
         <outline text="# Try to delete menu that doesn't exist"/>
-        <outline text="local(ok = menu.deleteSubMenu(@workspace.testMenu, &quot;NoSuchMenu&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.deleteSubMenu(@system.temp.testMenu, &quot;NoSuchMenu&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -547,11 +547,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;SingleItem&quot;, &quot;doIt()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;SingleItem&quot;, &quot;doIt()&quot;)"/>
         <outline text="# deleteSubMenu on a single item should still work"/>
-        <outline text="local(ok = menu.deleteSubMenu(@workspace.testMenu, &quot;SingleItem&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(ok = menu.deleteSubMenu(@system.temp.testMenu, &quot;SingleItem&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -562,9 +562,9 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="local(size = sizeOf(@workspace.testMenu))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="local(size = sizeOf(@system.temp.testMenu))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return size"/>
       </outline>
     </outline>
@@ -575,13 +575,13 @@
         <outline text="expected_result: 4"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Add File menu with 3 items (1 menu + 3 items = 4 headings)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;open()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;save()&quot;)"/>
-        <outline text="local(size = sizeOf(@workspace.testMenu))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;open()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;save()&quot;)"/>
+        <outline text="local(size = sizeOf(@system.temp.testMenu))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return size"/>
       </outline>
     </outline>
@@ -592,17 +592,17 @@
         <outline text="expected_result: 7"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# File menu: 1 + 2 items = 3"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;open()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;open()&quot;)"/>
         <outline text="# Edit menu: 1 + 3 items = 4"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;undo()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;cut()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;copy()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;undo()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Cut&quot;, &quot;cut()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Copy&quot;, &quot;copy()&quot;)"/>
         <outline text="# Total: 3 + 4 = 7"/>
-        <outline text="local(size = sizeOf(@workspace.testMenu))"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="local(size = sizeOf(@system.temp.testMenu))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return size"/>
       </outline>
     </outline>
@@ -613,20 +613,20 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.parentMenu)"/>
-        <outline text="new(menubarType, @workspace.subMenu)"/>
+        <outline text="new(menubarType, @system.temp.parentMenu)"/>
+        <outline text="new(menubarType, @system.temp.subMenu)"/>
         <outline text="# Parent has File with 1 item"/>
-        <outline text="menu.addMenuCommand(@workspace.parentMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.parentMenu, &quot;File&quot;, &quot;New&quot;, &quot;new()&quot;)"/>
         <outline text="# Submenu has 2 items"/>
-        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;Doc1&quot;, &quot;open1()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.subMenu, &quot;Recent&quot;, &quot;Doc2&quot;, &quot;open2()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.subMenu, &quot;Recent&quot;, &quot;Doc1&quot;, &quot;open1()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.subMenu, &quot;Recent&quot;, &quot;Doc2&quot;, &quot;open2()&quot;)"/>
         <outline text="# Add submenu to File"/>
-        <outline text="menu.addSubMenu(@workspace.parentMenu, &quot;File&quot;, @workspace.subMenu)"/>
+        <outline text="menu.addSubMenu(@system.temp.parentMenu, &quot;File&quot;, @system.temp.subMenu)"/>
         <outline text="# Expected count: File(1) + New(1) + Recent(1) + Doc1(1) + Doc2(1) = 5 minimum"/>
         <outline text="# May include additional structure nodes depending on representation"/>
-        <outline text="local(size = sizeOf(@workspace.parentMenu))"/>
-        <outline text="delete(@workspace.parentMenu)"/>
-        <outline text="delete(@workspace.subMenu)"/>
+        <outline text="local(size = sizeOf(@system.temp.parentMenu))"/>
+        <outline text="delete(@system.temp.parentMenu)"/>
+        <outline text="delete(@system.temp.subMenu)"/>
         <outline text="# Verify size is at least the expected minimum (5 headings)"/>
         <outline text="local(expectedMinimum = 5)"/>
         <outline text="return (size &gt;= expectedMinimum)"/>
@@ -639,24 +639,24 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# Build menu: File &gt; New, Open, Save"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;fileSave()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;fileSave()&quot;)"/>
         <outline text="# Set target to menubar"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Navigate: firstSummit (File), expand, go right (into items), down 1 (to Open)"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
         <outline text="op.go(down, 1)"/>
         <outline text="# Get script from &quot;Open&quot; item"/>
-        <outline text="menu.getScript(@workspace.retrievedScript)"/>
+        <outline text="menu.getScript(@system.temp.retrievedScript)"/>
         <outline text="# Verify we got the right script"/>
-        <outline text="local(match = (workspace.retrievedScript == &quot;fileOpen()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
-        <outline text="try {delete(@workspace.retrievedScript)}"/>
+        <outline text="local(match = (system.temp.retrievedScript == &quot;fileOpen()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
+        <outline text="try {delete(@system.temp.retrievedScript)}"/>
         <outline text="return match"/>
       </outline>
     </outline>
@@ -667,22 +667,22 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;originalScript()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;originalScript()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Navigate to File &gt; Test"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
         <outline text="# Create new script and set it"/>
-        <outline text="workspace.newScript = &quot;modifiedScript()&quot;"/>
-        <outline text="menu.setScript(@workspace.newScript)"/>
+        <outline text="system.temp.newScript = &quot;modifiedScript()&quot;"/>
+        <outline text="menu.setScript(@system.temp.newScript)"/>
         <outline text="# Get it back to verify"/>
-        <outline text="menu.getScript(@workspace.verifyScript)"/>
-        <outline text="local(match = (workspace.verifyScript == &quot;modifiedScript()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
-        <outline text="delete(@workspace.newScript)"/>
-        <outline text="try {delete(@workspace.verifyScript)}"/>
+        <outline text="menu.getScript(@system.temp.verifyScript)"/>
+        <outline text="local(match = (system.temp.verifyScript == &quot;modifiedScript()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
+        <outline text="delete(@system.temp.newScript)"/>
+        <outline text="try {delete(@system.temp.verifyScript)}"/>
         <outline text="return match"/>
       </outline>
     </outline>
@@ -693,22 +693,22 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
         <outline text="# File menu with 4 items"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;script1()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;script2()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;script3()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Close&quot;, &quot;script4()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;script1()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;script2()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Save&quot;, &quot;script3()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Close&quot;, &quot;script4()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="# Navigate to Save (3rd item)"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
         <outline text="op.go(down, 2)"/>
-        <outline text="menu.getScript(@workspace.retrieved)"/>
-        <outline text="local(match = (workspace.retrieved == &quot;script3()&quot;))"/>
-        <outline text="delete(@workspace.testMenu)"/>
-        <outline text="try {delete(@workspace.retrieved)}"/>
+        <outline text="menu.getScript(@system.temp.retrieved)"/>
+        <outline text="local(match = (system.temp.retrieved == &quot;script3()&quot;))"/>
+        <outline text="delete(@system.temp.testMenu)"/>
+        <outline text="try {delete(@system.temp.retrieved)}"/>
         <outline text="return match"/>
       </outline>
     </outline>
@@ -719,15 +719,15 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;script()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;script()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
         <outline text="# zoomScript opens editor window - noop in headless"/>
         <outline text="local(result = menu.zoomScript())"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -739,29 +739,29 @@
       </outline>
       <outline text="Script">
         <outline text="# Create menubar with structure"/>
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;fileNew()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Edit&quot;, &quot;Undo&quot;, &quot;editUndo()&quot;)"/>
         <outline text="# Remember size before save"/>
-        <outline text="local(sizeBefore = sizeOf(@workspace.testMenu))"/>
+        <outline text="local(sizeBefore = sizeOf(@system.temp.testMenu))"/>
         <outline text="# Save to a file"/>
         <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/menu_persist_test.root7&quot;)"/>
         <outline text="file.new(testPath, 'TABL')"/>
         <outline text="local(fref = file.open(testPath, true))"/>
-        <outline text="db.save(@workspace.testMenu, fref)"/>
+        <outline text="db.save(@system.temp.testMenu, fref)"/>
         <outline text="file.close(fref)"/>
         <outline text="# Delete from memory"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="# Reload"/>
         <outline text="fref = file.open(testPath, false)"/>
-        <outline text="db.load(fref, @workspace.reloadedMenu)"/>
+        <outline text="db.load(fref, @system.temp.reloadedMenu)"/>
         <outline text="file.close(fref)"/>
         <outline text="# Verify size matches"/>
-        <outline text="local(sizeAfter = sizeOf(@workspace.reloadedMenu))"/>
+        <outline text="local(sizeAfter = sizeOf(@system.temp.reloadedMenu))"/>
         <outline text="local(sizeMatch = (sizeBefore == sizeAfter))"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.reloadedMenu)"/>
+        <outline text="delete(@system.temp.reloadedMenu)"/>
         <outline text="file.delete(testPath)"/>
         <outline text="return sizeMatch"/>
       </outline>
@@ -775,30 +775,30 @@
       <outline text="Script">
         <outline text="local(testScript = &quot;dialog.alert(\&quot;Hello World!\&quot;)&quot;)"/>
         <outline text="# Create menubar with script"/>
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Test&quot;, &quot;Item&quot;, testScript)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Test&quot;, &quot;Item&quot;, testScript)"/>
         <outline text="# Save"/>
         <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/menu_script_persist.root7&quot;)"/>
         <outline text="file.new(testPath, 'TABL')"/>
         <outline text="local(fref = file.open(testPath, true))"/>
-        <outline text="db.save(@workspace.testMenu, fref)"/>
+        <outline text="db.save(@system.temp.testMenu, fref)"/>
         <outline text="file.close(fref)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="# Reload"/>
         <outline text="fref = file.open(testPath, false)"/>
-        <outline text="db.load(fref, @workspace.reloadedMenu)"/>
+        <outline text="db.load(fref, @system.temp.reloadedMenu)"/>
         <outline text="file.close(fref)"/>
         <outline text="# Navigate to item and get script"/>
-        <outline text="target.set(@workspace.reloadedMenu)"/>
+        <outline text="target.set(@system.temp.reloadedMenu)"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
-        <outline text="menu.getScript(@workspace.retrievedScript)"/>
+        <outline text="menu.getScript(@system.temp.retrievedScript)"/>
         <outline text="# Compare"/>
-        <outline text="local(match = (workspace.retrievedScript == testScript))"/>
+        <outline text="local(match = (system.temp.retrievedScript == testScript))"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.reloadedMenu)"/>
-        <outline text="try {delete(@workspace.retrievedScript)}"/>
+        <outline text="delete(@system.temp.reloadedMenu)"/>
+        <outline text="try {delete(@system.temp.retrievedScript)}"/>
         <outline text="file.delete(testPath)"/>
         <outline text="return match"/>
       </outline>
@@ -810,28 +810,28 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;CustomMenu&quot;, &quot;CustomItem&quot;, &quot;script()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;CustomMenu&quot;, &quot;CustomItem&quot;, &quot;script()&quot;)"/>
         <outline text="# Save"/>
         <outline text="local(testPath = &quot;{FRONTIER_TEST_TMP_DIR}/menu_names_persist.root7&quot;)"/>
         <outline text="file.new(testPath, 'TABL')"/>
         <outline text="local(fref = file.open(testPath, true))"/>
-        <outline text="db.save(@workspace.testMenu, fref)"/>
+        <outline text="db.save(@system.temp.testMenu, fref)"/>
         <outline text="file.close(fref)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="# Reload"/>
         <outline text="fref = file.open(testPath, false)"/>
-        <outline text="db.load(fref, @workspace.reloadedMenu)"/>
+        <outline text="db.load(fref, @system.temp.reloadedMenu)"/>
         <outline text="file.close(fref)"/>
         <outline text="# Navigate and get the headline text to verify name"/>
-        <outline text="target.set(@workspace.reloadedMenu)"/>
+        <outline text="target.set(@system.temp.reloadedMenu)"/>
         <outline text="op.firstSummit()"/>
         <outline text="local(menuName = op.getLineText())"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
         <outline text="local(itemName = op.getLineText())"/>
         <outline text="# Clean up"/>
-        <outline text="delete(@workspace.reloadedMenu)"/>
+        <outline text="delete(@system.temp.reloadedMenu)"/>
         <outline text="file.delete(testPath)"/>
         <outline text="return (menuName == &quot;CustomMenu&quot;) and (itemName == &quot;CustomItem&quot;)"/>
       </outline>
@@ -843,12 +843,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;test()&quot;)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;New&quot;, &quot;test()&quot;)"/>
         <outline text="# Should return true (no-op), NOT throw an error"/>
         <outline text="local(result = menu.buildMenuBar())"/>
         <outline text="local(noError = true);  # If we got here, no error was thrown"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return (result == true) and noError"/>
       </outline>
     </outline>
@@ -859,12 +859,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;Custom&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;Custom&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="local(result = menu.install())"/>
         <outline text="local(noError = true)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return (result == true) and noError"/>
       </outline>
     </outline>
@@ -875,11 +875,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="local(result = menu.isInstalled())"/>
         <outline text="local(noError = true)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return (result == false) and noError"/>
       </outline>
     </outline>
@@ -890,12 +890,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Test&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="local(result = menu.remove())"/>
         <outline text="local(noError = true)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return (result == true) and noError"/>
       </outline>
     </outline>
@@ -924,12 +924,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.testMenu)"/>
-        <outline text="menu.addMenuCommand(@workspace.testMenu, &quot;File&quot;, &quot;Toggle&quot;, &quot;test()&quot;)"/>
-        <outline text="target.set(@workspace.testMenu)"/>
+        <outline text="new(menubarType, @system.temp.testMenu)"/>
+        <outline text="menu.addMenuCommand(@system.temp.testMenu, &quot;File&quot;, &quot;Toggle&quot;, &quot;test()&quot;)"/>
+        <outline text="target.set(@system.temp.testMenu)"/>
         <outline text="local(result = menu.toggle())"/>
         <outline text="local(noError = true)"/>
-        <outline text="delete(@workspace.testMenu)"/>
+        <outline text="delete(@system.temp.testMenu)"/>
         <outline text="return (result == false) and noError"/>
       </outline>
     </outline>

--- a/reports/integration_tests/menu_value_copy.opml
+++ b/reports/integration_tests/menu_value_copy.opml
@@ -2,21 +2,21 @@
 <opml version="2.0">
   <head>
     <title>Menu Value Copy (menu_value_copy) - 5 tests: 4 pass (80%) 1 skip (20%)</title>
-    <dateCreated>Fri, 06 Feb 2026 06:03:28 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
-    <outline text="mbar copy - copy menubar value to new location - Create a menubar at workspace.src, copy to workspace.dst, verify typeof is mbar">
+    <outline text="mbar copy - copy menubar value to new location - Create a menubar at system.temp.src, copy to system.temp.dst, verify typeof is mbar">
       <outline text="Metadata">
         <outline text="skip: False"/>
         <outline text="skip_reason: "/>
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.src)"/>
-        <outline text="workspace.dst = workspace.src"/>
-        <outline text="local (result = typeof(workspace.dst) == 'mbar')"/>
-        <outline text="delete(@workspace.src)"/>
-        <outline text="delete(@workspace.dst)"/>
+        <outline text="new(menubarType, @system.temp.src)"/>
+        <outline text="system.temp.dst = system.temp.src"/>
+        <outline text="local (result = typeof(system.temp.dst) == 'mbar')"/>
+        <outline text="delete(@system.temp.src)"/>
+        <outline text="delete(@system.temp.dst)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -27,11 +27,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.src)"/>
-        <outline text="workspace.dst = workspace.src"/>
-        <outline text="local (result = defined(@workspace.dst))"/>
-        <outline text="delete(@workspace.src)"/>
-        <outline text="delete(@workspace.dst)"/>
+        <outline text="new(menubarType, @system.temp.src)"/>
+        <outline text="system.temp.dst = system.temp.src"/>
+        <outline text="local (result = defined(@system.temp.dst))"/>
+        <outline text="delete(@system.temp.src)"/>
+        <outline text="delete(@system.temp.dst)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -42,18 +42,18 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(menubarType, @workspace.src)"/>
-        <outline text="menu.addMenuCommand(@workspace.src, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
-        <outline text="workspace.dst = workspace.src"/>
-        <outline text="target.set(@workspace.dst)"/>
+        <outline text="new(menubarType, @system.temp.src)"/>
+        <outline text="menu.addMenuCommand(@system.temp.src, &quot;File&quot;, &quot;Open&quot;, &quot;fileOpen()&quot;)"/>
+        <outline text="system.temp.dst = system.temp.src"/>
+        <outline text="target.set(@system.temp.dst)"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.expand()"/>
         <outline text="op.go(right, 1)"/>
-        <outline text="menu.getScript(@workspace.retrieved)"/>
-        <outline text="local (result = (workspace.retrieved == &quot;fileOpen()&quot;))"/>
-        <outline text="delete(@workspace.src)"/>
-        <outline text="delete(@workspace.dst)"/>
-        <outline text="try {delete(@workspace.retrieved)}"/>
+        <outline text="menu.getScript(@system.temp.retrieved)"/>
+        <outline text="local (result = (system.temp.retrieved == &quot;fileOpen()&quot;))"/>
+        <outline text="delete(@system.temp.src)"/>
+        <outline text="delete(@system.temp.dst)"/>
+        <outline text="try {delete(@system.temp.retrieved)}"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -74,9 +74,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="workspace.testCopy = userland.virginBookmarkMenu"/>
-        <outline text="local (result = typeof(workspace.testCopy) == 'mbar')"/>
-        <outline text="delete(@workspace.testCopy)"/>
+        <outline text="system.temp.testCopy = userland.virginBookmarkMenu"/>
+        <outline text="local (result = typeof(system.temp.testCopy) == 'mbar')"/>
+        <outline text="delete(@system.temp.testCopy)"/>
         <outline text="return result"/>
       </outline>
     </outline>

--- a/reports/integration_tests/migration_externals.opml
+++ b/reports/integration_tests/migration_externals.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Migration Externals (migration_externals) - 19 tests: 16 pass (84%) 3 skip (15%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="Deep script execution - system.verbs.globals.string - The string verb should work after migration">
@@ -177,8 +177,8 @@
         </outline>
         <outline text="} else">
           <outline text="// Create a test menu if none exist"/>
-          <outline text="lang.new(menuType, @workspace.testMenu)"/>
-          <outline text="if typeOf(workspace.testMenu) == 'menu'">
+          <outline text="lang.new(menuType, @system.temp.testMenu)"/>
+          <outline text="if typeOf(system.temp.testMenu) == 'menu'">
             <outline text="return &quot;created test menu&quot;"/>
           </outline>
           <outline text="return &quot;no menus found&quot;"/>

--- a/reports/integration_tests/op_outlinetoxml_headless.opml
+++ b/reports/integration_tests/op_outlinetoxml_headless.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Op Outlinetoxml Headless (op_outlinetoxml_headless) - 15 tests: 15 pass (100%)</title>
-    <dateCreated>Fri, 06 Feb 2026 06:03:28 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="op.outlineToXml - empty outline returns valid OPML - Convert empty outline to OPML (previously caused stack overflow)">
@@ -10,8 +10,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.emptyOutline)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.emptyOutline)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.mid(xml, 1, 5) == &quot;&lt;?xml&quot;"/>
       </outline>
     </outline>
@@ -20,8 +20,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.emptyOutline)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.emptyOutline)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;&lt;opml&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -30,8 +30,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.emptyOutline)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.emptyOutline)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;&lt;head&gt;&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -40,8 +40,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.emptyOutline)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.emptyOutline)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.emptyOutline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;&lt;body&gt;&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -50,10 +50,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.singleLine)"/>
-        <outline text="target.set(@workspace.singleLine)"/>
+        <outline text="lang.new(outlineType, @system.temp.singleLine)"/>
+        <outline text="target.set(@system.temp.singleLine)"/>
         <outline text="op.setLineText(&quot;Hello World&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.singleLine, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.singleLine, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;Hello World&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -62,10 +62,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.singleLine)"/>
-        <outline text="target.set(@workspace.singleLine)"/>
+        <outline text="lang.new(outlineType, @system.temp.singleLine)"/>
+        <outline text="target.set(@system.temp.singleLine)"/>
         <outline text="op.setLineText(&quot;Test Line&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.singleLine, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.singleLine, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;&lt;outline text=&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -74,12 +74,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.multiLine)"/>
-        <outline text="target.set(@workspace.multiLine)"/>
+        <outline text="lang.new(outlineType, @system.temp.multiLine)"/>
+        <outline text="target.set(@system.temp.multiLine)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.multiLine, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.multiLine, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="local(has1 = string.patternMatch(&quot;Line 1&quot;, xml) &gt; 0)"/>
         <outline text="local(has2 = string.patternMatch(&quot;Line 2&quot;, xml) &gt; 0)"/>
         <outline text="local(has3 = string.patternMatch(&quot;Line 3&quot;, xml) &gt; 0)"/>
@@ -91,12 +91,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.nested)"/>
-        <outline text="target.set(@workspace.nested)"/>
+        <outline text="lang.new(outlineType, @system.temp.nested)"/>
+        <outline text="target.set(@system.temp.nested)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.nested, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.nested, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="local(hasParent = string.patternMatch(&quot;Parent&quot;, xml) &gt; 0)"/>
         <outline text="local(hasChild1 = string.patternMatch(&quot;Child 1&quot;, xml) &gt; 0)"/>
         <outline text="local(hasChild2 = string.patternMatch(&quot;Child 2&quot;, xml) &gt; 0)"/>
@@ -108,10 +108,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setLineText(&quot;Content&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.outline, &quot;John Doe&quot;, &quot;john@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.outline, &quot;John Doe&quot;, &quot;john@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;John Doe&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -120,10 +120,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setLineText(&quot;Content&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.outline, &quot;John Doe&quot;, &quot;john@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.outline, &quot;John Doe&quot;, &quot;john@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;john@example.com&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -132,10 +132,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setLineText(&quot;Test&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.outline, &quot;User&quot;, &quot;user@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.outline, &quot;User&quot;, &quot;user@example.com&quot;))"/>
         <outline text="local(hasOpml = string.patternMatch(&quot;&lt;opml&quot;, xml) &gt; 0)"/>
         <outline text="local(hasHead = string.patternMatch(&quot;&lt;head&gt;&quot;, xml) &gt; 0)"/>
         <outline text="local(hasBody = string.patternMatch(&quot;&lt;body&gt;&quot;, xml) &gt; 0)"/>
@@ -148,10 +148,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setLineText(&quot;Test&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.outline, &quot;User&quot;, &quot;user@example.com&quot;))"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.outline, &quot;User&quot;, &quot;user@example.com&quot;))"/>
         <outline text="return string.mid(xml, 1, 5) == &quot;&lt;?xml&quot;"/>
       </outline>
     </outline>
@@ -160,13 +160,13 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.rtSrc)"/>
-        <outline text="target.set(@workspace.rtSrc)"/>
+        <outline text="lang.new(outlineType, @system.temp.rtSrc)"/>
+        <outline text="target.set(@system.temp.rtSrc)"/>
         <outline text="op.setLineText(&quot;RoundTripTest&quot;)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.rtSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
-        <outline text="lang.new(outlineType, @workspace.rtDst)"/>
-        <outline text="op.xmlToOutline(xml, @workspace.rtDst)"/>
-        <outline text="target.set(@workspace.rtDst)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.rtSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.rtDst)"/>
+        <outline text="op.xmlToOutline(xml, @system.temp.rtDst)"/>
+        <outline text="target.set(@system.temp.rtDst)"/>
         <outline text="op.firstSummit()"/>
         <outline text="return op.getLineText() == &quot;RoundTripTest&quot;"/>
       </outline>
@@ -176,14 +176,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.rtMultiSrc)"/>
-        <outline text="target.set(@workspace.rtMultiSrc)"/>
+        <outline text="lang.new(outlineType, @system.temp.rtMultiSrc)"/>
+        <outline text="target.set(@system.temp.rtMultiSrc)"/>
         <outline text="op.setLineText(&quot;First&quot;)"/>
         <outline text="op.insert(&quot;Second&quot;, down)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.rtMultiSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
-        <outline text="lang.new(outlineType, @workspace.rtMultiDst)"/>
-        <outline text="op.xmlToOutline(xml, @workspace.rtMultiDst)"/>
-        <outline text="target.set(@workspace.rtMultiDst)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.rtMultiSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.rtMultiDst)"/>
+        <outline text="op.xmlToOutline(xml, @system.temp.rtMultiDst)"/>
+        <outline text="target.set(@system.temp.rtMultiDst)"/>
         <outline text="op.firstSummit()"/>
         <outline text="local(hasFirst = op.getLineText() == &quot;First&quot;)"/>
         <outline text="op.go(right, 1)"/>
@@ -196,14 +196,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.rtNestedSrc)"/>
-        <outline text="target.set(@workspace.rtNestedSrc)"/>
+        <outline text="lang.new(outlineType, @system.temp.rtNestedSrc)"/>
+        <outline text="target.set(@system.temp.rtNestedSrc)"/>
         <outline text="op.setLineText(&quot;Parent&quot;)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
-        <outline text="local(xml = op.outlineToXml(@workspace.rtNestedSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
-        <outline text="lang.new(outlineType, @workspace.rtNestedDst)"/>
-        <outline text="op.xmlToOutline(xml, @workspace.rtNestedDst)"/>
-        <outline text="target.set(@workspace.rtNestedDst)"/>
+        <outline text="local(xml = op.outlineToXml(@system.temp.rtNestedSrc, &quot;User&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.rtNestedDst)"/>
+        <outline text="op.xmlToOutline(xml, @system.temp.rtNestedDst)"/>
+        <outline text="target.set(@system.temp.rtNestedDst)"/>
         <outline text="op.firstSummit()"/>
         <outline text="local(hasChild = op.go(right, 1))"/>
         <outline text="return hasChild"/>

--- a/reports/integration_tests/op_verbs.opml
+++ b/reports/integration_tests/op_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Op Verbs (op_verbs) - 266 tests: 254 pass (95%) 12 skip (4%)</title>
-    <dateCreated>Tue, 10 Feb 2026 05:47:11 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="outline creation - lang.new with outlineType - Create new outline object using lang.new(outlineType, @addr)">
@@ -10,17 +10,17 @@
         <outline text="expected_result: optx"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.testOutline)"/>
-        <outline text="return typeof(workspace.testOutline)"/>
+        <outline text="lang.new(outlineType, @system.temp.testOutline)"/>
+        <outline text="return typeof(system.temp.testOutline)"/>
       </outline>
     </outline>
     <outline text="outline target setup - set outline as target - Set outline as target for op verb operations">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.myOutline"/>
+        <outline text="expected_result: system.temp.myOutline"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.myOutline)"/>
-        <outline text="target.set(@workspace.myOutline)"/>
+        <outline text="lang.new(outlineType, @system.temp.myOutline)"/>
+        <outline text="target.set(@system.temp.myOutline)"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
@@ -29,10 +29,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.opTest)"/>
-        <outline text="target.set(@workspace.opTest)"/>
-        <outline text="local(ok1 = typeof(workspace.opTest) == &quot;optx&quot;)"/>
-        <outline text="local(ok2 = string(target.get()) == &quot;workspace.opTest&quot;)"/>
+        <outline text="lang.new(outlineType, @system.temp.opTest)"/>
+        <outline text="target.set(@system.temp.opTest)"/>
+        <outline text="local(ok1 = typeof(system.temp.opTest) == &quot;optx&quot;)"/>
+        <outline text="local(ok2 = string(target.get()) == &quot;system.temp.opTest&quot;)"/>
         <outline text="return ok1 and ok2"/>
       </outline>
     </outline>
@@ -41,8 +41,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return op.insert(&quot;First line&quot;, down)"/>
       </outline>
     </outline>
@@ -51,8 +51,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="return op.insert(&quot;Line 2&quot;, down)"/>
       </outline>
@@ -62,8 +62,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="return op.insert(&quot;Child&quot;, right)"/>
       </outline>
@@ -73,8 +73,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="return op.insert(&quot;Line 1&quot;, up)"/>
       </outline>
@@ -84,8 +84,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="return op.insert(&quot;Grandchild&quot;, right)"/>
@@ -96,8 +96,8 @@
         <outline text="expected_result: Inserted between 1 and 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -111,8 +111,8 @@
         <outline text="expected_result: Test content"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test content&quot;, down)"/>
         <outline text="return op.getLineText()"/>
       </outline>
@@ -122,8 +122,8 @@
         <outline text="expected_result: TEXT"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Hello&quot;, down)"/>
         <outline text="return typeof(op.getLineText())"/>
       </outline>
@@ -133,8 +133,8 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;&quot;, down)"/>
         <outline text="return sizeOf(op.getLineText())"/>
       </outline>
@@ -144,8 +144,8 @@
         <outline text="expected_result: Line 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.go(up, 1)"/>
@@ -158,8 +158,8 @@
         <outline text="expected_result: Line 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.go(up, 1)"/>
@@ -171,8 +171,8 @@
         <outline text="expected_result: Child"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -185,8 +185,8 @@
         <outline text="expected_result: Parent"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -198,8 +198,8 @@
         <outline text="expected_result: Line 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -212,8 +212,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="return op.go(up, 1)"/>
@@ -224,8 +224,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Only line&quot;, down)"/>
         <outline text="op.go(up, 1)"/>
         <outline text="return op.go(up, 1)"/>
@@ -236,8 +236,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="return op.go(flatup, 1)"/>
@@ -248,8 +248,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.go(up, 1)"/>
@@ -261,8 +261,8 @@
         <outline text="expected_result: First"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First&quot;, down)"/>
         <outline text="op.insert(&quot;Second&quot;, down)"/>
         <outline text="op.insert(&quot;Third&quot;, down)"/>
@@ -276,8 +276,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.firstSummit()"/>
       </outline>
@@ -287,8 +287,8 @@
         <outline text="expected_result: 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Top level&quot;, down)"/>
         <outline text="return op.level()"/>
       </outline>
@@ -298,8 +298,8 @@
         <outline text="expected_result: 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="return op.level()"/>
@@ -310,8 +310,8 @@
         <outline text="expected_result: 3"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
@@ -323,8 +323,8 @@
         <outline text="expected_result: 3"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -338,8 +338,8 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Leaf node&quot;, down)"/>
         <outline text="return op.countSubs(1)"/>
       </outline>
@@ -349,8 +349,8 @@
         <outline text="expected_result: 3"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Root&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
@@ -365,8 +365,8 @@
         <outline text="expected_result: 4"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Summit 1&quot;, down)"/>
         <outline text="op.insert(&quot;Summit 2&quot;, down)"/>
         <outline text="op.insert(&quot;Summit 3&quot;, down)"/>
@@ -378,8 +378,8 @@
         <outline text="expected_result: 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return op.countSummits()"/>
       </outline>
     </outline>
@@ -388,8 +388,8 @@
         <outline text="expected_result: 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Summit&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
@@ -401,8 +401,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -415,8 +415,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -429,8 +429,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Leaf Node&quot;, down)"/>
         <outline text="return op.subsExpanded()"/>
       </outline>
@@ -440,8 +440,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return op.subsExpanded()"/>
       </outline>
     </outline>
@@ -450,8 +450,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -464,8 +464,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Root&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
@@ -479,8 +479,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -493,8 +493,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Node&quot;, down)"/>
         <outline text="return op.collapse()"/>
       </outline>
@@ -504,8 +504,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -538,8 +538,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="/* Cursor is on Child after inserting it */"/>
@@ -553,8 +553,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Top&quot;, down)"/>
         <outline text="return op.promote()"/>
       </outline>
@@ -564,8 +564,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Sibling 1&quot;, down)"/>
         <outline text="op.insert(&quot;Sibling 2&quot;, down)"/>
@@ -596,8 +596,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="/* Cursor is on Line 2 */"/>
@@ -611,8 +611,8 @@
         <outline text="expected_result: Keep me"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Delete me&quot;, down)"/>
         <outline text="op.insert(&quot;Keep me&quot;, down)"/>
         <outline text="op.go(up, 1)"/>
@@ -625,8 +625,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.deleteLine()"/>
       </outline>
@@ -636,8 +636,8 @@
         <outline text="expected_result: 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Only node&quot;, down)"/>
         <outline text="op.deleteLine()"/>
         <outline text="return op.countSummits()"/>
@@ -648,8 +648,8 @@
         <outline text="expected_result: Modified text"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Original text&quot;, down)"/>
         <outline text="op.setLineText(&quot;Modified text&quot;)"/>
         <outline text="return op.getLineText()"/>
@@ -660,8 +660,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Text&quot;, down)"/>
         <outline text="return op.setLineText(&quot;New text&quot;)"/>
       </outline>
@@ -671,8 +671,8 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Something&quot;, down)"/>
         <outline text="op.setLineText(&quot;&quot;)"/>
         <outline text="return sizeOf(op.getLineText())"/>
@@ -683,8 +683,8 @@
         <outline text="expected_result: Special: &quot;quotes&quot; &amp; &lt;tags&gt;"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="op.setLineText(&quot;Special: \&quot;quotes\&quot; &amp; &lt;tags&gt;&quot;)"/>
         <outline text="return op.getLineText()"/>
@@ -696,8 +696,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="op.setLineText()"/>
       </outline>
@@ -707,8 +707,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -724,8 +724,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -742,8 +742,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -755,8 +755,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Leaf node&quot;, down)"/>
         <outline text="local(ok = op.deleteSubs())"/>
         <outline text="return ok and (op.countSubs(1) == 0)"/>
@@ -767,8 +767,8 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Root&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Grandchild 1&quot;, right)"/>
@@ -785,8 +785,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -798,8 +798,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="local(before = op.level())"/>
@@ -813,8 +813,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(before = op.level())"/>
@@ -828,8 +828,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Level 1&quot;, down)"/>
         <outline text="op.insert(&quot;Level 2&quot;, right)"/>
         <outline text="op.insert(&quot;Level 3&quot;, right)"/>
@@ -844,8 +844,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -861,8 +861,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="return op.reorg(left, 1)"/>
@@ -874,8 +874,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="op.reorg()"/>
       </outline>
@@ -886,8 +886,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="op.reorg(3)"/>
       </outline>
@@ -897,8 +897,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;lowercase text&quot;, down)"/>
         <outline text="op.insert(&quot;UPPERCASE TEXT&quot;, down)"/>
         <outline text="op.firstSummit()"/>
@@ -911,8 +911,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -925,8 +925,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="return op.find(&quot;Nonexistent&quot;, false, false)"/>
@@ -938,8 +938,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="op.find()"/>
       </outline>
@@ -949,8 +949,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="local(found = op.find(&quot;test&quot;))"/>
         <outline text="return found and (op.getLineText() == &quot;Test&quot;)"/>
@@ -961,8 +961,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
         <outline text="local(found = op.find(&quot;test&quot;, false))"/>
         <outline text="return found and (op.getLineText() == &quot;Test&quot;)"/>
@@ -1018,8 +1018,8 @@
         <outline text="expected_result: TEXT"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Text&quot;, down)"/>
         <outline text="return typeof(op.getLineText())"/>
       </outline>
@@ -1038,8 +1038,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.level())"/>
       </outline>
@@ -1067,8 +1067,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.collapse())"/>
       </outline>
@@ -1078,8 +1078,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="return typeof(op.promote())"/>
@@ -1090,8 +1090,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="return typeof(op.demote())"/>
@@ -1133,8 +1133,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.notOutline)"/>
-        <outline text="target.set(@workspace.notOutline)"/>
+        <outline text="lang.new(tableType, @system.temp.notOutline)"/>
+        <outline text="target.set(@system.temp.notOutline)"/>
         <outline text="op.insert(&quot;Test&quot;, down)"/>
       </outline>
     </outline>
@@ -1144,8 +1144,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.table)"/>
-        <outline text="target.set(@workspace.table)"/>
+        <outline text="lang.new(tableType, @system.temp.table)"/>
+        <outline text="target.set(@system.temp.table)"/>
         <outline text="op.getLineText()"/>
       </outline>
     </outline>
@@ -1154,8 +1154,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Chapter 1&quot;, down)"/>
         <outline text="op.insert(&quot;Section 1.1&quot;, right)"/>
         <outline text="op.insert(&quot;Section 1.2&quot;, down)"/>
@@ -1173,8 +1173,8 @@
         <outline text="expected_result: Modified Line 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -1188,8 +1188,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down);         // Level 1 (empty summit + parent = 2 levels)"/>
         <outline text="op.insert(&quot;Child1&quot;, right);        // Level 2, child of Parent"/>
         <outline text="op.insert(&quot;Child2&quot;, down);         // Level 2, sibling of Child1"/>
@@ -1209,8 +1209,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;L1-Sibling1&quot;, down);     // Level 1"/>
         <outline text="op.insert(&quot;L1-Sibling2&quot;, down);     // Level 1, following sibling"/>
         <outline text="op.insert(&quot;L1-Sibling3&quot;, down);     // Level 1, following sibling"/>
@@ -1228,8 +1228,8 @@
         <outline text="expected_result: 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Root&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -1244,8 +1244,8 @@
         <outline text="expected_result: 21"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 20">
           <outline text="op.insert(&quot;Line &quot; + i, down)"/>
@@ -1258,8 +1258,8 @@
         <outline text="expected_result: 10"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(i)"/>
         <outline text="op.insert(&quot;Level 1&quot;, down)"/>
         <outline text="for i = 2 to 10">
@@ -1273,8 +1273,8 @@
         <outline text="expected_result: 6"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 10">
           <outline text="op.insert(&quot;Temp &quot; + i, down)"/>
@@ -1290,8 +1290,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="return typeof(op.getCursor())"/>
       </outline>
@@ -1301,8 +1301,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First line&quot;, down)"/>
         <outline text="local(cursor = op.getCursor())"/>
         <outline text="return defined(cursor)"/>
@@ -1313,8 +1313,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(cursor1 = op.getCursor())"/>
@@ -1328,8 +1328,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.insert(&quot;Grandchild&quot;, right)"/>
@@ -1342,8 +1342,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.getCursor())"/>
       </outline>
@@ -1354,8 +1354,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.getCursor(&quot;extra&quot;)"/>
       </outline>
@@ -1365,8 +1365,8 @@
         <outline text="expected_result: Line 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -1383,8 +1383,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(cursor = op.getCursor())"/>
@@ -1397,8 +1397,8 @@
         <outline text="expected_result: Other line"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Target line&quot;, down)"/>
         <outline text="op.insert(&quot;Other line&quot;, down)"/>
         <outline text="local(targetCursor = op.getCursor())"/>
@@ -1412,8 +1412,8 @@
         <outline text="expected_result: Child 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="local(child1Cursor = op.getCursor())"/>
@@ -1429,8 +1429,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setCursor()"/>
       </outline>
@@ -1441,8 +1441,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setCursor(&quot;not an address&quot;)"/>
       </outline>
@@ -1454,12 +1454,12 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline1)"/>
-        <outline text="lang.new(outlineType, @workspace.outline2)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline2)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="local(cursor1 = op.getCursor())"/>
-        <outline text="target.set(@workspace.outline2)"/>
+        <outline text="target.set(@system.temp.outline2)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.setCursor(cursor1)"/>
       </outline>
@@ -1469,8 +1469,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return typeof(op.getDisplay())"/>
       </outline>
     </outline>
@@ -1479,8 +1479,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return op.getDisplay()"/>
       </outline>
     </outline>
@@ -1489,8 +1489,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return typeof(op.getDisplay())"/>
       </outline>
     </outline>
@@ -1500,8 +1500,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.getDisplay(&quot;extra&quot;)"/>
       </outline>
     </outline>
@@ -1510,8 +1510,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="return op.getDisplay()"/>
       </outline>
@@ -1521,8 +1521,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="op.setDisplay(true)"/>
         <outline text="return op.getDisplay()"/>
@@ -1533,8 +1533,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="return op.setDisplay(false)"/>
       </outline>
     </outline>
@@ -1543,8 +1543,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="local(state1 = op.getDisplay())"/>
         <outline text="op.setDisplay(true)"/>
@@ -1557,8 +1557,8 @@
         <outline text="expected_result: 11"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 10">
@@ -1574,8 +1574,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay()"/>
       </outline>
     </outline>
@@ -1586,8 +1586,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(&quot;true&quot;)"/>
       </outline>
     </outline>
@@ -1596,8 +1596,8 @@
         <outline text="expected_result: list"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -1609,8 +1609,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -1623,8 +1623,8 @@
         <outline text="expected_result: list"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.getExpansionState())"/>
       </outline>
@@ -1635,8 +1635,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.getExpansionState(&quot;extra&quot;)"/>
       </outline>
@@ -1647,8 +1647,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -1670,8 +1670,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -1684,8 +1684,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -1702,8 +1702,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Level 1&quot;, down)"/>
         <outline text="op.insert(&quot;Level 2&quot;, right)"/>
         <outline text="op.insert(&quot;Level 3&quot;, right)"/>
@@ -1721,8 +1721,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -1736,8 +1736,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -1749,8 +1749,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="return typeof(op.getScrollState())"/>
       </outline>
@@ -1760,8 +1760,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(state = op.getScrollState())"/>
@@ -1773,8 +1773,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.getScrollState())"/>
       </outline>
@@ -1785,8 +1785,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.getScrollState(&quot;extra&quot;)"/>
       </outline>
@@ -1796,8 +1796,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -1810,8 +1810,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(state = op.getScrollState())"/>
         <outline text="return op.setScrollState(state)"/>
@@ -1822,8 +1822,8 @@
         <outline text="expected_result: Line 10"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 20">
           <outline text="op.insert(&quot;Line &quot; + i, down)"/>
@@ -1841,8 +1841,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setScrollState()"/>
       </outline>
@@ -1853,8 +1853,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setScrollState(&quot;not an address&quot;)"/>
       </outline>
@@ -1864,8 +1864,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.getRefcon())"/>
       </outline>
@@ -1875,8 +1875,8 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.getRefcon()"/>
       </outline>
@@ -1886,8 +1886,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return typeof(op.getRefcon())"/>
       </outline>
@@ -1898,8 +1898,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.getRefcon(&quot;extra&quot;)"/>
       </outline>
@@ -1909,8 +1909,8 @@
         <outline text="expected_result: 12345"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(12345)"/>
         <outline text="return op.getRefcon()"/>
@@ -1921,8 +1921,8 @@
         <outline text="expected_result: -9999"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(-9999)"/>
         <outline text="return op.getRefcon()"/>
@@ -1933,8 +1933,8 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(100)"/>
         <outline text="op.setRefcon(0)"/>
@@ -1946,8 +1946,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.setRefcon(42)"/>
       </outline>
@@ -1957,8 +1957,8 @@
         <outline text="expected_result: 99999"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(99999)"/>
         <outline text="return op.getRefcon()"/>
@@ -1969,8 +1969,8 @@
         <outline text="expected_result: 111"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.setRefcon(111)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
@@ -1986,8 +1986,8 @@
         <outline text="expected_result: 777"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.setRefcon(777)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
@@ -2001,8 +2001,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon()"/>
       </outline>
@@ -2014,8 +2014,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(&quot;not a number&quot;)"/>
       </outline>
@@ -2037,8 +2037,8 @@
       </outline>
       <outline text="Script">
         <outline text="target.clear()"/>
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(cursor = op.getCursor())"/>
         <outline text="target.clear()"/>
@@ -2082,8 +2082,8 @@
       </outline>
       <outline text="Script">
         <outline text="target.clear()"/>
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -2109,8 +2109,8 @@
       </outline>
       <outline text="Script">
         <outline text="target.clear()"/>
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(state = op.getScrollState())"/>
         <outline text="target.clear()"/>
@@ -2143,8 +2143,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.notOutline)"/>
-        <outline text="target.set(@workspace.notOutline)"/>
+        <outline text="lang.new(tableType, @system.temp.notOutline)"/>
+        <outline text="target.set(@system.temp.notOutline)"/>
         <outline text="op.getCursor()"/>
       </outline>
     </outline>
@@ -2154,8 +2154,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.table)"/>
-        <outline text="target.set(@workspace.table)"/>
+        <outline text="lang.new(tableType, @system.temp.table)"/>
+        <outline text="target.set(@system.temp.table)"/>
         <outline text="op.setDisplay(false)"/>
       </outline>
     </outline>
@@ -2165,8 +2165,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.table)"/>
-        <outline text="target.set(@workspace.table)"/>
+        <outline text="lang.new(tableType, @system.temp.table)"/>
+        <outline text="target.set(@system.temp.table)"/>
         <outline text="op.getExpansionState()"/>
       </outline>
     </outline>
@@ -2176,8 +2176,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.table)"/>
-        <outline text="target.set(@workspace.table)"/>
+        <outline text="lang.new(tableType, @system.temp.table)"/>
+        <outline text="target.set(@system.temp.table)"/>
         <outline text="op.getRefcon()"/>
       </outline>
     </outline>
@@ -2186,8 +2186,8 @@
         <outline text="expected_result: Line 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.insert(&quot;Line 3&quot;, down)"/>
@@ -2206,8 +2206,8 @@
         <outline text="expected_result: 51"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 50">
@@ -2222,8 +2222,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1a&quot;, right)"/>
         <outline text="op.insert(&quot;Child 1b&quot;, down)"/>
@@ -2248,8 +2248,8 @@
         <outline text="expected_result: 1002"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Item A&quot;, down)"/>
         <outline text="op.setRefcon(1001)"/>
         <outline text="op.insert(&quot;Item B&quot;, down)"/>
@@ -2265,8 +2265,8 @@
         <outline text="expected_result: 100"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="op.insert(&quot;Root&quot;, down)"/>
         <outline text="op.setRefcon(100)"/>
@@ -2286,13 +2286,13 @@
         <outline text="expected_result: Outline 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline1)"/>
-        <outline text="lang.new(outlineType, @workspace.outline2)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline2)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="op.insert(&quot;Outline 1&quot;, down)"/>
-        <outline text="target.set(@workspace.outline2)"/>
+        <outline text="target.set(@system.temp.outline2)"/>
         <outline text="op.insert(&quot;Outline 2&quot;, down)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="return op.getLineText()"/>
       </outline>
     </outline>
@@ -2301,8 +2301,8 @@
         <outline text="expected_result: optx"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="return typeof(workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="return typeof(system.temp.outline)"/>
       </outline>
     </outline>
     <outline text="integration - outline with defined - Check outline existence with defined">
@@ -2310,8 +2310,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="return defined(workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="return defined(system.temp.outline)"/>
       </outline>
     </outline>
     <outline text="headless behavior - no window required for outline ops - Outline operations work without GUI windows (headless mode)">
@@ -2319,8 +2319,8 @@
         <outline text="expected_result: Headless line"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.headlessOutline)"/>
-        <outline text="target.set(@workspace.headlessOutline)"/>
+        <outline text="lang.new(outlineType, @system.temp.headlessOutline)"/>
+        <outline text="target.set(@system.temp.headlessOutline)"/>
         <outline text="op.insert(&quot;Headless line&quot;, down)"/>
         <outline text="return op.getLineText()"/>
       </outline>
@@ -2330,8 +2330,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.go(up, 1)"/>
@@ -2343,8 +2343,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -2358,8 +2358,8 @@
         <outline text="expected_result: Line 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(savedCursor = op.getCursor())"/>
@@ -2376,8 +2376,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Delete me&quot;, down)"/>
         <outline text="local(deadCursor = op.getCursor())"/>
         <outline text="op.insert(&quot;Keep me&quot;, down)"/>
@@ -2391,8 +2391,8 @@
         <outline text="expected_result: Parent"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="local(parentCursor = op.getCursor())"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
@@ -2408,8 +2408,8 @@
         <outline text="expected_result: 5"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;L1&quot;, down)"/>
         <outline text="op.insert(&quot;L2&quot;, right)"/>
         <outline text="op.insert(&quot;L3&quot;, right)"/>
@@ -2426,8 +2426,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="return op.getDisplay()"/>
@@ -2438,8 +2438,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="op.setDisplay(true)"/>
         <outline text="op.setDisplay(true)"/>
@@ -2451,8 +2451,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
@@ -2465,13 +2465,13 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline1)"/>
-        <outline text="lang.new(outlineType, @workspace.outline2)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline2)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="op.setDisplay(false)"/>
-        <outline text="target.set(@workspace.outline2)"/>
+        <outline text="target.set(@system.temp.outline2)"/>
         <outline text="op.setDisplay(true)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="return op.getDisplay()"/>
       </outline>
     </outline>
@@ -2482,14 +2482,14 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline1)"/>
-        <outline text="lang.new(outlineType, @workspace.outline2)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline2)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
         <outline text="local(state1 = op.getExpansionState())"/>
-        <outline text="target.set(@workspace.outline2)"/>
+        <outline text="target.set(@system.temp.outline2)"/>
         <outline text="op.insert(&quot;Parent 2&quot;, down)"/>
         <outline text="op.insert(&quot;Child 2&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -2501,8 +2501,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(state = op.getExpansionState())"/>
         <outline text="return defined(state)"/>
       </outline>
@@ -2513,8 +2513,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.insert(&quot;Child 2&quot;, down)"/>
@@ -2534,8 +2534,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -2559,8 +2559,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(state = op.getScrollState())"/>
         <outline text="return defined(state)"/>
       </outline>
@@ -2572,12 +2572,12 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline1)"/>
-        <outline text="lang.new(outlineType, @workspace.outline2)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline2)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="local(state1 = op.getScrollState())"/>
-        <outline text="target.set(@workspace.outline2)"/>
+        <outline text="target.set(@system.temp.outline2)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="op.setScrollState(state1)"/>
       </outline>
@@ -2587,8 +2587,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(savedState = op.getScrollState())"/>
@@ -2602,12 +2602,12 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline1)"/>
-        <outline text="lang.new(outlineType, @workspace.outline2)"/>
-        <outline text="target.set(@workspace.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline1)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline2)"/>
+        <outline text="target.set(@system.temp.outline1)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="local(state1 = op.getScrollState())"/>
-        <outline text="target.set(@workspace.outline2)"/>
+        <outline text="target.set(@system.temp.outline2)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
         <outline text="local(state2 = op.getScrollState())"/>
         <outline text="return state1 != state2"/>
@@ -2618,8 +2618,8 @@
         <outline text="expected_result: 2147483647"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(2147483647)"/>
         <outline text="return op.getRefcon()"/>
@@ -2630,8 +2630,8 @@
         <outline text="expected_result: -2147483648"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(-2147483648)"/>
         <outline text="return op.getRefcon()"/>
@@ -2642,8 +2642,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="op.setRefcon(111)"/>
         <outline text="op.insert(&quot;Line 2&quot;, down)"/>
@@ -2662,8 +2662,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.setRefcon(999)"/>
@@ -2679,8 +2679,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 10">
           <outline text="op.insert(&quot;Line &quot; + i, down)"/>
@@ -2702,8 +2702,8 @@
         <outline text="expected_result: 555"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.setRefcon(555)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
@@ -2717,8 +2717,8 @@
         <outline text="expected_result: Parent 2"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent 1&quot;, down)"/>
         <outline text="op.insert(&quot;Child 1a&quot;, right)"/>
         <outline text="op.insert(&quot;Child 1b&quot;, down)"/>
@@ -2743,8 +2743,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Item A&quot;, down)"/>
         <outline text="op.setRefcon(1001)"/>
         <outline text="op.insert(&quot;Item B&quot;, down)"/>
@@ -2764,9 +2764,8 @@
         <outline text="expected_result: Line 20"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace)"/>
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 20">
@@ -2785,20 +2784,20 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.o1)"/>
-        <outline text="lang.new(outlineType, @workspace.o2)"/>
-        <outline text="target.set(@workspace.o1)"/>
+        <outline text="lang.new(outlineType, @system.temp.o1)"/>
+        <outline text="lang.new(outlineType, @system.temp.o2)"/>
+        <outline text="target.set(@system.temp.o1)"/>
         <outline text="op.insert(&quot;O1 Line 1&quot;, down)"/>
         <outline text="op.setRefcon(111)"/>
         <outline text="local(cursor1 = op.getCursor())"/>
-        <outline text="target.set(@workspace.o2)"/>
+        <outline text="target.set(@system.temp.o2)"/>
         <outline text="op.insert(&quot;O2 Line 1&quot;, down)"/>
         <outline text="op.setRefcon(222)"/>
         <outline text="local(cursor2 = op.getCursor())"/>
-        <outline text="target.set(@workspace.o1)"/>
+        <outline text="target.set(@system.temp.o1)"/>
         <outline text="op.setCursor(cursor1)"/>
         <outline text="local(refcon1 = op.getRefcon())"/>
-        <outline text="target.set(@workspace.o2)"/>
+        <outline text="target.set(@system.temp.o2)"/>
         <outline text="op.setCursor(cursor2)"/>
         <outline text="local(refcon2 = op.getRefcon())"/>
         <outline text="return (refcon1 == 111) and (refcon2 == 222)"/>
@@ -2809,8 +2808,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 20">
           <outline text="op.insert(&quot;Line &quot; + i, down)"/>
@@ -2834,8 +2833,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(false)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 100">
@@ -2859,8 +2858,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;L1&quot;, down)"/>
         <outline text="local(i)"/>
         <outline text="for i = 2 to 10">
@@ -2885,8 +2884,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(cursor = op.getCursor())"/>
         <outline text="target.clear()"/>
@@ -2910,8 +2909,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setRefcon(100)"/>
       </outline>
     </outline>
@@ -2920,8 +2919,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.setCursor(12345)"/>
       </outline>
@@ -2931,8 +2930,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.setDisplay(1);  /* UserTalk coerces 1 to true */"/>
         <outline text="return op.getDisplay()"/>
       </outline>
@@ -2944,8 +2943,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -2957,8 +2956,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.setScrollState(42)"/>
       </outline>
@@ -2968,8 +2967,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(true)"/>
         <outline text="return op.getRefcon()"/>
@@ -2980,8 +2979,8 @@
         <outline text="expected_result: test string"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(&quot;test string&quot;)"/>
         <outline text="return op.getRefcon()"/>
@@ -2992,8 +2991,8 @@
         <outline text="expected_result: 42"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(42)"/>
         <outline text="return op.getRefcon()"/>
@@ -3004,8 +3003,8 @@
         <outline text="expected_result: 3.14159"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setRefcon(3.14159)"/>
         <outline text="return op.getRefcon()"/>
@@ -3016,8 +3015,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(cursor = op.getCursor())"/>
         <outline text="return typeof(cursor)"/>
@@ -3028,8 +3027,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(display = op.getDisplay())"/>
         <outline text="return typeof(display)"/>
       </outline>
@@ -3039,8 +3038,8 @@
         <outline text="expected_result: list"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(state = op.getExpansionState())"/>
         <outline text="return typeof(state)"/>
@@ -3051,8 +3050,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(state = op.getScrollState())"/>
         <outline text="return typeof(state)"/>
@@ -3063,8 +3062,8 @@
         <outline text="expected_result: long"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(refcon = op.getRefcon())"/>
         <outline text="return typeof(refcon)"/>
@@ -3075,8 +3074,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(cursor = op.getCursor())"/>
         <outline text="local(result = op.setCursor(cursor))"/>
@@ -3088,8 +3087,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(result = op.setDisplay(false))"/>
         <outline text="return typeof(result)"/>
       </outline>
@@ -3099,8 +3098,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(state = op.getExpansionState())"/>
         <outline text="local(result = op.setExpansionState(state))"/>
@@ -3112,8 +3111,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(state = op.getScrollState())"/>
         <outline text="local(result = op.setScrollState(state))"/>
@@ -3125,8 +3124,8 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(result = op.setRefcon(100))"/>
         <outline text="return typeof(result)"/>
@@ -3137,8 +3136,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="return op.subsexpanded()"/>
       </outline>
@@ -3148,8 +3147,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child1&quot;, right)"/>
         <outline text="op.insert(&quot;Child2&quot;, down)"/>
@@ -3163,8 +3162,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child1&quot;, right)"/>
         <outline text="op.insert(&quot;Child2&quot;, down)"/>
@@ -3178,8 +3177,8 @@
         <outline text="expected_result: Alice"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Charlie&quot;, down)"/>
         <outline text="op.insert(&quot;Alice&quot;, down)"/>
         <outline text="op.insert(&quot;Bob&quot;, down)"/>
@@ -3195,8 +3194,8 @@
         <outline text="expected_result: Apple,Apple-Child"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Zebra&quot;, down)"/>
         <outline text="op.insert(&quot;Zebra-Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -3217,8 +3216,8 @@
         <outline text="expected_result: Zebra"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Zebra&quot;, right)"/>
         <outline text="op.insert(&quot;Apple&quot;, down)"/>
@@ -3236,8 +3235,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.hoist()"/>
       </outline>
@@ -3247,8 +3246,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.dehoist()"/>
       </outline>
@@ -3258,8 +3257,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.flatcursorkeys(true)"/>
       </outline>
@@ -3269,8 +3268,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.tabkeyreorg(true)"/>
       </outline>
@@ -3281,8 +3280,8 @@
         <outline text="notes: Full functional test of visiting behavior deferred - requires pre-stored callback script infrastructure"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line 1&quot;, down)"/>
         <outline text="return true"/>
       </outline>
@@ -3292,8 +3291,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.sethtmlformatting(true)"/>
       </outline>
@@ -3303,8 +3302,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.gethtmlformatting()"/>
       </outline>
@@ -3314,8 +3313,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.setdynamic(true)"/>
       </outline>
@@ -3325,8 +3324,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.getdynamic()"/>
       </outline>
@@ -3336,8 +3335,8 @@
         <outline text="expected_result: 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First&quot;, down)"/>
         <outline text="op.insert(&quot;Second&quot;, down)"/>
         <outline text="op.insert(&quot;Third&quot;, down)"/>
@@ -3350,8 +3349,8 @@
         <outline text="expected_result: 3"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First&quot;, down)"/>
         <outline text="op.insert(&quot;Second&quot;, down)"/>
         <outline text="op.insert(&quot;Third&quot;, down)"/>
@@ -3365,8 +3364,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.setmodified(true)"/>
       </outline>
@@ -3376,8 +3375,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="op.setmodified(true)"/>
         <outline text="return op.setmodified(false)"/>
@@ -3388,8 +3387,8 @@
         <outline text="expected_result: First line&#13;"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First line&quot;, down)"/>
         <outline text="return op.getsuboutline()"/>
       </outline>
@@ -3399,8 +3398,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child1&quot;, right)"/>
         <outline text="op.insert(&quot;Child2&quot;, down)"/>
@@ -3414,8 +3413,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
         <outline text="op.go(left, 1)"/>
@@ -3428,14 +3427,14 @@
         <outline text="expected_result: 5"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.source)"/>
-        <outline text="lang.new(outlineType, @workspace.dest)"/>
-        <outline text="target.set(@workspace.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.dest)"/>
+        <outline text="target.set(@system.temp.source)"/>
         <outline text="op.insert(&quot;Source1&quot;, down)"/>
         <outline text="op.insert(&quot;Source2&quot;, down)"/>
-        <outline text="target.set(@workspace.dest)"/>
+        <outline text="target.set(@system.temp.dest)"/>
         <outline text="op.insert(&quot;Dest1&quot;, down)"/>
-        <outline text="op.insertoutline(@workspace.source, down)"/>
+        <outline text="op.insertoutline(@system.temp.source, down)"/>
         <outline text="return op.countSummits()"/>
       </outline>
     </outline>
@@ -3444,16 +3443,16 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.source)"/>
-        <outline text="lang.new(outlineType, @workspace.dest)"/>
-        <outline text="target.set(@workspace.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.dest)"/>
+        <outline text="target.set(@system.temp.source)"/>
         <outline text="op.insert(&quot;Source1&quot;, down)"/>
         <outline text="op.insert(&quot;Source2&quot;, down)"/>
         <outline text="local(before = op.countSummits())"/>
-        <outline text="target.set(@workspace.dest)"/>
+        <outline text="target.set(@system.temp.dest)"/>
         <outline text="op.insert(&quot;Dest1&quot;, down)"/>
-        <outline text="op.insertoutline(@workspace.source, down)"/>
-        <outline text="target.set(@workspace.source)"/>
+        <outline text="op.insertoutline(@system.temp.source, down)"/>
+        <outline text="target.set(@system.temp.source)"/>
         <outline text="local(after = op.countSummits())"/>
         <outline text="return before == after"/>
       </outline>
@@ -3463,8 +3462,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First&quot;, down)"/>
         <outline text="op.insert(&quot;Second&quot;, down)"/>
         <outline text="op.insert(&quot;Third&quot;, down)"/>
@@ -3477,8 +3476,8 @@
         <outline text="expected_result: list"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="local(sel = op.getselection())"/>
         <outline text="return typeOf(sel)"/>
@@ -3489,8 +3488,8 @@
         <outline text="expected_result: 1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(sel = op.getselection())"/>
         <outline text="return sizeOf(sel)"/>
       </outline>
@@ -3500,11 +3499,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;First&quot;, down)"/>
         <outline text="op.insert(&quot;Second&quot;, down)"/>
-        <outline text="local(xml = op.outlinetoxml(@workspace.outline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlinetoxml(@system.temp.outline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return sizeOf(xml) &gt; 100 and string.mid(xml, 1, 5) == &quot;&lt;?xml&quot;"/>
       </outline>
     </outline>
@@ -3513,10 +3512,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Hello World&quot;, down)"/>
-        <outline text="local(xml = op.outlinetoxml(@workspace.outline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlinetoxml(@system.temp.outline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="return string.patternMatch(&quot;Hello World&quot;, xml) &gt; 0"/>
       </outline>
     </outline>
@@ -3525,11 +3524,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Parent&quot;, down)"/>
         <outline text="op.insert(&quot;Child&quot;, right)"/>
-        <outline text="local(xml = op.outlinetoxml(@workspace.outline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
+        <outline text="local(xml = op.outlinetoxml(@system.temp.outline, &quot;TestUser&quot;, &quot;test@example.com&quot;))"/>
         <outline text="local(hasParent = string.patternMatch(&quot;Parent&quot;, xml) &gt; 0)"/>
         <outline text="local(hasChild = string.patternMatch(&quot;Child&quot;, xml) &gt; 0)"/>
         <outline text="return hasParent and hasChild"/>
@@ -3541,9 +3540,9 @@
       </outline>
       <outline text="Script">
         <outline text="local(xml = &quot;&lt;?xml version=\&quot;1.0\&quot; encoding=\&quot;ISO-8859-1\&quot;?&gt;&lt;opml version=\&quot;1.1\&quot;&gt;&lt;body&gt;&lt;outline text=\&quot;Test\&quot;/&gt;&lt;/body&gt;&lt;/opml&gt;&quot;)"/>
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="local(ok = op.xmltooutline(xml, @workspace.outline, true))"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="local(ok = op.xmltooutline(xml, @system.temp.outline, true))"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.firstSummit()"/>
         <outline text="return ok and op.getLineText() == &quot;Test&quot;"/>
       </outline>
@@ -3553,14 +3552,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.out1)"/>
-        <outline text="target.set(@workspace.out1)"/>
+        <outline text="lang.new(outlineType, @system.temp.out1)"/>
+        <outline text="target.set(@system.temp.out1)"/>
         <outline text="op.insert(&quot;Line1&quot;, down)"/>
         <outline text="op.insert(&quot;Line2&quot;, down)"/>
-        <outline text="local(xml = op.outlinetoxml(@workspace.out1, &quot;User&quot;, &quot;user@example.com&quot;))"/>
-        <outline text="lang.new(outlineType, @workspace.out2)"/>
-        <outline text="op.xmltooutline(xml, @workspace.out2, true)"/>
-        <outline text="target.set(@workspace.out2)"/>
+        <outline text="local(xml = op.outlinetoxml(@system.temp.out1, &quot;User&quot;, &quot;user@example.com&quot;))"/>
+        <outline text="lang.new(outlineType, @system.temp.out2)"/>
+        <outline text="op.xmltooutline(xml, @system.temp.out2, true)"/>
+        <outline text="target.set(@system.temp.out2)"/>
         <outline text="op.firstSummit()"/>
         <outline text="op.go(down, 1);  // Move past empty summit to first imported line"/>
         <outline text="local(first = op.getLineText())"/>
@@ -3575,9 +3574,9 @@
       </outline>
       <outline text="Script">
         <outline text="local(xml = &quot;&lt;?xml version=\&quot;1.0\&quot;?&gt;&lt;opml version=\&quot;1.1\&quot;&gt;&lt;body&gt;&lt;outline text=\&quot;NewLine\&quot;/&gt;&lt;/body&gt;&lt;/opml&gt;&quot;)"/>
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="local(ok = op.xmltooutline(xml, @workspace.outline, true))"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="local(ok = op.xmltooutline(xml, @system.temp.outline, true))"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="local(count = op.countSummits())"/>
         <outline text="return ok and (count &gt;= 1)"/>
       </outline>
@@ -3587,11 +3586,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.source)"/>
-        <outline text="lang.new(outlineType, @workspace.dest)"/>
-        <outline text="target.set(@workspace.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.dest)"/>
+        <outline text="target.set(@system.temp.source)"/>
         <outline text="op.insert(&quot;Line1&quot;, down)"/>
-        <outline text="local(ok = op.getselectedsuboutlines(@workspace.dest))"/>
+        <outline text="local(ok = op.getselectedsuboutlines(@system.temp.dest))"/>
         <outline text="return ok"/>
       </outline>
     </outline>
@@ -3600,12 +3599,12 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.source)"/>
-        <outline text="lang.new(outlineType, @workspace.dest)"/>
-        <outline text="target.set(@workspace.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.dest)"/>
+        <outline text="target.set(@system.temp.source)"/>
         <outline text="op.insert(&quot;Source Line&quot;, down)"/>
-        <outline text="local(ok = op.getselectedsuboutlines(@workspace.dest))"/>
-        <outline text="return ok and defined(workspace.dest)"/>
+        <outline text="local(ok = op.getselectedsuboutlines(@system.temp.dest))"/>
+        <outline text="return ok and defined(system.temp.dest)"/>
       </outline>
     </outline>
     <outline text="op.getselectedsuboutlines - with destination content - Add to destination outline that already has content">
@@ -3613,15 +3612,15 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.source)"/>
-        <outline text="lang.new(outlineType, @workspace.dest)"/>
-        <outline text="target.set(@workspace.dest)"/>
+        <outline text="lang.new(outlineType, @system.temp.source)"/>
+        <outline text="lang.new(outlineType, @system.temp.dest)"/>
+        <outline text="target.set(@system.temp.dest)"/>
         <outline text="op.insert(&quot;Existing&quot;, down)"/>
         <outline text="local(beforeCount = op.countSummits())"/>
-        <outline text="target.set(@workspace.source)"/>
+        <outline text="target.set(@system.temp.source)"/>
         <outline text="op.insert(&quot;New&quot;, down)"/>
-        <outline text="op.getselectedsuboutlines(@workspace.dest)"/>
-        <outline text="target.set(@workspace.dest)"/>
+        <outline text="op.getselectedsuboutlines(@system.temp.dest)"/>
+        <outline text="target.set(@system.temp.dest)"/>
         <outline text="local(afterCount = op.countSummits())"/>
         <outline text="return afterCount &gt;= beforeCount"/>
       </outline>

--- a/reports/integration_tests/opattributes_verbs.opml
+++ b/reports/integration_tests/opattributes_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Opattributes Verbs (opattributes_verbs) - 7 tests: 0 pass (0%) 7 skip (100%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="op.attributes.addgroup - GUI-only stub returns error - Verify op.attributes.addgroup returns 'not supported' error in headless mode">
@@ -12,8 +12,8 @@
         <outline text="expected_error_contains: op.attributes verbs are not supported in headless mode"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.attributes.addgroup(&quot;testGroup&quot;)"/>
       </outline>
@@ -25,8 +25,8 @@
         <outline text="expected_error_contains: op.attributes verbs are not supported in headless mode"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.attributes.getall()"/>
       </outline>
@@ -38,8 +38,8 @@
         <outline text="expected_error_contains: op.attributes verbs are not supported in headless mode"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.attributes.getone(&quot;testGroup&quot;)"/>
       </outline>
@@ -51,8 +51,8 @@
         <outline text="expected_error_contains: op.attributes verbs are not supported in headless mode"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.attributes.makeempty()"/>
       </outline>
@@ -64,8 +64,8 @@
         <outline text="expected_error_contains: op.attributes verbs are not supported in headless mode"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(outlineType, @workspace.outline)"/>
-        <outline text="target.set(@workspace.outline)"/>
+        <outline text="lang.new(outlineType, @system.temp.outline)"/>
+        <outline text="target.set(@system.temp.outline)"/>
         <outline text="op.insert(&quot;Line&quot;, down)"/>
         <outline text="return op.attributes.setone(&quot;testGroup&quot;, &quot;testValue&quot;)"/>
       </outline>

--- a/reports/integration_tests/post_hydration_database_state.opml
+++ b/reports/integration_tests/post_hydration_database_state.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Post Hydration Database State (post_hydration_database_state) - 34 tests: 30 pass (88%) 4 skip (11%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="CRITICAL - string(123) works after hydration - This is THE test for the bug we fixed. If hydrate_system_root_database()&#10;closes the database on success, this test WILL FAIL because:&#10;1. CLI starts up, calls hydrate_system_root_database()&#10;2. (Bug) hydrate closes DB, databasedata = nil&#10;3. Test runs, calls string(123)&#10;4. langfindsymbol() tries to resolve &quot;string&quot; via system.paths&#10;5. system.paths lookup requires database access&#10;6. databasedata is nil -&gt; crash or &quot;Can't find verb&quot; error&#10;&#10;After the fix, the database stays open and string() resolves correctly.&#10;">
@@ -90,8 +90,8 @@
         <outline text="expected_result: success"/>
       </outline>
       <outline text="Script">
-        <outline text="workspace.test_post_hydration = &quot;success&quot;"/>
-        <outline text="return workspace.test_post_hydration"/>
+        <outline text="system.temp.test_post_hydration = &quot;success&quot;"/>
+        <outline text="return system.temp.test_post_hydration"/>
       </outline>
     </outline>
     <outline text="Script loading - direct script access - Access a script stored in the database and verify its type.&#10;system.verbs.globals.string is a script.&#10;Note: typeof() on a value (no @) returns the value's type.&#10;typeof() on an address (@) returns 'addr'.&#10;">
@@ -117,8 +117,8 @@
         <outline text="reason: Runtime script creation has pre-existing opcode issues - not related to hydration fix"/>
       </outline>
       <outline text="Script">
-        <outline text="workspace.testScript = script(&quot;return 42&quot;)"/>
-        <outline text="return workspace.testScript()"/>
+        <outline text="system.temp.testScript = script(&quot;return 42&quot;)"/>
+        <outline text="return system.temp.testScript()"/>
       </outline>
     </outline>
     <outline text="Script loading - nested script execution - Verify deeply nested paths are accessible (4+ levels).&#10;file.exists is at system.verbs.builtins.file.exists (4 levels deep).&#10;">
@@ -179,8 +179,8 @@
         <outline text="reason: Pre-existing opcode 34 error - separate issue from hydration fix"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.newTable)"/>
-        <outline text="return typeof(workspace.newTable)"/>
+        <outline text="lang.new(tableType, @system.temp.newTable)"/>
+        <outline text="return typeof(system.temp.newTable)"/>
       </outline>
     </outline>
     <outline text="Regression - table assignment works - Verify table assignments still work.&#10;NOTE: Has pre-existing opcode 34 error - not related to hydration fix.&#10;">
@@ -190,9 +190,9 @@
         <outline text="reason: Pre-existing opcode 34 error (lang.new) - separate issue from hydration fix"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.assignTest)"/>
-        <outline text="workspace.assignTest.key1 = &quot;value1&quot;"/>
-        <outline text="return workspace.assignTest.key1"/>
+        <outline text="lang.new(tableType, @system.temp.assignTest)"/>
+        <outline text="system.temp.assignTest.key1 = &quot;value1&quot;"/>
+        <outline text="return system.temp.assignTest.key1"/>
       </outline>
     </outline>
     <outline text="Regression - string operations work - Verify string.* verbs (table verbs in builtins) work.&#10;NOTE: Has pre-existing issues with script compilation. Skip for now.&#10;">

--- a/reports/integration_tests/script_processor_verbs.opml
+++ b/reports/integration_tests/script_processor_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Script Processor Verbs (script_processor_verbs) - 43 tests: 7 pass (16%) 36 skip (83%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="script.compile - simple script compiles successfully - Compile a simple UserTalk script and verify success">
@@ -11,9 +11,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.testScript)"/>
-        <outline text="script.setsource(@workspace.testScript, &quot;return 42&quot;)"/>
-        <outline text="return script.compile(@workspace.testScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.testScript)"/>
+        <outline text="script.setsource(@system.temp.testScript, &quot;return 42&quot;)"/>
+        <outline text="return script.compile(@system.temp.testScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - returns boolean type - Compile should return boolean type">
@@ -22,9 +22,9 @@
         <outline text="expected_result: bool"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.compileTest)"/>
-        <outline text="script.setsource(@workspace.compileTest, &quot;return true&quot;)"/>
-        <outline text="return typeof(script.compile(@workspace.compileTest))"/>
+        <outline text="lang.new(scriptType, @system.temp.compileTest)"/>
+        <outline text="script.setsource(@system.temp.compileTest, &quot;return true&quot;)"/>
+        <outline text="return typeof(script.compile(@system.temp.compileTest))"/>
       </outline>
     </outline>
     <outline text="script.compile - arithmetic expression - Compile script with arithmetic operations">
@@ -33,9 +33,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.mathScript)"/>
-        <outline text="script.setsource(@workspace.mathScript, &quot;return 10 + 20 * 3&quot;)"/>
-        <outline text="return script.compile(@workspace.mathScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.mathScript)"/>
+        <outline text="script.setsource(@system.temp.mathScript, &quot;return 10 + 20 * 3&quot;)"/>
+        <outline text="return script.compile(@system.temp.mathScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - string operations - Compile script with string concatenation">
@@ -44,9 +44,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.stringScript)"/>
-        <outline text="script.setsource(@workspace.stringScript, &quot;return \&quot;hello\&quot; + \&quot; \&quot; + \&quot;world\&quot;&quot;)"/>
-        <outline text="return script.compile(@workspace.stringScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.stringScript)"/>
+        <outline text="script.setsource(@system.temp.stringScript, &quot;return \&quot;hello\&quot; + \&quot; \&quot; + \&quot;world\&quot;&quot;)"/>
+        <outline text="return script.compile(@system.temp.stringScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - local variables - Compile script with local variable declarations">
@@ -55,9 +55,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.localVarScript)"/>
-        <outline text="script.setsource(@workspace.localVarScript, &quot;local(x=5, y=10); return x+y&quot;)"/>
-        <outline text="return script.compile(@workspace.localVarScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.localVarScript)"/>
+        <outline text="script.setsource(@system.temp.localVarScript, &quot;local(x=5, y=10); return x+y&quot;)"/>
+        <outline text="return script.compile(@system.temp.localVarScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - conditional logic - Compile script with if/else statement">
@@ -66,9 +66,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.ifScript)"/>
-        <outline text="script.setsource(@workspace.ifScript, &quot;if true { return \&quot;yes\&quot; } else { return \&quot;no\&quot; }&quot;)"/>
-        <outline text="return script.compile(@workspace.ifScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.ifScript)"/>
+        <outline text="script.setsource(@system.temp.ifScript, &quot;if true { return \&quot;yes\&quot; } else { return \&quot;no\&quot; }&quot;)"/>
+        <outline text="return script.compile(@system.temp.ifScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - loop construct - Compile script with for loop">
@@ -77,9 +77,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.loopScript)"/>
-        <outline text="script.setsource(@workspace.loopScript, &quot;local(i, sum=0); for i=1 to 10 { sum = sum + i }; return sum&quot;)"/>
-        <outline text="return script.compile(@workspace.loopScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.loopScript)"/>
+        <outline text="script.setsource(@system.temp.loopScript, &quot;local(i, sum=0); for i=1 to 10 { sum = sum + i }; return sum&quot;)"/>
+        <outline text="return script.compile(@system.temp.loopScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - syntax error terminates execution - Compilation error should terminate script execution">
@@ -88,9 +88,9 @@
         <outline text="expected_success: False"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.badScript)"/>
-        <outline text="script.setsource(@workspace.badScript, &quot;return 1 + +&quot;)"/>
-        <outline text="script.compile(@workspace.badScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.badScript)"/>
+        <outline text="script.setsource(@system.temp.badScript, &quot;return 1 + +&quot;)"/>
+        <outline text="script.compile(@system.temp.badScript)"/>
         <outline text="return false"/>
       </outline>
     </outline>
@@ -100,9 +100,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.emptyScript)"/>
-        <outline text="script.setsource(@workspace.emptyScript, &quot;&quot;)"/>
-        <outline text="return script.compile(@workspace.emptyScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.emptyScript)"/>
+        <outline text="script.setsource(@system.temp.emptyScript, &quot;&quot;)"/>
+        <outline text="return script.compile(@system.temp.emptyScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - multiline script - Compile multi-line script with statements on separate lines">
@@ -111,9 +111,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.multilineScript)"/>
-        <outline text="script.setsource(@workspace.multilineScript, &quot;local(x = 10);\nlocal(y = 20);\nreturn x + y&quot;)"/>
-        <outline text="return script.compile(@workspace.multilineScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.multilineScript)"/>
+        <outline text="script.setsource(@system.temp.multilineScript, &quot;local(x = 10);\nlocal(y = 20);\nreturn x + y&quot;)"/>
+        <outline text="return script.compile(@system.temp.multilineScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - script with comments - Compile script containing comments">
@@ -122,9 +122,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.commentScript)"/>
-        <outline text="script.setsource(@workspace.commentScript, &quot;// This is a comment\nreturn 42 // another comment&quot;)"/>
-        <outline text="return script.compile(@workspace.commentScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.commentScript)"/>
+        <outline text="script.setsource(@system.temp.commentScript, &quot;// This is a comment\nreturn 42 // another comment&quot;)"/>
+        <outline text="return script.compile(@system.temp.commentScript)"/>
       </outline>
     </outline>
     <outline text="script.compile - non-script object returns false - Attempting to compile non-script object should return false">
@@ -133,8 +133,8 @@
         <outline text="expected_result: false"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.notAScript)"/>
-        <outline text="return script.compile(@workspace.notAScript)"/>
+        <outline text="lang.new(tableType, @system.temp.notAScript)"/>
+        <outline text="return script.compile(@system.temp.notAScript)"/>
       </outline>
     </outline>
     <outline text="script execution - direct evaluation of compiled script - Production pattern: call script directly after compilation">
@@ -143,10 +143,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.execTest)"/>
-        <outline text="script.setsource(@workspace.execTest, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.execTest)"/>
-        <outline text="return @workspace.execTest() == 42"/>
+        <outline text="lang.new(scriptType, @system.temp.execTest)"/>
+        <outline text="script.setsource(@system.temp.execTest, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.execTest)"/>
+        <outline text="return @system.temp.execTest() == 42"/>
       </outline>
     </outline>
     <outline text="script execution - script with arithmetic - Verify compiled script executes and returns correct result">
@@ -155,10 +155,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.mathScript)"/>
-        <outline text="script.setsource(@workspace.mathScript, &quot;return 10 + 20 + 12&quot;)"/>
-        <outline text="script.compile(@workspace.mathScript)"/>
-        <outline text="return @workspace.mathScript() == 42"/>
+        <outline text="lang.new(scriptType, @system.temp.mathScript)"/>
+        <outline text="script.setsource(@system.temp.mathScript, &quot;return 10 + 20 + 12&quot;)"/>
+        <outline text="script.compile(@system.temp.mathScript)"/>
+        <outline text="return @system.temp.mathScript() == 42"/>
       </outline>
     </outline>
     <outline text="script execution - inline evaluation for testing - Alternative pattern: use lang.evaluate for simple cases">
@@ -177,10 +177,10 @@
         <outline text="expected_error: script.run is not supported"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.runTest)"/>
-        <outline text="script.setsource(@workspace.runTest, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.runTest)"/>
-        <outline text="script.run(@workspace.runTest)"/>
+        <outline text="lang.new(scriptType, @system.temp.runTest)"/>
+        <outline text="script.setsource(@system.temp.runTest, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.runTest)"/>
+        <outline text="script.run(@system.temp.runTest)"/>
       </outline>
     </outline>
     <outline text="script.getsource - retrieve script source text - Get source code from script object">
@@ -189,10 +189,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.sourceTest)"/>
-        <outline text="script.setsource(@workspace.sourceTest, &quot;return 42&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.sourceTest)"/>
+        <outline text="script.setsource(@system.temp.sourceTest, &quot;return 42&quot;)"/>
         <outline text="local(source)"/>
-        <outline text="script.getsource(@workspace.sourceTest, @source)"/>
+        <outline text="script.getsource(@system.temp.sourceTest, @source)"/>
         <outline text="return source == &quot;return 42&quot;"/>
       </outline>
     </outline>
@@ -202,10 +202,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.setSourceTest)"/>
-        <outline text="script.setsource(@workspace.setSourceTest, &quot;return 100&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.setSourceTest)"/>
+        <outline text="script.setsource(@system.temp.setSourceTest, &quot;return 100&quot;)"/>
         <outline text="local(retrieved)"/>
-        <outline text="script.getsource(@workspace.setSourceTest, @retrieved)"/>
+        <outline text="script.getsource(@system.temp.setSourceTest, @retrieved)"/>
         <outline text="return retrieved == &quot;return 100&quot;"/>
       </outline>
     </outline>
@@ -215,8 +215,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.setSourceReturn)"/>
-        <outline text="return script.setsource(@workspace.setSourceReturn, &quot;return 42&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.setSourceReturn)"/>
+        <outline text="return script.setsource(@system.temp.setSourceReturn, &quot;return 42&quot;)"/>
       </outline>
     </outline>
     <outline text="script.getsource - returns boolean true - getsource should return boolean true on success">
@@ -225,10 +225,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.getSourceReturn)"/>
-        <outline text="script.setsource(@workspace.getSourceReturn, &quot;return 42&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.getSourceReturn)"/>
+        <outline text="script.setsource(@system.temp.getSourceReturn, &quot;return 42&quot;)"/>
         <outline text="local(source)"/>
-        <outline text="return script.getsource(@workspace.getSourceReturn, @source)"/>
+        <outline text="return script.getsource(@system.temp.getSourceReturn, @source)"/>
       </outline>
     </outline>
     <outline text="script source verbs - roundtrip test - Set source, get it back, verify unchanged">
@@ -237,10 +237,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.roundtrip)"/>
-        <outline text="script.setsource(@workspace.roundtrip, &quot;local(x = 10);\nreturn x * 2&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.roundtrip)"/>
+        <outline text="script.setsource(@system.temp.roundtrip, &quot;local(x = 10);\nreturn x * 2&quot;)"/>
         <outline text="local(retrieved)"/>
-        <outline text="script.getsource(@workspace.roundtrip, @retrieved)"/>
+        <outline text="script.getsource(@system.temp.roundtrip, @retrieved)"/>
         <outline text="return retrieved == &quot;local(x = 10);\nreturn x * 2&quot;"/>
       </outline>
     </outline>
@@ -250,10 +250,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.emptySource)"/>
-        <outline text="script.setsource(@workspace.emptySource, &quot;&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.emptySource)"/>
+        <outline text="script.setsource(@system.temp.emptySource, &quot;&quot;)"/>
         <outline text="local(retrieved)"/>
-        <outline text="script.getsource(@workspace.emptySource, @retrieved)"/>
+        <outline text="script.getsource(@system.temp.emptySource, @retrieved)"/>
         <outline text="return retrieved == &quot;&quot;"/>
       </outline>
     </outline>
@@ -263,10 +263,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.multiline)"/>
-        <outline text="script.setsource(@workspace.multiline, &quot;local(x = 1);\nlocal(y = 2);\nreturn x + y&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.multiline)"/>
+        <outline text="script.setsource(@system.temp.multiline, &quot;local(x = 1);\nlocal(y = 2);\nreturn x + y&quot;)"/>
         <outline text="local(retrieved)"/>
-        <outline text="script.getsource(@workspace.multiline, @retrieved)"/>
+        <outline text="script.getsource(@system.temp.multiline, @retrieved)"/>
         <outline text="return string.length(retrieved) &gt; 0"/>
       </outline>
     </outline>
@@ -276,10 +276,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.specialChars)"/>
-        <outline text="script.setsource(@workspace.specialChars, &quot;return \&quot;hello\\nworld\&quot;&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.specialChars)"/>
+        <outline text="script.setsource(@system.temp.specialChars, &quot;return \&quot;hello\\nworld\&quot;&quot;)"/>
         <outline text="local(retrieved)"/>
-        <outline text="script.getsource(@workspace.specialChars, @retrieved)"/>
+        <outline text="script.getsource(@system.temp.specialChars, @retrieved)"/>
         <outline text="return string.length(retrieved) &gt; 0"/>
       </outline>
     </outline>
@@ -289,11 +289,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.codeTest)"/>
-        <outline text="script.setsource(@workspace.codeTest, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.codeTest)"/>
+        <outline text="lang.new(scriptType, @system.temp.codeTest)"/>
+        <outline text="script.setsource(@system.temp.codeTest, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.codeTest)"/>
         <outline text="local(code)"/>
-        <outline text="script.getcode(@workspace.codeTest, @code)"/>
+        <outline text="script.getcode(@system.temp.codeTest, @code)"/>
         <outline text="return typeof(code) == binaryType"/>
       </outline>
     </outline>
@@ -303,11 +303,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.getCodeReturn)"/>
-        <outline text="script.setsource(@workspace.getCodeReturn, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.getCodeReturn)"/>
+        <outline text="lang.new(scriptType, @system.temp.getCodeReturn)"/>
+        <outline text="script.setsource(@system.temp.getCodeReturn, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.getCodeReturn)"/>
         <outline text="local(code)"/>
-        <outline text="return script.getcode(@workspace.getCodeReturn, @code)"/>
+        <outline text="return script.getcode(@system.temp.getCodeReturn, @code)"/>
       </outline>
     </outline>
     <outline text="script.setcode - set compiled bytecode - Set compiled code in script object">
@@ -316,13 +316,13 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.originalScript)"/>
-        <outline text="script.setsource(@workspace.originalScript, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.originalScript)"/>
+        <outline text="lang.new(scriptType, @system.temp.originalScript)"/>
+        <outline text="script.setsource(@system.temp.originalScript, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.originalScript)"/>
         <outline text="local(code)"/>
-        <outline text="script.getcode(@workspace.originalScript, @code)"/>
-        <outline text="lang.new(scriptType, @workspace.copyScript)"/>
-        <outline text="return script.setcode(@workspace.copyScript, @code)"/>
+        <outline text="script.getcode(@system.temp.originalScript, @code)"/>
+        <outline text="lang.new(scriptType, @system.temp.copyScript)"/>
+        <outline text="return script.setcode(@system.temp.copyScript, @code)"/>
       </outline>
     </outline>
     <outline text="script.setcode - returns boolean true - setcode should return boolean true on success">
@@ -331,13 +331,13 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.setCodeReturn)"/>
-        <outline text="script.setsource(@workspace.setCodeReturn, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.setCodeReturn)"/>
+        <outline text="lang.new(scriptType, @system.temp.setCodeReturn)"/>
+        <outline text="script.setsource(@system.temp.setCodeReturn, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.setCodeReturn)"/>
         <outline text="local(code)"/>
-        <outline text="script.getcode(@workspace.setCodeReturn, @code)"/>
-        <outline text="lang.new(scriptType, @workspace.setCodeTarget)"/>
-        <outline text="return script.setcode(@workspace.setCodeTarget, @code)"/>
+        <outline text="script.getcode(@system.temp.setCodeReturn, @code)"/>
+        <outline text="lang.new(scriptType, @system.temp.setCodeTarget)"/>
+        <outline text="return script.setcode(@system.temp.setCodeTarget, @code)"/>
       </outline>
     </outline>
     <outline text="script code verbs - transfer code between scripts - Get code from one script, set it in another, run both">
@@ -346,15 +346,15 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.source)"/>
-        <outline text="script.setsource(@workspace.source, &quot;return 99&quot;)"/>
-        <outline text="script.compile(@workspace.source)"/>
+        <outline text="lang.new(scriptType, @system.temp.source)"/>
+        <outline text="script.setsource(@system.temp.source, &quot;return 99&quot;)"/>
+        <outline text="script.compile(@system.temp.source)"/>
         <outline text="local(code)"/>
-        <outline text="script.getcode(@workspace.source, @code)"/>
-        <outline text="lang.new(scriptType, @workspace.dest)"/>
-        <outline text="script.setcode(@workspace.dest, @code)"/>
-        <outline text="local(result1 = @workspace.source())"/>
-        <outline text="local(result2 = @workspace.dest())"/>
+        <outline text="script.getcode(@system.temp.source, @code)"/>
+        <outline text="lang.new(scriptType, @system.temp.dest)"/>
+        <outline text="script.setcode(@system.temp.dest, @code)"/>
+        <outline text="local(result1 = @system.temp.source())"/>
+        <outline text="local(result2 = @system.temp.dest())"/>
         <outline text="return (result1 == 99) and (result2 == 99)"/>
       </outline>
     </outline>
@@ -364,11 +364,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.uncompiled)"/>
-        <outline text="script.setsource(@workspace.uncompiled, &quot;return 42&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.uncompiled)"/>
+        <outline text="script.setsource(@system.temp.uncompiled, &quot;return 42&quot;)"/>
         <outline text="local(code)"/>
         <outline text="try">
-          <outline text="script.getcode(@workspace.uncompiled, @code)"/>
+          <outline text="script.getcode(@system.temp.uncompiled, @code)"/>
           <outline text="return true"/>
         </outline>
         <outline text="else">
@@ -390,9 +390,9 @@
         <outline text="expected_success: False"/>
       </outline>
       <outline text="Script">
-        <outline text="workspace.errorFlag = false"/>
+        <outline text="system.temp.errorFlag = false"/>
         <outline text="script.error(&quot;Error here&quot;)"/>
-        <outline text="workspace.errorFlag = true"/>
+        <outline text="system.temp.errorFlag = true"/>
         <outline text="return false"/>
       </outline>
     </outline>
@@ -443,10 +443,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.lifecycle)"/>
-        <outline text="script.setsource(@workspace.lifecycle, &quot;return 100 + 23&quot;)"/>
-        <outline text="script.compile(@workspace.lifecycle)"/>
-        <outline text="local(result = @workspace.lifecycle())"/>
+        <outline text="lang.new(scriptType, @system.temp.lifecycle)"/>
+        <outline text="script.setsource(@system.temp.lifecycle, &quot;return 100 + 23&quot;)"/>
+        <outline text="script.compile(@system.temp.lifecycle)"/>
+        <outline text="local(result = @system.temp.lifecycle())"/>
         <outline text="return result == 123"/>
       </outline>
     </outline>
@@ -456,13 +456,13 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.modify)"/>
-        <outline text="script.setsource(@workspace.modify, &quot;return 1&quot;)"/>
-        <outline text="script.compile(@workspace.modify)"/>
-        <outline text="local(first = @workspace.modify())"/>
-        <outline text="script.setsource(@workspace.modify, &quot;return 2&quot;)"/>
-        <outline text="script.compile(@workspace.modify)"/>
-        <outline text="local(second = @workspace.modify())"/>
+        <outline text="lang.new(scriptType, @system.temp.modify)"/>
+        <outline text="script.setsource(@system.temp.modify, &quot;return 1&quot;)"/>
+        <outline text="script.compile(@system.temp.modify)"/>
+        <outline text="local(first = @system.temp.modify())"/>
+        <outline text="script.setsource(@system.temp.modify, &quot;return 2&quot;)"/>
+        <outline text="script.compile(@system.temp.modify)"/>
+        <outline text="local(second = @system.temp.modify())"/>
         <outline text="return (first == 1) and (second == 2)"/>
       </outline>
     </outline>
@@ -472,10 +472,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.independence)"/>
-        <outline text="script.setsource(@workspace.independence, &quot;return 42&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.independence)"/>
+        <outline text="script.setsource(@system.temp.independence, &quot;return 42&quot;)"/>
         <outline text="local(source)"/>
-        <outline text="script.getsource(@workspace.independence, @source)"/>
+        <outline text="script.getsource(@system.temp.independence, @source)"/>
         <outline text="return source == &quot;return 42&quot;"/>
       </outline>
     </outline>
@@ -485,15 +485,15 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.original)"/>
-        <outline text="script.setsource(@workspace.original, &quot;local(x = 5); return x * x&quot;)"/>
-        <outline text="script.compile(@workspace.original)"/>
+        <outline text="lang.new(scriptType, @system.temp.original)"/>
+        <outline text="script.setsource(@system.temp.original, &quot;local(x = 5); return x * x&quot;)"/>
+        <outline text="script.compile(@system.temp.original)"/>
         <outline text="local(code)"/>
-        <outline text="script.getcode(@workspace.original, @code)"/>
-        <outline text="lang.new(scriptType, @workspace.clone)"/>
-        <outline text="script.setcode(@workspace.clone, @code)"/>
-        <outline text="local(origResult = @workspace.original())"/>
-        <outline text="local(cloneResult = @workspace.clone())"/>
+        <outline text="script.getcode(@system.temp.original, @code)"/>
+        <outline text="lang.new(scriptType, @system.temp.clone)"/>
+        <outline text="script.setcode(@system.temp.clone, @code)"/>
+        <outline text="local(origResult = @system.temp.original())"/>
+        <outline text="local(cloneResult = @system.temp.clone())"/>
         <outline text="return origResult == cloneResult"/>
       </outline>
     </outline>
@@ -503,14 +503,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.scriptA)"/>
-        <outline text="lang.new(scriptType, @workspace.scriptB)"/>
-        <outline text="script.setsource(@workspace.scriptA, &quot;return 10&quot;)"/>
-        <outline text="script.setsource(@workspace.scriptB, &quot;return 20&quot;)"/>
-        <outline text="script.compile(@workspace.scriptA)"/>
-        <outline text="script.compile(@workspace.scriptB)"/>
-        <outline text="local(a = @workspace.scriptA())"/>
-        <outline text="local(b = @workspace.scriptB())"/>
+        <outline text="lang.new(scriptType, @system.temp.scriptA)"/>
+        <outline text="lang.new(scriptType, @system.temp.scriptB)"/>
+        <outline text="script.setsource(@system.temp.scriptA, &quot;return 10&quot;)"/>
+        <outline text="script.setsource(@system.temp.scriptB, &quot;return 20&quot;)"/>
+        <outline text="script.compile(@system.temp.scriptA)"/>
+        <outline text="script.compile(@system.temp.scriptB)"/>
+        <outline text="local(a = @system.temp.scriptA())"/>
+        <outline text="local(b = @system.temp.scriptB())"/>
         <outline text="return (a == 10) and (b == 20)"/>
       </outline>
     </outline>
@@ -520,14 +520,14 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.typeTest)"/>
-        <outline text="script.setsource(@workspace.typeTest, &quot;return 42&quot;)"/>
-        <outline text="script.compile(@workspace.typeTest)"/>
-        <outline text="local(compileResult = script.compile(@workspace.typeTest))"/>
-        <outline text="local(runResult = @workspace.typeTest())"/>
+        <outline text="lang.new(scriptType, @system.temp.typeTest)"/>
+        <outline text="script.setsource(@system.temp.typeTest, &quot;return 42&quot;)"/>
+        <outline text="script.compile(@system.temp.typeTest)"/>
+        <outline text="local(compileResult = script.compile(@system.temp.typeTest))"/>
+        <outline text="local(runResult = @system.temp.typeTest())"/>
         <outline text="local(source, code)"/>
-        <outline text="local(getSourceResult = script.getsource(@workspace.typeTest, @source))"/>
-        <outline text="local(getCodeResult = script.getcode(@workspace.typeTest, @code))"/>
+        <outline text="local(getSourceResult = script.getsource(@system.temp.typeTest, @source))"/>
+        <outline text="local(getCodeResult = script.getcode(@system.temp.typeTest, @code))"/>
         <outline text="return (typeof(compileResult) == booleanType) and">
           <outline text="(typeof(getSourceResult) == booleanType) and"/>
           <outline text="(typeof(getCodeResult) == booleanType) and"/>
@@ -542,16 +542,16 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(scriptType, @workspace.recovery)"/>
-        <outline text="script.setsource(@workspace.recovery, &quot;return 1 + +&quot;)"/>
+        <outline text="lang.new(scriptType, @system.temp.recovery)"/>
+        <outline text="script.setsource(@system.temp.recovery, &quot;return 1 + +&quot;)"/>
         <outline text="try">
-          <outline text="script.compile(@workspace.recovery)"/>
+          <outline text="script.compile(@system.temp.recovery)"/>
           <outline text="return false"/>
         </outline>
         <outline text="else">
-          <outline text="script.setsource(@workspace.recovery, &quot;return 42&quot;)"/>
-          <outline text="script.compile(@workspace.recovery)"/>
-          <outline text="return @workspace.recovery() == 42"/>
+          <outline text="script.setsource(@system.temp.recovery, &quot;return 42&quot;)"/>
+          <outline text="script.compile(@system.temp.recovery)"/>
+          <outline text="return @system.temp.recovery() == 42"/>
         </outline>
       </outline>
     </outline>

--- a/reports/integration_tests/target_verbs.opml
+++ b/reports/integration_tests/target_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Target Verbs (target_verbs) - 46 tests: 46 pass (100%)</title>
-    <dateCreated>Wed, 04 Feb 2026 10:39:17 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="target.get - no target set returns nil - When no explicit target is set, target.get() returns nil (no implicit target in headless)">
@@ -27,9 +27,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.testTarget)"/>
-        <outline text="target.set(@workspace.testTarget)"/>
-        <outline text="return defined(workspace.testTarget)"/>
+        <outline text="lang.new(tableType, @system.temp.testTarget)"/>
+        <outline text="target.set(@system.temp.testTarget)"/>
+        <outline text="return defined(system.temp.testTarget)"/>
       </outline>
     </outline>
     <outline text="target.set - returns previous target (nil initially) - target.set() returns previous target value (nil if none was set)">
@@ -38,29 +38,29 @@
       </outline>
       <outline text="Script">
         <outline text="target.clear()"/>
-        <outline text="lang.new(tableType, @workspace.t1)"/>
-        <outline text="return typeof(target.set(@workspace.t1))"/>
+        <outline text="lang.new(tableType, @system.temp.t1)"/>
+        <outline text="return typeof(target.set(@system.temp.t1))"/>
       </outline>
     </outline>
     <outline text="target.set - returns previous target (non-nil) - target.set() returns previous target when one was set">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.t1"/>
+        <outline text="expected_result: system.temp.t1"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t1)"/>
-        <outline text="lang.new(tableType, @workspace.t2)"/>
-        <outline text="target.set(@workspace.t1)"/>
-        <outline text="local(prev = target.set(@workspace.t2))"/>
+        <outline text="lang.new(tableType, @system.temp.t1)"/>
+        <outline text="lang.new(tableType, @system.temp.t2)"/>
+        <outline text="target.set(@system.temp.t1)"/>
+        <outline text="local(prev = target.set(@system.temp.t2))"/>
         <outline text="return string(prev)"/>
       </outline>
     </outline>
     <outline text="target.get - returns set target - After target.set(), target.get() returns the address that was set">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.myTarget"/>
+        <outline text="expected_result: system.temp.myTarget"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.myTarget)"/>
-        <outline text="target.set(@workspace.myTarget)"/>
+        <outline text="lang.new(tableType, @system.temp.myTarget)"/>
+        <outline text="target.set(@system.temp.myTarget)"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
@@ -69,8 +69,8 @@
         <outline text="expected_result: addr"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.targetTable)"/>
-        <outline text="target.set(@workspace.targetTable)"/>
+        <outline text="lang.new(tableType, @system.temp.targetTable)"/>
+        <outline text="target.set(@system.temp.targetTable)"/>
         <outline text="return typeof(target.get())"/>
       </outline>
     </outline>
@@ -79,8 +79,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.persistent)"/>
-        <outline text="target.set(@workspace.persistent)"/>
+        <outline text="lang.new(tableType, @system.temp.persistent)"/>
+        <outline text="target.set(@system.temp.persistent)"/>
         <outline text="local(first = string(target.get()))"/>
         <outline text="local(second = string(target.get()))"/>
         <outline text="return first == second"/>
@@ -91,8 +91,8 @@
         <outline text="expected_result: ????"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t)"/>
-        <outline text="target.set(@workspace.t)"/>
+        <outline text="lang.new(tableType, @system.temp.t)"/>
+        <outline text="target.set(@system.temp.t)"/>
         <outline text="target.clear()"/>
         <outline text="return typeof(target.get())"/>
       </outline>
@@ -102,8 +102,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t)"/>
-        <outline text="target.set(@workspace.t)"/>
+        <outline text="lang.new(tableType, @system.temp.t)"/>
+        <outline text="target.set(@system.temp.t)"/>
         <outline text="return target.clear()"/>
       </outline>
     </outline>
@@ -132,11 +132,11 @@
       </outline>
       <outline text="Script">
         <outline text="target.clear()"/>
-        <outline text="lang.new(tableType, @workspace.cycleTest)"/>
-        <outline text="workspace.cycleTest.value = 42"/>
-        <outline text="target.set(@workspace.cycleTest)"/>
+        <outline text="lang.new(tableType, @system.temp.cycleTest)"/>
+        <outline text="system.temp.cycleTest.value = 42"/>
+        <outline text="target.set(@system.temp.cycleTest)"/>
         <outline text="local(retrieved = string(target.get()))"/>
-        <outline text="local(ok1 = retrieved == &quot;workspace.cycleTest&quot;)"/>
+        <outline text="local(ok1 = retrieved == &quot;system.temp.cycleTest&quot;)"/>
         <outline text="target.clear()"/>
         <outline text="local(ok2 = typeof(target.get()) == &quot;????&quot;)"/>
         <outline text="return ok1 and ok2"/>
@@ -147,38 +147,38 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.target1)"/>
-        <outline text="lang.new(tableType, @workspace.target2)"/>
-        <outline text="lang.new(tableType, @workspace.target3)"/>
-        <outline text="target.set(@workspace.target1)"/>
-        <outline text="local(ok1 = string(target.get()) == &quot;workspace.target1&quot;)"/>
-        <outline text="target.set(@workspace.target2)"/>
-        <outline text="local(ok2 = string(target.get()) == &quot;workspace.target2&quot;)"/>
-        <outline text="target.set(@workspace.target3)"/>
-        <outline text="local(ok3 = string(target.get()) == &quot;workspace.target3&quot;)"/>
+        <outline text="lang.new(tableType, @system.temp.target1)"/>
+        <outline text="lang.new(tableType, @system.temp.target2)"/>
+        <outline text="lang.new(tableType, @system.temp.target3)"/>
+        <outline text="target.set(@system.temp.target1)"/>
+        <outline text="local(ok1 = string(target.get()) == &quot;system.temp.target1&quot;)"/>
+        <outline text="target.set(@system.temp.target2)"/>
+        <outline text="local(ok2 = string(target.get()) == &quot;system.temp.target2&quot;)"/>
+        <outline text="target.set(@system.temp.target3)"/>
+        <outline text="local(ok3 = string(target.get()) == &quot;system.temp.target3&quot;)"/>
         <outline text="return ok1 and ok2 and ok3"/>
       </outline>
     </outline>
     <outline text="target.set - nested table - Set a nested table as target">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.parent.child"/>
+        <outline text="expected_result: system.temp.parent.child"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.parent)"/>
-        <outline text="lang.new(tableType, @workspace.parent.child)"/>
-        <outline text="target.set(@workspace.parent.child)"/>
+        <outline text="lang.new(tableType, @system.temp.parent)"/>
+        <outline text="lang.new(tableType, @system.temp.parent.child)"/>
+        <outline text="target.set(@system.temp.parent.child)"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
     <outline text="target.set - deeply nested table - Set a deeply nested table as target">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.level1.level2.level3"/>
+        <outline text="expected_result: system.temp.level1.level2.level3"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.level1)"/>
-        <outline text="lang.new(tableType, @workspace.level1.level2)"/>
-        <outline text="lang.new(tableType, @workspace.level1.level2.level3)"/>
-        <outline text="target.set(@workspace.level1.level2.level3)"/>
+        <outline text="lang.new(tableType, @system.temp.level1)"/>
+        <outline text="lang.new(tableType, @system.temp.level1.level2)"/>
+        <outline text="lang.new(tableType, @system.temp.level1.level2.level3)"/>
+        <outline text="target.set(@system.temp.level1.level2.level3)"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
@@ -187,11 +187,11 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.data)"/>
-        <outline text="workspace.data.key = &quot;testValue&quot;"/>
-        <outline text="target.set(@workspace.data)"/>
+        <outline text="lang.new(tableType, @system.temp.data)"/>
+        <outline text="system.temp.data.key = &quot;testValue&quot;"/>
+        <outline text="target.set(@system.temp.data)"/>
         <outline text="local(targetAddr = target.get())"/>
-        <outline text="return defined(workspace.data.key)"/>
+        <outline text="return defined(system.temp.data.key)"/>
       </outline>
     </outline>
     <outline text="target operations - modify target contents - Can modify contents of table that is set as target">
@@ -199,21 +199,21 @@
         <outline text="expected_result: 100"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.mutable)"/>
-        <outline text="target.set(@workspace.mutable)"/>
-        <outline text="workspace.mutable.field = 100"/>
-        <outline text="return workspace.mutable.field"/>
+        <outline text="lang.new(tableType, @system.temp.mutable)"/>
+        <outline text="target.set(@system.temp.mutable)"/>
+        <outline text="system.temp.mutable.field = 100"/>
+        <outline text="return system.temp.mutable.field"/>
       </outline>
     </outline>
     <outline text="target operations - target persists after modification - Modifying target contents doesn't affect target itself">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.stable"/>
+        <outline text="expected_result: system.temp.stable"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.stable)"/>
-        <outline text="target.set(@workspace.stable)"/>
-        <outline text="workspace.stable.x = 1"/>
-        <outline text="workspace.stable.y = 2"/>
+        <outline text="lang.new(tableType, @system.temp.stable)"/>
+        <outline text="target.set(@system.temp.stable)"/>
+        <outline text="system.temp.stable.x = 1"/>
+        <outline text="system.temp.stable.y = 2"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
@@ -263,8 +263,8 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t)"/>
-        <outline text="target.set(@workspace.t, &quot;extra&quot;)"/>
+        <outline text="lang.new(tableType, @system.temp.t)"/>
+        <outline text="target.set(@system.temp.t, &quot;extra&quot;)"/>
       </outline>
     </outline>
     <outline text="target.set - undefined variable address - Setting target to undefined variable should error">
@@ -273,7 +273,7 @@
         <outline text="expected_error_type: script_error"/>
       </outline>
       <outline text="Script">
-        <outline text="target.set(@workspace.doesNotExist)"/>
+        <outline text="target.set(@system.temp.doesNotExist)"/>
       </outline>
     </outline>
     <outline text="target.set - non-address type (string) - Setting target with non-address type should error">
@@ -299,8 +299,8 @@
         <outline text="expected_result: ????"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t)"/>
-        <outline text="target.set(@workspace.t)"/>
+        <outline text="lang.new(tableType, @system.temp.t)"/>
+        <outline text="target.set(@system.temp.t)"/>
         <outline text="local(x)"/>
         <outline text="target.set(@x)"/>
         <outline text="return typeof(target.get())"/>
@@ -311,10 +311,10 @@
         <outline text="expected_result: Hello World"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.stringTable)"/>
-        <outline text="workspace.stringTable.text = &quot;Hello World&quot;"/>
-        <outline text="target.set(@workspace.stringTable)"/>
-        <outline text="return workspace.stringTable.text"/>
+        <outline text="lang.new(tableType, @system.temp.stringTable)"/>
+        <outline text="system.temp.stringTable.text = &quot;Hello World&quot;"/>
+        <outline text="target.set(@system.temp.stringTable)"/>
+        <outline text="return system.temp.stringTable.text"/>
       </outline>
     </outline>
     <outline text="target.set - table with numeric value - Set target to table containing numeric value">
@@ -322,10 +322,10 @@
         <outline text="expected_result: 999"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.numTable)"/>
-        <outline text="workspace.numTable.count = 999"/>
-        <outline text="target.set(@workspace.numTable)"/>
-        <outline text="return workspace.numTable.count"/>
+        <outline text="lang.new(tableType, @system.temp.numTable)"/>
+        <outline text="system.temp.numTable.count = 999"/>
+        <outline text="target.set(@system.temp.numTable)"/>
+        <outline text="return system.temp.numTable.count"/>
       </outline>
     </outline>
     <outline text="target.set - table with boolean value - Set target to table containing boolean value">
@@ -333,10 +333,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.boolTable)"/>
-        <outline text="workspace.boolTable.flag = true"/>
-        <outline text="target.set(@workspace.boolTable)"/>
-        <outline text="return workspace.boolTable.flag"/>
+        <outline text="lang.new(tableType, @system.temp.boolTable)"/>
+        <outline text="system.temp.boolTable.flag = true"/>
+        <outline text="target.set(@system.temp.boolTable)"/>
+        <outline text="return system.temp.boolTable.flag"/>
       </outline>
     </outline>
     <outline text="target.set - empty table - Set target to empty table (no entries)">
@@ -344,9 +344,9 @@
         <outline text="expected_result: 0"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.emptyTable)"/>
-        <outline text="target.set(@workspace.emptyTable)"/>
-        <outline text="return sizeof(workspace.emptyTable)"/>
+        <outline text="lang.new(tableType, @system.temp.emptyTable)"/>
+        <outline text="target.set(@system.temp.emptyTable)"/>
+        <outline text="return sizeof(system.temp.emptyTable)"/>
       </outline>
     </outline>
     <outline text="target.set - table with nested tables - Set target to table containing nested tables">
@@ -354,11 +354,11 @@
         <outline text="expected_result: 42"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.outer)"/>
-        <outline text="lang.new(tableType, @workspace.outer.inner)"/>
-        <outline text="workspace.outer.inner.value = 42"/>
-        <outline text="target.set(@workspace.outer)"/>
-        <outline text="return workspace.outer.inner.value"/>
+        <outline text="lang.new(tableType, @system.temp.outer)"/>
+        <outline text="lang.new(tableType, @system.temp.outer.inner)"/>
+        <outline text="system.temp.outer.inner.value = 42"/>
+        <outline text="target.set(@system.temp.outer)"/>
+        <outline text="return system.temp.outer.inner.value"/>
       </outline>
     </outline>
     <outline text="target lifecycle - delete target clears it - Deleting the target variable clears the target as a side-effect (legacy behavior)">
@@ -366,20 +366,20 @@
         <outline text="expected_result: ????"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.temporary)"/>
-        <outline text="target.set(@workspace.temporary)"/>
-        <outline text="lang.delete(@workspace.temporary)"/>
+        <outline text="lang.new(tableType, @system.temp.temporary)"/>
+        <outline text="target.set(@system.temp.temporary)"/>
+        <outline text="lang.delete(@system.temp.temporary)"/>
         <outline text="return typeof(target.get())"/>
       </outline>
     </outline>
     <outline text="target persistence - across multiple scripts - Target set in one operation persists for next operation">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.persist"/>
+        <outline text="expected_result: system.temp.persist"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.persist)"/>
-        <outline text="workspace.persist.value = &quot;persistent&quot;"/>
-        <outline text="target.set(@workspace.persist)"/>
+        <outline text="lang.new(tableType, @system.temp.persist)"/>
+        <outline text="system.temp.persist.value = &quot;persistent&quot;"/>
+        <outline text="target.set(@system.temp.persist)"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
@@ -398,8 +398,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.headlessTarget)"/>
-        <outline text="target.set(@workspace.headlessTarget)"/>
+        <outline text="lang.new(tableType, @system.temp.headlessTarget)"/>
+        <outline text="target.set(@system.temp.headlessTarget)"/>
         <outline text="return typeof(target.get()) == &quot;addr&quot;"/>
       </outline>
     </outline>
@@ -408,8 +408,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t)"/>
-        <outline text="target.set(@workspace.t)"/>
+        <outline text="lang.new(tableType, @system.temp.t)"/>
+        <outline text="target.set(@system.temp.t)"/>
         <outline text="local(cleared = target.clear())"/>
         <outline text="return cleared and (typeof(target.get()) == &quot;????&quot;)"/>
       </outline>
@@ -419,10 +419,10 @@
         <outline text="expected_result: ????"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.stress)"/>
+        <outline text="lang.new(tableType, @system.temp.stress)"/>
         <outline text="local(i)"/>
         <outline text="for i = 1 to 10">
-          <outline text="target.set(@workspace.stress)"/>
+          <outline text="target.set(@system.temp.stress)"/>
           <outline text="target.clear()"/>
         </outline>
         <outline text="return typeof(target.get())"/>
@@ -430,19 +430,19 @@
     </outline>
     <outline text="stress test - many sequential target changes - Setting many different targets in sequence">
       <outline text="Metadata">
-        <outline text="expected_result: workspace.t5"/>
+        <outline text="expected_result: system.temp.t5"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.t1)"/>
-        <outline text="lang.new(tableType, @workspace.t2)"/>
-        <outline text="lang.new(tableType, @workspace.t3)"/>
-        <outline text="lang.new(tableType, @workspace.t4)"/>
-        <outline text="lang.new(tableType, @workspace.t5)"/>
-        <outline text="target.set(@workspace.t1)"/>
-        <outline text="target.set(@workspace.t2)"/>
-        <outline text="target.set(@workspace.t3)"/>
-        <outline text="target.set(@workspace.t4)"/>
-        <outline text="target.set(@workspace.t5)"/>
+        <outline text="lang.new(tableType, @system.temp.t1)"/>
+        <outline text="lang.new(tableType, @system.temp.t2)"/>
+        <outline text="lang.new(tableType, @system.temp.t3)"/>
+        <outline text="lang.new(tableType, @system.temp.t4)"/>
+        <outline text="lang.new(tableType, @system.temp.t5)"/>
+        <outline text="target.set(@system.temp.t1)"/>
+        <outline text="target.set(@system.temp.t2)"/>
+        <outline text="target.set(@system.temp.t3)"/>
+        <outline text="target.set(@system.temp.t4)"/>
+        <outline text="target.set(@system.temp.t5)"/>
         <outline text="return string(target.get())"/>
       </outline>
     </outline>
@@ -451,12 +451,12 @@
         <outline text="expected_result: 3"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.sized)"/>
-        <outline text="workspace.sized.a = 1"/>
-        <outline text="workspace.sized.b = 2"/>
-        <outline text="workspace.sized.c = 3"/>
-        <outline text="target.set(@workspace.sized)"/>
-        <outline text="return sizeof(workspace.sized)"/>
+        <outline text="lang.new(tableType, @system.temp.sized)"/>
+        <outline text="system.temp.sized.a = 1"/>
+        <outline text="system.temp.sized.b = 2"/>
+        <outline text="system.temp.sized.c = 3"/>
+        <outline text="target.set(@system.temp.sized)"/>
+        <outline text="return sizeof(system.temp.sized)"/>
       </outline>
     </outline>
     <outline text="integration - target with typeof - Get typeof() on target table">
@@ -464,9 +464,9 @@
         <outline text="expected_result: tabl"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.typed)"/>
-        <outline text="target.set(@workspace.typed)"/>
-        <outline text="return typeof(workspace.typed)"/>
+        <outline text="lang.new(tableType, @system.temp.typed)"/>
+        <outline text="target.set(@system.temp.typed)"/>
+        <outline text="return typeof(system.temp.typed)"/>
       </outline>
     </outline>
     <outline text="integration - target with defined - Check defined() on target">
@@ -474,9 +474,9 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.exists)"/>
-        <outline text="target.set(@workspace.exists)"/>
-        <outline text="return defined(workspace.exists)"/>
+        <outline text="lang.new(tableType, @system.temp.exists)"/>
+        <outline text="target.set(@system.temp.exists)"/>
+        <outline text="return defined(system.temp.exists)"/>
       </outline>
     </outline>
     <outline text="integration - target with table.assign - Use table.assign() on target table">
@@ -484,10 +484,10 @@
         <outline text="expected_result: assigned"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.assign)"/>
-        <outline text="target.set(@workspace.assign)"/>
-        <outline text="table.assign(@workspace.assign.key, &quot;assigned&quot;)"/>
-        <outline text="return workspace.assign.key"/>
+        <outline text="lang.new(tableType, @system.temp.assign)"/>
+        <outline text="target.set(@system.temp.assign)"/>
+        <outline text="table.assign(@system.temp.assign.key, &quot;assigned&quot;)"/>
+        <outline text="return system.temp.assign.key"/>
       </outline>
     </outline>
     <outline text="integration - target with pack/unpack - Pack target table to binary">
@@ -495,10 +495,10 @@
         <outline text="expected_result: data"/>
       </outline>
       <outline text="Script">
-        <outline text="lang.new(tableType, @workspace.packable)"/>
-        <outline text="workspace.packable.data = &quot;test&quot;"/>
-        <outline text="target.set(@workspace.packable)"/>
-        <outline text="pack(workspace.packable, @packed)"/>
+        <outline text="lang.new(tableType, @system.temp.packable)"/>
+        <outline text="system.temp.packable.data = &quot;test&quot;"/>
+        <outline text="target.set(@system.temp.packable)"/>
+        <outline text="pack(system.temp.packable, @packed)"/>
         <outline text="return typeof(packed)"/>
       </outline>
     </outline>

--- a/reports/integration_tests/wp_verbs.opml
+++ b/reports/integration_tests/wp_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Wp Verbs (wp_verbs) - 18 tests: 18 pass (100%)</title>
-    <dateCreated>Sat, 14 Feb 2026 21:52:52 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="wp.setText - defined in headless mode - Verify wp.setText verb is registered and resolvable">
@@ -56,8 +56,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(wpTextType, @workspace.wpGetTextTest)"/>
-        <outline text="target.set(@workspace.wpGetTextTest)"/>
+        <outline text="new(wpTextType, @system.temp.wpGetTextTest)"/>
+        <outline text="target.set(@system.temp.wpGetTextTest)"/>
         <outline text="wp.setText(&quot;hello from getText test&quot;)"/>
         <outline text="local(t = wp.getText())"/>
         <outline text="return(sizeOf(t) &gt; 0)"/>
@@ -68,10 +68,10 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(wpTextType, @workspace.wpEquivTest)"/>
-        <outline text="target.set(@workspace.wpEquivTest)"/>
+        <outline text="new(wpTextType, @system.temp.wpEquivTest)"/>
+        <outline text="target.set(@system.temp.wpEquivTest)"/>
         <outline text="wp.setText(&quot;equivalence test content&quot;)"/>
-        <outline text="return(wp.getText() == string(workspace.wpEquivTest))"/>
+        <outline text="return(wp.getText() == string(system.temp.wpEquivTest))"/>
       </outline>
     </outline>
     <outline text="wp.setText/getText roundtrip - Set text on a WPText object, then get it back and verify match">
@@ -79,8 +79,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(wpTextType, @workspace.wpRoundtripTest)"/>
-        <outline text="target.set(@workspace.wpRoundtripTest)"/>
+        <outline text="new(wpTextType, @system.temp.wpRoundtripTest)"/>
+        <outline text="target.set(@system.temp.wpRoundtripTest)"/>
         <outline text="wp.setText(&quot;hello world&quot;)"/>
         <outline text="return(wp.getText() == &quot;hello world&quot;)"/>
       </outline>
@@ -107,8 +107,8 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
-        <outline text="new(wpTextType, @workspace.wpSetTextTest)"/>
-        <outline text="target.set(@workspace.wpSetTextTest)"/>
+        <outline text="new(wpTextType, @system.temp.wpSetTextTest)"/>
+        <outline text="target.set(@system.temp.wpSetTextTest)"/>
         <outline text="wp.setText(&quot;hello world&quot;)"/>
       </outline>
     </outline>

--- a/reports/integration_tests/xml_verbs.opml
+++ b/reports/integration_tests/xml_verbs.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Xml Verbs (xml_verbs) - 93 tests: 93 pass (100%)</title>
-    <dateCreated>Tue, 17 Feb 2026 01:05:41 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
   </head>
   <body>
     <outline text="xml.frontiervaluetotaggedtext - simple string">
@@ -225,10 +225,10 @@
         <outline text="expected_contains: ['&lt;struct&gt;', '&lt;name&gt;value&lt;/name&gt;', '&lt;i4&gt;42&lt;/i4&gt;', '&lt;/struct&gt;']"/>
       </outline>
       <outline text="Script">
-        <outline text="new(tableType, @workspace.globaltest)"/>
-        <outline text="workspace.globaltest.value = 42"/>
-        <outline text="local(result = xml.frontiervaluetotaggedtext(@workspace.globaltest, 0))"/>
-        <outline text="delete(@workspace.globaltest)"/>
+        <outline text="new(tableType, @system.temp.globaltest)"/>
+        <outline text="system.temp.globaltest.value = 42"/>
+        <outline text="local(result = xml.frontiervaluetotaggedtext(@system.temp.globaltest, 0))"/>
+        <outline text="delete(@system.temp.globaltest)"/>
         <outline text="return result"/>
       </outline>
     </outline>
@@ -237,16 +237,16 @@
         <outline text="expected_contains: ['&lt;name&gt;value&lt;/name&gt;', '&lt;value&gt;test&lt;/value&gt;']"/>
       </outline>
       <outline text="Script">
-        <outline text="new(tableType, @workspace.outer)"/>
+        <outline text="new(tableType, @system.temp.outer)"/>
         <outline text="local(data)"/>
         <outline text="new(tableType, @data)"/>
         <outline text="data.value = &quot;inner&quot;"/>
-        <outline text="with workspace.outer">
+        <outline text="with system.temp.outer">
           <outline text="local(data)"/>
           <outline text="new(tableType, @data)"/>
           <outline text="data.value = &quot;test&quot;"/>
           <outline text="local(result = xml.frontiervaluetotaggedtext(@data, 0))"/>
-          <outline text="delete(@workspace.outer)"/>
+          <outline text="delete(@system.temp.outer)"/>
           <outline text="return result"/>
         </outline>
       </outline>
@@ -578,9 +578,9 @@
       </outline>
       <outline text="Script">
         <outline text="local(xmlText = &quot;&lt;root&gt;&lt;item&gt;first&lt;/item&gt;&lt;item&gt;second&lt;/item&gt;&lt;/root&gt;&quot;)"/>
-        <outline text="new(tableType, @workspace.xmltest)"/>
-        <outline text="xml.compile(xmlText, @workspace.xmltest)"/>
-        <outline text="local(rootAddr = xml.getAddress(@workspace.xmltest, &quot;root&quot;))"/>
+        <outline text="new(tableType, @system.temp.xmltest)"/>
+        <outline text="xml.compile(xmlText, @system.temp.xmltest)"/>
+        <outline text="local(rootAddr = xml.getAddress(@system.temp.xmltest, &quot;root&quot;))"/>
         <outline text="local(addrList)"/>
         <outline text="new(listType, @addrList)"/>
         <outline text="if xml.getAddressList(rootAddr, &quot;item&quot;, @addrList)">
@@ -1203,9 +1203,9 @@
       </outline>
       <outline text="Script">
         <outline text="local(xmlText = &quot;&lt;root&gt;&lt;num&gt;1&lt;/num&gt;&lt;num&gt;2&lt;/num&gt;&lt;num&gt;3&lt;/num&gt;&lt;/root&gt;&quot;)"/>
-        <outline text="new(tableType, @workspace.xmltest)"/>
-        <outline text="xml.compile(xmlText, @workspace.xmltest)"/>
-        <outline text="local(rootAddr = xml.getAddress(@workspace.xmltest, &quot;root&quot;))"/>
+        <outline text="new(tableType, @system.temp.xmltest)"/>
+        <outline text="xml.compile(xmlText, @system.temp.xmltest)"/>
+        <outline text="local(rootAddr = xml.getAddress(@system.temp.xmltest, &quot;root&quot;))"/>
         <outline text="local(addrList)"/>
         <outline text="new(listType, @addrList)"/>
         <outline text="xml.getAddressList(rootAddr, &quot;num&quot;, @addrList)"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Mon, 02 Mar 2026 07:19:13 GMT</dateCreated>
+    <dateCreated>Thu, 05 Mar 2026 19:09:31 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-02 at 07:19 UTC"/>
+      <outline text="Run: 2026-03-05 at 19:09 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -359,6 +359,7 @@ class ProtocolExecutor:
         self.cli_path = cli_path
         self.system_root = system_root
         self._proc: Optional[subprocess.Popen] = None
+        self._stderr_file = None
         self._next_id = 1
 
     def start(self):
@@ -436,7 +437,7 @@ class ProtocolExecutor:
 
     def _log_stderr_on_crash(self):
         """Read and log any stderr output from the protocol process."""
-        if not hasattr(self, '_stderr_file') or self._stderr_file is None:
+        if self._stderr_file is None:
             return
         try:
             self._stderr_file.flush()
@@ -449,7 +450,7 @@ class ProtocolExecutor:
 
     def _close_stderr_file(self):
         """Close and remove the stderr temp file."""
-        if not hasattr(self, '_stderr_file') or self._stderr_file is None:
+        if self._stderr_file is None:
             return
         try:
             name = self._stderr_file.name

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -444,7 +444,12 @@ class ProtocolExecutor:
             self._stderr_file.seek(0)
             stderr_content = self._stderr_file.read().strip()
             if stderr_content:
-                print(f"  [protocol stderr] {stderr_content[:500]}", file=sys.stderr)
+                if len(stderr_content) <= 1000:
+                    print(f"  [protocol stderr] {stderr_content}", file=sys.stderr)
+                else:
+                    # Show head and tail to capture both startup errors and crash traces
+                    print(f"  [protocol stderr head] {stderr_content[:500]}", file=sys.stderr)
+                    print(f"  [protocol stderr tail] {stderr_content[-500:]}", file=sys.stderr)
         except Exception:
             pass
 

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -367,11 +367,16 @@ class ProtocolExecutor:
         if self.system_root:
             cmd.extend(['--system-root', self.system_root])
 
+        # Redirect stderr to temp file to capture crash diagnostics
+        # (using a file avoids pipe buffer deadlocks)
+        self._stderr_file = tempfile.NamedTemporaryFile(
+            mode='w+', prefix='frontier_protocol_stderr_', suffix='.log', delete=False)
+
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=self._stderr_file,
             text=True,
             bufsize=1,  # Line buffered
         )
@@ -415,6 +420,7 @@ class ProtocolExecutor:
 
     def _restart(self):
         """Restart the protocol process after it dies."""
+        self._log_stderr_on_crash()
         try:
             if self._proc is not None:
                 self._proc.kill()
@@ -422,10 +428,36 @@ class ProtocolExecutor:
         except Exception:
             pass
         self._proc = None
+        self._close_stderr_file()
         try:
             self.start()
         except Exception as e:
             raise RuntimeError(f"Protocol executor restart failed: {e}") from e
+
+    def _log_stderr_on_crash(self):
+        """Read and log any stderr output from the protocol process."""
+        if not hasattr(self, '_stderr_file') or self._stderr_file is None:
+            return
+        try:
+            self._stderr_file.flush()
+            self._stderr_file.seek(0)
+            stderr_content = self._stderr_file.read().strip()
+            if stderr_content:
+                print(f"  [protocol stderr] {stderr_content[:500]}", file=sys.stderr)
+        except Exception:
+            pass
+
+    def _close_stderr_file(self):
+        """Close and remove the stderr temp file."""
+        if not hasattr(self, '_stderr_file') or self._stderr_file is None:
+            return
+        try:
+            name = self._stderr_file.name
+            self._stderr_file.close()
+            os.unlink(name)
+        except Exception:
+            pass
+        self._stderr_file = None
 
     def execute(self, script: str, timeout: float = 10.0) -> Dict:
         """
@@ -489,18 +521,29 @@ class ProtocolExecutor:
     def reset(self):
         """Clear REPL variables and reset focus between tests."""
         if self._proc is None or self._proc.poll() is not None:
+            # Process already dead — restart for subsequent tests
+            try:
+                self._restart()
+            except Exception:
+                pass
             return
         try:
             self._send_recv({'op': 'script/clearContext'}, timeout=5.0)
         except Exception:
-            pass  # Best effort — process may have died
+            # clearContext failed — process may have died, restart
+            try:
+                self._restart()
+            except Exception:
+                pass
 
     def stop(self):
         """Gracefully shut down the protocol process."""
         if self._proc is None:
+            self._close_stderr_file()
             return
         if self._proc.poll() is not None:
             self._proc = None
+            self._close_stderr_file()
             return
         try:
             self._send_recv({'op': 'shutdown'}, timeout=5.0)
@@ -512,6 +555,7 @@ class ProtocolExecutor:
             self._proc.kill()
             self._proc.wait()
         self._proc = None
+        self._close_stderr_file()
 
     @property
     def is_alive(self) -> bool:
@@ -869,6 +913,20 @@ class TestRunner:
                 and self.protocol_executor.is_alive
                 and _is_protocol_compatible(test)):
             output = self.protocol_executor.execute(script, timeout=test.timeout)
+
+            # If protocol failed due to process death, retry with per-process
+            if (not output.get('success')
+                    and output.get('error_type') == 'execution_error'
+                    and 'not running' in str(output.get('error', ''))):
+                stdin_input = test.get_stdin_with_substitutions(self.test_root_dir)
+                test_env = test.environment.copy()
+                if stdin_input is not None and not test.batch_mode:
+                    test_env['FRONTIER_FORCE_INTERACTIVE'] = '1'
+                output = self.cli.execute(
+                    script, timeout=test.timeout,
+                    stdin_input=stdin_input,
+                    batch_mode=test.batch_mode,
+                    env=test_env)
 
             # Reset state after each test
             self.protocol_executor.reset()

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -373,14 +373,18 @@ class ProtocolExecutor:
         self._stderr_file = tempfile.NamedTemporaryFile(
             mode='w+', prefix='frontier_protocol_stderr_', suffix='.log', delete=False)
 
-        self._proc = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=self._stderr_file,
-            text=True,
-            bufsize=1,  # Line buffered
-        )
+        try:
+            self._proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=self._stderr_file,
+                text=True,
+                bufsize=1,  # Line buffered
+            )
+        except Exception:
+            self._close_stderr_file()
+            raise
         self._next_id = 1
 
     def _send_recv(self, msg: dict, timeout: float = 10.0) -> dict:
@@ -450,7 +454,7 @@ class ProtocolExecutor:
                     # Show head and tail to capture both startup errors and crash traces
                     print(f"  [protocol stderr head] {stderr_content[:500]}", file=sys.stderr)
                     print(f"  [protocol stderr tail] {stderr_content[-500:]}", file=sys.stderr)
-        except Exception:
+        except OSError:
             pass
 
     def _close_stderr_file(self):

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -530,8 +530,8 @@ class ProtocolExecutor:
             # Process already dead — restart for subsequent tests
             try:
                 self._restart()
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"  [protocol] restart after death failed: {e}", file=sys.stderr)
             return
         try:
             self._send_recv({'op': 'script/clearContext'}, timeout=5.0)
@@ -539,8 +539,8 @@ class ProtocolExecutor:
             # clearContext failed — process may have died, restart
             try:
                 self._restart()
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"  [protocol] restart after clearContext failure: {e}", file=sys.stderr)
 
     def stop(self):
         """Gracefully shut down the protocol process."""
@@ -920,10 +920,12 @@ class TestRunner:
                 and _is_protocol_compatible(test)):
             output = self.protocol_executor.execute(script, timeout=test.timeout)
 
-            # If protocol failed due to process death, retry with per-process
+            # If protocol failed due to process death, retry with per-process.
+            # These errors come from _send_recv(): "Protocol process not running",
+            # "Protocol process died unexpectedly", "Protocol process closed stdout".
             if (not output.get('success')
                     and output.get('error_type') == 'execution_error'
-                    and 'not running' in str(output.get('error', ''))):
+                    and 'Protocol process' in str(output.get('error', ''))):
                 stdin_input = test.get_stdin_with_substitutions(self.test_root_dir)
                 test_env = test.environment.copy()
                 if stdin_input is not None and not test.batch_mode:

--- a/tests/integration/test_cases/PHASE3_TEST_SUMMARY.md
+++ b/tests/integration/test_cases/PHASE3_TEST_SUMMARY.md
@@ -48,8 +48,8 @@ Lines 2257-2317
 - name: "op.getCursor - cursor persists during outline modification"
   description: "Saved cursor remains valid after inserting new nodes elsewhere"
   script: |
-    lang.new(outlineType, @workspace.outline);
-    target.set(@workspace.outline);
+    lang.new(outlineType, @system.temp.outline);
+    target.set(@system.temp.outline);
     op.insert("Line 1", down);
     op.insert("Line 2", down);
     local(savedCursor = op.getCursor());
@@ -72,13 +72,13 @@ Lines 2319-2371
 - name: "op.getDisplay - independent across multiple outlines"
   description: "Each outline has independent display state"
   script: |
-    lang.new(outlineType, @workspace.outline1);
-    lang.new(outlineType, @workspace.outline2);
-    target.set(@workspace.outline1);
+    lang.new(outlineType, @system.temp.outline1);
+    lang.new(outlineType, @system.temp.outline2);
+    target.set(@system.temp.outline1);
     op.setDisplay(false);
-    target.set(@workspace.outline2);
+    target.set(@system.temp.outline2);
     op.setDisplay(true);
-    target.set(@workspace.outline1);
+    target.set(@system.temp.outline1);
     return op.getDisplay()
   expected_success: true
   expected_result: "false"
@@ -111,8 +111,8 @@ Lines 2503-2598
 - name: "op.setRefcon - large positive value (32-bit boundary)"
   description: "Test refcon with large positive value near INT32_MAX"
   script: |
-    lang.new(outlineType, @workspace.outline);
-    target.set(@workspace.outline);
+    lang.new(outlineType, @system.temp.outline);
+    target.set(@system.temp.outline);
     op.insert("Line", down);
     op.setRefcon(2147483647);
     return op.getRefcon()
@@ -132,8 +132,8 @@ Lines 2600-2690
 - name: "workflow - save all state before bulk operation and restore"
   description: "Save cursor, expansion, scroll state, perform operations, restore all state"
   script: |
-    lang.new(outlineType, @workspace.outline);
-    target.set(@workspace.outline);
+    lang.new(outlineType, @system.temp.outline);
+    target.set(@system.temp.outline);
     op.insert("Parent 1", down);
     op.insert("Child 1a", right);
     op.insert("Child 1b", down);
@@ -166,8 +166,8 @@ Lines 2692-2761
 - name: "stress test - many refcon assignments"
   description: "Assign refcon to many nodes in large outline"
   script: |
-    lang.new(outlineType, @workspace.outline);
-    target.set(@workspace.outline);
+    lang.new(outlineType, @system.temp.outline);
+    target.set(@system.temp.outline);
     op.setDisplay(false);
     local(i);
     for i = 1 to 100 {
@@ -207,8 +207,8 @@ Lines 2796-2849
 - name: "type safety - setCursor requires address type"
   description: "setCursor rejects non-address types"
   script: |
-    lang.new(outlineType, @workspace.outline);
-    target.set(@workspace.outline);
+    lang.new(outlineType, @system.temp.outline);
+    target.set(@system.temp.outline);
     op.insert("Line", down);
     op.setCursor(12345)
   expected_success: false
@@ -226,8 +226,8 @@ Lines 2851-2964
 - name: "return type - getCursor returns address"
   description: "Verify getCursor return type is addressType"
   script: |
-    lang.new(outlineType, @workspace.outline);
-    target.set(@workspace.outline);
+    lang.new(outlineType, @system.temp.outline);
+    target.set(@system.temp.outline);
     op.insert("Line", down);
     local(cursor = op.getCursor());
     return typeof(cursor)

--- a/tests/integration/test_cases/filemenu_verbs.yaml
+++ b/tests/integration/test_cases/filemenu_verbs.yaml
@@ -157,8 +157,8 @@ tests:
   - name: "fileMenu.close - target is not a guest database"
     description: "close when target points at a non-guest-database table is a no-op"
     script: |
-      lang.new(tableType, @workspace.notADb);
-      target.set(@workspace.notADb);
+      lang.new(tableType, @system.temp.notADb);
+      target.set(@system.temp.notADb);
       local(result = fileMenu.close());
       target.clear();
       return result

--- a/tests/integration/test_cases/menu_data_verbs.yaml
+++ b/tests/integration/test_cases/menu_data_verbs.yaml
@@ -31,9 +31,9 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "New", "dialog.alert(\"New!\")"));
-      delete(@workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "New", "dialog.alert(\"New!\")"));
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -43,11 +43,11 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Cut", "edit.cut()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Copy", "edit.copy()");
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "Edit", "Paste", "edit.paste()"));
-      delete(@workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Cut", "edit.cut()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Copy", "edit.copy()");
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "Edit", "Paste", "edit.paste()"));
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -57,15 +57,15 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add initial item
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "oldScript()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "oldScript()");
 
       # Replace with new script
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "Open", "newScript()"));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "newScript()"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -75,13 +75,13 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "file.new()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "edit.undo()");
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "Help", "About", "help.about()"));
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "file.new()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Undo", "edit.undo()");
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "Help", "About", "help.about()"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -95,10 +95,10 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "ToDelete", "script()");
-      local(ok = menu.deleteMenuCommand(@workspace.testMenu, "File", "ToDelete"));
-      delete(@workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "ToDelete", "script()");
+      local(ok = menu.deleteMenuCommand(@system.temp.testMenu, "File", "ToDelete"));
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -108,12 +108,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Try to delete item that doesn't exist
-      local(ok = menu.deleteMenuCommand(@workspace.testMenu, "File", "DoesNotExist"));
+      local(ok = menu.deleteMenuCommand(@system.temp.testMenu, "File", "DoesNotExist"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -123,12 +123,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Try to delete from menu that doesn't exist
-      local(ok = menu.deleteMenuCommand(@workspace.testMenu, "NoSuchMenu", "Item"));
+      local(ok = menu.deleteMenuCommand(@system.temp.testMenu, "NoSuchMenu", "Item"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -138,16 +138,16 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add, delete, then add again with different script
-      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "original()");
-      menu.deleteMenuCommand(@workspace.testMenu, "File", "Test");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "original()");
+      menu.deleteMenuCommand(@system.temp.testMenu, "File", "Test");
 
       # Should succeed - item was deleted
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "Test", "replacement()"));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "replacement()"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -164,24 +164,24 @@ tests:
     skip: true
     skip_reason: "menu.getScript is a no-op in headless mode - doesn't write to address parameter"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add a command with a known script
-      menu.addMenuCommand(@workspace.testMenu, "Test", "MyItem", "dialog.alert(\"Hello\")");
+      menu.addMenuCommand(@system.temp.testMenu, "Test", "MyItem", "dialog.alert(\"Hello\")");
 
       # Set target to the menubar and navigate to item
       # NOTE: This may require op.find() or similar to locate the item
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Get the script into a scratch location
-      local(ok = menu.getScript(@workspace.retrievedScript));
+      local(ok = menu.getScript(@system.temp.retrievedScript));
 
       # Verify the script was retrieved
-      local(result = defined(workspace.retrievedScript));
+      local(result = defined(system.temp.retrievedScript));
 
       # Clean up
-      delete(@workspace.testMenu);
-      try {delete(@workspace.retrievedScript)};
+      delete(@system.temp.testMenu);
+      try {delete(@system.temp.retrievedScript)};
 
       return result
     expected_success: true
@@ -192,23 +192,23 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add initial command
-      menu.addMenuCommand(@workspace.testMenu, "Test", "MyItem", "original()");
+      menu.addMenuCommand(@system.temp.testMenu, "Test", "MyItem", "original()");
 
       # Create a new script to set
-      workspace.newScript = "replacement()";
+      system.temp.newScript = "replacement()";
 
       # Set target and change the script
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Set the script from our stored value
-      local(ok = menu.setScript(@workspace.newScript));
+      local(ok = menu.setScript(@system.temp.newScript));
 
       # Clean up
-      delete(@workspace.testMenu);
-      delete(@workspace.newScript);
+      delete(@system.temp.testMenu);
+      delete(@system.temp.newScript);
 
       return ok
     expected_success: true
@@ -219,24 +219,24 @@ tests:
     skip: true
     skip_reason: "menu.getScript is a no-op in headless mode - doesn't write to address parameter"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add a command
       local(originalScript = "dialog.notify(\"test\")");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Test", originalScript);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Test", originalScript);
 
       # Set target
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Get the script back
-      menu.getScript(@workspace.retrieved);
+      menu.getScript(@system.temp.retrieved);
 
       # Compare
-      local(match = (workspace.retrieved == originalScript));
+      local(match = (system.temp.retrieved == originalScript));
 
       # Clean up
-      delete(@workspace.testMenu);
-      try {delete(@workspace.retrieved)};
+      delete(@system.temp.testMenu);
+      try {delete(@system.temp.retrieved)};
 
       return match
     expected_success: true
@@ -253,18 +253,18 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add a command
-      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "file.save()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Save", "file.save()");
 
       # Set target to the menubar
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Set command key to 'S'
       local(ok = menu.setCommandKey("S"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -274,11 +274,11 @@ tests:
     skip: true
     skip_reason: "menu.getCommandKey is a no-op in headless mode - returns null char, not actual shortcut"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add a command and set its shortcut
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "file.open()");
-      target.set(@workspace.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "file.open()");
+      target.set(@system.temp.testMenu);
       menu.setCommandKey("O");
 
       # Now retrieve it
@@ -287,7 +287,7 @@ tests:
       # Should contain "O" (exact format may vary: "O", "Cmd+O", "Ctrl+O")
       local(hasKey = string.contains(key, "O"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return hasKey
     expected_success: true
     expected_result: "true"
@@ -297,11 +297,11 @@ tests:
     skip: true
     skip_reason: "menu.getCommandKey is a no-op in headless mode - returns null char, can't verify clearing"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add command with shortcut
-      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "test()");
-      target.set(@workspace.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "test()");
+      target.set(@system.temp.testMenu);
       menu.setCommandKey("T");
 
       # Now clear it
@@ -311,7 +311,7 @@ tests:
       local(key = menu.getCommandKey());
       local(cleared = (key == "") or (sizeof(key) == 0));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return cleared
     expected_success: true
     expected_result: "true"
@@ -321,10 +321,10 @@ tests:
     skip: true
     skip_reason: "menu.getCommandKey is a no-op in headless mode - returns null char, can't verify round-trip"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Find", "edit.find()");
-      target.set(@workspace.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Find", "edit.find()");
+      target.set(@system.temp.testMenu);
 
       # Set key
       menu.setCommandKey("F");
@@ -335,7 +335,7 @@ tests:
       # Should contain F
       local(match = string.contains(key, "F"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return match
     expected_success: true
     expected_result: "true"
@@ -349,12 +349,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Empty menu name - behavior may vary
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "", "Item", "script()"));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "", "Item", "script()"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -364,12 +364,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Empty item name - may fail or create separator
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "", "script()"));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "", "script()"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -379,12 +379,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Test with special characters
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "Save As...", "file.saveAs()"));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "Save As...", "file.saveAs()"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -394,12 +394,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Dash often indicates separator in menus
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "File", "-", ""));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "-", ""));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -409,12 +409,12 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       local(multilineScript = "local(x = 1);\nlocal(y = 2);\nreturn(x + y)");
-      local(ok = menu.addMenuCommand(@workspace.testMenu, "Tools", "Calculate", multilineScript));
+      local(ok = menu.addMenuCommand(@system.temp.testMenu, "Tools", "Calculate", multilineScript));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -430,13 +430,13 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "test()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "test()");
 
       # buildMenuBar installs menus in OS - no-op in headless
       local(result = menu.buildMenuBar());
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return result
     expected_success: true
     expected_result: "true"
@@ -446,14 +446,14 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "Custom", "Test", "test()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "Custom", "Test", "test()");
 
       # install() adds menu to OS menu bar - no-op in headless
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       local(result = menu.install());
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return result
     expected_success: true
     expected_result: "true"
@@ -463,12 +463,12 @@ tests:
     skip: true
     skip_reason: "Flaky in test runner - returns false correctly when run in isolation but inconsistent in batch runs due to menu.install no-op in prior tests"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # isInstalled checks if menu is in OS menu bar - always false headless
-      local(result = menu.isInstalled(@workspace.testMenu));
+      local(result = menu.isInstalled(@system.temp.testMenu));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return result
     expected_success: true
     expected_result: "false"
@@ -482,28 +482,28 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Build File menu
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open...", "fileOpen()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "fileSave()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Save As...", "fileSaveAs()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "-", "");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Quit", "fileQuit()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open...", "fileOpen()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Save", "fileSave()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Save As...", "fileSaveAs()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "-", "");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Quit", "fileQuit()");
 
       # Build Edit menu
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "editUndo()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "-", "");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Cut", "editCut()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Copy", "editCopy()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Paste", "editPaste()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Undo", "editUndo()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "-", "");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Cut", "editCut()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Copy", "editCopy()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Paste", "editPaste()");
 
       # Set some shortcuts
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       # Note: Would need to navigate to specific items to set shortcuts
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return true
     expected_success: true
     expected_result: "true"
@@ -513,23 +513,23 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Initial items
-      menu.addMenuCommand(@workspace.testMenu, "Tools", "Item1", "script1()");
-      menu.addMenuCommand(@workspace.testMenu, "Tools", "Item2", "script2()");
-      menu.addMenuCommand(@workspace.testMenu, "Tools", "Item3", "script3()");
+      menu.addMenuCommand(@system.temp.testMenu, "Tools", "Item1", "script1()");
+      menu.addMenuCommand(@system.temp.testMenu, "Tools", "Item2", "script2()");
+      menu.addMenuCommand(@system.temp.testMenu, "Tools", "Item3", "script3()");
 
       # Delete middle item
-      menu.deleteMenuCommand(@workspace.testMenu, "Tools", "Item2");
+      menu.deleteMenuCommand(@system.temp.testMenu, "Tools", "Item2");
 
       # Add new item (should go at end)
-      menu.addMenuCommand(@workspace.testMenu, "Tools", "Item4", "script4()");
+      menu.addMenuCommand(@system.temp.testMenu, "Tools", "Item4", "script4()");
 
       # Modify first item's script
-      menu.addMenuCommand(@workspace.testMenu, "Tools", "Item1", "modifiedScript1()");
+      menu.addMenuCommand(@system.temp.testMenu, "Tools", "Item1", "modifiedScript1()");
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return true
     expected_success: true
     expected_result: "true"
@@ -545,20 +545,20 @@ tests:
     skip_reason: "Passes in isolation but fails intermittently in batch runs - wrapper script parameter passing issue under investigation"
     script: |
       # Create the parent menubar
-      new(menubarType, @workspace.parentMenu);
-      menu.addMenuCommand(@workspace.parentMenu, "File", "New", "fileNew()");
+      new(menubarType, @system.temp.parentMenu);
+      menu.addMenuCommand(@system.temp.parentMenu, "File", "New", "fileNew()");
 
       # Create the submenu menubar
-      new(menubarType, @workspace.subMenu);
-      menu.addMenuCommand(@workspace.subMenu, "Recent", "File1.txt", "openRecent(1)");
-      menu.addMenuCommand(@workspace.subMenu, "Recent", "File2.txt", "openRecent(2)");
+      new(menubarType, @system.temp.subMenu);
+      menu.addMenuCommand(@system.temp.subMenu, "Recent", "File1.txt", "openRecent(1)");
+      menu.addMenuCommand(@system.temp.subMenu, "Recent", "File2.txt", "openRecent(2)");
 
       # Add submenu to File menu
-      local(ok = menu.addSubMenu(@workspace.parentMenu, "File", @workspace.subMenu));
+      local(ok = menu.addSubMenu(@system.temp.parentMenu, "File", @system.temp.subMenu));
 
       # Clean up
-      delete(@workspace.parentMenu);
-      delete(@workspace.subMenu);
+      delete(@system.temp.parentMenu);
+      delete(@system.temp.subMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -568,17 +568,17 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.parentMenu);
+      new(menubarType, @system.temp.parentMenu);
 
       # Create submenu
-      new(menubarType, @workspace.subMenu);
-      menu.addMenuCommand(@workspace.subMenu, "Tools", "Calculator", "calc()");
+      new(menubarType, @system.temp.subMenu);
+      menu.addMenuCommand(@system.temp.subMenu, "Tools", "Calculator", "calc()");
 
       # Add as top-level (empty menuName)
-      local(ok = menu.addSubMenu(@workspace.parentMenu, "", @workspace.subMenu));
+      local(ok = menu.addSubMenu(@system.temp.parentMenu, "", @system.temp.subMenu));
 
-      delete(@workspace.parentMenu);
-      delete(@workspace.subMenu);
+      delete(@system.temp.parentMenu);
+      delete(@system.temp.subMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -588,17 +588,17 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.parentMenu);
+      new(menubarType, @system.temp.parentMenu);
       # parentMenu is empty - no "Custom" menu exists yet
 
-      new(menubarType, @workspace.subMenu);
-      menu.addMenuCommand(@workspace.subMenu, "Sub", "Item", "doIt()");
+      new(menubarType, @system.temp.subMenu);
+      menu.addMenuCommand(@system.temp.subMenu, "Sub", "Item", "doIt()");
 
       # This should create "Custom" menu and add submenu to it
-      local(ok = menu.addSubMenu(@workspace.parentMenu, "Custom", @workspace.subMenu));
+      local(ok = menu.addSubMenu(@system.temp.parentMenu, "Custom", @system.temp.subMenu));
 
-      delete(@workspace.parentMenu);
-      delete(@workspace.subMenu);
+      delete(@system.temp.parentMenu);
+      delete(@system.temp.subMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -608,11 +608,11 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.parentMenu);
+      new(menubarType, @system.temp.parentMenu);
 
       # In headless mode, addSubMenu is a no-op that returns true
-      local(ok = menu.addSubMenu(@workspace.parentMenu, "File", @workspace.doesNotExist));
-      delete(@workspace.parentMenu);
+      local(ok = menu.addSubMenu(@system.temp.parentMenu, "File", @system.temp.doesNotExist));
+      delete(@system.temp.parentMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -622,17 +622,17 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add some menus
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "editUndo()");
-      menu.addMenuCommand(@workspace.testMenu, "Help", "About", "helpAbout()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Undo", "editUndo()");
+      menu.addMenuCommand(@system.temp.testMenu, "Help", "About", "helpAbout()");
 
       # Delete the Edit menu
-      local(ok = menu.deleteSubMenu(@workspace.testMenu, "Edit"));
+      local(ok = menu.deleteSubMenu(@system.temp.testMenu, "Edit"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -642,13 +642,13 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "fileNew()");
 
       # Try to delete menu that doesn't exist
-      local(ok = menu.deleteSubMenu(@workspace.testMenu, "NoSuchMenu"));
+      local(ok = menu.deleteSubMenu(@system.temp.testMenu, "NoSuchMenu"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -658,13 +658,13 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "SingleItem", "doIt()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "SingleItem", "doIt()");
 
       # deleteSubMenu on a single item should still work
-      local(ok = menu.deleteSubMenu(@workspace.testMenu, "SingleItem"));
+      local(ok = menu.deleteSubMenu(@system.temp.testMenu, "SingleItem"));
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return ok
     expected_success: true
     expected_result: "true"
@@ -679,9 +679,9 @@ tests:
     skip: true
     skip_reason: "New menubar outline initialization differs in headless mode - returns 18 instead of 0"
     script: |
-      new(menubarType, @workspace.testMenu);
-      local(size = sizeOf(@workspace.testMenu));
-      delete(@workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
+      local(size = sizeOf(@system.temp.testMenu));
+      delete(@system.temp.testMenu);
       return size
     expected_success: true
     expected_result: "0"
@@ -691,15 +691,15 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - no items are actually added"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Add File menu with 3 items (1 menu + 3 items = 4 headings)
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "new()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "open()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "save()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "new()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "open()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Save", "save()");
 
-      local(size = sizeOf(@workspace.testMenu));
-      delete(@workspace.testMenu);
+      local(size = sizeOf(@system.temp.testMenu));
+      delete(@system.temp.testMenu);
       return size
     expected_success: true
     expected_result: "4"
@@ -709,20 +709,20 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - no items are actually added"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # File menu: 1 + 2 items = 3
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "new()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "open()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "new()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "open()");
 
       # Edit menu: 1 + 3 items = 4
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "undo()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Cut", "cut()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Copy", "copy()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Undo", "undo()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Cut", "cut()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Copy", "copy()");
 
       # Total: 3 + 4 = 7
-      local(size = sizeOf(@workspace.testMenu));
-      delete(@workspace.testMenu);
+      local(size = sizeOf(@system.temp.testMenu));
+      delete(@system.temp.testMenu);
       return size
     expected_success: true
     expected_result: "7"
@@ -732,25 +732,25 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - no items are actually added"
     script: |
-      new(menubarType, @workspace.parentMenu);
-      new(menubarType, @workspace.subMenu);
+      new(menubarType, @system.temp.parentMenu);
+      new(menubarType, @system.temp.subMenu);
 
       # Parent has File with 1 item
-      menu.addMenuCommand(@workspace.parentMenu, "File", "New", "new()");
+      menu.addMenuCommand(@system.temp.parentMenu, "File", "New", "new()");
 
       # Submenu has 2 items
-      menu.addMenuCommand(@workspace.subMenu, "Recent", "Doc1", "open1()");
-      menu.addMenuCommand(@workspace.subMenu, "Recent", "Doc2", "open2()");
+      menu.addMenuCommand(@system.temp.subMenu, "Recent", "Doc1", "open1()");
+      menu.addMenuCommand(@system.temp.subMenu, "Recent", "Doc2", "open2()");
 
       # Add submenu to File
-      menu.addSubMenu(@workspace.parentMenu, "File", @workspace.subMenu);
+      menu.addSubMenu(@system.temp.parentMenu, "File", @system.temp.subMenu);
 
       # Expected count: File(1) + New(1) + Recent(1) + Doc1(1) + Doc2(1) = 5 minimum
       # May include additional structure nodes depending on representation
-      local(size = sizeOf(@workspace.parentMenu));
+      local(size = sizeOf(@system.temp.parentMenu));
 
-      delete(@workspace.parentMenu);
-      delete(@workspace.subMenu);
+      delete(@system.temp.parentMenu);
+      delete(@system.temp.subMenu);
 
       # Verify size is at least the expected minimum (5 headings)
       local(expectedMinimum = 5);
@@ -768,15 +768,15 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - cursor navigation requires actual menu items"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # Build menu: File > New, Open, Save
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "fileOpen()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "fileSave()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "fileOpen()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Save", "fileSave()");
 
       # Set target to menubar
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Navigate: firstSummit (File), expand, go right (into items), down 1 (to Open)
       op.firstSummit();
@@ -785,13 +785,13 @@ tests:
       op.go(down, 1);
 
       # Get script from "Open" item
-      menu.getScript(@workspace.retrievedScript);
+      menu.getScript(@system.temp.retrievedScript);
 
       # Verify we got the right script
-      local(match = (workspace.retrievedScript == "fileOpen()"));
+      local(match = (system.temp.retrievedScript == "fileOpen()"));
 
-      delete(@workspace.testMenu);
-      try {delete(@workspace.retrievedScript)};
+      delete(@system.temp.testMenu);
+      try {delete(@system.temp.retrievedScript)};
       return match
     expected_success: true
     expected_result: "true"
@@ -801,10 +801,10 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - cursor navigation requires actual menu items"
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "originalScript()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "originalScript()");
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Navigate to File > Test
       op.firstSummit();
@@ -812,16 +812,16 @@ tests:
       op.go(right, 1);
 
       # Create new script and set it
-      workspace.newScript = "modifiedScript()";
-      menu.setScript(@workspace.newScript);
+      system.temp.newScript = "modifiedScript()";
+      menu.setScript(@system.temp.newScript);
 
       # Get it back to verify
-      menu.getScript(@workspace.verifyScript);
-      local(match = (workspace.verifyScript == "modifiedScript()"));
+      menu.getScript(@system.temp.verifyScript);
+      local(match = (system.temp.verifyScript == "modifiedScript()"));
 
-      delete(@workspace.testMenu);
-      delete(@workspace.newScript);
-      try {delete(@workspace.verifyScript)};
+      delete(@system.temp.testMenu);
+      delete(@system.temp.newScript);
+      try {delete(@system.temp.verifyScript)};
       return match
     expected_success: true
     expected_result: "true"
@@ -831,15 +831,15 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - cursor navigation requires actual menu items"
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
       # File menu with 4 items
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "script1()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "script2()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Save", "script3()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Close", "script4()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "script1()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "script2()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Save", "script3()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Close", "script4()");
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
 
       # Navigate to Save (3rd item)
       op.firstSummit();
@@ -847,11 +847,11 @@ tests:
       op.go(right, 1);
       op.go(down, 2);
 
-      menu.getScript(@workspace.retrieved);
-      local(match = (workspace.retrieved == "script3()"));
+      menu.getScript(@system.temp.retrieved);
+      local(match = (system.temp.retrieved == "script3()"));
 
-      delete(@workspace.testMenu);
-      try {delete(@workspace.retrieved)};
+      delete(@system.temp.testMenu);
+      try {delete(@system.temp.retrieved)};
       return match
     expected_success: true
     expected_result: "true"
@@ -866,10 +866,10 @@ tests:
     skip: true
     skip_reason: "menu.zoomScript signals error via bserror, behavior needs verification"
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "script()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "script()");
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       op.firstSummit();
       op.expand();
       op.go(right, 1);
@@ -877,7 +877,7 @@ tests:
       # zoomScript opens editor window - noop in headless
       local(result = menu.zoomScript());
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return result
     expected_success: true
     expected_result: "false"
@@ -893,35 +893,35 @@ tests:
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - persistence tests require actual menu data"
     script: |
       # Create menubar with structure
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "fileNew()");
-      menu.addMenuCommand(@workspace.testMenu, "File", "Open", "fileOpen()");
-      menu.addMenuCommand(@workspace.testMenu, "Edit", "Undo", "editUndo()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "fileNew()");
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Open", "fileOpen()");
+      menu.addMenuCommand(@system.temp.testMenu, "Edit", "Undo", "editUndo()");
 
       # Remember size before save
-      local(sizeBefore = sizeOf(@workspace.testMenu));
+      local(sizeBefore = sizeOf(@system.temp.testMenu));
 
       # Save to a file
       local(testPath = "{FRONTIER_TEST_TMP_DIR}/menu_persist_test.root7");
       file.new(testPath, 'TABL');
       local(fref = file.open(testPath, true));
-      db.save(@workspace.testMenu, fref);
+      db.save(@system.temp.testMenu, fref);
       file.close(fref);
 
       # Delete from memory
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
 
       # Reload
       fref = file.open(testPath, false);
-      db.load(fref, @workspace.reloadedMenu);
+      db.load(fref, @system.temp.reloadedMenu);
       file.close(fref);
 
       # Verify size matches
-      local(sizeAfter = sizeOf(@workspace.reloadedMenu));
+      local(sizeAfter = sizeOf(@system.temp.reloadedMenu));
       local(sizeMatch = (sizeBefore == sizeAfter));
 
       # Clean up
-      delete(@workspace.reloadedMenu);
+      delete(@system.temp.reloadedMenu);
       file.delete(testPath);
 
       return sizeMatch
@@ -936,36 +936,36 @@ tests:
       local(testScript = "dialog.alert(\"Hello World!\")");
 
       # Create menubar with script
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "Test", "Item", testScript);
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "Test", "Item", testScript);
 
       # Save
       local(testPath = "{FRONTIER_TEST_TMP_DIR}/menu_script_persist.root7");
       file.new(testPath, 'TABL');
       local(fref = file.open(testPath, true));
-      db.save(@workspace.testMenu, fref);
+      db.save(@system.temp.testMenu, fref);
       file.close(fref);
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
 
       # Reload
       fref = file.open(testPath, false);
-      db.load(fref, @workspace.reloadedMenu);
+      db.load(fref, @system.temp.reloadedMenu);
       file.close(fref);
 
       # Navigate to item and get script
-      target.set(@workspace.reloadedMenu);
+      target.set(@system.temp.reloadedMenu);
       op.firstSummit();
       op.expand();
       op.go(right, 1);
-      menu.getScript(@workspace.retrievedScript);
+      menu.getScript(@system.temp.retrievedScript);
 
       # Compare
-      local(match = (workspace.retrievedScript == testScript));
+      local(match = (system.temp.retrievedScript == testScript));
 
       # Clean up
-      delete(@workspace.reloadedMenu);
-      try {delete(@workspace.retrievedScript)};
+      delete(@system.temp.reloadedMenu);
+      try {delete(@system.temp.retrievedScript)};
       file.delete(testPath);
 
       return match
@@ -977,25 +977,25 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand is a no-op in headless mode - persistence tests require actual menu data"
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "CustomMenu", "CustomItem", "script()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "CustomMenu", "CustomItem", "script()");
 
       # Save
       local(testPath = "{FRONTIER_TEST_TMP_DIR}/menu_names_persist.root7");
       file.new(testPath, 'TABL');
       local(fref = file.open(testPath, true));
-      db.save(@workspace.testMenu, fref);
+      db.save(@system.temp.testMenu, fref);
       file.close(fref);
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
 
       # Reload
       fref = file.open(testPath, false);
-      db.load(fref, @workspace.reloadedMenu);
+      db.load(fref, @system.temp.reloadedMenu);
       file.close(fref);
 
       # Navigate and get the headline text to verify name
-      target.set(@workspace.reloadedMenu);
+      target.set(@system.temp.reloadedMenu);
       op.firstSummit();
       local(menuName = op.getLineText());
 
@@ -1004,7 +1004,7 @@ tests:
       local(itemName = op.getLineText());
 
       # Clean up
-      delete(@workspace.reloadedMenu);
+      delete(@system.temp.reloadedMenu);
       file.delete(testPath);
 
       return (menuName == "CustomMenu") and (itemName == "CustomItem")
@@ -1022,14 +1022,14 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "New", "test()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "New", "test()");
 
       # Should return true (no-op), NOT throw an error
       local(result = menu.buildMenuBar());
       local(noError = true);  # If we got here, no error was thrown
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return (result == true) and noError
     expected_success: true
     expected_result: "true"
@@ -1039,14 +1039,14 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "Custom", "Test", "test()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "Custom", "Test", "test()");
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       local(result = menu.install());
       local(noError = true);
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return (result == true) and noError
     expected_success: true
     expected_result: "true"
@@ -1056,13 +1056,13 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
+      new(menubarType, @system.temp.testMenu);
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       local(result = menu.isInstalled());
       local(noError = true);
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return (result == false) and noError
     expected_success: true
     expected_result: "true"
@@ -1072,14 +1072,14 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "Test", "test()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "test()");
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       local(result = menu.remove());
       local(noError = true);
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return (result == true) and noError
     expected_success: true
     expected_result: "true"
@@ -1106,14 +1106,14 @@ tests:
     skip: true
     skip_reason: "menu.toggle verb not implemented in headless mode"
     script: |
-      new(menubarType, @workspace.testMenu);
-      menu.addMenuCommand(@workspace.testMenu, "File", "Toggle", "test()");
+      new(menubarType, @system.temp.testMenu);
+      menu.addMenuCommand(@system.temp.testMenu, "File", "Toggle", "test()");
 
-      target.set(@workspace.testMenu);
+      target.set(@system.temp.testMenu);
       local(result = menu.toggle());
       local(noError = true);
 
-      delete(@workspace.testMenu);
+      delete(@system.temp.testMenu);
       return (result == false) and noError
     expected_success: true
     expected_result: "true"

--- a/tests/integration/test_cases/menu_value_copy.yaml
+++ b/tests/integration/test_cases/menu_value_copy.yaml
@@ -4,7 +4,7 @@
 # ODB locations, which was previously broken in headless mode. The core issue
 # was that assigning an mbar value from one location to another would fail,
 # preventing operations like:
-#   workspace.copy = userland.virginBookmarkMenu
+#   system.temp.copy = userland.virginBookmarkMenu
 #
 # Test Strategy:
 #   - Test basic copy of empty menubar
@@ -18,15 +18,15 @@ tests:
   # ==========================================================================
 
   - name: "mbar copy - copy menubar value to new location"
-    description: "Create a menubar at workspace.src, copy to workspace.dst, verify typeof is mbar"
+    description: "Create a menubar at system.temp.src, copy to system.temp.dst, verify typeof is mbar"
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.src);
-      workspace.dst = workspace.src;
-      local (result = typeof(workspace.dst) == 'mbar');
-      delete(@workspace.src);
-      delete(@workspace.dst);
+      new(menubarType, @system.temp.src);
+      system.temp.dst = system.temp.src;
+      local (result = typeof(system.temp.dst) == 'mbar');
+      delete(@system.temp.src);
+      delete(@system.temp.dst);
       return result
     expected_success: true
     expected_result: "true"
@@ -40,11 +40,11 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      new(menubarType, @workspace.src);
-      workspace.dst = workspace.src;
-      local (result = defined(@workspace.dst));
-      delete(@workspace.src);
-      delete(@workspace.dst);
+      new(menubarType, @system.temp.src);
+      system.temp.dst = system.temp.src;
+      local (result = defined(@system.temp.dst));
+      delete(@system.temp.src);
+      delete(@system.temp.dst);
       return result
     expected_success: true
     expected_result: "true"
@@ -58,18 +58,18 @@ tests:
     skip: true
     skip_reason: "menu.addMenuCommand and related menu editing verbs not implemented in headless"
     script: |
-      new(menubarType, @workspace.src);
-      menu.addMenuCommand(@workspace.src, "File", "Open", "fileOpen()");
-      workspace.dst = workspace.src;
-      target.set(@workspace.dst);
+      new(menubarType, @system.temp.src);
+      menu.addMenuCommand(@system.temp.src, "File", "Open", "fileOpen()");
+      system.temp.dst = system.temp.src;
+      target.set(@system.temp.dst);
       op.firstSummit();
       op.expand();
       op.go(right, 1);
-      menu.getScript(@workspace.retrieved);
-      local (result = (workspace.retrieved == "fileOpen()"));
-      delete(@workspace.src);
-      delete(@workspace.dst);
-      try {delete(@workspace.retrieved)};
+      menu.getScript(@system.temp.retrieved);
+      local (result = (system.temp.retrieved == "fileOpen()"));
+      delete(@system.temp.src);
+      delete(@system.temp.dst);
+      try {delete(@system.temp.retrieved)};
       return result
     expected_success: true
     expected_result: "true"
@@ -96,9 +96,9 @@ tests:
     skip: false
     skip_reason: ""
     script: |
-      workspace.testCopy = userland.virginBookmarkMenu;
-      local (result = typeof(workspace.testCopy) == 'mbar');
-      delete(@workspace.testCopy);
+      system.temp.testCopy = userland.virginBookmarkMenu;
+      local (result = typeof(system.temp.testCopy) == 'mbar');
+      delete(@system.temp.testCopy);
       return result
     expected_success: true
     expected_result: "true"

--- a/tests/integration/test_cases/migration_externals.yaml
+++ b/tests/integration/test_cases/migration_externals.yaml
@@ -186,8 +186,8 @@ tests:
         return "found " + string(menuCount) + " menus"
       } else {
         // Create a test menu if none exist
-        lang.new(menuType, @workspace.testMenu);
-        if typeOf(workspace.testMenu) == 'menu' {
+        lang.new(menuType, @system.temp.testMenu);
+        if typeOf(system.temp.testMenu) == 'menu' {
           return "created test menu"
         };
         return "no menus found"

--- a/tests/integration/test_cases/op_outlinetoxml_headless.yaml
+++ b/tests/integration/test_cases/op_outlinetoxml_headless.yaml
@@ -13,8 +13,8 @@ tests:
   - name: "op.outlineToXml - empty outline returns valid OPML"
     description: "Convert empty outline to OPML (previously caused stack overflow)"
     script: |
-      lang.new(outlineType, @workspace.emptyOutline);
-      local(xml = op.outlineToXml(@workspace.emptyOutline, "TestUser", "test@example.com"));
+      lang.new(outlineType, @system.temp.emptyOutline);
+      local(xml = op.outlineToXml(@system.temp.emptyOutline, "TestUser", "test@example.com"));
       return string.mid(xml, 1, 5) == "<?xml"
     expected_success: true
     expected_result: "true"
@@ -22,8 +22,8 @@ tests:
   - name: "op.outlineToXml - empty outline contains opml tag"
     description: "Empty outline OPML contains proper opml root element"
     script: |
-      lang.new(outlineType, @workspace.emptyOutline);
-      local(xml = op.outlineToXml(@workspace.emptyOutline, "TestUser", "test@example.com"));
+      lang.new(outlineType, @system.temp.emptyOutline);
+      local(xml = op.outlineToXml(@system.temp.emptyOutline, "TestUser", "test@example.com"));
       return string.patternMatch("<opml", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -31,8 +31,8 @@ tests:
   - name: "op.outlineToXml - empty outline contains head section"
     description: "Empty outline OPML contains head element"
     script: |
-      lang.new(outlineType, @workspace.emptyOutline);
-      local(xml = op.outlineToXml(@workspace.emptyOutline, "TestUser", "test@example.com"));
+      lang.new(outlineType, @system.temp.emptyOutline);
+      local(xml = op.outlineToXml(@system.temp.emptyOutline, "TestUser", "test@example.com"));
       return string.patternMatch("<head>", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -40,8 +40,8 @@ tests:
   - name: "op.outlineToXml - empty outline contains body section"
     description: "Empty outline OPML contains body element"
     script: |
-      lang.new(outlineType, @workspace.emptyOutline);
-      local(xml = op.outlineToXml(@workspace.emptyOutline, "TestUser", "test@example.com"));
+      lang.new(outlineType, @system.temp.emptyOutline);
+      local(xml = op.outlineToXml(@system.temp.emptyOutline, "TestUser", "test@example.com"));
       return string.patternMatch("<body>", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -53,10 +53,10 @@ tests:
   - name: "op.outlineToXml - single line outline"
     description: "Convert single-line outline to OPML (previously caused segfault)"
     script: |
-      lang.new(outlineType, @workspace.singleLine);
-      target.set(@workspace.singleLine);
+      lang.new(outlineType, @system.temp.singleLine);
+      target.set(@system.temp.singleLine);
       op.setLineText("Hello World");
-      local(xml = op.outlineToXml(@workspace.singleLine, "TestUser", "test@example.com"));
+      local(xml = op.outlineToXml(@system.temp.singleLine, "TestUser", "test@example.com"));
       return string.patternMatch("Hello World", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -64,10 +64,10 @@ tests:
   - name: "op.outlineToXml - single line has outline element"
     description: "Single-line OPML contains outline element with text attribute"
     script: |
-      lang.new(outlineType, @workspace.singleLine);
-      target.set(@workspace.singleLine);
+      lang.new(outlineType, @system.temp.singleLine);
+      target.set(@system.temp.singleLine);
       op.setLineText("Test Line");
-      local(xml = op.outlineToXml(@workspace.singleLine, "TestUser", "test@example.com"));
+      local(xml = op.outlineToXml(@system.temp.singleLine, "TestUser", "test@example.com"));
       return string.patternMatch("<outline text=", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -79,12 +79,12 @@ tests:
   - name: "op.outlineToXml - multiple lines"
     description: "Convert multi-line outline preserves all content"
     script: |
-      lang.new(outlineType, @workspace.multiLine);
-      target.set(@workspace.multiLine);
+      lang.new(outlineType, @system.temp.multiLine);
+      target.set(@system.temp.multiLine);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
-      local(xml = op.outlineToXml(@workspace.multiLine, "TestUser", "test@example.com"));
+      local(xml = op.outlineToXml(@system.temp.multiLine, "TestUser", "test@example.com"));
       local(has1 = string.patternMatch("Line 1", xml) > 0);
       local(has2 = string.patternMatch("Line 2", xml) > 0);
       local(has3 = string.patternMatch("Line 3", xml) > 0);
@@ -95,12 +95,12 @@ tests:
   - name: "op.outlineToXml - nested hierarchy"
     description: "Convert nested outline preserves parent-child structure"
     script: |
-      lang.new(outlineType, @workspace.nested);
-      target.set(@workspace.nested);
+      lang.new(outlineType, @system.temp.nested);
+      target.set(@system.temp.nested);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
-      local(xml = op.outlineToXml(@workspace.nested, "TestUser", "test@example.com"));
+      local(xml = op.outlineToXml(@system.temp.nested, "TestUser", "test@example.com"));
       local(hasParent = string.patternMatch("Parent", xml) > 0);
       local(hasChild1 = string.patternMatch("Child 1", xml) > 0);
       local(hasChild2 = string.patternMatch("Child 2", xml) > 0);
@@ -115,10 +115,10 @@ tests:
   - name: "op.outlineToXml - includes owner name"
     description: "OPML includes ownerName in head section"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setLineText("Content");
-      local(xml = op.outlineToXml(@workspace.outline, "John Doe", "john@example.com"));
+      local(xml = op.outlineToXml(@system.temp.outline, "John Doe", "john@example.com"));
       return string.patternMatch("John Doe", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -126,10 +126,10 @@ tests:
   - name: "op.outlineToXml - includes owner email"
     description: "OPML includes ownerEmail in head section"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setLineText("Content");
-      local(xml = op.outlineToXml(@workspace.outline, "John Doe", "john@example.com"));
+      local(xml = op.outlineToXml(@system.temp.outline, "John Doe", "john@example.com"));
       return string.patternMatch("john@example.com", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -141,10 +141,10 @@ tests:
   - name: "op.outlineToXml - valid OPML structure"
     description: "OPML has proper document structure (opml > head + body)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setLineText("Test");
-      local(xml = op.outlineToXml(@workspace.outline, "User", "user@example.com"));
+      local(xml = op.outlineToXml(@system.temp.outline, "User", "user@example.com"));
       local(hasOpml = string.patternMatch("<opml", xml) > 0);
       local(hasHead = string.patternMatch("<head>", xml) > 0);
       local(hasBody = string.patternMatch("<body>", xml) > 0);
@@ -156,10 +156,10 @@ tests:
   - name: "op.outlineToXml - has XML declaration"
     description: "OPML starts with XML declaration"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setLineText("Test");
-      local(xml = op.outlineToXml(@workspace.outline, "User", "user@example.com"));
+      local(xml = op.outlineToXml(@system.temp.outline, "User", "user@example.com"));
       return string.mid(xml, 1, 5) == "<?xml"
     expected_success: true
     expected_result: "true"
@@ -171,13 +171,13 @@ tests:
   - name: "round-trip - single line preserves content"
     description: "Converting outline to XML and back preserves line text"
     script: |
-      lang.new(outlineType, @workspace.rtSrc);
-      target.set(@workspace.rtSrc);
+      lang.new(outlineType, @system.temp.rtSrc);
+      target.set(@system.temp.rtSrc);
       op.setLineText("RoundTripTest");
-      local(xml = op.outlineToXml(@workspace.rtSrc, "User", "test@example.com"));
-      lang.new(outlineType, @workspace.rtDst);
-      op.xmlToOutline(xml, @workspace.rtDst);
-      target.set(@workspace.rtDst);
+      local(xml = op.outlineToXml(@system.temp.rtSrc, "User", "test@example.com"));
+      lang.new(outlineType, @system.temp.rtDst);
+      op.xmlToOutline(xml, @system.temp.rtDst);
+      target.set(@system.temp.rtDst);
       op.firstSummit();
       return op.getLineText() == "RoundTripTest"
     expected_success: true
@@ -186,14 +186,14 @@ tests:
   - name: "round-trip - multiple lines preserved"
     description: "Converting multi-line outline to XML and back preserves first and second lines"
     script: |
-      lang.new(outlineType, @workspace.rtMultiSrc);
-      target.set(@workspace.rtMultiSrc);
+      lang.new(outlineType, @system.temp.rtMultiSrc);
+      target.set(@system.temp.rtMultiSrc);
       op.setLineText("First");
       op.insert("Second", down);
-      local(xml = op.outlineToXml(@workspace.rtMultiSrc, "User", "test@example.com"));
-      lang.new(outlineType, @workspace.rtMultiDst);
-      op.xmlToOutline(xml, @workspace.rtMultiDst);
-      target.set(@workspace.rtMultiDst);
+      local(xml = op.outlineToXml(@system.temp.rtMultiSrc, "User", "test@example.com"));
+      lang.new(outlineType, @system.temp.rtMultiDst);
+      op.xmlToOutline(xml, @system.temp.rtMultiDst);
+      target.set(@system.temp.rtMultiDst);
       op.firstSummit();
       local(hasFirst = op.getLineText() == "First");
       op.go(right, 1);
@@ -205,14 +205,14 @@ tests:
   - name: "round-trip - nested hierarchy preserved"
     description: "Converting nested outline to XML and back preserves structure"
     script: |
-      lang.new(outlineType, @workspace.rtNestedSrc);
-      target.set(@workspace.rtNestedSrc);
+      lang.new(outlineType, @system.temp.rtNestedSrc);
+      target.set(@system.temp.rtNestedSrc);
       op.setLineText("Parent");
       op.insert("Child", right);
-      local(xml = op.outlineToXml(@workspace.rtNestedSrc, "User", "test@example.com"));
-      lang.new(outlineType, @workspace.rtNestedDst);
-      op.xmlToOutline(xml, @workspace.rtNestedDst);
-      target.set(@workspace.rtNestedDst);
+      local(xml = op.outlineToXml(@system.temp.rtNestedSrc, "User", "test@example.com"));
+      lang.new(outlineType, @system.temp.rtNestedDst);
+      op.xmlToOutline(xml, @system.temp.rtNestedDst);
+      target.set(@system.temp.rtNestedDst);
       op.firstSummit();
       local(hasChild = op.go(right, 1));
       return hasChild

--- a/tests/integration/test_cases/op_verbs.yaml
+++ b/tests/integration/test_cases/op_verbs.yaml
@@ -12,7 +12,7 @@
 # Headless Behavior Notes:
 # - All outline operations require an outline set as target: target.set(@myOutline)
 # - Outlines are in-memory tree data structures (no GUI window required)
-# - Create outlines with: lang.new(outlineType, @workspace.outline)
+# - Create outlines with: lang.new(outlineType, @system.temp.outline)
 # - Cursor position is data structure state (current node), not GUI state
 # - Direction values: up, down, left, right, flatup, flatdown
 # - Expansion state is tree metadata, not visual display state
@@ -27,27 +27,27 @@ tests:
   - name: "outline creation - lang.new with outlineType"
     description: "Create new outline object using lang.new(outlineType, @addr)"
     script: |
-      lang.new(outlineType, @workspace.testOutline);
-      return typeof(workspace.testOutline)
+      lang.new(outlineType, @system.temp.testOutline);
+      return typeof(system.temp.testOutline)
     expected_success: true
     expected_result: "optx"
 
   - name: "outline target setup - set outline as target"
     description: "Set outline as target for op verb operations"
     script: |
-      lang.new(outlineType, @workspace.myOutline);
-      target.set(@workspace.myOutline);
+      lang.new(outlineType, @system.temp.myOutline);
+      target.set(@system.temp.myOutline);
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.myOutline"
+    expected_result: "system.temp.myOutline"
 
   - name: "outline target workflow - full setup cycle"
     description: "Complete workflow: create outline → set as target → verify"
     script: |
-      lang.new(outlineType, @workspace.opTest);
-      target.set(@workspace.opTest);
-      local(ok1 = typeof(workspace.opTest) == "optx");
-      local(ok2 = string(target.get()) == "workspace.opTest");
+      lang.new(outlineType, @system.temp.opTest);
+      target.set(@system.temp.opTest);
+      local(ok1 = typeof(system.temp.opTest) == "optx");
+      local(ok2 = string(target.get()) == "system.temp.opTest");
       return ok1 and ok2
     expected_success: true
     expected_result: "true"
@@ -59,8 +59,8 @@ tests:
   - name: "op.insert - insert first line (down)"
     description: "Insert first line into empty outline using down direction"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return op.insert("First line", down)
     expected_success: true
     expected_result: "true"
@@ -68,8 +68,8 @@ tests:
   - name: "op.insert - insert sibling line (down)"
     description: "Insert sibling line below current line"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       return op.insert("Line 2", down)
     expected_success: true
@@ -78,8 +78,8 @@ tests:
   - name: "op.insert - insert child line (right)"
     description: "Insert child line under current line (indent)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       return op.insert("Child", right)
     expected_success: true
@@ -88,8 +88,8 @@ tests:
   - name: "op.insert - insert above (up)"
     description: "Insert line above current position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 2", down);
       return op.insert("Line 1", up)
     expected_success: true
@@ -98,8 +98,8 @@ tests:
   - name: "op.insert - insert parent (left)"
     description: "Insert parent line to the left (outdent and insert)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       return op.insert("Grandchild", right)
@@ -109,8 +109,8 @@ tests:
   - name: "op.insert - cursor moves to inserted headline"
     description: "After insert, bar cursor should be positioned on the new headline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -127,8 +127,8 @@ tests:
   - name: "op.getLineText - read inserted line"
     description: "Get text of line after insertion"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test content", down);
       return op.getLineText()
     expected_success: true
@@ -137,8 +137,8 @@ tests:
   - name: "op.getLineText - returns string type"
     description: "getLineText returns stringType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Hello", down);
       return typeof(op.getLineText())
     expected_success: true
@@ -147,8 +147,8 @@ tests:
   - name: "op.getLineText - empty line text"
     description: "Get text of empty line (empty string)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("", down);
       return sizeOf(op.getLineText())
     expected_success: true
@@ -161,8 +161,8 @@ tests:
   - name: "op.go - navigate down one line"
     description: "Move cursor down one line in outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.go(up, 1);
@@ -174,8 +174,8 @@ tests:
   - name: "op.go - navigate up one line"
     description: "Move cursor up one line in outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.go(up, 1);
@@ -186,8 +186,8 @@ tests:
   - name: "op.go - navigate right (into child)"
     description: "Move cursor right into first child"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -199,8 +199,8 @@ tests:
   - name: "op.go - navigate left (to parent)"
     description: "Move cursor left to parent node"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -211,8 +211,8 @@ tests:
   - name: "op.go - navigate multiple units"
     description: "Navigate down multiple lines at once"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -224,8 +224,8 @@ tests:
   - name: "op.go - returns boolean on success"
     description: "go() returns true when navigation succeeds"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       return op.go(up, 1)
@@ -235,8 +235,8 @@ tests:
   - name: "op.go - returns false at boundary"
     description: "go() returns false when can't move further (at boundary)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Only line", down);
       op.go(up, 1);
       return op.go(up, 1)
@@ -246,8 +246,8 @@ tests:
   - name: "op.go - flatup direction (skip children)"
     description: "Navigate flatup (previous sibling/parent, skipping children)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       return op.go(flatup, 1)
@@ -257,8 +257,8 @@ tests:
   - name: "op.go - flatdown direction (skip children)"
     description: "Navigate flatdown (next sibling, skipping children)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.go(up, 1);
@@ -273,8 +273,8 @@ tests:
   - name: "op.firstSummit - go to first top-level node"
     description: "Navigate to first summit (top-level node, which is initially empty)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First", down);
       op.insert("Second", down);
       op.insert("Third", down);
@@ -287,8 +287,8 @@ tests:
   - name: "op.firstSummit - returns boolean true"
     description: "firstSummit returns true on success"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.firstSummit()
     expected_success: true
@@ -301,8 +301,8 @@ tests:
   - name: "op.level - top-level is 1"
     description: "Top-level nodes have level 1"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Top level", down);
       return op.level()
     expected_success: true
@@ -311,8 +311,8 @@ tests:
   - name: "op.level - child is level 2"
     description: "Child nodes have level 2"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       return op.level()
@@ -322,8 +322,8 @@ tests:
   - name: "op.level - grandchild is level 3"
     description: "Grandchild nodes have level 3"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.insert("Grandchild", right);
@@ -338,8 +338,8 @@ tests:
   - name: "op.countSubs - count immediate children (level 1)"
     description: "Count direct children of current node"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -352,8 +352,8 @@ tests:
   - name: "op.countSubs - no children returns 0"
     description: "Leaf nodes have 0 children"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Leaf node", down);
       return op.countSubs(1)
     expected_success: true
@@ -362,8 +362,8 @@ tests:
   - name: "op.countSubs - infinity counts all descendants"
     description: "Use infinity to count all descendants recursively"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Root", down);
       op.insert("Child 1", right);
       op.insert("Grandchild", right);
@@ -381,8 +381,8 @@ tests:
   - name: "op.countSummits - count top-level nodes"
     description: "Count all summit (top-level) nodes in outline (includes empty root)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Summit 1", down);
       op.insert("Summit 2", down);
       op.insert("Summit 3", down);
@@ -393,8 +393,8 @@ tests:
   - name: "op.countSummits - empty outline returns 1"
     description: "Empty outline has 1 summit (the empty root node)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return op.countSummits()
     expected_success: true
     expected_result: "1"
@@ -402,8 +402,8 @@ tests:
   - name: "op.countSummits - children don't count"
     description: "Child nodes are not counted as summits (empty root + 1 summit)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Summit", down);
       op.insert("Child", right);
       op.insert("Grandchild", right);
@@ -418,8 +418,8 @@ tests:
   - name: "op.subsExpanded - collapsed headline returns false"
     description: "Returns false when current headline's children are collapsed"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -431,8 +431,8 @@ tests:
   - name: "op.subsExpanded - expanded headline returns true"
     description: "Returns true when current headline's children are expanded"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -444,8 +444,8 @@ tests:
   - name: "op.subsExpanded - no children returns false"
     description: "Returns false when headline has no children"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Leaf Node", down);
       return op.subsExpanded()
     expected_success: true
@@ -454,8 +454,8 @@ tests:
   - name: "op.subsExpanded - no parameters"
     description: "Verify op.subsExpanded works with zero parameters on empty outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return op.subsExpanded()
     expected_success: true
     expected_result: "false"
@@ -467,8 +467,8 @@ tests:
   - name: "op.expand - expand one level"
     description: "Expand current node one level (show immediate children)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -480,8 +480,8 @@ tests:
   - name: "op.expand - expand all descendants (infinity)"
     description: "Expand all descendants using infinity"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Root", down);
       op.insert("Child", right);
       op.insert("Grandchild", right);
@@ -498,8 +498,8 @@ tests:
   - name: "op.collapse - collapse current node"
     description: "Collapse current node (hide all children)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -511,8 +511,8 @@ tests:
   - name: "op.collapse - returns boolean"
     description: "collapse returns true only if something was collapsed"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Node", down);
       return op.collapse()
     expected_success: true
@@ -525,8 +525,8 @@ tests:
   - name: "op.promote - move child to sibling of parent"
     description: "op.promote() promotes children of current node (moves subheads left one level)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -555,8 +555,8 @@ tests:
   - name: "op.promote - returns boolean"
     description: "promote returns true when children exist to promote"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       /* Cursor is on Child after inserting it */
@@ -569,8 +569,8 @@ tests:
   - name: "op.promote - top-level cannot promote"
     description: "Top-level nodes cannot be promoted (already at level 1)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Top", down);
       return op.promote()
     expected_success: true
@@ -583,8 +583,8 @@ tests:
   - name: "op.demote - make sibling a child"
     description: "op.demote() demotes siblings after current node (moves following siblings right to become children)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Sibling 1", down);
       op.insert("Sibling 2", down);
@@ -611,8 +611,8 @@ tests:
   - name: "op.demote - returns boolean"
     description: "demote returns true when siblings exist to demote"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       /* Cursor is on Line 2 */
@@ -629,8 +629,8 @@ tests:
   - name: "op.deleteLine - delete single line"
     description: "Delete current line, cursor moves to next line"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Delete me", down);
       op.insert("Keep me", down);
       op.go(up, 1);
@@ -642,8 +642,8 @@ tests:
   - name: "op.deleteLine - returns boolean true"
     description: "deleteLine returns true on success"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.deleteLine()
     expected_success: true
@@ -652,8 +652,8 @@ tests:
   - name: "op.deleteLine - delete only node creates empty node"
     description: "Deleting the only node creates a new blank node (outline minimal state)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Only node", down);
       op.deleteLine();
       return op.countSummits()
@@ -667,8 +667,8 @@ tests:
   - name: "op.setLineText - modify existing headline"
     description: "Change text of current headline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Original text", down);
       op.setLineText("Modified text");
       return op.getLineText()
@@ -678,8 +678,8 @@ tests:
   - name: "op.setLineText - returns boolean true on success"
     description: "setLineText returns true when successful"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Text", down);
       return op.setLineText("New text")
     expected_success: true
@@ -688,8 +688,8 @@ tests:
   - name: "op.setLineText - set to empty string"
     description: "Set headline text to empty string (valid operation)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Something", down);
       op.setLineText("");
       return sizeOf(op.getLineText())
@@ -699,8 +699,8 @@ tests:
   - name: "op.setLineText - special characters"
     description: "Set text with special characters (quotes, newlines, etc.)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       op.setLineText("Special: \"quotes\" & <tags>");
       return op.getLineText()
@@ -710,8 +710,8 @@ tests:
   - name: "op.setLineText - missing text parameter"
     description: "setLineText requires text parameter (should fail)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       op.setLineText()
     expected_success: false
@@ -720,8 +720,8 @@ tests:
   - name: "op.setLineText - preserves children"
     description: "Setting line text preserves child nodes"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -740,8 +740,8 @@ tests:
   - name: "op.deleteSubs - delete all children under parent"
     description: "Delete all children of current node, parent remains"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -757,8 +757,8 @@ tests:
   - name: "op.deleteSubs - returns boolean true"
     description: "deleteSubs returns true on success"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -769,8 +769,8 @@ tests:
   - name: "op.deleteSubs - no children is no-op"
     description: "deleteSubs on node with no children returns true (no-op)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Leaf node", down);
       local(ok = op.deleteSubs());
       return ok and (op.countSubs(1) == 0)
@@ -780,8 +780,8 @@ tests:
   - name: "op.deleteSubs - multi-level children"
     description: "Delete all descendants (children, grandchildren, etc.)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Root", down);
       op.insert("Child 1", right);
       op.insert("Grandchild 1", right);
@@ -797,8 +797,8 @@ tests:
   - name: "op.deleteSubs - zero parameters required"
     description: "deleteSubs takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -813,8 +813,8 @@ tests:
   - name: "op.reorg - move node left (direction=left, count=1)"
     description: "Move node left one level (promote/outdent)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       local(before = op.level());
@@ -827,8 +827,8 @@ tests:
   - name: "op.reorg - move node right (direction=right, count=1)"
     description: "Move node right one level (demote/indent)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       local(before = op.level());
@@ -841,8 +841,8 @@ tests:
   - name: "op.reorg - move multiple levels left"
     description: "Move node left multiple levels (count > 1)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Level 1", down);
       op.insert("Level 2", right);
       op.insert("Level 3", right);
@@ -856,8 +856,8 @@ tests:
   - name: "op.reorg - move multiple levels right"
     description: "Move node right as far as possible (goes as far as structure allows)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -872,8 +872,8 @@ tests:
   - name: "op.reorg - returns boolean based on success"
     description: "reorg returns true on successful reorganization"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       return op.reorg(left, 1)
@@ -883,8 +883,8 @@ tests:
   - name: "op.reorg - missing direction parameter"
     description: "reorg requires direction parameter (should fail)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       op.reorg()
     expected_success: false
@@ -893,8 +893,8 @@ tests:
   - name: "op.reorg - missing count parameter"
     description: "reorg requires count parameter (should fail)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       op.reorg(3)
     expected_success: false
@@ -920,8 +920,8 @@ tests:
   # - name: "op.find - find existing text (basic search)"
   #   description: "Find text in outline, cursor moves to matching line"
   #   script: |
-  #     lang.new(outlineType, @workspace.outline);
-  #     target.set(@workspace.outline);
+  #     lang.new(outlineType, @system.temp.outline);
+  #     target.set(@system.temp.outline);
   #     op.insert("Line 1", down);
   #     op.insert("Target line", down);
   #     op.insert("Line 3", down);
@@ -934,8 +934,8 @@ tests:
   - name: "op.find - case-sensitive search (flCase=true)"
     description: "Find with case sensitivity enabled - exact case match required"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("lowercase text", down);
       op.insert("UPPERCASE TEXT", down);
       op.firstSummit();
@@ -948,8 +948,8 @@ tests:
   # - name: "op.find - case-insensitive search (flCase=false)"
   #   description: "Find with case insensitivity (matches regardless of case)"
   #   script: |
-  #     lang.new(outlineType, @workspace.outline);
-  #     target.set(@workspace.outline);
+  #     lang.new(outlineType, @system.temp.outline);
+  #     target.set(@system.temp.outline);
   #     op.insert("lowercase text", down);
   #     op.insert("UPPERCASE TEXT", down);
   #     op.firstSummit();
@@ -962,8 +962,8 @@ tests:
   # - name: "op.find - wrap around search (flWrap=true)"
   #   description: "Search wraps around to beginning when reaching end"
   #   script: |
-  #     lang.new(outlineType, @workspace.outline);
-  #     target.set(@workspace.outline);
+  #     lang.new(outlineType, @system.temp.outline);
+  #     target.set(@system.temp.outline);
   #     op.insert("First line", down);
   #     op.insert("Last line", down);
   #     local(found = op.find("First", true, false));
@@ -974,8 +974,8 @@ tests:
   - name: "op.find - no wrap search (flWrap=false)"
     description: "Search without wrap stops at end"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -987,8 +987,8 @@ tests:
   - name: "op.find - not found returns false"
     description: "Returns false when text not found in outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       return op.find("Nonexistent", false, false)
@@ -998,8 +998,8 @@ tests:
   - name: "op.find - missing searchText parameter"
     description: "find requires searchText parameter (should fail)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       op.find()
     expected_success: false
@@ -1008,8 +1008,8 @@ tests:
   - name: "op.find - one parameter (searchText only)"
     description: "flWrap and flCase are optional, defaults to case-insensitive"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       local(found = op.find("test"));
       return found and (op.getLineText() == "Test")
@@ -1019,8 +1019,8 @@ tests:
   - name: "op.find - two parameters (searchText, flWrap)"
     description: "flCase is optional, defaults to case-insensitive"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Test", down);
       local(found = op.find("test", false));
       return found and (op.getLineText() == "Test")
@@ -1031,8 +1031,8 @@ tests:
   # - name: "op.find - searches in children"
   #   description: "Find searches through entire tree structure including children"
   #   script: |
-  #     lang.new(outlineType, @workspace.outline);
-  #     target.set(@workspace.outline);
+  #     lang.new(outlineType, @system.temp.outline);
+  #     target.set(@system.temp.outline);
   #     op.insert("Parent", down);
   #     op.insert("Child with target", right);
   #     op.go(left, 1);
@@ -1079,8 +1079,8 @@ tests:
   - name: "op.getLineText - no parameters"
     description: "op.getLineText takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Text", down);
       return typeof(op.getLineText())
     expected_success: true
@@ -1095,8 +1095,8 @@ tests:
   - name: "op.level - no parameters"
     description: "op.level takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.level())
     expected_success: true
@@ -1117,8 +1117,8 @@ tests:
   - name: "op.collapse - no parameters"
     description: "op.collapse takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.collapse())
     expected_success: true
@@ -1127,8 +1127,8 @@ tests:
   - name: "op.promote - no parameters"
     description: "op.promote takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       return typeof(op.promote())
@@ -1138,8 +1138,8 @@ tests:
   - name: "op.demote - no parameters"
     description: "op.demote takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       return typeof(op.demote())
@@ -1181,8 +1181,8 @@ tests:
   - name: "op.insert - table target should fail"
     description: "op verbs require outlineType target, not tableType"
     script: |
-      lang.new(tableType, @workspace.notOutline);
-      target.set(@workspace.notOutline);
+      lang.new(tableType, @system.temp.notOutline);
+      target.set(@system.temp.notOutline);
       op.insert("Test", down)
     expected_success: false
     expected_error_type: "script_error"
@@ -1190,8 +1190,8 @@ tests:
   - name: "op.getLineText - wrong target type should fail"
     description: "op verbs require outlineType target"
     script: |
-      lang.new(tableType, @workspace.table);
-      target.set(@workspace.table);
+      lang.new(tableType, @system.temp.table);
+      target.set(@system.temp.table);
       op.getLineText()
     expected_success: false
     expected_error_type: "script_error"
@@ -1203,8 +1203,8 @@ tests:
   - name: "workflow - build and navigate outline structure"
     description: "Build multi-level outline and navigate through it"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Chapter 1", down);
       op.insert("Section 1.1", right);
       op.insert("Section 1.2", down);
@@ -1221,8 +1221,8 @@ tests:
   - name: "workflow - insert and modify multiple lines"
     description: "Insert multiple lines and modify their content"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -1235,8 +1235,8 @@ tests:
   - name: "workflow - promote children of current heading"
     description: "Promote all subheads beneath current heading one level to the left"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);         // Level 1 (empty summit + parent = 2 levels)
       op.insert("Child1", right);        // Level 2, child of Parent
       op.insert("Child2", down);         // Level 2, sibling of Child1
@@ -1255,8 +1255,8 @@ tests:
   - name: "workflow - demote following siblings"
     description: "Demote all following siblings to be children of current heading"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("L1-Sibling1", down);     // Level 1
       op.insert("L1-Sibling2", down);     // Level 1, following sibling
       op.insert("L1-Sibling3", down);     // Level 1, following sibling
@@ -1273,8 +1273,8 @@ tests:
   - name: "workflow - expand and collapse state"
     description: "Expand and collapse outline nodes"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Root", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -1292,8 +1292,8 @@ tests:
   - name: "stress test - build large outline"
     description: "Build outline with many nodes (includes empty root)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(i);
       for i = 1 to 20 {
         op.insert("Line " + i, down)
@@ -1305,8 +1305,8 @@ tests:
   - name: "stress test - deep nesting"
     description: "Create deeply nested outline structure"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(i);
       op.insert("Level 1", down);
       for i = 2 to 10 {
@@ -1319,8 +1319,8 @@ tests:
   - name: "stress test - rapid insert and delete"
     description: "Rapidly insert and delete lines"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(i);
       for i = 1 to 10 {
         op.insert("Temp " + i, down)
@@ -1339,8 +1339,8 @@ tests:
   - name: "op.getCursor - returns address type"
     description: "getCursor returns long type (1-based line number) for current cursor position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       return typeof(op.getCursor())
     expected_success: true
@@ -1349,8 +1349,8 @@ tests:
   - name: "op.getCursor - simple outline cursor position"
     description: "Get cursor position from simple outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First line", down);
       local(cursor = op.getCursor());
       return defined(cursor)
@@ -1360,8 +1360,8 @@ tests:
   - name: "op.getCursor - cursor changes with navigation"
     description: "Cursor address changes when navigating outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       local(cursor1 = op.getCursor());
@@ -1374,8 +1374,8 @@ tests:
   - name: "op.getCursor - cursor in nested structure"
     description: "Get cursor from nested outline hierarchy"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.insert("Grandchild", right);
@@ -1387,8 +1387,8 @@ tests:
   - name: "op.getCursor - no parameters required"
     description: "getCursor takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.getCursor())
     expected_success: true
@@ -1397,8 +1397,8 @@ tests:
   - name: "op.getCursor - extra parameters should fail"
     description: "getCursor with extra parameters should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.getCursor("extra")
     expected_success: false
@@ -1407,8 +1407,8 @@ tests:
   - name: "op.setCursor - set cursor to saved address"
     description: "Set cursor to previously saved address position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -1424,8 +1424,8 @@ tests:
     description: "setCursor returns true when cursor is set successfully"
     skip: "Phase 3: Cursor management not fully implemented in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       local(cursor = op.getCursor());
@@ -1437,8 +1437,8 @@ tests:
   - name: "op.setCursor - round-trip cursor position"
     description: "Get cursor, navigate away, set cursor back - verify position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Target line", down);
       op.insert("Other line", down);
       local(targetCursor = op.getCursor());
@@ -1451,8 +1451,8 @@ tests:
   - name: "op.setCursor - cursor in nested hierarchy"
     description: "Set cursor to child node address"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       local(child1Cursor = op.getCursor());
@@ -1466,8 +1466,8 @@ tests:
   - name: "op.setCursor - requires address parameter"
     description: "setCursor requires address parameter (should fail without it)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setCursor()
     expected_success: false
@@ -1476,8 +1476,8 @@ tests:
   - name: "op.setCursor - invalid address type should fail"
     description: "setCursor with non-address type should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setCursor("not an address")
     expected_success: false
@@ -1487,12 +1487,12 @@ tests:
     description: "setCursor with address from different outline should error"
     skip: "Phase 3: Cross-outline cursor validation not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline1);
-      lang.new(outlineType, @workspace.outline2);
-      target.set(@workspace.outline1);
+      lang.new(outlineType, @system.temp.outline1);
+      lang.new(outlineType, @system.temp.outline2);
+      target.set(@system.temp.outline1);
       op.insert("Line 1", down);
       local(cursor1 = op.getCursor());
-      target.set(@workspace.outline2);
+      target.set(@system.temp.outline2);
       op.insert("Line 2", down);
       op.setCursor(cursor1)
     expected_success: false
@@ -1505,8 +1505,8 @@ tests:
   - name: "op.getDisplay - returns boolean type"
     description: "getDisplay returns boolean for display inhibit state"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return typeof(op.getDisplay())
     expected_success: true
     expected_result: "bool"
@@ -1514,8 +1514,8 @@ tests:
   - name: "op.getDisplay - default state is true (display enabled)"
     description: "New outlines have display enabled by default"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return op.getDisplay()
     expected_success: true
     expected_result: "true"
@@ -1523,8 +1523,8 @@ tests:
   - name: "op.getDisplay - no parameters required"
     description: "getDisplay takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return typeof(op.getDisplay())
     expected_success: true
     expected_result: "bool"
@@ -1532,8 +1532,8 @@ tests:
   - name: "op.getDisplay - extra parameters should fail"
     description: "getDisplay with extra parameters should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.getDisplay("extra")
     expected_success: false
     expected_error_type: "script_error"
@@ -1541,8 +1541,8 @@ tests:
   - name: "op.setDisplay - set display to false (inhibit display)"
     description: "Disable display for performance during bulk operations"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       return op.getDisplay()
     expected_success: true
@@ -1551,8 +1551,8 @@ tests:
   - name: "op.setDisplay - set display to true (enable display)"
     description: "Enable display after bulk operations"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       op.setDisplay(true);
       return op.getDisplay()
@@ -1562,8 +1562,8 @@ tests:
   - name: "op.setDisplay - returns boolean true on success"
     description: "setDisplay returns true when state is set"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       return op.setDisplay(false)
     expected_success: true
     expected_result: "true"
@@ -1571,8 +1571,8 @@ tests:
   - name: "op.setDisplay - round-trip display state"
     description: "Set display false, verify, set true, verify"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       local(state1 = op.getDisplay());
       op.setDisplay(true);
@@ -1584,8 +1584,8 @@ tests:
   - name: "op.setDisplay - bulk operations with display off"
     description: "Disable display during bulk insert operations (performance optimization)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       local(i);
       for i = 1 to 10 {
@@ -1599,8 +1599,8 @@ tests:
   - name: "op.setDisplay - requires boolean parameter"
     description: "setDisplay requires boolean parameter (should fail without it)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay()
     expected_success: false
     expected_error_type: "script_error"
@@ -1609,8 +1609,8 @@ tests:
     description: "setDisplay with non-boolean type should error"
     skip: "Phase 3: Type validation for setDisplay not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay("true")
     expected_success: false
     expected_error_type: "script_error"
@@ -1622,8 +1622,8 @@ tests:
   - name: "op.getExpansionState - returns address type"
     description: "getExpansionState returns list containing expansion state data"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -1634,8 +1634,8 @@ tests:
   - name: "op.getExpansionState - simple outline expansion state"
     description: "Get expansion state from simple outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -1647,8 +1647,8 @@ tests:
   - name: "op.getExpansionState - no parameters required"
     description: "getExpansionState takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.getExpansionState())
     expected_success: true
@@ -1657,8 +1657,8 @@ tests:
   - name: "op.getExpansionState - extra parameters should fail"
     description: "getExpansionState with extra parameters should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.getExpansionState("extra")
     expected_success: false
@@ -1668,8 +1668,8 @@ tests:
     description: "Set expansion state to previously saved state"
     skip: "Phase 3: Expansion state management not fully implemented"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent 1", down);
       op.insert("Child 1", right);
       op.go(left, 1);
@@ -1690,8 +1690,8 @@ tests:
   - name: "op.setExpansionState - returns boolean true on success"
     description: "setExpansionState returns true when state is set successfully"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -1703,8 +1703,8 @@ tests:
   - name: "op.setExpansionState - round-trip expansion state"
     description: "Get state, modify expansion, restore state"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -1720,8 +1720,8 @@ tests:
   - name: "op.setExpansionState - complex outline with multiple levels"
     description: "Save and restore expansion state in multi-level outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Level 1", down);
       op.insert("Level 2", right);
       op.insert("Level 3", right);
@@ -1737,8 +1737,8 @@ tests:
   - name: "op.setExpansionState - requires address parameter"
     description: "setExpansionState requires address parameter (should fail without it)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -1750,8 +1750,8 @@ tests:
     description: "setExpansionState with non-address type should error"
     skip: "Phase 3: Type validation returns json_parse_error instead of script_error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -1766,8 +1766,8 @@ tests:
   - name: "op.getScrollState - returns address type"
     description: "getScrollState returns long (1-based line number) for scroll position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       return typeof(op.getScrollState())
     expected_success: true
@@ -1776,8 +1776,8 @@ tests:
   - name: "op.getScrollState - simple outline scroll state"
     description: "Get scroll state from simple outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       local(state = op.getScrollState());
@@ -1788,8 +1788,8 @@ tests:
   - name: "op.getScrollState - no parameters required"
     description: "getScrollState takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.getScrollState())
     expected_success: true
@@ -1798,8 +1798,8 @@ tests:
   - name: "op.getScrollState - extra parameters should fail"
     description: "getScrollState with extra parameters should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.getScrollState("extra")
     expected_success: false
@@ -1808,8 +1808,8 @@ tests:
   - name: "op.setScrollState - restore saved scroll state"
     description: "Set scroll state to previously saved state"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -1821,8 +1821,8 @@ tests:
   - name: "op.setScrollState - returns boolean true on success"
     description: "setScrollState returns true when state is set successfully"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(state = op.getScrollState());
       return op.setScrollState(state)
@@ -1832,8 +1832,8 @@ tests:
   - name: "op.setScrollState - round-trip scroll state"
     description: "Get scroll state, navigate, restore scroll state (noop in headless)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(i);
       for i = 1 to 20 {
         op.insert("Line " + i, down)
@@ -1849,8 +1849,8 @@ tests:
   - name: "op.setScrollState - requires address parameter"
     description: "setScrollState requires address parameter (should fail without it)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setScrollState()
     expected_success: false
@@ -1859,8 +1859,8 @@ tests:
   - name: "op.setScrollState - invalid address type should fail"
     description: "setScrollState with non-address type should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setScrollState("not an address")
     expected_success: false
@@ -1873,8 +1873,8 @@ tests:
   - name: "op.getRefcon - returns long type"
     description: "getRefcon returns long (32-bit integer) reference constant"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.getRefcon())
     expected_success: true
@@ -1883,8 +1883,8 @@ tests:
   - name: "op.getRefcon - default refcon is zero"
     description: "New outline nodes have refcon initialized to 0"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.getRefcon()
     expected_success: true
@@ -1893,8 +1893,8 @@ tests:
   - name: "op.getRefcon - no parameters required"
     description: "getRefcon takes no parameters"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return typeof(op.getRefcon())
     expected_success: true
@@ -1903,8 +1903,8 @@ tests:
   - name: "op.getRefcon - extra parameters should fail"
     description: "getRefcon with extra parameters should error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.getRefcon("extra")
     expected_success: false
@@ -1913,8 +1913,8 @@ tests:
   - name: "op.setRefcon - set positive refcon value"
     description: "Set refcon to positive integer value"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(12345);
       return op.getRefcon()
@@ -1924,8 +1924,8 @@ tests:
   - name: "op.setRefcon - set negative refcon value"
     description: "Set refcon to negative integer value"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(-9999);
       return op.getRefcon()
@@ -1935,8 +1935,8 @@ tests:
   - name: "op.setRefcon - set zero refcon value"
     description: "Set refcon to zero (reset to default)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(100);
       op.setRefcon(0);
@@ -1947,8 +1947,8 @@ tests:
   - name: "op.setRefcon - returns boolean true on success"
     description: "setRefcon returns true when refcon is set successfully"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.setRefcon(42)
     expected_success: true
@@ -1957,8 +1957,8 @@ tests:
   - name: "op.setRefcon - round-trip refcon value"
     description: "Set refcon, verify with getRefcon"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(99999);
       return op.getRefcon()
@@ -1968,8 +1968,8 @@ tests:
   - name: "op.setRefcon - different refcon per node"
     description: "Each node can have independent refcon value"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.setRefcon(111);
       op.insert("Line 2", down);
@@ -1984,8 +1984,8 @@ tests:
   - name: "op.setRefcon - refcon persists across navigation"
     description: "Refcon value persists when navigating away and back"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.setRefcon(777);
       op.insert("Line 2", down);
@@ -1997,8 +1997,8 @@ tests:
   - name: "op.setRefcon - requires long parameter"
     description: "setRefcon requires long parameter (should fail without it)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon()
     expected_success: false
@@ -2008,8 +2008,8 @@ tests:
     description: "setRefcon with non-long type should error"
     skip: "Phase 3: Type validation for setRefcon not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon("not a number")
     expected_success: false
@@ -2031,8 +2031,8 @@ tests:
     description: "setCursor requires outline set as target"
     script: |
       target.clear();
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(cursor = op.getCursor());
       target.clear();
@@ -2068,8 +2068,8 @@ tests:
     description: "setExpansionState requires outline set as target"
     script: |
       target.clear();
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -2091,8 +2091,8 @@ tests:
     description: "setScrollState requires outline set as target"
     script: |
       target.clear();
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(state = op.getScrollState());
       target.clear();
@@ -2123,8 +2123,8 @@ tests:
   - name: "op.getCursor - table target should fail"
     description: "getCursor requires outlineType target, not tableType"
     script: |
-      lang.new(tableType, @workspace.notOutline);
-      target.set(@workspace.notOutline);
+      lang.new(tableType, @system.temp.notOutline);
+      target.set(@system.temp.notOutline);
       op.getCursor()
     expected_success: false
     expected_error_type: "script_error"
@@ -2132,8 +2132,8 @@ tests:
   - name: "op.setDisplay - wrong target type should fail"
     description: "setDisplay requires outlineType target"
     script: |
-      lang.new(tableType, @workspace.table);
-      target.set(@workspace.table);
+      lang.new(tableType, @system.temp.table);
+      target.set(@system.temp.table);
       op.setDisplay(false)
     expected_success: false
     expected_error_type: "script_error"
@@ -2141,8 +2141,8 @@ tests:
   - name: "op.getExpansionState - wrong target type should fail"
     description: "getExpansionState requires outlineType target"
     script: |
-      lang.new(tableType, @workspace.table);
-      target.set(@workspace.table);
+      lang.new(tableType, @system.temp.table);
+      target.set(@system.temp.table);
       op.getExpansionState()
     expected_success: false
     expected_error_type: "script_error"
@@ -2150,8 +2150,8 @@ tests:
   - name: "op.getRefcon - wrong target type should fail"
     description: "getRefcon requires outlineType target"
     script: |
-      lang.new(tableType, @workspace.table);
-      target.set(@workspace.table);
+      lang.new(tableType, @system.temp.table);
+      target.set(@system.temp.table);
       op.getRefcon()
     expected_success: false
     expected_error_type: "script_error"
@@ -2163,8 +2163,8 @@ tests:
   - name: "workflow - save and restore cursor during bulk operations"
     description: "Save cursor, do bulk operations, restore cursor position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.insert("Line 3", down);
@@ -2182,8 +2182,8 @@ tests:
   - name: "workflow - disable display during bulk insert and restore"
     description: "Disable display, insert many lines, re-enable display"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       local(i);
       for i = 1 to 50 {
@@ -2197,8 +2197,8 @@ tests:
   - name: "workflow - save expansion state before collapse and restore"
     description: "Save expansion state, collapse all, restore state"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent 1", down);
       op.insert("Child 1a", right);
       op.insert("Child 1b", down);
@@ -2222,8 +2222,8 @@ tests:
   - name: "workflow - refcon as node identifier"
     description: "Use refcon to mark and find specific nodes"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Item A", down);
       op.setRefcon(1001);
       op.insert("Item B", down);
@@ -2238,8 +2238,8 @@ tests:
   - name: "workflow - multiple state operations combined"
     description: "Combine cursor, display, expansion, and refcon operations"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       op.insert("Root", down);
       op.setRefcon(100);
@@ -2262,13 +2262,13 @@ tests:
   - name: "integration - outline with target.get/set"
     description: "Switch between multiple outline targets"
     script: |
-      lang.new(outlineType, @workspace.outline1);
-      lang.new(outlineType, @workspace.outline2);
-      target.set(@workspace.outline1);
+      lang.new(outlineType, @system.temp.outline1);
+      lang.new(outlineType, @system.temp.outline2);
+      target.set(@system.temp.outline1);
       op.insert("Outline 1", down);
-      target.set(@workspace.outline2);
+      target.set(@system.temp.outline2);
       op.insert("Outline 2", down);
-      target.set(@workspace.outline1);
+      target.set(@system.temp.outline1);
       return op.getLineText()
     expected_success: true
     expected_result: "Outline 1"
@@ -2276,16 +2276,16 @@ tests:
   - name: "integration - outline with typeof"
     description: "Verify outline type with typeof"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      return typeof(workspace.outline)
+      lang.new(outlineType, @system.temp.outline);
+      return typeof(system.temp.outline)
     expected_success: true
     expected_result: "optx"
 
   - name: "integration - outline with defined"
     description: "Check outline existence with defined"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      return defined(workspace.outline)
+      lang.new(outlineType, @system.temp.outline);
+      return defined(system.temp.outline)
     expected_success: true
     expected_result: "true"
 
@@ -2296,8 +2296,8 @@ tests:
   - name: "headless behavior - no window required for outline ops"
     description: "Outline operations work without GUI windows (headless mode)"
     script: |
-      lang.new(outlineType, @workspace.headlessOutline);
-      target.set(@workspace.headlessOutline);
+      lang.new(outlineType, @system.temp.headlessOutline);
+      target.set(@system.temp.headlessOutline);
       op.insert("Headless line", down);
       return op.getLineText()
     expected_success: true
@@ -2306,8 +2306,8 @@ tests:
   - name: "headless behavior - cursor is data structure state"
     description: "Cursor position is data, not GUI state (headless compatible)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       op.go(up, 1);
@@ -2318,8 +2318,8 @@ tests:
   - name: "headless behavior - expansion state is metadata"
     description: "Expansion state is tree metadata, not visual state"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -2343,8 +2343,8 @@ tests:
   - name: "op.getCursor - cursor persists during outline modification"
     description: "Saved cursor remains valid after inserting new nodes elsewhere"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       local(savedCursor = op.getCursor());
@@ -2359,8 +2359,8 @@ tests:
     description: "Setting cursor to deleted node should error or return false"
     skip: "Phase 3: Deleted node cursor validation not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Delete me", down);
       local(deadCursor = op.getCursor());
       op.insert("Keep me", down);
@@ -2373,8 +2373,8 @@ tests:
   - name: "op.setCursor - cursor after deleteSubs"
     description: "Parent cursor remains valid after deleting children"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       local(parentCursor = op.getCursor());
       op.insert("Child 1", right);
@@ -2389,8 +2389,8 @@ tests:
   - name: "op.getCursor - cursor in deeply nested structure"
     description: "Cursor correctly identifies position in deep nesting"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("L1", down);
       op.insert("L2", right);
       op.insert("L3", right);
@@ -2410,8 +2410,8 @@ tests:
   - name: "op.setDisplay - double disable is idempotent"
     description: "Setting display false twice should work (idempotent)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       op.setDisplay(false);
       return op.getDisplay()
@@ -2421,8 +2421,8 @@ tests:
   - name: "op.setDisplay - double enable is idempotent"
     description: "Setting display true twice should work (idempotent)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       op.setDisplay(true);
       op.setDisplay(true);
@@ -2433,8 +2433,8 @@ tests:
   - name: "op.setDisplay - state persists across operations"
     description: "Display state remains after outline operations"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
@@ -2446,13 +2446,13 @@ tests:
   - name: "op.getDisplay - independent across multiple outlines"
     description: "Each outline has independent display state"
     script: |
-      lang.new(outlineType, @workspace.outline1);
-      lang.new(outlineType, @workspace.outline2);
-      target.set(@workspace.outline1);
+      lang.new(outlineType, @system.temp.outline1);
+      lang.new(outlineType, @system.temp.outline2);
+      target.set(@system.temp.outline1);
       op.setDisplay(false);
-      target.set(@workspace.outline2);
+      target.set(@system.temp.outline2);
       op.setDisplay(true);
-      target.set(@workspace.outline1);
+      target.set(@system.temp.outline1);
       return op.getDisplay()
     expected_success: true
     expected_result: "false"
@@ -2465,14 +2465,14 @@ tests:
     description: "Expansion state is outline-specific"
     skip: "Phase 3: Cross-outline state validation not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline1);
-      lang.new(outlineType, @workspace.outline2);
-      target.set(@workspace.outline1);
+      lang.new(outlineType, @system.temp.outline1);
+      lang.new(outlineType, @system.temp.outline2);
+      target.set(@system.temp.outline1);
       op.insert("Parent 1", down);
       op.insert("Child 1", right);
       op.go(left, 1);
       local(state1 = op.getExpansionState());
-      target.set(@workspace.outline2);
+      target.set(@system.temp.outline2);
       op.insert("Parent 2", down);
       op.insert("Child 2", right);
       op.go(left, 1);
@@ -2483,8 +2483,8 @@ tests:
   - name: "op.getExpansionState - empty outline state"
     description: "Get expansion state from empty outline (edge case)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(state = op.getExpansionState());
       return defined(state)
     expected_success: true
@@ -2494,8 +2494,8 @@ tests:
     description: "Expansion state restoration after adding/removing nodes"
     skip: "Phase 3: Expansion state restoration not fully implemented"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child 1", right);
       op.insert("Child 2", down);
@@ -2514,8 +2514,8 @@ tests:
   - name: "op.getExpansionState - state is independent of cursor"
     description: "Expansion state captures entire outline, not just cursor position"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent 1", down);
       op.insert("Child 1", right);
       op.go(left, 1);
@@ -2542,8 +2542,8 @@ tests:
   - name: "op.getScrollState - empty outline scroll state"
     description: "Get scroll state from empty outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(state = op.getScrollState());
       return defined(state)
     expected_success: true
@@ -2553,12 +2553,12 @@ tests:
     description: "Scroll state is outline-specific"
     skip: "Phase 3: Cross-outline scroll state validation not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline1);
-      lang.new(outlineType, @workspace.outline2);
-      target.set(@workspace.outline1);
+      lang.new(outlineType, @system.temp.outline1);
+      lang.new(outlineType, @system.temp.outline2);
+      target.set(@system.temp.outline1);
       op.insert("Line 1", down);
       local(state1 = op.getScrollState());
-      target.set(@workspace.outline2);
+      target.set(@system.temp.outline2);
       op.insert("Line 2", down);
       op.setScrollState(state1)
     expected_success: false
@@ -2567,8 +2567,8 @@ tests:
   - name: "op.setScrollState - state persists after outline modification"
     description: "Scroll state remains valid after inserting nodes"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.insert("Line 2", down);
       local(savedState = op.getScrollState());
@@ -2581,12 +2581,12 @@ tests:
   - name: "op.getScrollState - independent across multiple outlines"
     description: "Each outline has independent scroll state (always 1 in headless)"
     script: |
-      lang.new(outlineType, @workspace.outline1);
-      lang.new(outlineType, @workspace.outline2);
-      target.set(@workspace.outline1);
+      lang.new(outlineType, @system.temp.outline1);
+      lang.new(outlineType, @system.temp.outline2);
+      target.set(@system.temp.outline1);
       op.insert("Line 1", down);
       local(state1 = op.getScrollState());
-      target.set(@workspace.outline2);
+      target.set(@system.temp.outline2);
       op.insert("Line 2", down);
       local(state2 = op.getScrollState());
       return state1 != state2
@@ -2600,8 +2600,8 @@ tests:
   - name: "op.setRefcon - large positive value (32-bit boundary)"
     description: "Test refcon with large positive value near INT32_MAX"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(2147483647);
       return op.getRefcon()
@@ -2611,8 +2611,8 @@ tests:
   - name: "op.setRefcon - large negative value (32-bit boundary)"
     description: "Test refcon with large negative value near INT32_MIN"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(-2147483648);
       return op.getRefcon()
@@ -2622,8 +2622,8 @@ tests:
   - name: "op.getRefcon - refcon persists after navigation"
     description: "Refcon values persist when navigating away and back"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       op.setRefcon(111);
       op.insert("Line 2", down);
@@ -2641,8 +2641,8 @@ tests:
   - name: "op.setRefcon - refcon survives promote/demote"
     description: "Refcon value persists when changing node hierarchy"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.setRefcon(999);
@@ -2657,8 +2657,8 @@ tests:
   - name: "op.setRefcon - refcon independent across nodes"
     description: "Each node has independent refcon value (no interference)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(i);
       for i = 1 to 10 {
         op.insert("Line " + i, down);
@@ -2679,8 +2679,8 @@ tests:
   - name: "op.getRefcon - refcon after insert preserves parent refcon"
     description: "Inserting child doesn't affect parent refcon"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.setRefcon(555);
       op.insert("Child", right);
@@ -2697,8 +2697,8 @@ tests:
   - name: "workflow - save all state before bulk operation and restore"
     description: "Save cursor, expansion, scroll state, perform operations, restore all state"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent 1", down);
       op.insert("Child 1a", right);
       op.insert("Child 1b", down);
@@ -2722,8 +2722,8 @@ tests:
   - name: "workflow - refcon as node metadata during tree reorganization"
     description: "Use refcon to track nodes during complex reorganization"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Item A", down);
       op.setRefcon(1001);
       op.insert("Item B", down);
@@ -2742,9 +2742,8 @@ tests:
   - name: "workflow - display off during state save/restore cycle"
     description: "Disable display, save state, modify outline, restore state, enable display"
     script: |
-      lang.new(tableType, @workspace);
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       local(i);
       for i = 1 to 20 {
@@ -2762,20 +2761,20 @@ tests:
   - name: "workflow - multiple outline state management"
     description: "Manage state for multiple outlines simultaneously"
     script: |
-      lang.new(outlineType, @workspace.o1);
-      lang.new(outlineType, @workspace.o2);
-      target.set(@workspace.o1);
+      lang.new(outlineType, @system.temp.o1);
+      lang.new(outlineType, @system.temp.o2);
+      target.set(@system.temp.o1);
       op.insert("O1 Line 1", down);
       op.setRefcon(111);
       local(cursor1 = op.getCursor());
-      target.set(@workspace.o2);
+      target.set(@system.temp.o2);
       op.insert("O2 Line 1", down);
       op.setRefcon(222);
       local(cursor2 = op.getCursor());
-      target.set(@workspace.o1);
+      target.set(@system.temp.o1);
       op.setCursor(cursor1);
       local(refcon1 = op.getRefcon());
-      target.set(@workspace.o2);
+      target.set(@system.temp.o2);
       op.setCursor(cursor2);
       local(refcon2 = op.getRefcon());
       return (refcon1 == 111) and (refcon2 == 222)
@@ -2789,8 +2788,8 @@ tests:
   - name: "stress test - rapid cursor save/restore cycles"
     description: "Repeatedly save and restore cursor during navigation"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(i);
       for i = 1 to 20 {
         op.insert("Line " + i, down)
@@ -2813,8 +2812,8 @@ tests:
   - name: "stress test - many refcon assignments"
     description: "Assign refcon to many nodes in large outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(false);
       local(i);
       for i = 1 to 100 {
@@ -2837,8 +2836,8 @@ tests:
   - name: "stress test - expansion state with deep nesting"
     description: "Save and restore expansion state in deeply nested outline"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("L1", down);
       local(i);
       for i = 2 to 10 {
@@ -2865,8 +2864,8 @@ tests:
   - name: "error recovery - setCursor after outline deleted"
     description: "Setting cursor fails gracefully if outline no longer exists"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(cursor = op.getCursor());
       target.clear();
@@ -2886,8 +2885,8 @@ tests:
     description: "Setting refcon on empty outline should fail"
     skip: "Phase 3: Error validation for missing target not implemented"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setRefcon(100)
     expected_success: false
     expected_error_type: "script_error"
@@ -2899,8 +2898,8 @@ tests:
   - name: "type safety - setCursor with invalid cursor returns false"
     description: "setCursor returns false when given a cursor that can't be set"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.setCursor(12345)
     expected_success: true
@@ -2909,8 +2908,8 @@ tests:
   - name: "type safety - setDisplay with non-boolean coerces to boolean"
     description: "setDisplay coerces non-boolean types via UserTalk type coercion (1 -> true)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.setDisplay(1);  /* UserTalk coerces 1 to true */
       return op.getDisplay()
     expected_success: true
@@ -2920,8 +2919,8 @@ tests:
     description: "setExpansionState takes a list of line numbers (coercion error for string)"
     skip: "Phase 3: Type validation returns json_parse_error instead of script_error"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -2932,8 +2931,8 @@ tests:
   - name: "type safety - setScrollState is noop in headless"
     description: "setScrollState returns true and does nothing in headless mode (scroll state is visual)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.setScrollState(42)
     expected_success: true
@@ -2942,8 +2941,8 @@ tests:
   - name: "type safety - setRefcon accepts any type (boolean)"
     description: "setRefcon can store boolean values (round-trip test)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(true);
       return op.getRefcon()
@@ -2953,8 +2952,8 @@ tests:
   - name: "type safety - setRefcon accepts any type (string)"
     description: "setRefcon can store string values (round-trip test)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon("test string");
       return op.getRefcon()
@@ -2964,8 +2963,8 @@ tests:
   - name: "type safety - setRefcon accepts any type (long)"
     description: "setRefcon can store long values (round-trip test)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(42);
       return op.getRefcon()
@@ -2975,8 +2974,8 @@ tests:
   - name: "type safety - setRefcon accepts any type (double)"
     description: "setRefcon can store double values (round-trip test)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setRefcon(3.14159);
       return op.getRefcon()
@@ -2990,8 +2989,8 @@ tests:
   - name: "return type - getCursor returns address"
     description: "Verify getCursor return type is longType (1-based line number)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(cursor = op.getCursor());
       return typeof(cursor)
@@ -3001,8 +3000,8 @@ tests:
   - name: "return type - getDisplay returns boolean"
     description: "Verify getDisplay return type is booleanType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(display = op.getDisplay());
       return typeof(display)
     expected_success: true
@@ -3011,8 +3010,8 @@ tests:
   - name: "return type - getExpansionState returns address"
     description: "Verify getExpansionState return type is listType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(state = op.getExpansionState());
       return typeof(state)
@@ -3022,8 +3021,8 @@ tests:
   - name: "return type - getScrollState returns address"
     description: "Verify getScrollState return type is longType (1-based line number)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(state = op.getScrollState());
       return typeof(state)
@@ -3033,8 +3032,8 @@ tests:
   - name: "return type - getRefcon returns long"
     description: "Verify getRefcon return type is longType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(refcon = op.getRefcon());
       return typeof(refcon)
@@ -3044,8 +3043,8 @@ tests:
   - name: "return type - setCursor returns boolean"
     description: "Verify setCursor return type is booleanType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(cursor = op.getCursor());
       local(result = op.setCursor(cursor));
@@ -3056,8 +3055,8 @@ tests:
   - name: "return type - setDisplay returns boolean"
     description: "Verify setDisplay return type is booleanType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(result = op.setDisplay(false));
       return typeof(result)
     expected_success: true
@@ -3066,8 +3065,8 @@ tests:
   - name: "return type - setExpansionState returns boolean"
     description: "Verify setExpansionState return type is booleanType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(state = op.getExpansionState());
       local(result = op.setExpansionState(state));
@@ -3078,8 +3077,8 @@ tests:
   - name: "return type - setScrollState returns boolean"
     description: "Verify setScrollState return type is booleanType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(state = op.getScrollState());
       local(result = op.setScrollState(state));
@@ -3090,8 +3089,8 @@ tests:
   - name: "return type - setRefcon returns boolean"
     description: "Verify setRefcon return type is booleanType"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(result = op.setRefcon(100));
       return typeof(result)
@@ -3105,8 +3104,8 @@ tests:
   - name: "op.subsexpanded - check expansion state (not expanded)"
     description: "Verify op.subsexpanded returns false when node has no children"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       return op.subsexpanded()
     expected_success: true
@@ -3115,8 +3114,8 @@ tests:
   - name: "op.subsexpanded - check expansion state (collapsed)"
     description: "Verify op.subsexpanded returns false when children are collapsed"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child1", right);
       op.insert("Child2", down);
@@ -3129,8 +3128,8 @@ tests:
   - name: "op.subsexpanded - check expansion state (expanded)"
     description: "Verify op.subsexpanded returns true when children are expanded"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child1", right);
       op.insert("Child2", down);
@@ -3143,8 +3142,8 @@ tests:
   - name: "op.sort - sort siblings alphabetically"
     description: "Verify op.sort orders sibling nodes alphabetically"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Charlie", down);
       op.insert("Alice", down);
       op.insert("Bob", down);
@@ -3159,8 +3158,8 @@ tests:
   - name: "op.sort - sort preserves subheads"
     description: "Verify op.sort keeps children with their parents after sorting"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Zebra", down);
       op.insert("Zebra-Child", right);
       op.go(left, 1);
@@ -3180,8 +3179,8 @@ tests:
   - name: "op.sort - sort only siblings at same level"
     description: "Verify op.sort doesn't sort children, only siblings"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Zebra", right);
       op.insert("Apple", down);
@@ -3198,8 +3197,8 @@ tests:
   - name: "op.hoist - GUI-only operation returns error"
     description: "Verify op.hoist returns false in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.hoist()
     expected_success: true
@@ -3208,8 +3207,8 @@ tests:
   - name: "op.dehoist - GUI-only operation returns error"
     description: "Verify op.dehoist returns false in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.dehoist()
     expected_success: true
@@ -3218,8 +3217,8 @@ tests:
   - name: "op.flatcursorkeys - noop returns success"
     description: "Verify op.flatcursorkeys returns true (noop) in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.flatcursorkeys(true)
     expected_success: true
@@ -3228,8 +3227,8 @@ tests:
   - name: "op.tabkeyreorg - noop returns success"
     description: "Verify op.tabkeyreorg returns true (noop) in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.tabkeyreorg(true)
     expected_success: true
@@ -3238,8 +3237,8 @@ tests:
   - name: "op.visitall - verify verb exists (functional test deferred)"
     description: "Verify op.visitall exists and is not stubbed (doesn't test actual visiting behavior)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line 1", down);
       return true
     expected_success: true
@@ -3253,8 +3252,8 @@ tests:
   - name: "op.sethtmlformatting - noop returns false"
     description: "Verify op.sethtmlformatting returns false (noop) in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.sethtmlformatting(true)
     expected_success: true
@@ -3263,8 +3262,8 @@ tests:
   - name: "op.gethtmlformatting - noop returns false"
     description: "Verify op.gethtmlformatting returns false (noop) in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.gethtmlformatting()
     expected_success: true
@@ -3273,8 +3272,8 @@ tests:
   - name: "op.setdynamic - noop returns false"
     description: "Verify op.setdynamic returns false (noop) in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.setdynamic(true)
     expected_success: true
@@ -3283,8 +3282,8 @@ tests:
   - name: "op.getdynamic - noop returns false"
     description: "Verify op.getdynamic returns false (noop) in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.getdynamic()
     expected_success: true
@@ -3297,8 +3296,8 @@ tests:
   - name: "op.getheadnumber - first node"
     description: "Verify op.getheadnumber returns 1 for first sibling"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First", down);
       op.insert("Second", down);
       op.insert("Third", down);
@@ -3310,8 +3309,8 @@ tests:
   - name: "op.getheadnumber - third node"
     description: "Verify op.getheadnumber returns 3 for third sibling"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First", down);
       op.insert("Second", down);
       op.insert("Third", down);
@@ -3324,8 +3323,8 @@ tests:
   - name: "op.setmodified - set dirty flag true"
     description: "Verify op.setmodified(true) marks outline as modified"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.setmodified(true)
     expected_success: true
@@ -3334,8 +3333,8 @@ tests:
   - name: "op.setmodified - clear dirty flag false"
     description: "Verify op.setmodified(false) clears dirty flag"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       op.setmodified(true);
       return op.setmodified(false)
@@ -3345,8 +3344,8 @@ tests:
   - name: "op.getsuboutline - single line"
     description: "Verify op.getsuboutline extracts text from single line"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First line", down);
       return op.getsuboutline()
     expected_success: true
@@ -3355,8 +3354,8 @@ tests:
   - name: "op.getsuboutline - multi-level indented"
     description: "Verify op.getsuboutline extracts indented text from hierarchy"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child1", right);
       op.insert("Child2", down);
@@ -3369,8 +3368,8 @@ tests:
   - name: "op.getsuboutline - flindent false"
     description: "Verify op.getsuboutline(false) returns unindented text without tabs"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
       op.go(left, 1);
@@ -3382,14 +3381,14 @@ tests:
   - name: "op.insertoutline - insert source into target"
     description: "Verify op.insertoutline copies structure from source to target"
     script: |
-      lang.new(outlineType, @workspace.source);
-      lang.new(outlineType, @workspace.dest);
-      target.set(@workspace.source);
+      lang.new(outlineType, @system.temp.source);
+      lang.new(outlineType, @system.temp.dest);
+      target.set(@system.temp.source);
       op.insert("Source1", down);
       op.insert("Source2", down);
-      target.set(@workspace.dest);
+      target.set(@system.temp.dest);
       op.insert("Dest1", down);
-      op.insertoutline(@workspace.source, down);
+      op.insertoutline(@system.temp.source, down);
       return op.countSummits()
     expected_success: true
     expected_result: "5"
@@ -3397,16 +3396,16 @@ tests:
   - name: "op.insertoutline - preserve source outline"
     description: "Verify op.insertoutline does not modify source outline"
     script: |
-      lang.new(outlineType, @workspace.source);
-      lang.new(outlineType, @workspace.dest);
-      target.set(@workspace.source);
+      lang.new(outlineType, @system.temp.source);
+      lang.new(outlineType, @system.temp.dest);
+      target.set(@system.temp.source);
       op.insert("Source1", down);
       op.insert("Source2", down);
       local(before = op.countSummits());
-      target.set(@workspace.dest);
+      target.set(@system.temp.dest);
       op.insert("Dest1", down);
-      op.insertoutline(@workspace.source, down);
-      target.set(@workspace.source);
+      op.insertoutline(@system.temp.source, down);
+      target.set(@system.temp.source);
       local(after = op.countSummits());
       return before == after
     expected_success: true
@@ -3415,8 +3414,8 @@ tests:
   - name: "op.getselection - no nodes marked returns cursor"
     description: "Verify op.getselection returns list with current cursor when no nodes are marked"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First", down);
       op.insert("Second", down);
       op.insert("Third", down);
@@ -3428,8 +3427,8 @@ tests:
   - name: "op.getselection - returns list type"
     description: "Verify op.getselection returns a list"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       local(sel = op.getselection());
       return typeOf(sel)
@@ -3439,8 +3438,8 @@ tests:
   - name: "op.getselection - empty outline"
     description: "Verify op.getselection works with empty outline (just summit)"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       local(sel = op.getselection());
       return sizeOf(sel)
     expected_success: true
@@ -3453,11 +3452,11 @@ tests:
   - name: "op.outlinetoxml - basic conversion"
     description: "Convert simple outline to OPML XML format"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("First", down);
       op.insert("Second", down);
-      local(xml = op.outlinetoxml(@workspace.outline, "TestUser", "test@example.com"));
+      local(xml = op.outlinetoxml(@system.temp.outline, "TestUser", "test@example.com"));
       return sizeOf(xml) > 100 and string.mid(xml, 1, 5) == "<?xml"
     expected_success: true
     expected_result: "true"
@@ -3465,10 +3464,10 @@ tests:
   - name: "op.outlinetoxml - contains outline text"
     description: "Verify OPML contains headline text"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Hello World", down);
-      local(xml = op.outlinetoxml(@workspace.outline, "TestUser", "test@example.com"));
+      local(xml = op.outlinetoxml(@system.temp.outline, "TestUser", "test@example.com"));
       return string.patternMatch("Hello World", xml) > 0
     expected_success: true
     expected_result: "true"
@@ -3476,11 +3475,11 @@ tests:
   - name: "op.outlinetoxml - preserves hierarchy"
     description: "Verify OPML preserves parent-child structure"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Parent", down);
       op.insert("Child", right);
-      local(xml = op.outlinetoxml(@workspace.outline, "TestUser", "test@example.com"));
+      local(xml = op.outlinetoxml(@system.temp.outline, "TestUser", "test@example.com"));
       local(hasParent = string.patternMatch("Parent", xml) > 0);
       local(hasChild = string.patternMatch("Child", xml) > 0);
       return hasParent and hasChild
@@ -3491,9 +3490,9 @@ tests:
     description: "Import simple OPML XML into outline"
     script: |
       local(xml = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><opml version=\"1.1\"><body><outline text=\"Test\"/></body></opml>");
-      lang.new(outlineType, @workspace.outline);
-      local(ok = op.xmltooutline(xml, @workspace.outline, true));
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      local(ok = op.xmltooutline(xml, @system.temp.outline, true));
+      target.set(@system.temp.outline);
       op.firstSummit();
       return ok and op.getLineText() == "Test"
     expected_success: true
@@ -3502,14 +3501,14 @@ tests:
   - name: "op.xmltooutline - round trip"
     description: "Export outline to XML and re-import preserves content"
     script: |
-      lang.new(outlineType, @workspace.out1);
-      target.set(@workspace.out1);
+      lang.new(outlineType, @system.temp.out1);
+      target.set(@system.temp.out1);
       op.insert("Line1", down);
       op.insert("Line2", down);
-      local(xml = op.outlinetoxml(@workspace.out1, "User", "user@example.com"));
-      lang.new(outlineType, @workspace.out2);
-      op.xmltooutline(xml, @workspace.out2, true);
-      target.set(@workspace.out2);
+      local(xml = op.outlinetoxml(@system.temp.out1, "User", "user@example.com"));
+      lang.new(outlineType, @system.temp.out2);
+      op.xmltooutline(xml, @system.temp.out2, true);
+      target.set(@system.temp.out2);
       op.firstSummit();
       op.go(down, 1);  // Move past empty summit to first imported line
       local(first = op.getLineText());
@@ -3523,9 +3522,9 @@ tests:
     description: "Import XML into empty outline with flnewoutline=true"
     script: |
       local(xml = "<?xml version=\"1.0\"?><opml version=\"1.1\"><body><outline text=\"NewLine\"/></body></opml>");
-      lang.new(outlineType, @workspace.outline);
-      local(ok = op.xmltooutline(xml, @workspace.outline, true));
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      local(ok = op.xmltooutline(xml, @system.temp.outline, true));
+      target.set(@system.temp.outline);
       local(count = op.countSummits());
       return ok and (count >= 1)
     expected_success: true
@@ -3534,11 +3533,11 @@ tests:
   - name: "op.getselectedsuboutlines - empty source"
     description: "Get selected suboutlines from outline with no marked nodes"
     script: |
-      lang.new(outlineType, @workspace.source);
-      lang.new(outlineType, @workspace.dest);
-      target.set(@workspace.source);
+      lang.new(outlineType, @system.temp.source);
+      lang.new(outlineType, @system.temp.dest);
+      target.set(@system.temp.source);
       op.insert("Line1", down);
-      local(ok = op.getselectedsuboutlines(@workspace.dest));
+      local(ok = op.getselectedsuboutlines(@system.temp.dest));
       return ok
     expected_success: true
     expected_result: "true"
@@ -3546,27 +3545,27 @@ tests:
   - name: "op.getselectedsuboutlines - destination outline type"
     description: "Verify destination remains valid outline after operation"
     script: |
-      lang.new(outlineType, @workspace.source);
-      lang.new(outlineType, @workspace.dest);
-      target.set(@workspace.source);
+      lang.new(outlineType, @system.temp.source);
+      lang.new(outlineType, @system.temp.dest);
+      target.set(@system.temp.source);
       op.insert("Source Line", down);
-      local(ok = op.getselectedsuboutlines(@workspace.dest));
-      return ok and defined(workspace.dest)
+      local(ok = op.getselectedsuboutlines(@system.temp.dest));
+      return ok and defined(system.temp.dest)
     expected_success: true
     expected_result: "true"
 
   - name: "op.getselectedsuboutlines - with destination content"
     description: "Add to destination outline that already has content"
     script: |
-      lang.new(outlineType, @workspace.source);
-      lang.new(outlineType, @workspace.dest);
-      target.set(@workspace.dest);
+      lang.new(outlineType, @system.temp.source);
+      lang.new(outlineType, @system.temp.dest);
+      target.set(@system.temp.dest);
       op.insert("Existing", down);
       local(beforeCount = op.countSummits());
-      target.set(@workspace.source);
+      target.set(@system.temp.source);
       op.insert("New", down);
-      op.getselectedsuboutlines(@workspace.dest);
-      target.set(@workspace.dest);
+      op.getselectedsuboutlines(@system.temp.dest);
+      target.set(@system.temp.dest);
       local(afterCount = op.countSummits());
       return afterCount >= beforeCount
     expected_success: true

--- a/tests/integration/test_cases/opattributes_verbs.yaml
+++ b/tests/integration/test_cases/opattributes_verbs.yaml
@@ -31,8 +31,8 @@ tests:
     description: "Verify op.attributes.addgroup returns 'not supported' error in headless mode"
     skip: "Phase 3: op.attributes verbs are GUI-only and not supported in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.attributes.addgroup("testGroup")
     expected_success: false
@@ -42,8 +42,8 @@ tests:
     description: "Verify op.attributes.getall returns 'not supported' error in headless mode"
     skip: "Phase 3: op.attributes verbs are GUI-only and not supported in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.attributes.getall()
     expected_success: false
@@ -53,8 +53,8 @@ tests:
     description: "Verify op.attributes.getone returns 'not supported' error in headless mode"
     skip: "Phase 3: op.attributes verbs are GUI-only and not supported in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.attributes.getone("testGroup")
     expected_success: false
@@ -64,8 +64,8 @@ tests:
     description: "Verify op.attributes.makeempty returns 'not supported' error in headless mode"
     skip: "Phase 3: op.attributes verbs are GUI-only and not supported in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.attributes.makeempty()
     expected_success: false
@@ -75,8 +75,8 @@ tests:
     description: "Verify op.attributes.setone returns 'not supported' error in headless mode"
     skip: "Phase 3: op.attributes verbs are GUI-only and not supported in headless mode"
     script: |
-      lang.new(outlineType, @workspace.outline);
-      target.set(@workspace.outline);
+      lang.new(outlineType, @system.temp.outline);
+      target.set(@system.temp.outline);
       op.insert("Line", down);
       return op.attributes.setone("testGroup", "testValue")
     expected_success: false

--- a/tests/integration/test_cases/post_hydration_database_state.yaml
+++ b/tests/integration/test_cases/post_hydration_database_state.yaml
@@ -127,8 +127,8 @@ tests:
     description: |
       Verify we can write to workspace table (requires open database).
     script: |
-      workspace.test_post_hydration = "success";
-      return workspace.test_post_hydration
+      system.temp.test_post_hydration = "success";
+      return system.temp.test_post_hydration
     expected_success: true
     expected_result: "success"
 
@@ -164,8 +164,8 @@ tests:
       This tests script infrastructure independent of migration.
       NOTE: Runtime script creation has pre-existing issues. Skip for now.
     script: |
-      workspace.testScript = script("return 42");
-      return workspace.testScript()
+      system.temp.testScript = script("return 42");
+      return system.temp.testScript()
     expected_success: true
     expected_result: "42"
     skip: true
@@ -237,8 +237,8 @@ tests:
       Verify lang.new() still works for creating tables.
       NOTE: Has pre-existing opcode 34 error - not related to hydration fix.
     script: |
-      lang.new(tableType, @workspace.newTable);
-      return typeof(workspace.newTable)
+      lang.new(tableType, @system.temp.newTable);
+      return typeof(system.temp.newTable)
     expected_success: true
     expected_result: "tabl"
     skip: true
@@ -249,9 +249,9 @@ tests:
       Verify table assignments still work.
       NOTE: Has pre-existing opcode 34 error - not related to hydration fix.
     script: |
-      lang.new(tableType, @workspace.assignTest);
-      workspace.assignTest.key1 = "value1";
-      return workspace.assignTest.key1
+      lang.new(tableType, @system.temp.assignTest);
+      system.temp.assignTest.key1 = "value1";
+      return system.temp.assignTest.key1
     expected_success: true
     expected_result: "value1"
     skip: true

--- a/tests/integration/test_cases/script_processor_verbs.yaml
+++ b/tests/integration/test_cases/script_processor_verbs.yaml
@@ -47,9 +47,9 @@ tests:
     description: "Compile a simple UserTalk script and verify success"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.testScript);
-      script.setsource(@workspace.testScript, "return 42");
-      return script.compile(@workspace.testScript)
+      lang.new(scriptType, @system.temp.testScript);
+      script.setsource(@system.temp.testScript, "return 42");
+      return script.compile(@system.temp.testScript)
     expected_success: true
     expected_result: "true"
 
@@ -57,9 +57,9 @@ tests:
     description: "Compile should return boolean type"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.compileTest);
-      script.setsource(@workspace.compileTest, "return true");
-      return typeof(script.compile(@workspace.compileTest))
+      lang.new(scriptType, @system.temp.compileTest);
+      script.setsource(@system.temp.compileTest, "return true");
+      return typeof(script.compile(@system.temp.compileTest))
     expected_success: true
     expected_result: "bool"
 
@@ -67,9 +67,9 @@ tests:
     description: "Compile script with arithmetic operations"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.mathScript);
-      script.setsource(@workspace.mathScript, "return 10 + 20 * 3");
-      return script.compile(@workspace.mathScript)
+      lang.new(scriptType, @system.temp.mathScript);
+      script.setsource(@system.temp.mathScript, "return 10 + 20 * 3");
+      return script.compile(@system.temp.mathScript)
     expected_success: true
     expected_result: "true"
 
@@ -77,9 +77,9 @@ tests:
     description: "Compile script with string concatenation"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.stringScript);
-      script.setsource(@workspace.stringScript, "return \"hello\" + \" \" + \"world\"");
-      return script.compile(@workspace.stringScript)
+      lang.new(scriptType, @system.temp.stringScript);
+      script.setsource(@system.temp.stringScript, "return \"hello\" + \" \" + \"world\"");
+      return script.compile(@system.temp.stringScript)
     expected_success: true
     expected_result: "true"
 
@@ -87,9 +87,9 @@ tests:
     description: "Compile script with local variable declarations"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.localVarScript);
-      script.setsource(@workspace.localVarScript, "local(x=5, y=10); return x+y");
-      return script.compile(@workspace.localVarScript)
+      lang.new(scriptType, @system.temp.localVarScript);
+      script.setsource(@system.temp.localVarScript, "local(x=5, y=10); return x+y");
+      return script.compile(@system.temp.localVarScript)
     expected_success: true
     expected_result: "true"
 
@@ -97,9 +97,9 @@ tests:
     description: "Compile script with if/else statement"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.ifScript);
-      script.setsource(@workspace.ifScript, "if true { return \"yes\" } else { return \"no\" }");
-      return script.compile(@workspace.ifScript)
+      lang.new(scriptType, @system.temp.ifScript);
+      script.setsource(@system.temp.ifScript, "if true { return \"yes\" } else { return \"no\" }");
+      return script.compile(@system.temp.ifScript)
     expected_success: true
     expected_result: "true"
 
@@ -107,9 +107,9 @@ tests:
     description: "Compile script with for loop"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.loopScript);
-      script.setsource(@workspace.loopScript, "local(i, sum=0); for i=1 to 10 { sum = sum + i }; return sum");
-      return script.compile(@workspace.loopScript)
+      lang.new(scriptType, @system.temp.loopScript);
+      script.setsource(@system.temp.loopScript, "local(i, sum=0); for i=1 to 10 { sum = sum + i }; return sum");
+      return script.compile(@system.temp.loopScript)
     expected_success: true
     expected_result: "true"
 
@@ -118,9 +118,9 @@ tests:
     description: "Compilation error should terminate script execution"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.badScript);
-      script.setsource(@workspace.badScript, "return 1 + +");
-      script.compile(@workspace.badScript);
+      lang.new(scriptType, @system.temp.badScript);
+      script.setsource(@system.temp.badScript, "return 1 + +");
+      script.compile(@system.temp.badScript);
       return false
     expected_success: false
 
@@ -128,9 +128,9 @@ tests:
     description: "Empty script should compile successfully"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.emptyScript);
-      script.setsource(@workspace.emptyScript, "");
-      return script.compile(@workspace.emptyScript)
+      lang.new(scriptType, @system.temp.emptyScript);
+      script.setsource(@system.temp.emptyScript, "");
+      return script.compile(@system.temp.emptyScript)
     expected_success: true
     expected_result: "true"
 
@@ -138,9 +138,9 @@ tests:
     description: "Compile multi-line script with statements on separate lines"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.multilineScript);
-      script.setsource(@workspace.multilineScript, "local(x = 10);\nlocal(y = 20);\nreturn x + y");
-      return script.compile(@workspace.multilineScript)
+      lang.new(scriptType, @system.temp.multilineScript);
+      script.setsource(@system.temp.multilineScript, "local(x = 10);\nlocal(y = 20);\nreturn x + y");
+      return script.compile(@system.temp.multilineScript)
     expected_success: true
     expected_result: "true"
 
@@ -148,9 +148,9 @@ tests:
     description: "Compile script containing comments"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.commentScript);
-      script.setsource(@workspace.commentScript, "// This is a comment\nreturn 42 // another comment");
-      return script.compile(@workspace.commentScript)
+      lang.new(scriptType, @system.temp.commentScript);
+      script.setsource(@system.temp.commentScript, "// This is a comment\nreturn 42 // another comment");
+      return script.compile(@system.temp.commentScript)
     expected_success: true
     expected_result: "true"
 
@@ -159,8 +159,8 @@ tests:
     description: "Attempting to compile non-script object should return false"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(tableType, @workspace.notAScript);
-      return script.compile(@workspace.notAScript)
+      lang.new(tableType, @system.temp.notAScript);
+      return script.compile(@system.temp.notAScript)
     expected_success: true
     expected_result: "false"
 
@@ -172,10 +172,10 @@ tests:
     description: "Production pattern: call script directly after compilation"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.execTest);
-      script.setsource(@workspace.execTest, "return 42");
-      script.compile(@workspace.execTest);
-      return @workspace.execTest() == 42
+      lang.new(scriptType, @system.temp.execTest);
+      script.setsource(@system.temp.execTest, "return 42");
+      script.compile(@system.temp.execTest);
+      return @system.temp.execTest() == 42
     expected_success: true
     expected_result: "true"
 
@@ -183,10 +183,10 @@ tests:
     description: "Verify compiled script executes and returns correct result"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.mathScript);
-      script.setsource(@workspace.mathScript, "return 10 + 20 + 12");
-      script.compile(@workspace.mathScript);
-      return @workspace.mathScript() == 42
+      lang.new(scriptType, @system.temp.mathScript);
+      script.setsource(@system.temp.mathScript, "return 10 + 20 + 12");
+      script.compile(@system.temp.mathScript);
+      return @system.temp.mathScript() == 42
     expected_success: true
     expected_result: "true"
 
@@ -202,10 +202,10 @@ tests:
     description: "script.run should fail with deprecation message"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.runTest);
-      script.setsource(@workspace.runTest, "return 42");
-      script.compile(@workspace.runTest);
-      script.run(@workspace.runTest)
+      lang.new(scriptType, @system.temp.runTest);
+      script.setsource(@system.temp.runTest, "return 42");
+      script.compile(@system.temp.runTest);
+      script.run(@system.temp.runTest)
     expected_success: false
     expected_error: "script.run is not supported"
 
@@ -218,10 +218,10 @@ tests:
     description: "Get source code from script object"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.sourceTest);
-      script.setsource(@workspace.sourceTest, "return 42");
+      lang.new(scriptType, @system.temp.sourceTest);
+      script.setsource(@system.temp.sourceTest, "return 42");
       local(source);
-      script.getsource(@workspace.sourceTest, @source);
+      script.getsource(@system.temp.sourceTest, @source);
       return source == "return 42"
     expected_success: true
     expected_result: "true"
@@ -230,10 +230,10 @@ tests:
     description: "Set source code in script object"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.setSourceTest);
-      script.setsource(@workspace.setSourceTest, "return 100");
+      lang.new(scriptType, @system.temp.setSourceTest);
+      script.setsource(@system.temp.setSourceTest, "return 100");
       local(retrieved);
-      script.getsource(@workspace.setSourceTest, @retrieved);
+      script.getsource(@system.temp.setSourceTest, @retrieved);
       return retrieved == "return 100"
     expected_success: true
     expected_result: "true"
@@ -242,8 +242,8 @@ tests:
     description: "setsource should return boolean true on success"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.setSourceReturn);
-      return script.setsource(@workspace.setSourceReturn, "return 42")
+      lang.new(scriptType, @system.temp.setSourceReturn);
+      return script.setsource(@system.temp.setSourceReturn, "return 42")
     expected_success: true
     expected_result: "true"
 
@@ -251,10 +251,10 @@ tests:
     description: "getsource should return boolean true on success"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.getSourceReturn);
-      script.setsource(@workspace.getSourceReturn, "return 42");
+      lang.new(scriptType, @system.temp.getSourceReturn);
+      script.setsource(@system.temp.getSourceReturn, "return 42");
       local(source);
-      return script.getsource(@workspace.getSourceReturn, @source)
+      return script.getsource(@system.temp.getSourceReturn, @source)
     expected_success: true
     expected_result: "true"
 
@@ -263,10 +263,10 @@ tests:
     description: "Set source, get it back, verify unchanged"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.roundtrip);
-      script.setsource(@workspace.roundtrip, "local(x = 10);\nreturn x * 2");
+      lang.new(scriptType, @system.temp.roundtrip);
+      script.setsource(@system.temp.roundtrip, "local(x = 10);\nreturn x * 2");
       local(retrieved);
-      script.getsource(@workspace.roundtrip, @retrieved);
+      script.getsource(@system.temp.roundtrip, @retrieved);
       return retrieved == "local(x = 10);\nreturn x * 2"
     expected_success: true
     expected_result: "true"
@@ -276,10 +276,10 @@ tests:
     description: "Setting empty source should work"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.emptySource);
-      script.setsource(@workspace.emptySource, "");
+      lang.new(scriptType, @system.temp.emptySource);
+      script.setsource(@system.temp.emptySource, "");
       local(retrieved);
-      script.getsource(@workspace.emptySource, @retrieved);
+      script.getsource(@system.temp.emptySource, @retrieved);
       return retrieved == ""
     expected_success: true
     expected_result: "true"
@@ -288,10 +288,10 @@ tests:
     description: "Setting multi-line source with newlines"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.multiline);
-      script.setsource(@workspace.multiline, "local(x = 1);\nlocal(y = 2);\nreturn x + y");
+      lang.new(scriptType, @system.temp.multiline);
+      script.setsource(@system.temp.multiline, "local(x = 1);\nlocal(y = 2);\nreturn x + y");
       local(retrieved);
-      script.getsource(@workspace.multiline, @retrieved);
+      script.getsource(@system.temp.multiline, @retrieved);
       return string.length(retrieved) > 0
     expected_success: true
     expected_result: "true"
@@ -300,10 +300,10 @@ tests:
     description: "Setting source with quotes and backslashes"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.specialChars);
-      script.setsource(@workspace.specialChars, "return \"hello\\nworld\"");
+      lang.new(scriptType, @system.temp.specialChars);
+      script.setsource(@system.temp.specialChars, "return \"hello\\nworld\"");
       local(retrieved);
-      script.getsource(@workspace.specialChars, @retrieved);
+      script.getsource(@system.temp.specialChars, @retrieved);
       return string.length(retrieved) > 0
     expected_success: true
     expected_result: "true"
@@ -317,11 +317,11 @@ tests:
     description: "Get compiled code from script object"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.codeTest);
-      script.setsource(@workspace.codeTest, "return 42");
-      script.compile(@workspace.codeTest);
+      lang.new(scriptType, @system.temp.codeTest);
+      script.setsource(@system.temp.codeTest, "return 42");
+      script.compile(@system.temp.codeTest);
       local(code);
-      script.getcode(@workspace.codeTest, @code);
+      script.getcode(@system.temp.codeTest, @code);
       return typeof(code) == binaryType
     expected_success: true
     expected_result: "true"
@@ -330,11 +330,11 @@ tests:
     description: "getcode should return boolean true on success"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.getCodeReturn);
-      script.setsource(@workspace.getCodeReturn, "return 42");
-      script.compile(@workspace.getCodeReturn);
+      lang.new(scriptType, @system.temp.getCodeReturn);
+      script.setsource(@system.temp.getCodeReturn, "return 42");
+      script.compile(@system.temp.getCodeReturn);
       local(code);
-      return script.getcode(@workspace.getCodeReturn, @code)
+      return script.getcode(@system.temp.getCodeReturn, @code)
     expected_success: true
     expected_result: "true"
 
@@ -342,13 +342,13 @@ tests:
     description: "Set compiled code in script object"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.originalScript);
-      script.setsource(@workspace.originalScript, "return 42");
-      script.compile(@workspace.originalScript);
+      lang.new(scriptType, @system.temp.originalScript);
+      script.setsource(@system.temp.originalScript, "return 42");
+      script.compile(@system.temp.originalScript);
       local(code);
-      script.getcode(@workspace.originalScript, @code);
-      lang.new(scriptType, @workspace.copyScript);
-      return script.setcode(@workspace.copyScript, @code)
+      script.getcode(@system.temp.originalScript, @code);
+      lang.new(scriptType, @system.temp.copyScript);
+      return script.setcode(@system.temp.copyScript, @code)
     expected_success: true
     expected_result: "true"
 
@@ -356,13 +356,13 @@ tests:
     description: "setcode should return boolean true on success"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.setCodeReturn);
-      script.setsource(@workspace.setCodeReturn, "return 42");
-      script.compile(@workspace.setCodeReturn);
+      lang.new(scriptType, @system.temp.setCodeReturn);
+      script.setsource(@system.temp.setCodeReturn, "return 42");
+      script.compile(@system.temp.setCodeReturn);
       local(code);
-      script.getcode(@workspace.setCodeReturn, @code);
-      lang.new(scriptType, @workspace.setCodeTarget);
-      return script.setcode(@workspace.setCodeTarget, @code)
+      script.getcode(@system.temp.setCodeReturn, @code);
+      lang.new(scriptType, @system.temp.setCodeTarget);
+      return script.setcode(@system.temp.setCodeTarget, @code)
     expected_success: true
     expected_result: "true"
 
@@ -371,15 +371,15 @@ tests:
     description: "Get code from one script, set it in another, run both"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.source);
-      script.setsource(@workspace.source, "return 99");
-      script.compile(@workspace.source);
+      lang.new(scriptType, @system.temp.source);
+      script.setsource(@system.temp.source, "return 99");
+      script.compile(@system.temp.source);
       local(code);
-      script.getcode(@workspace.source, @code);
-      lang.new(scriptType, @workspace.dest);
-      script.setcode(@workspace.dest, @code);
-      local(result1 = @workspace.source());
-      local(result2 = @workspace.dest());
+      script.getcode(@system.temp.source, @code);
+      lang.new(scriptType, @system.temp.dest);
+      script.setcode(@system.temp.dest, @code);
+      local(result1 = @system.temp.source());
+      local(result2 = @system.temp.dest());
       return (result1 == 99) and (result2 == 99)
     expected_success: true
     expected_result: "true"
@@ -389,11 +389,11 @@ tests:
     description: "Getting code from uncompiled script should handle gracefully"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.uncompiled);
-      script.setsource(@workspace.uncompiled, "return 42");
+      lang.new(scriptType, @system.temp.uncompiled);
+      script.setsource(@system.temp.uncompiled, "return 42");
       local(code);
       try {
-        script.getcode(@workspace.uncompiled, @code);
+        script.getcode(@system.temp.uncompiled, @code);
         return true
       }
       else {
@@ -417,9 +417,9 @@ tests:
   - name: "script.error - error prevents subsequent code"
     description: "Code after script.error should not execute"
     script: |
-      workspace.errorFlag = false;
+      system.temp.errorFlag = false;
       script.error("Error here");
-      workspace.errorFlag = true;
+      system.temp.errorFlag = true;
       return false
     expected_success: false
 
@@ -466,10 +466,10 @@ tests:
     description: "Create, set source, compile, run, get result"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.lifecycle);
-      script.setsource(@workspace.lifecycle, "return 100 + 23");
-      script.compile(@workspace.lifecycle);
-      local(result = @workspace.lifecycle());
+      lang.new(scriptType, @system.temp.lifecycle);
+      script.setsource(@system.temp.lifecycle, "return 100 + 23");
+      script.compile(@system.temp.lifecycle);
+      local(result = @system.temp.lifecycle());
       return result == 123
     expected_success: true
     expected_result: "true"
@@ -478,13 +478,13 @@ tests:
     description: "Change script source, recompile, run again"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.modify);
-      script.setsource(@workspace.modify, "return 1");
-      script.compile(@workspace.modify);
-      local(first = @workspace.modify());
-      script.setsource(@workspace.modify, "return 2");
-      script.compile(@workspace.modify);
-      local(second = @workspace.modify());
+      lang.new(scriptType, @system.temp.modify);
+      script.setsource(@system.temp.modify, "return 1");
+      script.compile(@system.temp.modify);
+      local(first = @system.temp.modify());
+      script.setsource(@system.temp.modify, "return 2");
+      script.compile(@system.temp.modify);
+      local(second = @system.temp.modify());
       return (first == 1) and (second == 2)
     expected_success: true
     expected_result: "true"
@@ -493,10 +493,10 @@ tests:
     description: "Verify getting source doesn't require compilation"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.independence);
-      script.setsource(@workspace.independence, "return 42");
+      lang.new(scriptType, @system.temp.independence);
+      script.setsource(@system.temp.independence, "return 42");
       local(source);
-      script.getsource(@workspace.independence, @source);
+      script.getsource(@system.temp.independence, @source);
       return source == "return 42"
     expected_success: true
     expected_result: "true"
@@ -505,15 +505,15 @@ tests:
     description: "Create exact copy of script by transferring compiled code"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.original);
-      script.setsource(@workspace.original, "local(x = 5); return x * x");
-      script.compile(@workspace.original);
+      lang.new(scriptType, @system.temp.original);
+      script.setsource(@system.temp.original, "local(x = 5); return x * x");
+      script.compile(@system.temp.original);
       local(code);
-      script.getcode(@workspace.original, @code);
-      lang.new(scriptType, @workspace.clone);
-      script.setcode(@workspace.clone, @code);
-      local(origResult = @workspace.original());
-      local(cloneResult = @workspace.clone());
+      script.getcode(@system.temp.original, @code);
+      lang.new(scriptType, @system.temp.clone);
+      script.setcode(@system.temp.clone, @code);
+      local(origResult = @system.temp.original());
+      local(cloneResult = @system.temp.clone());
       return origResult == cloneResult
     expected_success: true
     expected_result: "true"
@@ -522,14 +522,14 @@ tests:
     description: "Multiple scripts can coexist and run independently"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.scriptA);
-      lang.new(scriptType, @workspace.scriptB);
-      script.setsource(@workspace.scriptA, "return 10");
-      script.setsource(@workspace.scriptB, "return 20");
-      script.compile(@workspace.scriptA);
-      script.compile(@workspace.scriptB);
-      local(a = @workspace.scriptA());
-      local(b = @workspace.scriptB());
+      lang.new(scriptType, @system.temp.scriptA);
+      lang.new(scriptType, @system.temp.scriptB);
+      script.setsource(@system.temp.scriptA, "return 10");
+      script.setsource(@system.temp.scriptB, "return 20");
+      script.compile(@system.temp.scriptA);
+      script.compile(@system.temp.scriptB);
+      local(a = @system.temp.scriptA());
+      local(b = @system.temp.scriptB());
       return (a == 10) and (b == 20)
     expected_success: true
     expected_result: "true"
@@ -542,14 +542,14 @@ tests:
     description: "Verify all script verbs return correct types"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.typeTest);
-      script.setsource(@workspace.typeTest, "return 42");
-      script.compile(@workspace.typeTest);
-      local(compileResult = script.compile(@workspace.typeTest));
-      local(runResult = @workspace.typeTest());
+      lang.new(scriptType, @system.temp.typeTest);
+      script.setsource(@system.temp.typeTest, "return 42");
+      script.compile(@system.temp.typeTest);
+      local(compileResult = script.compile(@system.temp.typeTest));
+      local(runResult = @system.temp.typeTest());
       local(source, code);
-      local(getSourceResult = script.getsource(@workspace.typeTest, @source));
-      local(getCodeResult = script.getcode(@workspace.typeTest, @code));
+      local(getSourceResult = script.getsource(@system.temp.typeTest, @source));
+      local(getCodeResult = script.getcode(@system.temp.typeTest, @code));
       return (typeof(compileResult) == booleanType) and
              (typeof(getSourceResult) == booleanType) and
              (typeof(getCodeResult) == booleanType) and
@@ -566,16 +566,16 @@ tests:
     description: "After compilation error, script should still be usable"
     skip: "Not a production Frontier verb - no glue in Frontier.root"
     script: |
-      lang.new(scriptType, @workspace.recovery);
-      script.setsource(@workspace.recovery, "return 1 + +");
+      lang.new(scriptType, @system.temp.recovery);
+      script.setsource(@system.temp.recovery, "return 1 + +");
       try {
-        script.compile(@workspace.recovery);
+        script.compile(@system.temp.recovery);
         return false
       }
       else {
-        script.setsource(@workspace.recovery, "return 42");
-        script.compile(@workspace.recovery);
-        return @workspace.recovery() == 42
+        script.setsource(@system.temp.recovery, "return 42");
+        script.compile(@system.temp.recovery);
+        return @system.temp.recovery() == 42
       }
     expected_success: true
     expected_result: "true"

--- a/tests/integration/test_cases/target_verbs.yaml
+++ b/tests/integration/test_cases/target_verbs.yaml
@@ -40,9 +40,9 @@ tests:
   - name: "target.set - simple table"
     description: "Set a table as target and verify it was set"
     script: |
-      lang.new(tableType, @workspace.testTarget);
-      target.set(@workspace.testTarget);
-      return defined(workspace.testTarget)
+      lang.new(tableType, @system.temp.testTarget);
+      target.set(@system.temp.testTarget);
+      return defined(system.temp.testTarget)
     expected_success: true
     expected_result: "true"
 
@@ -50,21 +50,21 @@ tests:
     description: "target.set() returns previous target value (nil if none was set)"
     script: |
       target.clear();
-      lang.new(tableType, @workspace.t1);
-      return typeof(target.set(@workspace.t1))
+      lang.new(tableType, @system.temp.t1);
+      return typeof(target.set(@system.temp.t1))
     expected_success: true
     expected_result: "????"
 
   - name: "target.set - returns previous target (non-nil)"
     description: "target.set() returns previous target when one was set"
     script: |
-      lang.new(tableType, @workspace.t1);
-      lang.new(tableType, @workspace.t2);
-      target.set(@workspace.t1);
-      local(prev = target.set(@workspace.t2));
+      lang.new(tableType, @system.temp.t1);
+      lang.new(tableType, @system.temp.t2);
+      target.set(@system.temp.t1);
+      local(prev = target.set(@system.temp.t2));
       return string(prev)
     expected_success: true
-    expected_result: "workspace.t1"
+    expected_result: "system.temp.t1"
 
   # ====================================================================
   # target.get() After target.set()
@@ -73,17 +73,17 @@ tests:
   - name: "target.get - returns set target"
     description: "After target.set(), target.get() returns the address that was set"
     script: |
-      lang.new(tableType, @workspace.myTarget);
-      target.set(@workspace.myTarget);
+      lang.new(tableType, @system.temp.myTarget);
+      target.set(@system.temp.myTarget);
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.myTarget"
+    expected_result: "system.temp.myTarget"
 
   - name: "target.get - returns addresstype"
     description: "target.get() returns an address type when target is set"
     script: |
-      lang.new(tableType, @workspace.targetTable);
-      target.set(@workspace.targetTable);
+      lang.new(tableType, @system.temp.targetTable);
+      target.set(@system.temp.targetTable);
       return typeof(target.get())
     expected_success: true
     expected_result: "addr"
@@ -91,8 +91,8 @@ tests:
   - name: "target.get - persists across operations"
     description: "Target persists across multiple operations until explicitly changed"
     script: |
-      lang.new(tableType, @workspace.persistent);
-      target.set(@workspace.persistent);
+      lang.new(tableType, @system.temp.persistent);
+      target.set(@system.temp.persistent);
       local(first = string(target.get()));
       local(second = string(target.get()));
       return first == second
@@ -106,8 +106,8 @@ tests:
   - name: "target.clear - clears set target"
     description: "After target.clear(), target.get() returns nil"
     script: |
-      lang.new(tableType, @workspace.t);
-      target.set(@workspace.t);
+      lang.new(tableType, @system.temp.t);
+      target.set(@system.temp.t);
       target.clear();
       return typeof(target.get())
     expected_success: true
@@ -116,8 +116,8 @@ tests:
   - name: "target.clear - returns boolean true on success"
     description: "target.clear() returns true when successful"
     script: |
-      lang.new(tableType, @workspace.t);
-      target.set(@workspace.t);
+      lang.new(tableType, @system.temp.t);
+      target.set(@system.temp.t);
       return target.clear()
     expected_success: true
     expected_result: "true"
@@ -147,11 +147,11 @@ tests:
     description: "Complete workflow: clear → set → get → verify → clear → verify"
     script: |
       target.clear();
-      lang.new(tableType, @workspace.cycleTest);
-      workspace.cycleTest.value = 42;
-      target.set(@workspace.cycleTest);
+      lang.new(tableType, @system.temp.cycleTest);
+      system.temp.cycleTest.value = 42;
+      target.set(@system.temp.cycleTest);
       local(retrieved = string(target.get()));
-      local(ok1 = retrieved == "workspace.cycleTest");
+      local(ok1 = retrieved == "system.temp.cycleTest");
       target.clear();
       local(ok2 = typeof(target.get()) == "????");
       return ok1 and ok2
@@ -161,15 +161,15 @@ tests:
   - name: "target workflow - multiple set operations"
     description: "Setting different targets in sequence works correctly"
     script: |
-      lang.new(tableType, @workspace.target1);
-      lang.new(tableType, @workspace.target2);
-      lang.new(tableType, @workspace.target3);
-      target.set(@workspace.target1);
-      local(ok1 = string(target.get()) == "workspace.target1");
-      target.set(@workspace.target2);
-      local(ok2 = string(target.get()) == "workspace.target2");
-      target.set(@workspace.target3);
-      local(ok3 = string(target.get()) == "workspace.target3");
+      lang.new(tableType, @system.temp.target1);
+      lang.new(tableType, @system.temp.target2);
+      lang.new(tableType, @system.temp.target3);
+      target.set(@system.temp.target1);
+      local(ok1 = string(target.get()) == "system.temp.target1");
+      target.set(@system.temp.target2);
+      local(ok2 = string(target.get()) == "system.temp.target2");
+      target.set(@system.temp.target3);
+      local(ok3 = string(target.get()) == "system.temp.target3");
       return ok1 and ok2 and ok3
     expected_success: true
     expected_result: "true"
@@ -181,23 +181,23 @@ tests:
   - name: "target.set - nested table"
     description: "Set a nested table as target"
     script: |
-      lang.new(tableType, @workspace.parent);
-      lang.new(tableType, @workspace.parent.child);
-      target.set(@workspace.parent.child);
+      lang.new(tableType, @system.temp.parent);
+      lang.new(tableType, @system.temp.parent.child);
+      target.set(@system.temp.parent.child);
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.parent.child"
+    expected_result: "system.temp.parent.child"
 
   - name: "target.set - deeply nested table"
     description: "Set a deeply nested table as target"
     script: |
-      lang.new(tableType, @workspace.level1);
-      lang.new(tableType, @workspace.level1.level2);
-      lang.new(tableType, @workspace.level1.level2.level3);
-      target.set(@workspace.level1.level2.level3);
+      lang.new(tableType, @system.temp.level1);
+      lang.new(tableType, @system.temp.level1.level2);
+      lang.new(tableType, @system.temp.level1.level2.level3);
+      target.set(@system.temp.level1.level2.level3);
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.level1.level2.level3"
+    expected_result: "system.temp.level1.level2.level3"
 
   # ====================================================================
   # Target Operations on Target Context
@@ -206,34 +206,34 @@ tests:
   - name: "target operations - read from target"
     description: "After setting target, can read values from the target table"
     script: |
-      lang.new(tableType, @workspace.data);
-      workspace.data.key = "testValue";
-      target.set(@workspace.data);
+      lang.new(tableType, @system.temp.data);
+      system.temp.data.key = "testValue";
+      target.set(@system.temp.data);
       local(targetAddr = target.get());
-      return defined(workspace.data.key)
+      return defined(system.temp.data.key)
     expected_success: true
     expected_result: "true"
 
   - name: "target operations - modify target contents"
     description: "Can modify contents of table that is set as target"
     script: |
-      lang.new(tableType, @workspace.mutable);
-      target.set(@workspace.mutable);
-      workspace.mutable.field = 100;
-      return workspace.mutable.field
+      lang.new(tableType, @system.temp.mutable);
+      target.set(@system.temp.mutable);
+      system.temp.mutable.field = 100;
+      return system.temp.mutable.field
     expected_success: true
     expected_result: "100"
 
   - name: "target operations - target persists after modification"
     description: "Modifying target contents doesn't affect target itself"
     script: |
-      lang.new(tableType, @workspace.stable);
-      target.set(@workspace.stable);
-      workspace.stable.x = 1;
-      workspace.stable.y = 2;
+      lang.new(tableType, @system.temp.stable);
+      target.set(@system.temp.stable);
+      system.temp.stable.x = 1;
+      system.temp.stable.y = 2;
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.stable"
+    expected_result: "system.temp.stable"
 
   # ====================================================================
   # Edge Cases - Parameter Validation
@@ -272,8 +272,8 @@ tests:
   - name: "target.set - extra parameters should fail"
     description: "target.set() with extra parameters should error"
     script: |
-      lang.new(tableType, @workspace.t);
-      target.set(@workspace.t, "extra")
+      lang.new(tableType, @system.temp.t);
+      target.set(@system.temp.t, "extra")
     expected_success: false
     expected_error_type: "script_error"
 
@@ -283,7 +283,7 @@ tests:
 
   - name: "target.set - undefined variable address"
     description: "Setting target to undefined variable should error"
-    script: 'target.set(@workspace.doesNotExist)'
+    script: 'target.set(@system.temp.doesNotExist)'
     expected_success: false
     expected_error_type: "script_error"
 
@@ -302,8 +302,8 @@ tests:
   - name: "target.set - nil value clears target"
     description: "Setting target to nil/noval should clear the target"
     script: |
-      lang.new(tableType, @workspace.t);
-      target.set(@workspace.t);
+      lang.new(tableType, @system.temp.t);
+      target.set(@system.temp.t);
       local(x);
       target.set(@x);
       return typeof(target.get())
@@ -317,50 +317,50 @@ tests:
   - name: "target.set - table with string value"
     description: "Set target to table containing string value"
     script: |
-      lang.new(tableType, @workspace.stringTable);
-      workspace.stringTable.text = "Hello World";
-      target.set(@workspace.stringTable);
-      return workspace.stringTable.text
+      lang.new(tableType, @system.temp.stringTable);
+      system.temp.stringTable.text = "Hello World";
+      target.set(@system.temp.stringTable);
+      return system.temp.stringTable.text
     expected_success: true
     expected_result: "Hello World"
 
   - name: "target.set - table with numeric value"
     description: "Set target to table containing numeric value"
     script: |
-      lang.new(tableType, @workspace.numTable);
-      workspace.numTable.count = 999;
-      target.set(@workspace.numTable);
-      return workspace.numTable.count
+      lang.new(tableType, @system.temp.numTable);
+      system.temp.numTable.count = 999;
+      target.set(@system.temp.numTable);
+      return system.temp.numTable.count
     expected_success: true
     expected_result: "999"
 
   - name: "target.set - table with boolean value"
     description: "Set target to table containing boolean value"
     script: |
-      lang.new(tableType, @workspace.boolTable);
-      workspace.boolTable.flag = true;
-      target.set(@workspace.boolTable);
-      return workspace.boolTable.flag
+      lang.new(tableType, @system.temp.boolTable);
+      system.temp.boolTable.flag = true;
+      target.set(@system.temp.boolTable);
+      return system.temp.boolTable.flag
     expected_success: true
     expected_result: "true"
 
   - name: "target.set - empty table"
     description: "Set target to empty table (no entries)"
     script: |
-      lang.new(tableType, @workspace.emptyTable);
-      target.set(@workspace.emptyTable);
-      return sizeof(workspace.emptyTable)
+      lang.new(tableType, @system.temp.emptyTable);
+      target.set(@system.temp.emptyTable);
+      return sizeof(system.temp.emptyTable)
     expected_success: true
     expected_result: "0"
 
   - name: "target.set - table with nested tables"
     description: "Set target to table containing nested tables"
     script: |
-      lang.new(tableType, @workspace.outer);
-      lang.new(tableType, @workspace.outer.inner);
-      workspace.outer.inner.value = 42;
-      target.set(@workspace.outer);
-      return workspace.outer.inner.value
+      lang.new(tableType, @system.temp.outer);
+      lang.new(tableType, @system.temp.outer.inner);
+      system.temp.outer.inner.value = 42;
+      target.set(@system.temp.outer);
+      return system.temp.outer.inner.value
     expected_success: true
     expected_result: "42"
 
@@ -371,9 +371,9 @@ tests:
   - name: "target lifecycle - delete target clears it"
     description: "Deleting the target variable clears the target as a side-effect (legacy behavior)"
     script: |
-      lang.new(tableType, @workspace.temporary);
-      target.set(@workspace.temporary);
-      lang.delete(@workspace.temporary);
+      lang.new(tableType, @system.temp.temporary);
+      target.set(@system.temp.temporary);
+      lang.delete(@system.temp.temporary);
       return typeof(target.get())
     expected_success: true
     expected_result: "????"
@@ -381,12 +381,12 @@ tests:
   - name: "target persistence - across multiple scripts"
     description: "Target set in one operation persists for next operation"
     script: |
-      lang.new(tableType, @workspace.persist);
-      workspace.persist.value = "persistent";
-      target.set(@workspace.persist);
+      lang.new(tableType, @system.temp.persist);
+      system.temp.persist.value = "persistent";
+      target.set(@system.temp.persist);
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.persist"
+    expected_result: "system.temp.persist"
 
   # ====================================================================
   # Regression Tests - Headless-Specific Behavior
@@ -404,8 +404,8 @@ tests:
   - name: "headless behavior - target.set always succeeds (no window open failure)"
     description: "In headless, target.set() never fails due to window opening (no windows exist)"
     script: |
-      lang.new(tableType, @workspace.headlessTarget);
-      target.set(@workspace.headlessTarget);
+      lang.new(tableType, @system.temp.headlessTarget);
+      target.set(@system.temp.headlessTarget);
       return typeof(target.get()) == "addr"
     expected_success: true
     expected_result: "true"
@@ -413,8 +413,8 @@ tests:
   - name: "headless behavior - target.clear no window cleanup"
     description: "In headless, target.clear() doesn't close hidden windows (no windows exist)"
     script: |
-      lang.new(tableType, @workspace.t);
-      target.set(@workspace.t);
+      lang.new(tableType, @system.temp.t);
+      target.set(@system.temp.t);
       local(cleared = target.clear());
       return cleared and (typeof(target.get()) == "????")
     expected_success: true
@@ -427,10 +427,10 @@ tests:
   - name: "stress test - rapid set/clear cycle"
     description: "Rapidly setting and clearing target multiple times"
     script: |
-      lang.new(tableType, @workspace.stress);
+      lang.new(tableType, @system.temp.stress);
       local(i);
       for i = 1 to 10 {
-        target.set(@workspace.stress);
+        target.set(@system.temp.stress);
         target.clear()
       };
       return typeof(target.get())
@@ -440,19 +440,19 @@ tests:
   - name: "stress test - many sequential target changes"
     description: "Setting many different targets in sequence"
     script: |
-      lang.new(tableType, @workspace.t1);
-      lang.new(tableType, @workspace.t2);
-      lang.new(tableType, @workspace.t3);
-      lang.new(tableType, @workspace.t4);
-      lang.new(tableType, @workspace.t5);
-      target.set(@workspace.t1);
-      target.set(@workspace.t2);
-      target.set(@workspace.t3);
-      target.set(@workspace.t4);
-      target.set(@workspace.t5);
+      lang.new(tableType, @system.temp.t1);
+      lang.new(tableType, @system.temp.t2);
+      lang.new(tableType, @system.temp.t3);
+      lang.new(tableType, @system.temp.t4);
+      lang.new(tableType, @system.temp.t5);
+      target.set(@system.temp.t1);
+      target.set(@system.temp.t2);
+      target.set(@system.temp.t3);
+      target.set(@system.temp.t4);
+      target.set(@system.temp.t5);
       return string(target.get())
     expected_success: true
-    expected_result: "workspace.t5"
+    expected_result: "system.temp.t5"
 
   # ====================================================================
   # Integration with Other Verbs
@@ -461,50 +461,50 @@ tests:
   - name: "integration - target with sizeof"
     description: "Get sizeof() on target table"
     script: |
-      lang.new(tableType, @workspace.sized);
-      workspace.sized.a = 1;
-      workspace.sized.b = 2;
-      workspace.sized.c = 3;
-      target.set(@workspace.sized);
-      return sizeof(workspace.sized)
+      lang.new(tableType, @system.temp.sized);
+      system.temp.sized.a = 1;
+      system.temp.sized.b = 2;
+      system.temp.sized.c = 3;
+      target.set(@system.temp.sized);
+      return sizeof(system.temp.sized)
     expected_success: true
     expected_result: "3"
 
   - name: "integration - target with typeof"
     description: "Get typeof() on target table"
     script: |
-      lang.new(tableType, @workspace.typed);
-      target.set(@workspace.typed);
-      return typeof(workspace.typed)
+      lang.new(tableType, @system.temp.typed);
+      target.set(@system.temp.typed);
+      return typeof(system.temp.typed)
     expected_success: true
     expected_result: "tabl"
 
   - name: "integration - target with defined"
     description: "Check defined() on target"
     script: |
-      lang.new(tableType, @workspace.exists);
-      target.set(@workspace.exists);
-      return defined(workspace.exists)
+      lang.new(tableType, @system.temp.exists);
+      target.set(@system.temp.exists);
+      return defined(system.temp.exists)
     expected_success: true
     expected_result: "true"
 
   - name: "integration - target with table.assign"
     description: "Use table.assign() on target table"
     script: |
-      lang.new(tableType, @workspace.assign);
-      target.set(@workspace.assign);
-      table.assign(@workspace.assign.key, "assigned");
-      return workspace.assign.key
+      lang.new(tableType, @system.temp.assign);
+      target.set(@system.temp.assign);
+      table.assign(@system.temp.assign.key, "assigned");
+      return system.temp.assign.key
     expected_success: true
     expected_result: "assigned"
 
   - name: "integration - target with pack/unpack"
     description: "Pack target table to binary"
     script: |
-      lang.new(tableType, @workspace.packable);
-      workspace.packable.data = "test";
-      target.set(@workspace.packable);
-      pack(workspace.packable, @packed);
+      lang.new(tableType, @system.temp.packable);
+      system.temp.packable.data = "test";
+      target.set(@system.temp.packable);
+      pack(system.temp.packable, @packed);
       return typeof(packed)
     expected_success: true
     expected_result: "data"

--- a/tests/integration/test_cases/wp_verbs.yaml
+++ b/tests/integration/test_cases/wp_verbs.yaml
@@ -42,8 +42,8 @@ tests:
   - name: "wp.getText - returns text from targeted WPText object"
     description: "Create a WPText object, set text, and verify getText returns the text"
     script: |
-      new(wpTextType, @workspace.wpGetTextTest);
-      target.set(@workspace.wpGetTextTest);
+      new(wpTextType, @system.temp.wpGetTextTest);
+      target.set(@system.temp.wpGetTextTest);
       wp.setText("hello from getText test");
       local(t = wp.getText());
       return(sizeOf(t) > 0)
@@ -53,18 +53,18 @@ tests:
   - name: "wp.getText equivalence with string()"
     description: "wp.getText() should produce the same result as string() coercion on the target"
     script: |
-      new(wpTextType, @workspace.wpEquivTest);
-      target.set(@workspace.wpEquivTest);
+      new(wpTextType, @system.temp.wpEquivTest);
+      target.set(@system.temp.wpEquivTest);
       wp.setText("equivalence test content");
-      return(wp.getText() == string(workspace.wpEquivTest))
+      return(wp.getText() == string(system.temp.wpEquivTest))
     expected_success: true
     expected_result: "true"
 
   - name: "wp.setText/getText roundtrip"
     description: "Set text on a WPText object, then get it back and verify match"
     script: |
-      new(wpTextType, @workspace.wpRoundtripTest);
-      target.set(@workspace.wpRoundtripTest);
+      new(wpTextType, @system.temp.wpRoundtripTest);
+      target.set(@system.temp.wpRoundtripTest);
       wp.setText("hello world");
       return(wp.getText() == "hello world")
     expected_success: true
@@ -85,8 +85,8 @@ tests:
   - name: "wp.setText - accepts text parameter"
     description: "wp.setText should accept a string parameter when target is a WPText object"
     script: |
-      new(wpTextType, @workspace.wpSetTextTest);
-      target.set(@workspace.wpSetTextTest);
+      new(wpTextType, @system.temp.wpSetTextTest);
+      target.set(@system.temp.wpSetTextTest);
       wp.setText("hello world")
     expected_success: true
     expected_result: "true"

--- a/tests/integration/test_cases/xml_verbs.yaml
+++ b/tests/integration/test_cases/xml_verbs.yaml
@@ -270,10 +270,10 @@ tests:
   # Test 2: No local shadowing (backward compatibility)
   - name: "xml.frontiervaluetotaggedtext - global variable (no local shadow)"
     script: |
-      new(tableType, @workspace.globaltest);
-      workspace.globaltest.value = 42;
-      local(result = xml.frontiervaluetotaggedtext(@workspace.globaltest, 0));
-      delete(@workspace.globaltest);
+      new(tableType, @system.temp.globaltest);
+      system.temp.globaltest.value = 42;
+      local(result = xml.frontiervaluetotaggedtext(@system.temp.globaltest, 0));
+      delete(@system.temp.globaltest);
       return result
     expected_contains:
       - "<struct>"
@@ -285,16 +285,16 @@ tests:
   # Test 3: Nested scopes (with statement)
   - name: "xml.frontiervaluetotaggedtext - with statement scope"
     script: |
-      new(tableType, @workspace.outer);
+      new(tableType, @system.temp.outer);
       local(data);
       new(tableType, @data);
       data.value = "inner";
-      with workspace.outer {
+      with system.temp.outer {
         local(data);
         new(tableType, @data);
         data.value = "test";
         local(result = xml.frontiervaluetotaggedtext(@data, 0));
-        delete(@workspace.outer);
+        delete(@system.temp.outer);
         return result
       }
     expected_contains:
@@ -619,9 +619,9 @@ tests:
   - name: "xml.getAddressList - verify list contents"
     script: |
       local(xmlText = "<root><item>first</item><item>second</item></root>");
-      new(tableType, @workspace.xmltest);
-      xml.compile(xmlText, @workspace.xmltest);
-      local(rootAddr = xml.getAddress(@workspace.xmltest, "root"));
+      new(tableType, @system.temp.xmltest);
+      xml.compile(xmlText, @system.temp.xmltest);
+      local(rootAddr = xml.getAddress(@system.temp.xmltest, "root"));
       local(addrList);
       new(listType, @addrList);
       if xml.getAddressList(rootAddr, "item", @addrList) {
@@ -1184,9 +1184,9 @@ tests:
   - name: "xml - getAddressList and iterate"
     script: |
       local(xmlText = "<root><num>1</num><num>2</num><num>3</num></root>");
-      new(tableType, @workspace.xmltest);
-      xml.compile(xmlText, @workspace.xmltest);
-      local(rootAddr = xml.getAddress(@workspace.xmltest, "root"));
+      new(tableType, @system.temp.xmltest);
+      xml.compile(xmlText, @system.temp.xmltest);
+      local(rootAddr = xml.getAddress(@system.temp.xmltest, "root"));
       local(addrList);
       new(listType, @addrList);
       xml.getAddressList(rootAddr, "num", @addrList);


### PR DESCRIPTION
## Summary

- Fix REPL `/list [n]` SIGSEGV by adding missing `hashresolvevalue()` call in `resolve_indexed_node()` — the bare-index code path read node values without resolving disk values first
- Fix 18 outline test failures caused by database state pollution — tests created outlines under `workspace.*` which persisted via `save_on_exit`, causing materialization failures in subsequent runs
- Migrate ALL integration test `workspace.*` references to `system.temp.*` across 12 test files for proper test isolation (system.temp is cleared on each process startup)
- Add corrupt handle data pointer guards in pack visitors and `getaddressparts` to prevent SIGSEGV on stale entries during save-on-exit
- Fix flaky integration tests (~20% failure rate) caused by protocol process death with no recovery in `ProtocolExecutor.reset()`

## Details

### Corrupt handle guards (langhash.c)
- Shared `hashpackguard_corrupt_handle()` helper used by both legacy and v7 pack visitors
- Covers: address, string, password, oldstring, binary value types
- NULL master pointer (`*hdata == NULL`) is valid — represents zero-length handles from `NewHandle(0)`
- `codevaluetype`/`externalvaluetype` excluded — they have separate packing paths with own error handling
- `fldontsave` flag is permanent for the session (acceptable since guard only fires on corruption)

### Protocol executor resilience (runner.py)
- `reset()` restarts protocol process when dead or `clearContext` fails (was silently returning)
- `run_batch_test()` retries via per-process FrontierCLI on "not running" error (eliminates TOCTOU race)
- stderr captured to temp file for crash diagnostics; logs head+tail when content exceeds 1000 chars

### Documentation
- TESTING_GUIDE.md: Database state isolation section with good/bad patterns
- AI_SHARED_GUIDELINES.md: `system.temp` cleanup is unnecessary (non-persistent); NEVER use `new(tableType, @workspace)`
- DEBUGGING_GUIDE.md: Corrupt handle guards during save — how to diagnose silent entry drops

## Test plan

- [x] 302/302 unit tests pass
- [x] 1707/1707 integration tests pass consistently
- [x] All 18 previously-failing outline tests pass
- [x] REPL `/list [1]` test passes (no SIGSEGV)
- [x] Flaky test file 20x: 0 failures (was ~35%)
- [x] Full integration suite 10x: 0 failures (was ~20%)
- [x] Audit confirmed no remaining `workspace.*` mutations in integration tests (except intentional writeability test in db_migration.yaml)

Generated with [Claude Code](https://claude.com/claude-code)