### PR TITLE
fix: window.getFile returns empty string for nonexistent addresses

### DIFF
--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Wed, 11 Mar 2026 08:12:59 GMT</dateCreated>
+    <dateCreated>Thu, 12 Mar 2026 00:09:01 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-11 at 08:12 UTC"/>
+      <outline text="Run: 2026-03-12 at 00:09 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/headless_window_verbs.c
+++ b/tests/headless_window_verbs.c
@@ -508,7 +508,7 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
                         hdb = langexternalgetdatabase((hdlexternalvariable) (**hnode).val.data.externalvalue);
                 }
 
-                if (hdb == nil)
+                if (hdb == nil && equalstrings(bsname, nameroottable))
                     hdb = tablegetdatabase(roottable);
             }
             else if (htable == filewindowtable) {


### PR DESCRIPTION
## Summary

- Fixes window.getFile(@doesNotExist) returning the system root path instead of empty string
- Windows Frontier returns empty string for addresses that do not resolve to any database
- The htable==nil fallback to roottable is now gated on the name actually being "root"
- One-line fix: `equalstrings(bsname, nameroottable)` guard added

Follow-up to PR #474 based on post-merge review feedback and manual testing against Windows Frontier.

## Test plan

- [x] 302/302 unit tests pass
- [x] 1726/1726 integration tests pass (0 failures)
- [x] `window.getFile(@doesNotExist)` returns empty string (matches Windows)
- [x] `window.getFile(@root)` still returns system root path

Generated with [Claude Code](https://claude.com/claude-code)