### PR TITLE
test: Add error recovery and concurrency integration tests (gaps #6-#8)

### DIFF
--- a/planning/INTEGRATION_TEST_GAPS.md
+++ b/planning/INTEGRATION_TEST_GAPS.md
@@ -35,9 +35,9 @@ These gaps risk inconsistent state or resource leaks.
 
 | # | Gap | Description | Status |
 |---|-----|-------------|--------|
-| 6 | **Error mid-transaction** | No test for: `try { db.setvalue(x); error(); db.setvalue(y) }` — verify first setvalue committed and DB not left in inconsistent state. | Not started |
-| 7 | **Thread modifying DB while main thread saves** | GIL serializes access, but no test proves databasedata global stays consistent when a background thread is actively modifying tables while `filemenu.save()` runs on the main thread. | Not started |
-| 8 | **`fileMenu.closeall()` actually closes everything** | Tests check return value is true but don't verify all guest DB handles are actually released and the `hodblist` linked list is properly cleared. | Not started |
+| 6 | **Error mid-transaction** | No test for: `try { db.setvalue(x); error(); db.setvalue(y) }` — verify first setvalue committed and DB not left in inconsistent state. | Done — `error_recovery_concurrency_tests.yaml` |
+| 7 | **Thread modifying DB while main thread saves** | GIL serializes access, but no test proves databasedata global stays consistent when a background thread is actively modifying tables while `filemenu.save()` runs on the main thread. | Done — `error_recovery_concurrency_tests.yaml` |
+| 8 | **`fileMenu.closeall()` actually closes everything** | Tests check return value is true but don't verify all guest DB handles are actually released and the `hodblist` linked list is properly cleared. | Done — `error_recovery_concurrency_tests.yaml` |
 | 9 | **Webserver HTTP round-trip** | HTTP request → webserver dispatch → responder script → response. Currently skipped due to port conflicts. This is the primary external-facing interface. | Not started |
 | 10 | **bigstring boundary values** | No tests for strings at exactly 254, 255, and 256 bytes. The 255-byte bigstring limit (issue #475, #423) truncates silently — tests should document and verify this boundary behavior. | Not started |
 

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2007 tests: 1817 pass (90%) 190 skip (9%)</title>
-    <dateCreated>Sat, 21 Mar 2026 00:12:46 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 00:36:30 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-21 at 00:12 UTC"/>
-      <outline text="Results: 13 passed (100%), 0 skipped (0%), 0 failed (0%)"/>
-      <outline text="Duration: 0.7s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-03-21 at 00:13 UTC"/>
+      <outline text="Results: 1766 passed (89%), 190 skipped (10%), 33 failed (2%)"/>
+      <outline text="Duration: 33.4s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2007 tests (1817 active, 190 marked skip) across 56 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,16 +1,17 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 2006 tests: 1816 pass (90%) 190 skip (9%)</title>
-    <dateCreated>Sat, 21 Mar 2026 00:13:56 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2056 tests: 1864 pass (90%) 192 skip (9%)</title>
+    <dateCreated>Sat, 21 Mar 2026 04:19:56 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
       <outline text="Run: 2026-03-21 at 00:13 UTC"/>
-      <outline text="Results: 1762 passed (89%), 190 skipped (10%), 36 failed (2%)"/>
-      <outline text="Duration: 34.0s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 2006 tests (1816 active, 190 marked skip) across 56 categories"/>
+      <outline text="Results: 1766 passed (89%), 190 skipped (10%), 33 failed (2%)"/>
+      <outline text="Duration: 33.4s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 2056 tests (1864 active, 192 marked skip) across 59 categories"/>
     </outline>
+    <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
     <outline text="Callback Tcp (callback_tcp) - 20 tests: 20 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_tcp.opml"/>
@@ -19,6 +20,7 @@
     <outline text="Dialog Verbs (dialog_verbs) - 41 tests: 41 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dialog_verbs.opml"/>
     <outline text="Dist Stability (dist_stability) - 7 tests: 7 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dist_stability.opml"/>
     <outline text="Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
+    <outline text="Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/error_recovery_concurrency_tests.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs) - 14 tests: 13 pass (92%) 1 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
     <outline text="File Verbs (file_verbs) - 84 tests: 78 pass (92%) 6 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
     <outline text="Filemenu Verbs (filemenu_verbs) - 34 tests: 31 pass (91%) 3 skip (8%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
@@ -64,6 +66,7 @@
     <outline text="Time Verbs Binary (time_verbs_binary) - 7 tests: 7 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/time_verbs_binary.opml"/>
     <outline text="Try Error (try_error) - 9 tests: 9 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/try_error.opml"/>
     <outline text="Webserver Hello World (webserver_hello_world) - 11 tests: 6 pass (54%) 5 skip (45%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/webserver_hello_world.opml"/>
+    <outline text="Webserver Http Roundtrip Tests (webserver_http_roundtrip_tests) - 9 tests: 7 pass (77%) 2 skip (22%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/webserver_http_roundtrip_tests.opml"/>
     <outline text="Window Verbs (window_verbs) - 16 tests: 13 pass (81%) 3 skip (18%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/window_verbs.opml"/>
     <outline text="Wp Verbs (wp_verbs) - 18 tests: 18 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/wp_verbs.opml"/>
     <outline text="Xml Verbs (xml_verbs) - 93 tests: 93 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/xml_verbs.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2007 tests: 1817 pass (90%) 190 skip (9%)</title>
-    <dateCreated>Fri, 20 Mar 2026 22:59:12 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 00:12:46 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-20 at 22:58 UTC"/>
-      <outline text="Results: 1766 passed (89%), 190 skipped (10%), 33 failed (2%)"/>
-      <outline text="Duration: 38.2s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-03-21 at 00:12 UTC"/>
+      <outline text="Results: 13 passed (100%), 0 skipped (0%), 0 failed (0%)"/>
+      <outline text="Duration: 0.7s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2007 tests (1817 active, 190 marked skip) across 56 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 1993 tests: 1803 pass (90%) 190 skip (9%)</title>
-    <dateCreated>Wed, 18 Mar 2026 19:46:32 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2007 tests: 1817 pass (90%) 190 skip (9%)</title>
+    <dateCreated>Fri, 20 Mar 2026 22:59:12 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-18 at 19:45 UTC"/>
-      <outline text="Results: 1785 passed (90%), 190 skipped (10%), 0 failed (0%)"/>
-      <outline text="Duration: 34.4s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 1993 tests (1803 active, 190 marked skip) across 55 categories"/>
+      <outline text="Run: 2026-03-20 at 22:58 UTC"/>
+      <outline text="Results: 1766 passed (89%), 190 skipped (10%), 33 failed (2%)"/>
+      <outline text="Duration: 38.2s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 2007 tests (1817 active, 190 marked skip) across 56 categories"/>
     </outline>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
@@ -19,6 +19,7 @@
     <outline text="Dialog Verbs (dialog_verbs) - 41 tests: 41 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dialog_verbs.opml"/>
     <outline text="Dist Stability (dist_stability) - 7 tests: 7 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dist_stability.opml"/>
     <outline text="Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
+    <outline text="Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/error_recovery_concurrency_tests.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs) - 14 tests: 13 pass (92%) 1 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
     <outline text="File Verbs (file_verbs) - 84 tests: 78 pass (92%) 6 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
     <outline text="Filemenu Verbs (filemenu_verbs) - 34 tests: 31 pass (91%) 3 skip (8%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
@@ -38,7 +39,7 @@
     <outline text="Opattributes Verbs (opattributes_verbs) - 7 tests: 0 pass (0%) 7 skip (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/opattributes_verbs.opml"/>
     <outline text="Path Resolution (path_resolution) - 39 tests: 39 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/path_resolution.opml"/>
     <outline text="Post Hydration Database State (post_hydration_database_state) - 40 tests: 36 pass (90%) 4 skip (10%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/post_hydration_database_state.opml"/>
-    <outline text="Protocol Odb Ops (protocol_odb_ops) - 34 tests: 34 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/protocol_odb_ops.opml"/>
+    <outline text="Protocol Odb Ops (protocol_odb_ops) - 35 tests: 35 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/protocol_odb_ops.opml"/>
     <outline text="Protocol Script Ops (protocol_script_ops) - 9 tests: 9 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/protocol_script_ops.opml"/>
     <outline text="Repl Basic (repl_basic) - 56 tests: 56 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/repl_basic.opml"/>
     <outline text="Repl Commands (repl_commands) - 81 tests: 61 pass (75%) 20 skip (24%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/repl_commands.opml"/>

--- a/reports/integration_tests/bigstring_boundary_tests.opml
+++ b/reports/integration_tests/bigstring_boundary_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)</title>
-    <dateCreated>Sat, 21 Mar 2026 01:12:45 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 04:19:56 GMT</dateCreated>
   </head>
   <body>
     <outline text="bigstring boundary - string of exactly 254 bytes - Create and verify a string of exactly 254 bytes (one below bigstring limit)">
@@ -312,7 +312,9 @@
         <outline text="local(val = string.filledString(&quot;V&quot;, 255))"/>
         <outline text="sys.setenvironmentvariable(&quot;FRONTIER_BS_TEST&quot;, val)"/>
         <outline text="local(result = sys.getenvironmentvariable(&quot;FRONTIER_BS_TEST&quot;))"/>
-        <outline text="return string.length(result) == 255"/>
+        <outline text="local(ok = string.length(result) == 255)"/>
+        <outline text="sys.setenvironmentvariable(&quot;FRONTIER_BS_TEST&quot;, &quot;&quot;)"/>
+        <outline text="return ok"/>
       </outline>
     </outline>
     <outline text="bigstring boundary - env var value at 256 bytes (beyond bigstring limit) - Environment variable get/set passes through C bigstring buffers.&#10;This test documents behavior at 256 bytes — if truncation occurs,&#10;the returned value will be shorter than what was set.&#10;See issues #475, #423, #380 for bigstring limit context.&#10;">
@@ -326,6 +328,7 @@
         <outline text="local(got = sys.getenvironmentvariable(&quot;FRONTIER_TEST_BS256&quot;))"/>
         <outline text="local(setLen = string.length(val))"/>
         <outline text="local(gotLen = string.length(got))"/>
+        <outline text="sys.setenvironmentvariable(&quot;FRONTIER_TEST_BS256&quot;, &quot;&quot;)"/>
         <outline text="if gotLen == setLen">
           <outline text="return &quot;no_truncation:&quot; + string(setLen)}"/>
         </outline>

--- a/reports/integration_tests/error_recovery_concurrency_tests.opml
+++ b/reports/integration_tests/error_recovery_concurrency_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)</title>
-    <dateCreated>Sat, 21 Mar 2026 01:11:30 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 04:19:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="error mid-transaction - first setvalue persists, second does not - Verify that when scriptError fires between two db.setvalue calls inside&#10;a try block, the first setvalue's effect persists but the second never&#10;executes. Uses system.temp as scratchpad.&#10;">
@@ -79,6 +79,7 @@
       <outline text="Script">
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;error_midtxn_db.root7&quot;)"/>
+        <outline text="try {file.delete(dbPath)} else {1}"/>
         <outline text="db.new(dbPath)"/>
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="try">
@@ -110,6 +111,7 @@
       <outline text="Script">
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;error_db_recovery.root7&quot;)"/>
+        <outline text="try {file.delete(dbPath)} else {1}"/>
         <outline text="db.new(dbPath)"/>
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="try">
@@ -146,6 +148,7 @@
         <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true&quot;)"/>
         <outline text="thread.sleepTicks(12)"/>
         <outline text="filemenu.save()"/>
+        <outline text="«Timing: background thread needs ~20 ticks (20 iterations * 1 tick). 60-tick wait provides 3x margin for GIL contention and save latency.»"/>
         <outline text="thread.sleepTicks(60)"/>
         <outline text="local(ok = system.temp.threadsave.done and system.temp.threadsave.counter &gt; 5)"/>
         <outline text="delete(@system.temp.threadsave)"/>
@@ -160,6 +163,7 @@
       <outline text="Script">
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;thread_save_guest.root7&quot;)"/>
+        <outline text="try {file.delete(dbPath)} else {1}"/>
         <outline text="db.new(dbPath)"/>
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="new(tableType, @system.temp.tsg)"/>
@@ -167,6 +171,7 @@
         <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 10) {db.setvalue(\&quot;&quot; + dbPath + &quot;\&quot;, \&quot;iter\&quot;, i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true&quot;)"/>
         <outline text="thread.sleepTicks(12)"/>
         <outline text="filemenu.save()"/>
+        <outline text="«Timing: background thread needs ~20 ticks (10 iterations * 2 ticks). 60-tick wait provides 3x margin for GIL contention and save latency.»"/>
         <outline text="thread.sleepTicks(60)"/>
         <outline text="local(ok = system.temp.tsg.done)"/>
         <outline text="delete(@system.temp.tsg)"/>
@@ -191,7 +196,7 @@
         <outline text="return ok"/>
       </outline>
     </outline>
-    <outline text="closeall - closes multiple guest databases - Open 3 guest databases, write values to each, call fileMenu.closeall(),&#10;verify it returns true. Then verify access to closed databases fails.&#10;">
+    <outline text="closeall - closes multiple guest databases - Open 3 guest databases, write values to each, call fileMenu.closeall(),&#10;and verify it returns true.&#10;">
       <outline text="Metadata">
         <outline text="expected_result: true"/>
         <outline text="timeout: 5"/>
@@ -201,6 +206,9 @@
         <outline text="local(db1 = tmpDir + &quot;/&quot; + &quot;closeall_verify1.root7&quot;)"/>
         <outline text="local(db2 = tmpDir + &quot;/&quot; + &quot;closeall_verify2.root7&quot;)"/>
         <outline text="local(db3 = tmpDir + &quot;/&quot; + &quot;closeall_verify3.root7&quot;)"/>
+        <outline text="try {file.delete(db1)} else {1}"/>
+        <outline text="try {file.delete(db2)} else {1}"/>
+        <outline text="try {file.delete(db3)} else {1}"/>
         <outline text="db.new(db1)"/>
         <outline text="db.new(db2)"/>
         <outline text="db.new(db3)"/>
@@ -222,6 +230,7 @@
       <outline text="Script">
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;closeall_access_fail.root7&quot;)"/>
+        <outline text="try {file.delete(dbPath)} else {1}"/>
         <outline text="db.new(dbPath)"/>
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="db.setvalue(dbPath, &quot;testKey&quot;, &quot;testVal&quot;)"/>
@@ -243,6 +252,7 @@
       <outline text="Script">
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;closeall_reopen.root7&quot;)"/>
+        <outline text="try {file.delete(dbPath)} else {1}"/>
         <outline text="db.new(dbPath)"/>
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="db.setvalue(dbPath, &quot;persistKey&quot;, &quot;persistVal&quot;)"/>
@@ -263,6 +273,8 @@
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(db1 = tmpDir + &quot;/&quot; + &quot;closeall_cycle1.root7&quot;)"/>
         <outline text="local(db2 = tmpDir + &quot;/&quot; + &quot;closeall_cycle2.root7&quot;)"/>
+        <outline text="try {file.delete(db1)} else {1}"/>
+        <outline text="try {file.delete(db2)} else {1}"/>
         <outline text="db.new(db1)"/>
         <outline text="db.new(db2)"/>
         <outline text="fileMenu.open(db1)"/>
@@ -282,6 +294,7 @@
       <outline text="Script">
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;closeall_sysroot.root7&quot;)"/>
+        <outline text="try {file.delete(dbPath)} else {1}"/>
         <outline text="db.new(dbPath)"/>
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="fileMenu.closeall()"/>

--- a/reports/integration_tests/error_recovery_concurrency_tests.opml
+++ b/reports/integration_tests/error_recovery_concurrency_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)</title>
-    <dateCreated>Sat, 21 Mar 2026 00:12:45 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 00:36:30 GMT</dateCreated>
   </head>
   <body>
     <outline text="error mid-transaction - first setvalue persists, second does not - Verify that when scriptError fires between two db.setvalue calls inside&#10;a try block, the first setvalue's effect persists but the second never&#10;executes. Uses system.temp as scratchpad.&#10;">
@@ -24,6 +24,7 @@
           <outline text="delete(@system.temp.midtxn)"/>
           <outline text="return has1 and (not has2) and (v1 == &quot;committed&quot;)}"/>
         </outline>
+        <outline text="return false"/>
       </outline>
     </outline>
     <outline text="error mid-transaction - error in nested function call - Verify partial state consistency when error occurs inside a nested call.&#10;The outer script sets val1, calls a helper that errors, val2 never set.&#10;">
@@ -46,6 +47,7 @@
           <outline text="delete(@system.temp.nested)"/>
           <outline text="return has1 and (not has2) and (v1 == &quot;before_call&quot;)}"/>
         </outline>
+        <outline text="return false"/>
       </outline>
     </outline>
     <outline text="error mid-transaction - recovery after try/else - After a try/else handles an error, normal operations should still work.&#10;This verifies the runtime is in a consistent state post-error.&#10;">
@@ -78,7 +80,7 @@
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;error_midtxn_db.root7&quot;)"/>
         <outline text="db.new(dbPath)"/>
-        <outline text="db.open(dbPath, false)"/>
+        <outline text="fileMenu.open(dbPath)"/>
         <outline text="try">
           <outline text="db.setvalue(dbPath, &quot;key1&quot;, &quot;value1&quot;)"/>
           <outline text="scriptError(&quot;boom&quot;)"/>
@@ -103,7 +105,7 @@
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;error_db_recovery.root7&quot;)"/>
         <outline text="db.new(dbPath)"/>
-        <outline text="db.open(dbPath, false)"/>
+        <outline text="fileMenu.open(dbPath)"/>
         <outline text="try">
           <outline text="db.setvalue(dbPath, &quot;pre&quot;, &quot;before&quot;)"/>
           <outline text="scriptError(&quot;intentional&quot;)"/>
@@ -130,7 +132,7 @@
         <outline text="system.temp.threadsave.counter = 0"/>
         <outline text="system.temp.threadsave.done = false"/>
         <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true&quot;)"/>
-        <outline text="thread.sleepTicks(5)"/>
+        <outline text="thread.sleepTicks(12)"/>
         <outline text="filemenu.save()"/>
         <outline text="thread.sleepTicks(60)"/>
         <outline text="local(ok = system.temp.threadsave.done and system.temp.threadsave.counter &gt; 5)"/>
@@ -151,7 +153,7 @@
         <outline text="new(tableType, @system.temp.tsg)"/>
         <outline text="system.temp.tsg.done = false"/>
         <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 10) {db.setvalue(\&quot;&quot; + dbPath + &quot;\&quot;, \&quot;iter\&quot;, i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true&quot;)"/>
-        <outline text="thread.sleepTicks(5)"/>
+        <outline text="thread.sleepTicks(12)"/>
         <outline text="filemenu.save()"/>
         <outline text="thread.sleepTicks(60)"/>
         <outline text="local(ok = system.temp.tsg.done)"/>
@@ -212,7 +214,7 @@
         <outline text="fileMenu.open(dbPath)"/>
         <outline text="db.setvalue(dbPath, &quot;testKey&quot;, &quot;testVal&quot;)"/>
         <outline text="fileMenu.closeall()"/>
-        <outline text="try">
+        <outline text="try { «db.getvalue errors ARE catchable via try/else (unlike fileMenu verb errors)»">
           <outline text="local(val = db.getvalue(dbPath, &quot;testKey&quot;))"/>
           <outline text="return &quot;should_have_failed&quot;}"/>
         </outline>

--- a/reports/integration_tests/error_recovery_concurrency_tests.opml
+++ b/reports/integration_tests/error_recovery_concurrency_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)</title>
-    <dateCreated>Fri, 20 Mar 2026 22:59:11 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 00:12:45 GMT</dateCreated>
   </head>
   <body>
     <outline text="error mid-transaction - first setvalue persists, second does not - Verify that when scriptError fires between two db.setvalue calls inside&#10;a try block, the first setvalue's effect persists but the second never&#10;executes. Uses system.temp as scratchpad.&#10;">
@@ -132,8 +132,8 @@
         <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true&quot;)"/>
         <outline text="thread.sleepTicks(5)"/>
         <outline text="filemenu.save()"/>
-        <outline text="thread.sleepTicks(30)"/>
-        <outline text="local(ok = system.temp.threadsave.done and system.temp.threadsave.counter &gt;= 0)"/>
+        <outline text="thread.sleepTicks(60)"/>
+        <outline text="local(ok = system.temp.threadsave.done and system.temp.threadsave.counter &gt; 5)"/>
         <outline text="delete(@system.temp.threadsave)"/>
         <outline text="return ok"/>
       </outline>
@@ -153,7 +153,7 @@
         <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 10) {db.setvalue(\&quot;&quot; + dbPath + &quot;\&quot;, \&quot;iter\&quot;, i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true&quot;)"/>
         <outline text="thread.sleepTicks(5)"/>
         <outline text="filemenu.save()"/>
-        <outline text="thread.sleepTicks(30)"/>
+        <outline text="thread.sleepTicks(60)"/>
         <outline text="local(ok = system.temp.tsg.done)"/>
         <outline text="delete(@system.temp.tsg)"/>
         <outline text="fileMenu.closeall()"/>

--- a/reports/integration_tests/error_recovery_concurrency_tests.opml
+++ b/reports/integration_tests/error_recovery_concurrency_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)</title>
-    <dateCreated>Sat, 21 Mar 2026 00:36:30 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 01:11:30 GMT</dateCreated>
   </head>
   <body>
     <outline text="error mid-transaction - first setvalue persists, second does not - Verify that when scriptError fires between two db.setvalue calls inside&#10;a try block, the first setvalue's effect persists but the second never&#10;executes. Uses system.temp as scratchpad.&#10;">
@@ -89,11 +89,17 @@
         <outline text="else">
           <outline text="local(msg = tryError)}"/>
         </outline>
-        <outline text="local(has1 = db.defined(dbPath, &quot;key1&quot;))"/>
-        <outline text="local(has2 = db.defined(dbPath, &quot;key2&quot;))"/>
-        <outline text="local(v1 = db.getvalue(dbPath, &quot;key1&quot;))"/>
-        <outline text="db.close(dbPath)"/>
-        <outline text="return has1 and (not has2) and (v1 == &quot;value1&quot;)"/>
+        <outline text="try">
+          <outline text="local(has1 = db.defined(dbPath, &quot;key1&quot;))"/>
+          <outline text="local(has2 = db.defined(dbPath, &quot;key2&quot;))"/>
+          <outline text="local(v1 = db.getvalue(dbPath, &quot;key1&quot;))"/>
+          <outline text="db.close(dbPath)"/>
+          <outline text="return has1 and (not has2) and (v1 == &quot;value1&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="db.close(dbPath)"/>
+          <outline text="return false}"/>
+        </outline>
       </outline>
     </outline>
     <outline text="error mid-transaction - db still usable after error - After an error mid-transaction on a guest database, verify&#10;the database is still fully usable (read and write).&#10;">
@@ -114,12 +120,18 @@
         <outline text="else">
           <outline text="local(msg = tryError)}"/>
         </outline>
-        <outline text="db.setvalue(dbPath, &quot;post&quot;, &quot;after&quot;)"/>
-        <outline text="local(pre = db.getvalue(dbPath, &quot;pre&quot;))"/>
-        <outline text="local(post = db.getvalue(dbPath, &quot;post&quot;))"/>
-        <outline text="local(noUnreachable = not(db.defined(dbPath, &quot;unreachable&quot;)))"/>
-        <outline text="db.close(dbPath)"/>
-        <outline text="return (pre == &quot;before&quot;) and (post == &quot;after&quot;) and noUnreachable"/>
+        <outline text="try">
+          <outline text="db.setvalue(dbPath, &quot;post&quot;, &quot;after&quot;)"/>
+          <outline text="local(pre = db.getvalue(dbPath, &quot;pre&quot;))"/>
+          <outline text="local(post = db.getvalue(dbPath, &quot;post&quot;))"/>
+          <outline text="local(noUnreachable = not(db.defined(dbPath, &quot;unreachable&quot;)))"/>
+          <outline text="db.close(dbPath)"/>
+          <outline text="return (pre == &quot;before&quot;) and (post == &quot;after&quot;) and noUnreachable}"/>
+        </outline>
+        <outline text="else">
+          <outline text="db.close(dbPath)"/>
+          <outline text="return false}"/>
+        </outline>
       </outline>
     </outline>
     <outline text="thread writes during save - no crash - Spawn a background thread that writes values to system.temp in a loop,&#10;then save from the main thread while the background thread is active.&#10;GIL serializes access, so this should be safe. Verify no crash and&#10;values are readable after save completes.&#10;">

--- a/reports/integration_tests/error_recovery_concurrency_tests.opml
+++ b/reports/integration_tests/error_recovery_concurrency_tests.opml
@@ -1,0 +1,282 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)</title>
+    <dateCreated>Fri, 20 Mar 2026 22:59:11 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="error mid-transaction - first setvalue persists, second does not - Verify that when scriptError fires between two db.setvalue calls inside&#10;a try block, the first setvalue's effect persists but the second never&#10;executes. Uses system.temp as scratchpad.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(tableType, @system.temp.midtxn)"/>
+        <outline text="try">
+          <outline text="system.temp.midtxn.val1 = &quot;committed&quot;"/>
+          <outline text="scriptError(&quot;boom&quot;)"/>
+          <outline text="system.temp.midtxn.val2 = &quot;should_not_exist&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="local(has1 = defined(system.temp.midtxn.val1))"/>
+          <outline text="local(has2 = defined(system.temp.midtxn.val2))"/>
+          <outline text="local(v1 = system.temp.midtxn.val1)"/>
+          <outline text="delete(@system.temp.midtxn)"/>
+          <outline text="return has1 and (not has2) and (v1 == &quot;committed&quot;)}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="error mid-transaction - error in nested function call - Verify partial state consistency when error occurs inside a nested call.&#10;The outer script sets val1, calls a helper that errors, val2 never set.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(tableType, @system.temp.nested)"/>
+        <outline text="script.newScriptObject(&quot;scriptError(\&quot;nested boom\&quot;)&quot;, @system.temp.nested.helper)"/>
+        <outline text="try">
+          <outline text="system.temp.nested.val1 = &quot;before_call&quot;"/>
+          <outline text="system.temp.nested.helper()"/>
+          <outline text="system.temp.nested.val2 = &quot;after_call&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="local(has1 = defined(system.temp.nested.val1))"/>
+          <outline text="local(has2 = defined(system.temp.nested.val2))"/>
+          <outline text="local(v1 = system.temp.nested.val1)"/>
+          <outline text="delete(@system.temp.nested)"/>
+          <outline text="return has1 and (not has2) and (v1 == &quot;before_call&quot;)}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="error mid-transaction - recovery after try/else - After a try/else handles an error, normal operations should still work.&#10;This verifies the runtime is in a consistent state post-error.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(tableType, @system.temp.recovery)"/>
+        <outline text="try">
+          <outline text="system.temp.recovery.a = 1"/>
+          <outline text="scriptError(&quot;mid-error&quot;)"/>
+          <outline text="system.temp.recovery.b = 2}"/>
+        </outline>
+        <outline text="else">
+          <outline text="system.temp.recovery.caught = tryError}"/>
+        </outline>
+        <outline text="system.temp.recovery.postError = &quot;still_works&quot;"/>
+        <outline text="local(ok = system.temp.recovery.a == 1 and system.temp.recovery.postError == &quot;still_works&quot; and (system.temp.recovery.caught contains &quot;mid-error&quot;) and not(defined(system.temp.recovery.b)))"/>
+        <outline text="delete(@system.temp.recovery)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="error mid-transaction - db.setvalue partial commit - Verify db.setvalue on a guest database: first write persists, second&#10;does not execute due to scriptError. Database remains consistent.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;error_midtxn_db.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="db.open(dbPath, false)"/>
+        <outline text="try">
+          <outline text="db.setvalue(dbPath, &quot;key1&quot;, &quot;value1&quot;)"/>
+          <outline text="scriptError(&quot;boom&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;key2&quot;, &quot;value2&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="local(msg = tryError)}"/>
+        </outline>
+        <outline text="local(has1 = db.defined(dbPath, &quot;key1&quot;))"/>
+        <outline text="local(has2 = db.defined(dbPath, &quot;key2&quot;))"/>
+        <outline text="local(v1 = db.getvalue(dbPath, &quot;key1&quot;))"/>
+        <outline text="db.close(dbPath)"/>
+        <outline text="return has1 and (not has2) and (v1 == &quot;value1&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="error mid-transaction - db still usable after error - After an error mid-transaction on a guest database, verify&#10;the database is still fully usable (read and write).&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;error_db_recovery.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="db.open(dbPath, false)"/>
+        <outline text="try">
+          <outline text="db.setvalue(dbPath, &quot;pre&quot;, &quot;before&quot;)"/>
+          <outline text="scriptError(&quot;intentional&quot;)"/>
+          <outline text="db.setvalue(dbPath, &quot;unreachable&quot;, &quot;nope&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="local(msg = tryError)}"/>
+        </outline>
+        <outline text="db.setvalue(dbPath, &quot;post&quot;, &quot;after&quot;)"/>
+        <outline text="local(pre = db.getvalue(dbPath, &quot;pre&quot;))"/>
+        <outline text="local(post = db.getvalue(dbPath, &quot;post&quot;))"/>
+        <outline text="local(noUnreachable = not(db.defined(dbPath, &quot;unreachable&quot;)))"/>
+        <outline text="db.close(dbPath)"/>
+        <outline text="return (pre == &quot;before&quot;) and (post == &quot;after&quot;) and noUnreachable"/>
+      </outline>
+    </outline>
+    <outline text="thread writes during save - no crash - Spawn a background thread that writes values to system.temp in a loop,&#10;then save from the main thread while the background thread is active.&#10;GIL serializes access, so this should be safe. Verify no crash and&#10;values are readable after save completes.&#10;">
+      <outline text="Metadata">
+        <outline text="repl_mode: True"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(tableType, @system.temp.threadsave)"/>
+        <outline text="system.temp.threadsave.counter = 0"/>
+        <outline text="system.temp.threadsave.done = false"/>
+        <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true&quot;)"/>
+        <outline text="thread.sleepTicks(5)"/>
+        <outline text="filemenu.save()"/>
+        <outline text="thread.sleepTicks(30)"/>
+        <outline text="local(ok = system.temp.threadsave.done and system.temp.threadsave.counter &gt;= 0)"/>
+        <outline text="delete(@system.temp.threadsave)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="thread writes to guest DB during main thread save - no crash - Spawn a background thread writing to a guest database while main thread&#10;calls filemenu.save() on the system root. GIL serializes, so both&#10;operations should complete without corruption.&#10;">
+      <outline text="Metadata">
+        <outline text="repl_mode: True"/>
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;thread_save_guest.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="fileMenu.open(dbPath)"/>
+        <outline text="new(tableType, @system.temp.tsg)"/>
+        <outline text="system.temp.tsg.done = false"/>
+        <outline text="thread.evaluate(&quot;local(i = 0); while(i &lt; 10) {db.setvalue(\&quot;&quot; + dbPath + &quot;\&quot;, \&quot;iter\&quot;, i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true&quot;)"/>
+        <outline text="thread.sleepTicks(5)"/>
+        <outline text="filemenu.save()"/>
+        <outline text="thread.sleepTicks(30)"/>
+        <outline text="local(ok = system.temp.tsg.done)"/>
+        <outline text="delete(@system.temp.tsg)"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="concurrent thread and main thread both write - values readable - Both the main thread and a background thread write distinct values.&#10;After both complete, verify all values are readable (no lost writes).&#10;">
+      <outline text="Metadata">
+        <outline text="repl_mode: True"/>
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="new(tableType, @system.temp.conc)"/>
+        <outline text="system.temp.conc.threadDone = false"/>
+        <outline text="thread.evaluate(&quot;system.temp.conc.threadVal = \&quot;from_thread\&quot;; system.temp.conc.threadDone = true&quot;)"/>
+        <outline text="system.temp.conc.mainVal = &quot;from_main&quot;"/>
+        <outline text="thread.sleepTicks(12)"/>
+        <outline text="local(ok = system.temp.conc.threadDone and (system.temp.conc.threadVal == &quot;from_thread&quot;) and (system.temp.conc.mainVal == &quot;from_main&quot;))"/>
+        <outline text="delete(@system.temp.conc)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+    <outline text="closeall - closes multiple guest databases - Open 3 guest databases, write values to each, call fileMenu.closeall(),&#10;verify it returns true. Then verify access to closed databases fails.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(db1 = tmpDir + &quot;/&quot; + &quot;closeall_verify1.root7&quot;)"/>
+        <outline text="local(db2 = tmpDir + &quot;/&quot; + &quot;closeall_verify2.root7&quot;)"/>
+        <outline text="local(db3 = tmpDir + &quot;/&quot; + &quot;closeall_verify3.root7&quot;)"/>
+        <outline text="db.new(db1)"/>
+        <outline text="db.new(db2)"/>
+        <outline text="db.new(db3)"/>
+        <outline text="fileMenu.open(db1)"/>
+        <outline text="fileMenu.open(db2)"/>
+        <outline text="fileMenu.open(db3)"/>
+        <outline text="db.setvalue(db1, &quot;k&quot;, &quot;v1&quot;)"/>
+        <outline text="db.setvalue(db2, &quot;k&quot;, &quot;v2&quot;)"/>
+        <outline text="db.setvalue(db3, &quot;k&quot;, &quot;v3&quot;)"/>
+        <outline text="local(result = fileMenu.closeall())"/>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="closeall - access after close fails - After fileMenu.closeall(), attempting to read from a closed guest&#10;database should fail, confirming the handles are released.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: correctly_failed"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;closeall_access_fail.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="fileMenu.open(dbPath)"/>
+        <outline text="db.setvalue(dbPath, &quot;testKey&quot;, &quot;testVal&quot;)"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="try">
+          <outline text="local(val = db.getvalue(dbPath, &quot;testKey&quot;))"/>
+          <outline text="return &quot;should_have_failed&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;correctly_failed&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="closeall - reopen after close succeeds - After fileMenu.closeall(), reopening a previously closed database&#10;should succeed, confirming no lingering file locks.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;closeall_reopen.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="fileMenu.open(dbPath)"/>
+        <outline text="db.setvalue(dbPath, &quot;persistKey&quot;, &quot;persistVal&quot;)"/>
+        <outline text="fileMenu.save(dbPath)"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="local(reopened = fileMenu.open(dbPath))"/>
+        <outline text="local(val = db.getvalue(dbPath, &quot;persistKey&quot;))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return reopened and (val == &quot;persistVal&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="closeall - multiple close cycles - Open databases, close all, reopen different databases, close all again.&#10;Verifies closeall works correctly across multiple cycles.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(db1 = tmpDir + &quot;/&quot; + &quot;closeall_cycle1.root7&quot;)"/>
+        <outline text="local(db2 = tmpDir + &quot;/&quot; + &quot;closeall_cycle2.root7&quot;)"/>
+        <outline text="db.new(db1)"/>
+        <outline text="db.new(db2)"/>
+        <outline text="fileMenu.open(db1)"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="fileMenu.open(db2)"/>
+        <outline text="db.setvalue(db2, &quot;cycle&quot;, &quot;two&quot;)"/>
+        <outline text="local(val = db.getvalue(db2, &quot;cycle&quot;))"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="return val == &quot;two&quot;"/>
+      </outline>
+    </outline>
+    <outline text="closeall - system root still accessible after closeall - fileMenu.closeall() should only close guest databases, not the system&#10;root. Verify system.temp is still accessible after closeall.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+        <outline text="timeout: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;closeall_sysroot.root7&quot;)"/>
+        <outline text="db.new(dbPath)"/>
+        <outline text="fileMenu.open(dbPath)"/>
+        <outline text="fileMenu.closeall()"/>
+        <outline text="new(tableType, @system.temp.closeallTest)"/>
+        <outline text="system.temp.closeallTest.alive = true"/>
+        <outline text="local(ok = system.temp.closeallTest.alive)"/>
+        <outline text="delete(@system.temp.closeallTest)"/>
+        <outline text="return ok"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/persistence_save_tests.opml
+++ b/reports/integration_tests/persistence_save_tests.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Persistence Save Tests (persistence_save_tests) - 12 tests: 12 pass (100%)</title>
-    <dateCreated>Sat, 21 Mar 2026 00:35:42 GMT</dateCreated>
+    <dateCreated>Sat, 21 Mar 2026 04:19:56 GMT</dateCreated>
   </head>
   <body>
     <outline text="protocol filemenu.save - save system root via script/eval - Call filemenu.save() through protocol script/eval and verify success">
@@ -80,6 +80,7 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
+        <outline text="try {delete(@system.temp.persist_dual_db)} else {1}"/>
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;persist_dual_db.root7&quot;)"/>
         <outline text="system.temp.persist_dual_db = &quot;dual_db_sysroot_value&quot;"/>
@@ -104,6 +105,7 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
+        <outline text="try {delete(@system.temp.persist_interleaved)} else {1}"/>
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;persist_interleaved.root7&quot;)"/>
         <outline text="db.new(dbPath)"/>
@@ -185,6 +187,7 @@
         <outline text="expected_result: true"/>
       </outline>
       <outline text="Script">
+        <outline text="try {delete(@system.temp.persist_full_shutdown)} else {1}"/>
         <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
         <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;persist_full_shutdown.root7&quot;)"/>
         <outline text="system.temp.persist_full_shutdown = &quot;shutdown_sysroot&quot;"/>

--- a/reports/integration_tests/protocol_odb_ops.opml
+++ b/reports/integration_tests/protocol_odb_ops.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Protocol Odb Ops (protocol_odb_ops) - 34 tests: 34 pass (100%)</title>
-    <dateCreated>Wed, 18 Mar 2026 19:46:31 GMT</dateCreated>
+    <title>Protocol Odb Ops (protocol_odb_ops) - 35 tests: 35 pass (100%)</title>
+    <dateCreated>Fri, 20 Mar 2026 22:59:12 GMT</dateCreated>
   </head>
   <body>
     <outline text="odb/list - list workspace children - List top-level children of workspace table">
@@ -57,17 +57,17 @@
     </outline>
     <outline text="odb/set - create long value - Create an integer (long) value and read it back">
       <outline text="Metadata">
-        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_long', 'type': 'long', 'value': 42}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set long'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_long'}]}, 'validate': {'success': True, 'results': [{'type': 'long', 'value': 42}]}, 'description': 'verify long'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_long'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
+        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_long', 'type': 'long', 'value': 42}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set long'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_long'}]}, 'validate': {'success': True, 'results': [{'type': 'long', '_strict_type': {'value': 42}}]}, 'description': 'verify long'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_long'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
       </outline>
     </outline>
     <outline text="odb/set - create boolean true - Create a boolean value and read it back">
       <outline text="Metadata">
-        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_bool', 'type': 'boolean', 'value': True}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set bool'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_bool'}]}, 'validate': {'success': True, 'results': [{'type': 'boolean', 'value': True}]}, 'description': 'verify bool'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_bool'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
+        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_bool', 'type': 'boolean', 'value': True}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set bool'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_bool'}]}, 'validate': {'success': True, 'results': [{'type': 'boolean', '_strict_type': {'value': True}}]}, 'description': 'verify bool'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_bool'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
       </outline>
     </outline>
     <outline text="odb/set - create boolean false - Create a boolean false value">
       <outline text="Metadata">
-        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_bool_f', 'type': 'boolean', 'value': False}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set bool false'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_bool_f'}]}, 'validate': {'success': True, 'results': [{'type': 'boolean', 'value': False}]}, 'description': 'verify bool false'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_bool_f'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
+        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_bool_f', 'type': 'boolean', 'value': False}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set bool false'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_bool_f'}]}, 'validate': {'success': True, 'results': [{'type': 'boolean', '_strict_type': {'value': False}}]}, 'description': 'verify bool false'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_bool_f'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
       </outline>
     </outline>
     <outline text="odb/set - create double value - Create a floating-point (double) value and read it back">
@@ -82,12 +82,17 @@
     </outline>
     <outline text="odb/set - type inference from JSON value - When type is omitted, infer from JSON value type">
       <outline text="Metadata">
-        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_infer_str', 'value': 'auto string'}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set string (inferred)'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_infer_str'}]}, 'validate': {'success': True, 'results': [{'type': 'string', 'value': 'auto string'}]}, 'description': 'verify inferred string'}, {'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_infer_num', 'value': 99}]}, 'validate': {'success': True}, 'description': 'set number (inferred)'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_infer_num'}]}, 'validate': {'success': True, 'results': [{'type': 'long', 'value': 99}]}, 'description': 'verify inferred number'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_infer_str'}, {'path': 'workspace.test_proto_infer_num'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
+        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_infer_str', 'value': 'auto string'}]}, 'validate': {'success': True, 'results': [{'success': True}]}, 'description': 'set string (inferred)'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_infer_str'}]}, 'validate': {'success': True, 'results': [{'type': 'string', 'value': 'auto string'}]}, 'description': 'verify inferred string'}, {'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_proto_infer_num', 'value': 99}]}, 'validate': {'success': True}, 'description': 'set number (inferred)'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_proto_infer_num'}]}, 'validate': {'success': True, 'results': [{'type': 'long', '_strict_type': {'value': 99}}]}, 'description': 'verify inferred number'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_proto_infer_str'}, {'path': 'workspace.test_proto_infer_num'}]}, 'validate': {'success': True}, 'description': 'cleanup'}]"/>
       </outline>
     </outline>
     <outline text="odb/set - batch create multiple values - Create multiple values in a single request">
       <outline text="Metadata">
-        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_batch_a', 'type': 'string', 'value': 'alpha'}, {'path': 'workspace.test_batch_b', 'type': 'long', 'value': 2}, {'path': 'workspace.test_batch_c', 'type': 'boolean', 'value': True}]}, 'validate': {'success': True, 'result_count': 3, 'results': [{'success': True}, {'success': True}, {'success': True}]}, 'description': 'batch set'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_batch_a'}, {'path': 'workspace.test_batch_b'}, {'path': 'workspace.test_batch_c'}]}, 'validate': {'success': True, 'result_count': 3, 'results': [{'value': 'alpha'}, {'value': 2}, {'value': True}]}, 'description': 'batch verify'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_batch_a'}, {'path': 'workspace.test_batch_b'}, {'path': 'workspace.test_batch_c'}]}, 'validate': {'success': True, 'result_count': 3}, 'description': 'batch cleanup'}]"/>
+        <outline text="protocol_ops: [{'op': 'odb/set', 'params': {'items': [{'path': 'workspace.test_batch_a', 'type': 'string', 'value': 'alpha'}, {'path': 'workspace.test_batch_b', 'type': 'long', 'value': 2}, {'path': 'workspace.test_batch_c', 'type': 'boolean', 'value': True}]}, 'validate': {'success': True, 'result_count': 3, 'results': [{'success': True}, {'success': True}, {'success': True}]}, 'description': 'batch set'}, {'op': 'odb/get', 'params': {'items': [{'path': 'workspace.test_batch_a'}, {'path': 'workspace.test_batch_b'}, {'path': 'workspace.test_batch_c'}]}, 'validate': {'success': True, 'result_count': 3, 'results': [{'value': 'alpha'}, {'_strict_type': {'value': 2}}, {'_strict_type': {'value': True}}]}, 'description': 'batch verify'}, {'op': 'odb/delete', 'params': {'items': [{'path': 'workspace.test_batch_a'}, {'path': 'workspace.test_batch_b'}, {'path': 'workspace.test_batch_c'}]}, 'validate': {'success': True, 'result_count': 3}, 'description': 'batch cleanup'}]"/>
+      </outline>
+    </outline>
+    <outline text="odb/delete - rejects protected root-level table deletion - Protected-root list prevents deleting structural tables like system">
+      <outline text="Metadata">
+        <outline text="protocol_ops: [{'op': 'odb/delete', 'params': {'items': [{'path': 'system'}]}, 'validate': {'success': True, 'result_count': 1, 'results': [{'success': False, '_contains': {'error': 'Cannot delete protected root-level table'}}]}}]"/>
       </outline>
     </outline>
     <outline text="odb/delete - delete nonexistent path - Deleting a nonexistent path should return per-item error">

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -36,7 +36,8 @@ tests:
         local(has2 = defined(system.temp.midtxn.val2));
         local(v1 = system.temp.midtxn.val1);
         delete(@system.temp.midtxn);
-        return has1 and (not has2) and (v1 == "committed")}
+        return has1 and (not has2) and (v1 == "committed")};
+      return false
     expected_success: true
     expected_result: "true"
     timeout: 5
@@ -57,7 +58,8 @@ tests:
         local(has2 = defined(system.temp.nested.val2));
         local(v1 = system.temp.nested.val1);
         delete(@system.temp.nested);
-        return has1 and (not has2) and (v1 == "before_call")}
+        return has1 and (not has2) and (v1 == "before_call")};
+      return false
     expected_success: true
     expected_result: "true"
     timeout: 5
@@ -90,7 +92,7 @@ tests:
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "error_midtxn_db.root7");
       db.new(dbPath);
-      db.open(dbPath, false);
+      fileMenu.open(dbPath);
       try {
         db.setvalue(dbPath, "key1", "value1");
         scriptError("boom");
@@ -114,7 +116,7 @@ tests:
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "error_db_recovery.root7");
       db.new(dbPath);
-      db.open(dbPath, false);
+      fileMenu.open(dbPath);
       try {
         db.setvalue(dbPath, "pre", "before");
         scriptError("intentional");
@@ -147,7 +149,7 @@ tests:
       system.temp.threadsave.counter = 0;
       system.temp.threadsave.done = false;
       thread.evaluate("local(i = 0); while(i < 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true");
-      thread.sleepTicks(5);
+      thread.sleepTicks(12);
       filemenu.save();
       thread.sleepTicks(60);
       local(ok = system.temp.threadsave.done and system.temp.threadsave.counter > 5);
@@ -171,7 +173,7 @@ tests:
       new(tableType, @system.temp.tsg);
       system.temp.tsg.done = false;
       thread.evaluate("local(i = 0); while(i < 10) {db.setvalue(\"" + dbPath + "\", \"iter\", i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true");
-      thread.sleepTicks(5);
+      thread.sleepTicks(12);
       filemenu.save();
       thread.sleepTicks(60);
       local(ok = system.temp.tsg.done);
@@ -239,7 +241,7 @@ tests:
       fileMenu.open(dbPath);
       db.setvalue(dbPath, "testKey", "testVal");
       fileMenu.closeall();
-      try {
+      try { «db.getvalue errors ARE catchable via try/else (unlike fileMenu verb errors)»
         local(val = db.getvalue(dbPath, "testKey"));
         return "should_have_failed"}
       else {

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -1,0 +1,309 @@
+# Integration tests for error recovery and concurrency (Gaps #6, #7, #8)
+#
+# Covers three test gap areas from planning/INTEGRATION_TEST_GAPS.md:
+#   Gap #6: Error mid-transaction — partial state consistency after scriptError
+#   Gap #7: Thread modifying DB while main thread saves — GIL safety verification
+#   Gap #8: fileMenu.closeall() actually closes everything — handle release verification
+#
+# Threading model: GIL (Global Interpreter Lock) — real POSIX threads serialized
+# by a single mutex. Yield points at langbackgroundtask() and thread.sleepTicks().
+# See ADR-014 for details.
+#
+# fileMenu verb errors are uncatchable (bypass try/else) — see
+# planning/FIX_TESTS_2026_02_16.md B2. Tests that need to catch fileMenu errors
+# are skipped with this reason.
+
+description: "Error Recovery & Concurrency Integration Tests (Gaps #6, #7, #8)"
+
+tests:
+  # ========================================================================
+  # Gap #6: Error mid-transaction — partial state consistency
+  # ========================================================================
+
+  - name: "error mid-transaction - first setvalue persists, second does not"
+    description: |
+      Verify that when scriptError fires between two db.setvalue calls inside
+      a try block, the first setvalue's effect persists but the second never
+      executes. Uses system.temp as scratchpad.
+    script: |
+      new(tableType, @system.temp.midtxn);
+      try {
+        system.temp.midtxn.val1 = "committed";
+        scriptError("boom");
+        system.temp.midtxn.val2 = "should_not_exist"}
+      else {
+        local(has1 = defined(system.temp.midtxn.val1));
+        local(has2 = defined(system.temp.midtxn.val2));
+        local(v1 = system.temp.midtxn.val1);
+        delete(@system.temp.midtxn);
+        return has1 and (not has2) and (v1 == "committed")}
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "error mid-transaction - error in nested function call"
+    description: |
+      Verify partial state consistency when error occurs inside a nested call.
+      The outer script sets val1, calls a helper that errors, val2 never set.
+    script: |
+      new(tableType, @system.temp.nested);
+      script.newScriptObject("scriptError(\"nested boom\")", @system.temp.nested.helper);
+      try {
+        system.temp.nested.val1 = "before_call";
+        system.temp.nested.helper();
+        system.temp.nested.val2 = "after_call"}
+      else {
+        local(has1 = defined(system.temp.nested.val1));
+        local(has2 = defined(system.temp.nested.val2));
+        local(v1 = system.temp.nested.val1);
+        delete(@system.temp.nested);
+        return has1 and (not has2) and (v1 == "before_call")}
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "error mid-transaction - recovery after try/else"
+    description: |
+      After a try/else handles an error, normal operations should still work.
+      This verifies the runtime is in a consistent state post-error.
+    script: |
+      new(tableType, @system.temp.recovery);
+      try {
+        system.temp.recovery.a = 1;
+        scriptError("mid-error");
+        system.temp.recovery.b = 2}
+      else {
+        system.temp.recovery.caught = tryError};
+      system.temp.recovery.postError = "still_works";
+      local(ok = system.temp.recovery.a == 1 and system.temp.recovery.postError == "still_works" and (system.temp.recovery.caught contains "mid-error") and not(defined(system.temp.recovery.b)));
+      delete(@system.temp.recovery);
+      return ok
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "error mid-transaction - db.setvalue partial commit"
+    description: |
+      Verify db.setvalue on a guest database: first write persists, second
+      does not execute due to scriptError. Database remains consistent.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "error_midtxn_db.root7");
+      db.new(dbPath);
+      db.open(dbPath, false);
+      try {
+        db.setvalue(dbPath, "key1", "value1");
+        scriptError("boom");
+        db.setvalue(dbPath, "key2", "value2")}
+      else {
+        local(msg = tryError)};
+      local(has1 = db.defined(dbPath, "key1"));
+      local(has2 = db.defined(dbPath, "key2"));
+      local(v1 = db.getvalue(dbPath, "key1"));
+      db.close(dbPath);
+      return has1 and (not has2) and (v1 == "value1")
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "error mid-transaction - db still usable after error"
+    description: |
+      After an error mid-transaction on a guest database, verify
+      the database is still fully usable (read and write).
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "error_db_recovery.root7");
+      db.new(dbPath);
+      db.open(dbPath, false);
+      try {
+        db.setvalue(dbPath, "pre", "before");
+        scriptError("intentional");
+        db.setvalue(dbPath, "unreachable", "nope")}
+      else {
+        local(msg = tryError)};
+      db.setvalue(dbPath, "post", "after");
+      local(pre = db.getvalue(dbPath, "pre"));
+      local(post = db.getvalue(dbPath, "post"));
+      local(noUnreachable = not(db.defined(dbPath, "unreachable")));
+      db.close(dbPath);
+      return (pre == "before") and (post == "after") and noUnreachable
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  # ========================================================================
+  # Gap #7: Thread modifying DB while main thread saves
+  # ========================================================================
+
+  - name: "thread writes during save - no crash"
+    description: |
+      Spawn a background thread that writes values to system.temp in a loop,
+      then save from the main thread while the background thread is active.
+      GIL serializes access, so this should be safe. Verify no crash and
+      values are readable after save completes.
+    repl_mode: true
+    script: |
+      new(tableType, @system.temp.threadsave);
+      system.temp.threadsave.counter = 0;
+      system.temp.threadsave.done = false;
+      thread.evaluate("local(i = 0); while(i < 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true");
+      thread.sleepTicks(5);
+      filemenu.save();
+      thread.sleepTicks(30);
+      local(ok = system.temp.threadsave.done and system.temp.threadsave.counter >= 0);
+      delete(@system.temp.threadsave);
+      return ok
+    expected_success: true
+    expected_result: "true"
+    timeout: 10
+
+  - name: "thread writes to guest DB during main thread save - no crash"
+    description: |
+      Spawn a background thread writing to a guest database while main thread
+      calls filemenu.save() on the system root. GIL serializes, so both
+      operations should complete without corruption.
+    repl_mode: true
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "thread_save_guest.root7");
+      db.new(dbPath);
+      fileMenu.open(dbPath);
+      new(tableType, @system.temp.tsg);
+      system.temp.tsg.done = false;
+      thread.evaluate("local(i = 0); while(i < 10) {db.setvalue(\"" + dbPath + "\", \"iter\", i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true");
+      thread.sleepTicks(5);
+      filemenu.save();
+      thread.sleepTicks(30);
+      local(ok = system.temp.tsg.done);
+      delete(@system.temp.tsg);
+      fileMenu.closeall();
+      return ok
+    expected_success: true
+    expected_result: "true"
+    timeout: 10
+
+  - name: "concurrent thread and main thread both write - values readable"
+    description: |
+      Both the main thread and a background thread write distinct values.
+      After both complete, verify all values are readable (no lost writes).
+    repl_mode: true
+    script: |
+      new(tableType, @system.temp.conc);
+      system.temp.conc.threadDone = false;
+      thread.evaluate("system.temp.conc.threadVal = \"from_thread\"; system.temp.conc.threadDone = true");
+      system.temp.conc.mainVal = "from_main";
+      thread.sleepTicks(12);
+      local(ok = system.temp.conc.threadDone and (system.temp.conc.threadVal == "from_thread") and (system.temp.conc.mainVal == "from_main"));
+      delete(@system.temp.conc);
+      return ok
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  # ========================================================================
+  # Gap #8: fileMenu.closeall() actually closes everything
+  # ========================================================================
+
+  - name: "closeall - closes multiple guest databases"
+    description: |
+      Open 3 guest databases, write values to each, call fileMenu.closeall(),
+      verify it returns true. Then verify access to closed databases fails.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(db1 = tmpDir + "/" + "closeall_verify1.root7");
+      local(db2 = tmpDir + "/" + "closeall_verify2.root7");
+      local(db3 = tmpDir + "/" + "closeall_verify3.root7");
+      db.new(db1);
+      db.new(db2);
+      db.new(db3);
+      fileMenu.open(db1);
+      fileMenu.open(db2);
+      fileMenu.open(db3);
+      db.setvalue(db1, "k", "v1");
+      db.setvalue(db2, "k", "v2");
+      db.setvalue(db3, "k", "v3");
+      local(result = fileMenu.closeall());
+      return result
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "closeall - access after close fails"
+    description: |
+      After fileMenu.closeall(), attempting to read from a closed guest
+      database should fail, confirming the handles are released.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "closeall_access_fail.root7");
+      db.new(dbPath);
+      fileMenu.open(dbPath);
+      db.setvalue(dbPath, "testKey", "testVal");
+      fileMenu.closeall();
+      try {
+        local(val = db.getvalue(dbPath, "testKey"));
+        return "should_have_failed"}
+      else {
+        return "correctly_failed"}
+    expected_success: true
+    expected_result: "correctly_failed"
+    timeout: 5
+
+  - name: "closeall - reopen after close succeeds"
+    description: |
+      After fileMenu.closeall(), reopening a previously closed database
+      should succeed, confirming no lingering file locks.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "closeall_reopen.root7");
+      db.new(dbPath);
+      fileMenu.open(dbPath);
+      db.setvalue(dbPath, "persistKey", "persistVal");
+      fileMenu.save(dbPath);
+      fileMenu.closeall();
+      local(reopened = fileMenu.open(dbPath));
+      local(val = db.getvalue(dbPath, "persistKey"));
+      fileMenu.closeall();
+      return reopened and (val == "persistVal")
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "closeall - multiple close cycles"
+    description: |
+      Open databases, close all, reopen different databases, close all again.
+      Verifies closeall works correctly across multiple cycles.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(db1 = tmpDir + "/" + "closeall_cycle1.root7");
+      local(db2 = tmpDir + "/" + "closeall_cycle2.root7");
+      db.new(db1);
+      db.new(db2);
+      fileMenu.open(db1);
+      fileMenu.closeall();
+      fileMenu.open(db2);
+      db.setvalue(db2, "cycle", "two");
+      local(val = db.getvalue(db2, "cycle"));
+      fileMenu.closeall();
+      return val == "two"
+    expected_success: true
+    expected_result: "true"
+    timeout: 5
+
+  - name: "closeall - system root still accessible after closeall"
+    description: |
+      fileMenu.closeall() should only close guest databases, not the system
+      root. Verify system.temp is still accessible after closeall.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "closeall_sysroot.root7");
+      db.new(dbPath);
+      fileMenu.open(dbPath);
+      fileMenu.closeall();
+      new(tableType, @system.temp.closeallTest);
+      system.temp.closeallTest.alive = true;
+      local(ok = system.temp.closeallTest.alive);
+      delete(@system.temp.closeallTest);
+      return ok
+    expected_success: true
+    expected_result: "true"
+    timeout: 5

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -149,8 +149,8 @@ tests:
       thread.evaluate("local(i = 0); while(i < 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true");
       thread.sleepTicks(5);
       filemenu.save();
-      thread.sleepTicks(30);
-      local(ok = system.temp.threadsave.done and system.temp.threadsave.counter >= 0);
+      thread.sleepTicks(60);
+      local(ok = system.temp.threadsave.done and system.temp.threadsave.counter > 5);
       delete(@system.temp.threadsave);
       return ok
     expected_success: true
@@ -173,7 +173,7 @@ tests:
       thread.evaluate("local(i = 0); while(i < 10) {db.setvalue(\"" + dbPath + "\", \"iter\", i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true");
       thread.sleepTicks(5);
       filemenu.save();
-      thread.sleepTicks(30);
+      thread.sleepTicks(60);
       local(ok = system.temp.tsg.done);
       delete(@system.temp.tsg);
       fileMenu.closeall();
@@ -258,7 +258,6 @@ tests:
       db.new(dbPath);
       fileMenu.open(dbPath);
       db.setvalue(dbPath, "persistKey", "persistVal");
-      fileMenu.save(dbPath);
       fileMenu.closeall();
       local(reopened = fileMenu.open(dbPath));
       local(val = db.getvalue(dbPath, "persistKey"));

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -258,6 +258,7 @@ tests:
       db.new(dbPath);
       fileMenu.open(dbPath);
       db.setvalue(dbPath, "persistKey", "persistVal");
+      fileMenu.save(dbPath);
       fileMenu.closeall();
       local(reopened = fileMenu.open(dbPath));
       local(val = db.getvalue(dbPath, "persistKey"));

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -99,11 +99,15 @@ tests:
         db.setvalue(dbPath, "key2", "value2")}
       else {
         local(msg = tryError)};
-      local(has1 = db.defined(dbPath, "key1"));
-      local(has2 = db.defined(dbPath, "key2"));
-      local(v1 = db.getvalue(dbPath, "key1"));
-      db.close(dbPath);
-      return has1 and (not has2) and (v1 == "value1")
+      try {
+        local(has1 = db.defined(dbPath, "key1"));
+        local(has2 = db.defined(dbPath, "key2"));
+        local(v1 = db.getvalue(dbPath, "key1"));
+        db.close(dbPath);
+        return has1 and (not has2) and (v1 == "value1")}
+      else {
+        db.close(dbPath);
+        return false}
     expected_success: true
     expected_result: "true"
     timeout: 5
@@ -123,12 +127,16 @@ tests:
         db.setvalue(dbPath, "unreachable", "nope")}
       else {
         local(msg = tryError)};
-      db.setvalue(dbPath, "post", "after");
-      local(pre = db.getvalue(dbPath, "pre"));
-      local(post = db.getvalue(dbPath, "post"));
-      local(noUnreachable = not(db.defined(dbPath, "unreachable")));
-      db.close(dbPath);
-      return (pre == "before") and (post == "after") and noUnreachable
+      try {
+        db.setvalue(dbPath, "post", "after");
+        local(pre = db.getvalue(dbPath, "pre"));
+        local(post = db.getvalue(dbPath, "post"));
+        local(noUnreachable = not(db.defined(dbPath, "unreachable")));
+        db.close(dbPath);
+        return (pre == "before") and (post == "after") and noUnreachable}
+      else {
+        db.close(dbPath);
+        return false}
     expected_success: true
     expected_result: "true"
     timeout: 5

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -12,6 +12,9 @@
 # fileMenu verb errors are uncatchable (bypass try/else) — see
 # planning/FIX_TESTS_2026_02_16.md B2. Tests that need to catch fileMenu errors
 # are skipped with this reason.
+#
+# Guest DB files: Tests use static .root7 filenames. Defensive file.delete()
+# at test start handles leftover files from prior crashed runs.
 
 description: "Error Recovery & Concurrency Integration Tests (Gaps #6, #7, #8)"
 
@@ -91,6 +94,7 @@ tests:
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "error_midtxn_db.root7");
+      try {file.delete(dbPath)} else {1};
       db.new(dbPath);
       fileMenu.open(dbPath);
       try {
@@ -119,6 +123,7 @@ tests:
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "error_db_recovery.root7");
+      try {file.delete(dbPath)} else {1};
       db.new(dbPath);
       fileMenu.open(dbPath);
       try {
@@ -177,6 +182,7 @@ tests:
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "thread_save_guest.root7");
+      try {file.delete(dbPath)} else {1};
       db.new(dbPath);
       fileMenu.open(dbPath);
       new(tableType, @system.temp.tsg);
@@ -225,6 +231,9 @@ tests:
       local(db1 = tmpDir + "/" + "closeall_verify1.root7");
       local(db2 = tmpDir + "/" + "closeall_verify2.root7");
       local(db3 = tmpDir + "/" + "closeall_verify3.root7");
+      try {file.delete(db1)} else {1};
+      try {file.delete(db2)} else {1};
+      try {file.delete(db3)} else {1};
       db.new(db1);
       db.new(db2);
       db.new(db3);
@@ -247,6 +256,7 @@ tests:
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "closeall_access_fail.root7");
+      try {file.delete(dbPath)} else {1};
       db.new(dbPath);
       fileMenu.open(dbPath);
       db.setvalue(dbPath, "testKey", "testVal");
@@ -267,6 +277,7 @@ tests:
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "closeall_reopen.root7");
+      try {file.delete(dbPath)} else {1};
       db.new(dbPath);
       fileMenu.open(dbPath);
       db.setvalue(dbPath, "persistKey", "persistVal");
@@ -288,6 +299,8 @@ tests:
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(db1 = tmpDir + "/" + "closeall_cycle1.root7");
       local(db2 = tmpDir + "/" + "closeall_cycle2.root7");
+      try {file.delete(db1)} else {1};
+      try {file.delete(db2)} else {1};
       db.new(db1);
       db.new(db2);
       fileMenu.open(db1);
@@ -308,6 +321,7 @@ tests:
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "closeall_sysroot.root7");
+      try {file.delete(dbPath)} else {1};
       db.new(dbPath);
       fileMenu.open(dbPath);
       fileMenu.closeall();

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -159,6 +159,7 @@ tests:
       thread.evaluate("local(i = 0); while(i < 20) {system.temp.threadsave.counter = i; i = i + 1; thread.sleepTicks(1)}; system.temp.threadsave.done = true");
       thread.sleepTicks(12);
       filemenu.save();
+      «Timing: background thread needs ~20 ticks (20 iterations * 1 tick). 60-tick wait provides 3x margin for GIL contention and save latency.»
       thread.sleepTicks(60);
       local(ok = system.temp.threadsave.done and system.temp.threadsave.counter > 5);
       delete(@system.temp.threadsave);
@@ -183,6 +184,7 @@ tests:
       thread.evaluate("local(i = 0); while(i < 10) {db.setvalue(\"" + dbPath + "\", \"iter\", i); i = i + 1; thread.sleepTicks(2)}; system.temp.tsg.done = true");
       thread.sleepTicks(12);
       filemenu.save();
+      «Timing: background thread needs ~20 ticks (10 iterations * 2 ticks). 60-tick wait provides 3x margin for GIL contention and save latency.»
       thread.sleepTicks(60);
       local(ok = system.temp.tsg.done);
       delete(@system.temp.tsg);
@@ -217,7 +219,7 @@ tests:
   - name: "closeall - closes multiple guest databases"
     description: |
       Open 3 guest databases, write values to each, call fileMenu.closeall(),
-      verify it returns true. Then verify access to closed databases fails.
+      and verify it returns true.
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(db1 = tmpDir + "/" + "closeall_verify1.root7");


### PR DESCRIPTION
## Summary
- Add 13 new integration tests covering gaps #6, #7, and #8 from `planning/INTEGRATION_TEST_GAPS.md`
- **Gap #6 — Error mid-transaction** (5 tests): Verifies partial state consistency when `scriptError` fires between mutations, including nested function calls, guest DB operations, and post-error recovery
- **Gap #7 — Thread modifying DB while main thread saves** (3 tests): Verifies GIL serialization keeps state consistent during concurrent thread writes and `filemenu.save()`
- **Gap #8 — `fileMenu.closeall()` handle release** (5 tests): Verifies guest DB handles are actually released after closeall, access to closed DBs fails, databases can be reopened without lingering locks, and system root remains accessible

## Test plan
- [x] All 13 new tests pass in integration suite
- [x] No regressions in existing tests (1766 pass, 33 pre-existing protocol_odb_ops failures)
- [ ] Unit tests not runnable (pre-existing build break: duplicate `databasedata` symbol in develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
