### PR TITLE
fix: Suppress getfullpath error in wp conversion for guest databases

### DIFF
--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -172,8 +172,20 @@ static boolean langhash_prepare_wordprocessor_value(const db_context *ctx, bigst
 	if ((**hv).id != idwordprocessor)
 		return true;
 
+	/*
+	 * 2026-03-11: Suppress errors during path lookup. This is only for
+	 * a logging hint — failure is expected for guest database items
+	 * where getfullpath can't walk the table hierarchy across database
+	 * boundaries. Without suppression, getfullpath raises nopatherror
+	 * which poisons the script's error state (fllangerror) and breaks
+	 * try/else blocks. See issue #477.
+	 */
+	disablelangerror ();
+
 	if (!langexternalgetfullpath(currenthashtable, bsname, bspath, nil))
 		copystring(bsname, bspath);
+
+	enablelangerror ();
 
 	/* Pascal string length byte must fit plus NUL. */
 	if ((size_t) bspath[0] >= (sizeof pathbuf) - 1)


### PR DESCRIPTION
## Summary

- Fixes the "Can't get the address of mailTemplate" error that blocked setupFrontier form completion
- Root cause: `langhash_prepare_wordprocessor_value()` calls `langexternalgetfullpath()` for a logging path hint during word processor value conversion. For guest database items (e.g., `members.root`), `getfullpath()` can't walk the table hierarchy across database boundaries and raises `nopatherror`
- Although the return value was already handled (falling back to bare name), the error callback still fired, setting `fllangerror=true` and poisoning the script's error state
- Fix: Wrap the `getfullpath` call with `disablelangerror()`/`enablelangerror()` to suppress the error, matching the pattern used by `defined()` for expected failures
- This is the second part of the #477 fix — the first part (PR #478) fixed tryError capture across thread context switches

## Test plan

- [x] Unit tests: 302/302 pass
- [x] Integration tests: 1735 pass, 0 fail
- [x] Manual curl test: setupFrontier form submission returns "It Worked!" page
- [x] Verified with clean dist rebuild

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)