### PR TITLE
fix: Remove stale headless EFP fast-path blocking database script resolution

### DIFF
--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8843,7 +8843,7 @@ boolean langhandlercall (hdltreenode htree, hdltreenode hparam1, tyvaluerecord *
 
 	if (langgethandlercode (efptable, htree, &hcode, &htable, &hnode)) {
 		
-		assert (hcode == nil); /*see special case in gethandlercode*/
+		assert (hcode == nil); /*kernel verb nodes in efptable produce hcode==nil from langgetnodecode; dispatch is via hnode*/
 		
 		goto runhandler;
 		}

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8704,10 +8704,7 @@ static boolean langgethandlercode (hdlhashtable intable, hdltreenode hnamenode, 
         return (false);
     
     ht = *htable; /*move into register*/
-#if defined(FRONTIER_HEADLESS)
-    /* debug disabled */
-#endif
-	
+
 	if (ht == nil) { /*no table specified*/
 		
 		pushhashtable (intable);

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8670,51 +8670,12 @@ static boolean langgethandlercode (hdlhashtable intable, hdltreenode hnamenode, 
 	
     disablelangerror (); /*no dialog if an error is encountered*/
 
-/* Headless dotted-name efp fast-path removed; rely on efptable path below. */
-
-#if defined(FRONTIER_HEADLESS)
-    /* Headless fast-path: if asked to resolve within efptable and name is dotted,
-       interpret left as EFP table and right as verb directly. */
-    if ((intable == efptable) && hnamenode && ((**hnamenode).nodetype == dotop)) {
-        bigstring bsleft, bsright;
-        hdlhashtable hleft = nil;
-        setemptystring(bsleft); setemptystring(bsright);
-        if (langgetidentifier((**hnamenode).param1, bsleft) && langgetidentifier((**hnamenode).param2, bsright)) {
-            /* Look up the EFP table by name under efptable */
-            pushhashtable(efptable);
-            if (langexternalgettable(bsleft, &hleft) && (hleft != nil)) {
-                pophashtable();
-                /* Find the verb token in that table */
-                pushhashtable(hleft);
-                if (hashtablelookupnode(hleft, bsright, hnode)) {
-                    pophashtable();
-                    *htable = hleft;
-                    /* Produce kernel special-case: no code (handled by langfunctioncall) */
-                    if (!langgetnodecode(hleft, bsright, *hnode, hcode)) {
-                        /* If not a kernel token, fall back to kernelfunctionvalue via nil code */
-                        *hcode = nil;
-                    }
-                    /* Ensure bsfunctionname is set for kernelfunctionvalue */
-                    copystring(bsright, bsfunctionname);
-                    enablelangerror (); /*re-enable before early return*/
-                    return (true);
-                }
-                pophashtable();
-                /* Even if the verb token wasn't present, allow kernel fallback in headless */
-                *htable = hleft;
-                *hcode = nil;
-                /* Ensure bsfunctionname is set for fallback */
-                copystring(bsright, bsfunctionname);
-                *hnode = nil;
-                enablelangerror (); /*re-enable before early return*/
-                return (true);
-            } else {
-                pophashtable();
-            }
-        }
-        /* fall through to generic path on failure */
-    }
-#endif
+    /* 2025-10-08: A headless EFP fast-path was added here (commit 4e217f09) as a
+     * temporary shim to resolve dotted verbs like file.exists when system tables
+     * weren't loaded. It checked efptable FIRST, violating the correct search
+     * order (system.paths THEN efptable — see VERB_RESOLUTION_ARCHITECTURE.md).
+     * Now that database hydration loads system tables, the generic path below
+     * handles all verb resolution correctly, so the fast-path has been removed. */
 	
 	/* 2026-01-25: RESTORED legacy guard behavior.
 	 * The guard is set ONLY when searching non-default scope (path search iterations).

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1914 tests: 1725 pass (90%) 189 skip (9%)</title>
-    <dateCreated>Sun, 08 Mar 2026 05:59:25 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1918 tests: 1729 pass (90%) 189 skip (9%)</title>
+    <dateCreated>Sun, 08 Mar 2026 10:00:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-08 at 05:58 UTC"/>
-      <outline text="Results: 1707 passed (90%), 189 skipped (10%), 0 failed (0%)"/>
-      <outline text="Duration: 37.3s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 1914 tests (1725 active, 189 marked skip) across 51 categories"/>
+      <outline text="Run: 2026-03-08 at 09:59 UTC"/>
+      <outline text="Results: 1711 passed (90%), 189 skipped (10%), 0 failed (0%)"/>
+      <outline text="Duration: 37.9s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 1918 tests (1729 active, 189 marked skip) across 51 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
@@ -37,7 +37,7 @@
     <outline text="Op Verbs (op_verbs) - 266 tests: 254 pass (95%) 12 skip (4%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_verbs.opml"/>
     <outline text="Opattributes Verbs (opattributes_verbs) - 7 tests: 0 pass (0%) 7 skip (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/opattributes_verbs.opml"/>
     <outline text="Path Resolution (path_resolution) - 39 tests: 39 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/path_resolution.opml"/>
-    <outline text="Post Hydration Database State (post_hydration_database_state) - 34 tests: 30 pass (88%) 4 skip (11%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/post_hydration_database_state.opml"/>
+    <outline text="Post Hydration Database State (post_hydration_database_state) - 38 tests: 34 pass (89%) 4 skip (10%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/post_hydration_database_state.opml"/>
     <outline text="Repl Basic (repl_basic) - 56 tests: 56 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/repl_basic.opml"/>
     <outline text="Repl Commands (repl_commands) - 81 tests: 61 pass (75%) 20 skip (24%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/repl_commands.opml"/>
     <outline text="Repl Sessions (repl_sessions) - 57 tests: 52 pass (91%) 5 skip (8%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/repl_sessions.opml"/>

--- a/reports/integration_tests/post_hydration_database_state.opml
+++ b/reports/integration_tests/post_hydration_database_state.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Post Hydration Database State (post_hydration_database_state) - 34 tests: 30 pass (88%) 4 skip (11%)</title>
-    <dateCreated>Thu, 05 Mar 2026 19:10:44 GMT</dateCreated>
+    <title>Post Hydration Database State (post_hydration_database_state) - 38 tests: 34 pass (89%) 4 skip (10%)</title>
+    <dateCreated>Sun, 08 Mar 2026 10:00:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="CRITICAL - string(123) works after hydration - This is THE test for the bug we fixed. If hydrate_system_root_database()&#10;closes the database on success, this test WILL FAIL because:&#10;1. CLI starts up, calls hydrate_system_root_database()&#10;2. (Bug) hydrate closes DB, databasedata = nil&#10;3. Test runs, calls string(123)&#10;4. langfindsymbol() tries to resolve &quot;string&quot; via system.paths&#10;5. system.paths lookup requires database access&#10;6. databasedata is nil -&gt; crash or &quot;Can't find verb&quot; error&#10;&#10;After the fix, the database stays open and string() resolves correctly.&#10;">
@@ -300,6 +300,38 @@
       </outline>
       <outline text="Script">
         <outline text="defined(system) and defined(string) and string(123) == &quot;123&quot;"/>
+      </outline>
+    </outline>
+    <outline text="EFP fallback - inetd.startOne is defined - inetd.startOne is a UserTalk script in the database, NOT a kernel verb.&#10;It must be reachable through the system.paths search, not blocked by&#10;EFP table lookup. Regression test for the headless fast-path bug.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(inetd.startOne)"/>
+      </outline>
+    </outline>
+    <outline text="EFP fallback - inetd.startOne is script type - Verifies typeOf() correctly identifies inetd.startOne as a script (scpt),&#10;not a kernel token (tokn). If the EFP fast-path intercepts, typeOf may&#10;return the wrong type or fail entirely.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="typeOf(inetd.startOne) == &quot;scpt&quot;"/>
+      </outline>
+    </outline>
+    <outline text="EFP fallback - inetd.isDaemonRunning is defined - Another UserTalk script under inetd that must be reachable via database&#10;lookup, not blocked by EFP table.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(inetd.isDaemonRunning)"/>
+      </outline>
+    </outline>
+    <outline text="EFP fallback - inetd.supervisor is defined - inetd.supervisor IS a kernel verb (registered in headless_inetd_verbs.c).&#10;This test verifies kernel verbs still resolve correctly without the&#10;fast-path.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="defined(inetd.supervisor)"/>
       </outline>
     </outline>
   </body>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Thu, 05 Mar 2026 19:09:31 GMT</dateCreated>
+    <dateCreated>Sun, 08 Mar 2026 09:59:47 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-05 at 19:09 UTC"/>
+      <outline text="Run: 2026-03-08 at 09:59 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/integration/test_cases/post_hydration_database_state.yaml
+++ b/tests/integration/test_cases/post_hydration_database_state.yaml
@@ -396,6 +396,9 @@ tests:
       inetd.startOne is a UserTalk script in the database, NOT a kernel verb.
       It must be reachable through the system.paths search, not blocked by
       EFP table lookup. Regression test for the headless fast-path bug.
+      NOTE: We test defined() rather than calling the verb because inetd.startOne
+      requires network infrastructure (tcp.listenStream, user.inetd tables) that
+      is not available in headless integration tests.
     script: 'defined(inetd.startOne)'
     expected_success: true
     expected_result: "true"
@@ -423,5 +426,14 @@ tests:
       This test verifies kernel verbs still resolve correctly without the
       fast-path.
     script: 'defined(inetd.supervisor)'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "EFP fallback - tcp.statusStream is defined (non-inetd namespace)"
+    description: |
+      Verify the fix is namespace-general, not inetd-specific. tcp.statusStream
+      is a UserTalk script under the tcp EFP namespace that must also be
+      reachable through system.paths, not blocked by EFP table lookup.
+    script: 'defined(tcp.statusStream)'
     expected_success: true
     expected_result: "true"

--- a/tests/integration/test_cases/post_hydration_database_state.yaml
+++ b/tests/integration/test_cases/post_hydration_database_state.yaml
@@ -375,3 +375,53 @@ tests:
     script: 'defined(system) and defined(string) and string(123) == "123"'
     expected_success: true
     expected_result: "true"
+
+  # ==========================================================================
+  # EFP database script fallback tests
+  #
+  # REGRESSION: Commit 4e217f09 added a headless fast-path in langgethandlercode
+  # that checked efptable BEFORE system.paths for dotted verbs. This violated the
+  # correct search order (system.paths first, efptable last — see
+  # docs/VERB_RESOLUTION_ARCHITECTURE.md). When a verb existed as a UserTalk
+  # script in system.verbs.builtins.<efp>.<verb> but NOT as a kernel verb in the
+  # EFP table, the fast-path claimed success with hnode=nil, blocking the database
+  # fallback and causing "not implemented" errors.
+  #
+  # These tests verify that database scripts under EFP-named tables (inetd, tcp,
+  # file, etc.) are reachable through normal verb resolution.
+  # ==========================================================================
+
+  - name: "EFP fallback - inetd.startOne is defined"
+    description: |
+      inetd.startOne is a UserTalk script in the database, NOT a kernel verb.
+      It must be reachable through the system.paths search, not blocked by
+      EFP table lookup. Regression test for the headless fast-path bug.
+    script: 'defined(inetd.startOne)'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "EFP fallback - inetd.startOne is script type"
+    description: |
+      Verifies typeOf() correctly identifies inetd.startOne as a script (scpt),
+      not a kernel token (tokn). If the EFP fast-path intercepts, typeOf may
+      return the wrong type or fail entirely.
+    script: 'typeOf(inetd.startOne) == "scpt"'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "EFP fallback - inetd.isDaemonRunning is defined"
+    description: |
+      Another UserTalk script under inetd that must be reachable via database
+      lookup, not blocked by EFP table.
+    script: 'defined(inetd.isDaemonRunning)'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "EFP fallback - inetd.supervisor is defined"
+    description: |
+      inetd.supervisor IS a kernel verb (registered in headless_inetd_verbs.c).
+      This test verifies kernel verbs still resolve correctly without the
+      fast-path.
+    script: 'defined(inetd.supervisor)'
+    expected_success: true
+    expected_result: "true"

--- a/tests/integration/test_cases/post_hydration_database_state.yaml
+++ b/tests/integration/test_cases/post_hydration_database_state.yaml
@@ -437,3 +437,14 @@ tests:
     script: 'defined(tcp.statusStream)'
     expected_success: true
     expected_result: "true"
+
+  - name: "EFP fallback - nonexistent verb under EFP namespace returns false"
+    description: |
+      Guards against the exact failure mode of the removed fast-path: a dotted
+      name under an EFP namespace that does NOT exist must return defined()==false,
+      not silently succeed with a nil node. The old fast-path returned true with
+      hnode=nil for any EFP-prefixed verb not in the kernel table, which blocked
+      the database fallback and caused false "not implemented" results.
+    script: 'defined(inetd.nonExistentVerb1234)'
+    expected_success: true
+    expected_result: "false"


### PR DESCRIPTION
## Summary

- Removes stale headless EFP fast-path in `langgethandlercode()` that checked `efptable` BEFORE `system.paths` for dotted verbs, violating the correct verb resolution search order
- The fast-path (added in commit 4e217f09 as a "temporary shim") returned success with `hnode=nil` for UserTalk scripts stored under EFP-named tables, blocking the database fallback
- This broke `inetd.startOne`, `inetd.isDaemonRunning`, and any other UserTalk scripts under EFP-named tables (file, tcp, inetd, etc.)
- Adds 4 regression tests verifying database scripts under EFP-named tables are reachable through normal verb resolution

## Root Cause

The headless EFP fast-path was originally needed when system tables were not loaded at startup. Now that `hydrate_system_root_database()` loads system tables, the generic verb resolution path (system.paths first, efptable last) handles all cases correctly. The fast-path had become a violation of the documented architecture in `docs/VERB_RESOLUTION_ARCHITECTURE.md`.

## Test plan

- [x] Unit tests: 302/302 passing
- [x] Integration tests: 1711/1711 passing (4 new regression tests)
- [x] Manual test: `inetd.startOne(@user.inetd.config.http)` no longer returns "not implemented"
- [x] Regression tests verify both UserTalk scripts (inetd.startOne, inetd.isDaemonRunning) and kernel verbs (inetd.supervisor) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)