### PR TITLE
fix: Return boolean false from timeModified/timeCreated for binary objects

### DIFF
--- a/Common/source/langverbs.c
+++ b/Common/source/langverbs.c
@@ -1600,12 +1600,15 @@ boolean langtimecreatedfunc (hdltreenode hparam1, tyvaluerecord *vreturned) {
 	Get creation time of an object (table, outline, script, etc.)
 	Parameters:
 	  1. address - object address (table, outline, etc.)
-	Returns: date value (frontier_time_t)
+	Returns: date value, or false if the object doesn't support timestamps.
+
+	2026-03-13: Return boolean false (not error) for unsupported types.
+	Matches original Frontier dispatch behavior (case timecreatedfunc).
 	*/
 	int64_t timecreated, timemodified;
 
 	if (!gettimesverb (hparam1, &timecreated, &timemodified))
-		return (false);  /* Propagate error */
+		return (setbooleanvalue (false, vreturned));
 
 	return (setdatevalue (timecreated, vreturned));
 	} /*langtimecreatedfunc*/
@@ -1616,12 +1619,17 @@ boolean langtimemodifiedfunc (hdltreenode hparam1, tyvaluerecord *vreturned) {
 	Get modification time of an object (table, outline, script, etc.)
 	Parameters:
 	  1. address - object address (table, outline, etc.)
-	Returns: date value (frontier_time_t)
+	Returns: date value, or false if the object doesn't support timestamps.
+
+	2026-03-13: Return boolean false (not error) for unsupported types.
+	Matches original Frontier dispatch behavior (case timemodifiedfunc).
+	UserTalk code like respond.ut checks typeof(moddate)==booleantype
+	to detect objects without timestamps (e.g. binaryType).
 	*/
 	int64_t timecreated, timemodified;
 
 	if (!gettimesverb (hparam1, &timecreated, &timemodified))
-		return (false);  /* Propagate error */
+		return (setbooleanvalue (false, vreturned));
 
 	return (setdatevalue (timemodified, vreturned));
 	} /*langtimemodifiedfunc*/

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1943 tests: 1753 pass (90%) 190 skip (9%)</title>
-    <dateCreated>Thu, 12 Mar 2026 05:37:05 GMT</dateCreated>
+    <title>Frontier Integration Tests - 1948 tests: 1758 pass (90%) 190 skip (9%)</title>
+    <dateCreated>Fri, 13 Mar 2026 07:34:35 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-12 at 05:34 UTC"/>
-      <outline text="Results: 1735 passed (90%), 190 skipped (10%), 0 failed (0%)"/>
-      <outline text="Duration: 33.7s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 1943 tests (1753 active, 190 marked skip) across 52 categories"/>
+      <outline text="Run: 2026-03-13 at 07:34 UTC"/>
+      <outline text="Results: 1740 passed (90%), 190 skipped (10%), 0 failed (0%)"/>
+      <outline text="Duration: 34.8s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 1948 tests (1758 active, 190 marked skip) across 53 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
@@ -58,6 +58,7 @@
     <outline text="Tcp Verbs (tcp_verbs) - 53 tests: 53 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/tcp_verbs.opml"/>
     <outline text="Tcp Verbs Network (tcp_verbs_network) - 18 tests: 18 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/tcp_verbs_network.opml"/>
     <outline text="Thread Verbs Foundation (thread_verbs_foundation) - 17 tests: 17 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/thread_verbs_foundation.opml"/>
+    <outline text="Time Verbs Binary (time_verbs_binary) - 5 tests: 5 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/time_verbs_binary.opml"/>
     <outline text="Try Error (try_error) - 9 tests: 9 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/try_error.opml"/>
     <outline text="Webserver Hello World (webserver_hello_world) - 11 tests: 6 pass (54%) 5 skip (45%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/webserver_hello_world.opml"/>
     <outline text="Window Verbs (window_verbs) - 16 tests: 13 pass (81%) 3 skip (18%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/window_verbs.opml"/>

--- a/reports/integration_tests/time_verbs_binary.opml
+++ b/reports/integration_tests/time_verbs_binary.opml
@@ -1,0 +1,69 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Time Verbs Binary (time_verbs_binary) - 5 tests: 5 pass (100%)</title>
+    <dateCreated>Fri, 13 Mar 2026 07:34:35 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="timeModified - binary object returns boolean type - timeModified on a binaryType should return boolean false, not throw">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(binaryType, @scratchpad.testBin)"/>
+        <outline text="local (result = timeModified(@scratchpad.testBin))"/>
+        <outline text="local (t = typeOf(result) == booleanType)"/>
+        <outline text="delete(@scratchpad.testBin)"/>
+        <outline text="return t"/>
+      </outline>
+    </outline>
+    <outline text="timeModified - binary object value is false - timeModified on a binaryType should return false">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(binaryType, @scratchpad.testBin2)"/>
+        <outline text="local (r = timeModified(@scratchpad.testBin2))"/>
+        <outline text="delete(@scratchpad.testBin2)"/>
+        <outline text="return r"/>
+      </outline>
+    </outline>
+    <outline text="timeModified - table object returns date - timeModified on a table should return a date, not boolean">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(tableType, @scratchpad.testTbl)"/>
+        <outline text="local (result = timeModified(@scratchpad.testTbl))"/>
+        <outline text="local (t = typeOf(result) == dateType)"/>
+        <outline text="delete(@scratchpad.testTbl)"/>
+        <outline text="return t"/>
+      </outline>
+    </outline>
+    <outline text="timeCreated - binary object returns boolean false - timeCreated on a binaryType should return false, not throw">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(binaryType, @scratchpad.testBin3)"/>
+        <outline text="local (result = timeCreated(@scratchpad.testBin3))"/>
+        <outline text="local (t = typeOf(result) == booleanType)"/>
+        <outline text="delete(@scratchpad.testBin3)"/>
+        <outline text="return t"/>
+      </outline>
+    </outline>
+    <outline text="timeModified - respond.ut fallback pattern works - The pattern from respond.ut: check typeof, fallback to clock.now()">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(binaryType, @scratchpad.testBin4)"/>
+        <outline text="local (moddate = timeModified(@scratchpad.testBin4))"/>
+        <outline text="if typeOf(moddate) == booleanType {moddate = clock.now()}"/>
+        <outline text="local (t = typeOf(moddate) == dateType)"/>
+        <outline text="delete(@scratchpad.testBin4)"/>
+        <outline text="return t"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/tests/integration/test_cases/time_verbs_binary.yaml
+++ b/tests/integration/test_cases/time_verbs_binary.yaml
@@ -1,0 +1,74 @@
+# Integration tests for timeModified/timeCreated on binary objects
+#
+# Bug: timeModified() and timeCreated() returned a script error for
+# binaryType objects instead of boolean false. This broke mainResponder
+# image serving because respond.ut calls timeModified(adr) on binary
+# resources and expects typeof(result)==booleanType for unsupported types.
+
+tests:
+  # ========================================================================
+  # timeModified on binary objects — must return false, not error
+  # ========================================================================
+
+  - name: "timeModified - binary object returns boolean type"
+    description: "timeModified on a binaryType should return boolean false, not throw"
+    script: |
+      new(binaryType, @scratchpad.testBin);
+      local (result = timeModified(@scratchpad.testBin));
+      local (t = typeOf(result) == booleanType);
+      delete(@scratchpad.testBin);
+      return t
+    expected_success: true
+    expected_result: "true"
+
+  - name: "timeModified - binary object value is false"
+    description: "timeModified on a binaryType should return false"
+    script: |
+      new(binaryType, @scratchpad.testBin2);
+      local (r = timeModified(@scratchpad.testBin2));
+      delete(@scratchpad.testBin2);
+      return r
+    expected_success: true
+    expected_result: "false"
+
+  - name: "timeModified - table object returns date"
+    description: "timeModified on a table should return a date, not boolean"
+    script: |
+      new(tableType, @scratchpad.testTbl);
+      local (result = timeModified(@scratchpad.testTbl));
+      local (t = typeOf(result) == dateType);
+      delete(@scratchpad.testTbl);
+      return t
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # timeCreated on binary objects — same fix
+  # ========================================================================
+
+  - name: "timeCreated - binary object returns boolean false"
+    description: "timeCreated on a binaryType should return false, not throw"
+    script: |
+      new(binaryType, @scratchpad.testBin3);
+      local (result = timeCreated(@scratchpad.testBin3));
+      local (t = typeOf(result) == booleanType);
+      delete(@scratchpad.testBin3);
+      return t
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Respond pattern — typeof check for fallback
+  # ========================================================================
+
+  - name: "timeModified - respond.ut fallback pattern works"
+    description: "The pattern from respond.ut: check typeof, fallback to clock.now()"
+    script: |
+      new(binaryType, @scratchpad.testBin4);
+      local (moddate = timeModified(@scratchpad.testBin4));
+      if typeOf(moddate) == booleanType {moddate = clock.now()};
+      local (t = typeOf(moddate) == dateType);
+      delete(@scratchpad.testBin4);
+      return t
+    expected_success: true
+    expected_result: "true"


### PR DESCRIPTION
## Summary

- Fixes 500 "Unknown error" when serving binaryType objects (images, etc.) from mainResponder
- Root cause: `langtimemodifiedfunc()` and `langtimecreatedfunc()` wrapper functions returned `false` as a **script error** when `gettimesverb()` failed for binary objects. The original Frontier dispatch (`case timemodifiedfunc:`) correctly returned `setbooleanvalue(false, v)` — a boolean false **value**
- `respond.ut` expects this at line 316-318: `local (moddate = timeModified(adr)); if typeof(moddate) == booleanType {moddate = clock.now()}`
- With the error instead of a value, any request for a binaryType resource threw an uncaught error

## Test plan

- [x] Unit tests: 302/302 pass
- [x] Integration tests: 1740 pass, 0 fail (5 new tests in `time_verbs_binary.yaml`)
- [x] Manual curl test: `GET /mainResponderResources/adminSite/shim` returns 200 OK with image/gif
- [x] Manual curl test: `GET /mainResponderResources/adminSite/userlandLogo` returns 200 OK with image/gif
- [x] Verified binary data integrity: `file.writeWholeFile` produces valid GIF files

🤖 Generated with [Claude Code](https://claude.com/claude-code)