### PR TITLE
feat: Expose CLI arguments in system.environment.args

### DIFF
--- a/Common/headers/langinternal.h
+++ b/Common/headers/langinternal.h
@@ -610,4 +610,11 @@ extern boolean langremotefunctioncall (hdltreenode htree, hdltreenode hparam1, t
 extern boolean langrunscriptcode (hdlhashtable htable, bigstring bsverb, hdltreenode hcode, tyvaluerecord *vparams, hdlhashtable hcontext, tyvaluerecord *vreturned);
 
 
+// langstartup.c — environment args callback (dependency inversion for CLI layer)
+
+typedef boolean (*env_args_populate_callback) (hdlhashtable htargs);
+
+extern void langenvironment_set_args_callback (env_args_populate_callback cb);
+
+
 #endif /*langinternalinclude*/

--- a/Common/headers/langinternal.h
+++ b/Common/headers/langinternal.h
@@ -612,9 +612,13 @@ extern boolean langrunscriptcode (hdlhashtable htable, bigstring bsverb, hdltree
 
 // langstartup.c — environment args callback (dependency inversion for CLI layer)
 
+#ifdef FRONTIER_HEADLESS
+
 typedef boolean (*env_args_populate_callback) (hdlhashtable htargs);
 
 extern void langenvironment_set_args_callback (env_args_populate_callback cb);
+
+#endif
 
 
 #endif /*langinternalinclude*/

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -110,6 +110,23 @@ static boolean cb_false_event(EventRecord* e) { (void)e; return false; }
 #define str_isLinux					BIGSTRING ("\x07" "isLinux")
 #define str_maxTcpConnections		BIGSTRING ("\x11" "maxTcpConnections")
 
+/* CLI args subtable key names (camelCase from CLI flags) */
+#define str_args					BIGSTRING ("\x04" "args")
+#define str_systemRoot				BIGSTRING ("\x0a" "systemRoot")
+#define str_skipStartup				BIGSTRING ("\x0b" "skipStartup")
+#define str_execute					BIGSTRING ("\x07" "execute")
+#define str_output					BIGSTRING ("\x06" "output")
+#define str_verbose					BIGSTRING ("\x07" "verbose")
+#define str_debug					BIGSTRING ("\x05" "debug")
+#define str_outputJson				BIGSTRING ("\x0a" "outputJson")
+#define str_batch					BIGSTRING ("\x05" "batch")
+#define str_protocol				BIGSTRING ("\x08" "protocol")
+#define str_wsPort					BIGSTRING ("\x06" "wsPort")
+#define str_log						BIGSTRING ("\x03" "log")
+#define str_force					BIGSTRING ("\x05" "force")
+#define str_migrate					BIGSTRING ("\x07" "migrate")
+#define str_hydrate					BIGSTRING ("\x07" "hydrate")
+
 
 void initsegment (void) {
 	
@@ -210,6 +227,104 @@ boolean loadfunctionprocessor (short id, langvaluecallback valuecallback) {
 
 
 #ifdef FRONTIER_HEADLESS
+
+#include "../../frontier-cli/cli_parser.h"
+
+/*
+ * cli_get_options is defined in frontier-cli/main.c.
+ * Declared weak so unit tests (which don't link main.c) resolve to NULL
+ * instead of a linker error. initenvironment_args checks for NULL.
+ */
+extern const cli_options_t* cli_get_options (void) __attribute__((weak));
+
+static boolean initenvironment_args (hdlhashtable htenvironment) {
+
+	/*
+	 * Populate system.environment.args subtable from CLI options.
+	 * Only flags that were explicitly set on the command line appear;
+	 * absence means the flag was not passed.
+	 */
+
+	if (cli_get_options == NULL)
+		return (true); /* unit test build — function not linked */
+
+	const cli_options_t *opts = cli_get_options ();
+
+	if (opts == NULL)
+		return (true); /* no CLI options available — skip silently */
+
+	hdlhashtable htargs;
+
+	if (!tablenewsystemtable (htenvironment, str_args, &htargs))
+		return (false);
+
+	/* String fields — only add when non-NULL */
+
+	if (opts->system_root != NULL) {
+		bigstring bs;
+		copyctopstring (opts->system_root, bs);
+		langassignstringvalue (htargs, str_systemRoot, bs);
+	}
+
+	if (opts->inline_script != NULL) {
+		bigstring bs;
+		copyctopstring (opts->inline_script, bs);
+		langassignstringvalue (htargs, str_execute, bs);
+	}
+
+	if (opts->output_path != NULL) {
+		bigstring bs;
+		copyctopstring (opts->output_path, bs);
+		langassignstringvalue (htargs, str_output, bs);
+	}
+
+	if (opts->log_spec != NULL) {
+		bigstring bs;
+		copyctopstring (opts->log_spec, bs);
+		langassignstringvalue (htargs, str_log, bs);
+	}
+
+	if (opts->migrate_database != NULL) {
+		bigstring bs;
+		copyctopstring (opts->migrate_database, bs);
+		langassignstringvalue (htargs, str_migrate, bs);
+	}
+
+	/* Boolean flags — only add when true */
+
+	if (opts->verbose)
+		langassignbooleanvalue (htargs, str_verbose, true);
+
+	if (opts->debug)
+		langassignbooleanvalue (htargs, str_debug, true);
+
+	if (opts->output_json)
+		langassignbooleanvalue (htargs, str_outputJson, true);
+
+	if (opts->batch_mode)
+		langassignbooleanvalue (htargs, str_batch, true);
+
+	if (opts->protocol_mode)
+		langassignbooleanvalue (htargs, str_protocol, true);
+
+	if (opts->skip_startup)
+		langassignbooleanvalue (htargs, str_skipStartup, true);
+
+	if (opts->force_overwrite)
+		langassignbooleanvalue (htargs, str_force, true);
+
+	if (opts->hydrate_system_root)
+		langassignbooleanvalue (htargs, str_hydrate, true);
+
+	/* Integer fields — only add when non-zero */
+
+	if (opts->ws_port > 0)
+		langassignlongvalue (htargs, str_wsPort, (long) opts->ws_port);
+
+	return (true);
+} /*initenvironment_args*/
+
+
 static boolean initenvironment (hdlhashtable ht) {
 
 	/*
@@ -403,6 +518,11 @@ static boolean initenvironment (hdlhashtable ht) {
 	langassignstringvalue (ht, str_winServicePackNumber, bs);
 
 	langassignlongvalue (ht, str_maxTcpConnections, 0);
+
+	/* Populate system.environment.args from CLI options */
+
+	if (!initenvironment_args (ht))
+		return (false);
 
 	return (true);
 }

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -110,22 +110,8 @@ static boolean cb_false_event(EventRecord* e) { (void)e; return false; }
 #define str_isLinux					BIGSTRING ("\x07" "isLinux")
 #define str_maxTcpConnections		BIGSTRING ("\x11" "maxTcpConnections")
 
-/* CLI args subtable key names (camelCase from CLI flags) */
+/* CLI args subtable name */
 #define str_args					BIGSTRING ("\x04" "args")
-#define str_systemRoot				BIGSTRING ("\x0a" "systemRoot")
-#define str_skipStartup				BIGSTRING ("\x0b" "skipStartup")
-#define str_execute					BIGSTRING ("\x07" "execute")
-#define str_output					BIGSTRING ("\x06" "output")
-#define str_verbose					BIGSTRING ("\x07" "verbose")
-#define str_debug					BIGSTRING ("\x05" "debug")
-#define str_outputJson				BIGSTRING ("\x0a" "outputJson")
-#define str_batch					BIGSTRING ("\x05" "batch")
-#define str_protocol				BIGSTRING ("\x08" "protocol")
-#define str_wsPort					BIGSTRING ("\x06" "wsPort")
-#define str_log						BIGSTRING ("\x03" "log")
-#define str_force					BIGSTRING ("\x05" "force")
-#define str_migrate					BIGSTRING ("\x07" "migrate")
-#define str_hydrate					BIGSTRING ("\x07" "hydrate")
 
 
 void initsegment (void) {
@@ -228,98 +214,34 @@ boolean loadfunctionprocessor (short id, langvaluecallback valuecallback) {
 
 #ifdef FRONTIER_HEADLESS
 
-#include "../../frontier-cli/cli_parser.h"
-
 /*
- * cli_get_options is defined in frontier-cli/main.c.
- * Declared weak so unit tests (which don't link main.c) resolve to NULL
- * instead of a linker error. initenvironment_args checks for NULL.
+ * Environment args callback — registered by the CLI layer via
+ * langenvironment_set_args_callback(). Common never sees cli_options_t;
+ * the callback knows how to populate the args subtable.
  */
-extern const cli_options_t* cli_get_options (void) __attribute__((weak));
+static env_args_populate_callback g_env_args_callback = NULL;
+
+void langenvironment_set_args_callback (env_args_populate_callback cb) {
+
+	g_env_args_callback = cb;
+} /*langenvironment_set_args_callback*/
 
 static boolean initenvironment_args (hdlhashtable htenvironment) {
 
 	/*
-	 * Populate system.environment.args subtable from CLI options.
-	 * Only flags that were explicitly set on the command line appear;
-	 * absence means the flag was not passed.
+	 * Create system.environment.args subtable and delegate population
+	 * to the registered callback (if any). When no callback is registered
+	 * (e.g. unit tests), we still create the empty subtable so scripts
+	 * can safely call defined(system.environment.args).
 	 */
-
-	if (cli_get_options == NULL)
-		return (true); /* unit test build — function not linked */
-
-	const cli_options_t *opts = cli_get_options ();
-
-	if (opts == NULL)
-		return (true); /* no CLI options available — skip silently */
 
 	hdlhashtable htargs;
 
 	if (!tablenewsystemtable (htenvironment, str_args, &htargs))
 		return (false);
 
-	/* String fields — only add when non-NULL */
-
-	if (opts->system_root != NULL) {
-		bigstring bs;
-		copyctopstring (opts->system_root, bs);
-		langassignstringvalue (htargs, str_systemRoot, bs);
-	}
-
-	if (opts->inline_script != NULL) {
-		bigstring bs;
-		copyctopstring (opts->inline_script, bs);
-		langassignstringvalue (htargs, str_execute, bs);
-	}
-
-	if (opts->output_path != NULL) {
-		bigstring bs;
-		copyctopstring (opts->output_path, bs);
-		langassignstringvalue (htargs, str_output, bs);
-	}
-
-	if (opts->log_spec != NULL) {
-		bigstring bs;
-		copyctopstring (opts->log_spec, bs);
-		langassignstringvalue (htargs, str_log, bs);
-	}
-
-	if (opts->migrate_database != NULL) {
-		bigstring bs;
-		copyctopstring (opts->migrate_database, bs);
-		langassignstringvalue (htargs, str_migrate, bs);
-	}
-
-	/* Boolean flags — only add when true */
-
-	if (opts->verbose)
-		langassignbooleanvalue (htargs, str_verbose, true);
-
-	if (opts->debug)
-		langassignbooleanvalue (htargs, str_debug, true);
-
-	if (opts->output_json)
-		langassignbooleanvalue (htargs, str_outputJson, true);
-
-	if (opts->batch_mode)
-		langassignbooleanvalue (htargs, str_batch, true);
-
-	if (opts->protocol_mode)
-		langassignbooleanvalue (htargs, str_protocol, true);
-
-	if (opts->skip_startup)
-		langassignbooleanvalue (htargs, str_skipStartup, true);
-
-	if (opts->force_overwrite)
-		langassignbooleanvalue (htargs, str_force, true);
-
-	if (opts->hydrate_system_root)
-		langassignbooleanvalue (htargs, str_hydrate, true);
-
-	/* Integer fields — only add when non-zero */
-
-	if (opts->ws_port > 0)
-		langassignlongvalue (htargs, str_wsPort, (long) opts->ws_port);
+	if (g_env_args_callback != NULL)
+		return ((*g_env_args_callback) (htargs));
 
 	return (true);
 } /*initenvironment_args*/

--- a/frontier-cli/cli_utils.h
+++ b/frontier-cli/cli_utils.h
@@ -60,4 +60,8 @@ void cli_clear_error(void);
 void cli_init_interactive_mode(boolean batch_mode_flag);
 boolean isInteractiveMode(void);
 
+// CLI options accessor (for system.environment.args)
+#include "cli_parser.h"
+const cli_options_t* cli_get_options(void);
+
 #endif /* CLI_UTILS_H */

--- a/frontier-cli/cli_utils.h
+++ b/frontier-cli/cli_utils.h
@@ -61,7 +61,4 @@ void cli_clear_error(void);
 void cli_init_interactive_mode(boolean batch_mode_flag);
 boolean isInteractiveMode(void);
 
-// CLI options accessor (for system.environment.args)
-const cli_options_t* cli_get_options(void);
-
 #endif /* CLI_UTILS_H */

--- a/frontier-cli/cli_utils.h
+++ b/frontier-cli/cli_utils.h
@@ -9,6 +9,7 @@
 #define CLI_UTILS_H
 
 #include "../Common/headers/frontier.h"
+#include "cli_parser.h"
 #include <stdarg.h>
 #include <stddef.h>
 
@@ -61,7 +62,6 @@ void cli_init_interactive_mode(boolean batch_mode_flag);
 boolean isInteractiveMode(void);
 
 // CLI options accessor (for system.environment.args)
-#include "cli_parser.h"
 const cli_options_t* cli_get_options(void);
 
 #endif /* CLI_UTILS_H */

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -64,6 +64,7 @@
 #include "cli_parser.h"
 #include "cli_executor.h"
 #include "cli_utils.h"
+#include "../Common/headers/langinternal.h"
 #include "repl.h"
 #include "protocol_handler.h"
 #include "ws_server.h"
@@ -120,6 +121,120 @@ boolean cli_should_skip_startup(void) {
 const cli_options_t* cli_get_options(void) {
     return &g_cli_options;
 }
+
+/*
+ * system.environment.args key names (camelCase from CLI flags).
+ *
+ * Note: script_file (positional arg) is intentionally not exposed here.
+ * It is not a named flag; scripts that need their own path can use
+ * frontier.getProgramPath() or receive it as a parameter.
+ */
+#define str_systemRoot      BIGSTRING ("\x0a" "systemRoot")
+#define str_skipStartup     BIGSTRING ("\x0b" "skipStartup")
+#define str_execute         BIGSTRING ("\x07" "execute")
+#define str_output          BIGSTRING ("\x06" "output")
+#define str_verbose         BIGSTRING ("\x07" "verbose")
+#define str_debug           BIGSTRING ("\x05" "debug")
+#define str_outputJson      BIGSTRING ("\x0a" "outputJson")
+#define str_batch           BIGSTRING ("\x05" "batch")
+#define str_protocol        BIGSTRING ("\x08" "protocol")
+#define str_wsPort          BIGSTRING ("\x06" "wsPort")
+#define str_log             BIGSTRING ("\x03" "log")
+#define str_force           BIGSTRING ("\x05" "force")
+#define str_migrate         BIGSTRING ("\x07" "migrate")
+#define str_hydrate         BIGSTRING ("\x07" "hydrate")
+
+/*
+ * Helper: assign a C string to a hash table entry using a Handle.
+ * Handles arbitrarily long strings (unlike copyctopstring which truncates at 255).
+ */
+static boolean assign_cstring_value (hdlhashtable ht, const bigstring bskey, const char *cstr) {
+
+    long len = (long) strlen (cstr);
+    Handle h;
+
+    if (!newhandle (len, &h))
+        return (false);
+
+    memmove (*h, cstr, (size_t) len);
+
+    if (!langassigntextvalue (ht, bskey, h)) {
+        disposehandle (h);
+        return (false);
+    }
+
+    return (true);
+} /*assign_cstring_value*/
+
+/*
+ * Callback registered with langenvironment_set_args_callback().
+ * Populates system.environment.args subtable from g_cli_options.
+ * Only flags actually set on the command line appear; absence = not set.
+ */
+static boolean populate_environment_args (hdlhashtable htargs) {
+
+    const cli_options_t *opts = &g_cli_options;
+
+    /* String fields — only add when non-NULL */
+
+    if (opts->system_root != NULL) {
+        if (!assign_cstring_value (htargs, str_systemRoot, opts->system_root))
+            return (false);
+    }
+
+    if (opts->inline_script != NULL) {
+        if (!assign_cstring_value (htargs, str_execute, opts->inline_script))
+            return (false);
+    }
+
+    if (opts->output_path != NULL) {
+        if (!assign_cstring_value (htargs, str_output, opts->output_path))
+            return (false);
+    }
+
+    if (opts->log_spec != NULL) {
+        if (!assign_cstring_value (htargs, str_log, opts->log_spec))
+            return (false);
+    }
+
+    if (opts->migrate_database != NULL) {
+        if (!assign_cstring_value (htargs, str_migrate, opts->migrate_database))
+            return (false);
+    }
+
+    /* Boolean flags — only add when true */
+
+    if (opts->verbose)
+        langassignbooleanvalue (htargs, str_verbose, true);
+
+    if (opts->debug)
+        langassignbooleanvalue (htargs, str_debug, true);
+
+    if (opts->output_json)
+        langassignbooleanvalue (htargs, str_outputJson, true);
+
+    if (opts->batch_mode)
+        langassignbooleanvalue (htargs, str_batch, true);
+
+    if (opts->protocol_mode)
+        langassignbooleanvalue (htargs, str_protocol, true);
+
+    if (opts->skip_startup)
+        langassignbooleanvalue (htargs, str_skipStartup, true);
+
+    if (opts->force_overwrite)
+        langassignbooleanvalue (htargs, str_force, true);
+
+    if (opts->hydrate_system_root)
+        langassignbooleanvalue (htargs, str_hydrate, true);
+
+    /* Integer fields — only add when non-zero */
+
+    if (opts->ws_port > 0)
+        langassignlongvalue (htargs, str_wsPort, (long) opts->ws_port);
+
+    return (true);
+} /*populate_environment_args*/
 
 // Function prototypes
 static void print_usage(const char* program_name);
@@ -663,6 +778,9 @@ static boolean initialize_frontier_runtime(void) {
         log_error(LOG_COMP_GENERAL, "Error: Failed to initialize logging");
         return false;
     }
+
+    /* Register CLI args callback before inittablestructure runs */
+    langenvironment_set_args_callback (populate_environment_args);
 
     if (!db_format_prepare_runtime()) {
         log_error(LOG_COMP_GENERAL, "Error: Failed to initialize Frontier runtime core");

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -117,6 +117,10 @@ boolean cli_should_skip_startup(void) {
     return g_cli_options.skip_startup;
 }
 
+const cli_options_t* cli_get_options(void) {
+    return &g_cli_options;
+}
+
 // Function prototypes
 static void print_usage(const char* program_name);
 static void print_version(void);

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -143,6 +143,7 @@ boolean cli_should_skip_startup(void) {
 /*
  * Helper: assign a C string to a hash table entry using a Handle.
  * Handles arbitrarily long strings (unlike copyctopstring which truncates at 255).
+ * langassigntextvalue takes ownership of h on success; we only dispose on failure.
  */
 static boolean assign_cstring_value (hdlhashtable ht, const bigstring bskey, const char *cstr) {
 
@@ -152,7 +153,8 @@ static boolean assign_cstring_value (hdlhashtable ht, const bigstring bskey, con
     if (!newhandle (len, &h))
         return (false);
 
-    memmove (*h, cstr, (size_t) len);
+    if (len > 0)
+        memcpy (*h, cstr, (size_t) len);
 
     if (!langassigntextvalue (ht, bskey, h)) {
         disposehandle (h);

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -118,10 +118,6 @@ boolean cli_should_skip_startup(void) {
     return g_cli_options.skip_startup;
 }
 
-const cli_options_t* cli_get_options(void) {
-    return &g_cli_options;
-}
-
 /*
  * system.environment.args key names (camelCase from CLI flags).
  *
@@ -204,34 +200,52 @@ static boolean populate_environment_args (hdlhashtable htargs) {
 
     /* Boolean flags — only add when true */
 
-    if (opts->verbose)
-        langassignbooleanvalue (htargs, str_verbose, true);
+    if (opts->verbose) {
+        if (!langassignbooleanvalue (htargs, str_verbose, true))
+            return (false);
+    }
 
-    if (opts->debug)
-        langassignbooleanvalue (htargs, str_debug, true);
+    if (opts->debug) {
+        if (!langassignbooleanvalue (htargs, str_debug, true))
+            return (false);
+    }
 
-    if (opts->output_json)
-        langassignbooleanvalue (htargs, str_outputJson, true);
+    if (opts->output_json) {
+        if (!langassignbooleanvalue (htargs, str_outputJson, true))
+            return (false);
+    }
 
-    if (opts->batch_mode)
-        langassignbooleanvalue (htargs, str_batch, true);
+    if (opts->batch_mode) {
+        if (!langassignbooleanvalue (htargs, str_batch, true))
+            return (false);
+    }
 
-    if (opts->protocol_mode)
-        langassignbooleanvalue (htargs, str_protocol, true);
+    if (opts->protocol_mode) {
+        if (!langassignbooleanvalue (htargs, str_protocol, true))
+            return (false);
+    }
 
-    if (opts->skip_startup)
-        langassignbooleanvalue (htargs, str_skipStartup, true);
+    if (opts->skip_startup) {
+        if (!langassignbooleanvalue (htargs, str_skipStartup, true))
+            return (false);
+    }
 
-    if (opts->force_overwrite)
-        langassignbooleanvalue (htargs, str_force, true);
+    if (opts->force_overwrite) {
+        if (!langassignbooleanvalue (htargs, str_force, true))
+            return (false);
+    }
 
-    if (opts->hydrate_system_root)
-        langassignbooleanvalue (htargs, str_hydrate, true);
+    if (opts->hydrate_system_root) {
+        if (!langassignbooleanvalue (htargs, str_hydrate, true))
+            return (false);
+    }
 
     /* Integer fields — only add when non-zero */
 
-    if (opts->ws_port > 0)
-        langassignlongvalue (htargs, str_wsPort, (long) opts->ws_port);
+    if (opts->ws_port > 0) {
+        if (!langassignlongvalue (htargs, str_wsPort, (long) opts->ws_port))
+            return (false);
+    }
 
     return (true);
 } /*populate_environment_args*/

--- a/tests/integration/test_cases/sys_environment_args.yaml
+++ b/tests/integration/test_cases/sys_environment_args.yaml
@@ -4,6 +4,12 @@
 # The args subtable is populated from CLI options at startup.
 # Only flags actually passed on the command line appear in the table.
 # Absence of a key means the flag was not passed.
+#
+# Test coverage gap: The integration runner uses --protocol --skip-startup
+# --system-root, so only those flags (plus absence checks) can be tested
+# here. The following keys are only exercisable via manual smoke tests:
+#   batch, force, output, log, migrate, hydrate, outputJson, wsPort (as present)
+# Manual: frontier-cli --verbose --system-root databases/Frontier.root -e 'system.environment.args.verbose'
 
 tests:
   # system.environment.args subtable exists

--- a/tests/integration/test_cases/sys_environment_args.yaml
+++ b/tests/integration/test_cases/sys_environment_args.yaml
@@ -1,0 +1,88 @@
+# Integration tests for system.environment.args
+# Tests CLI argument exposure via system.environment.args subtable
+#
+# The args subtable is populated from CLI options at startup.
+# Only flags actually passed on the command line appear in the table.
+# Absence of a key means the flag was not passed.
+
+tests:
+  # system.environment.args subtable exists
+  - name: "args subtable exists"
+    description: "system.environment.args should be defined"
+    script: |
+      return defined(system.environment.args)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args subtable is a table type"
+    description: "system.environment.args should have table type"
+    script: |
+      return typeof(system.environment.args) == 'tabl'
+    expected_success: true
+    expected_result: "true"
+
+  # system.environment.args.systemRoot - always present in integration tests
+  - name: "args.systemRoot - present"
+    description: "systemRoot should be defined (integration tests always pass --system-root)"
+    script: |
+      return defined(system.environment.args.systemRoot)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args.systemRoot - is a string"
+    description: "systemRoot should be a string value"
+    script: |
+      return typeof(system.environment.args.systemRoot) == 'TEXT'
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args.systemRoot - contains Frontier.root"
+    description: "systemRoot path should reference the system root database"
+    script: |
+      return system.environment.args.systemRoot contains "Frontier.root"
+    expected_success: true
+    expected_result: "true"
+
+  # Integration tests run with --protocol --skip-startup, so these should be set
+  - name: "args.skipStartup - present in integration tests"
+    description: "skipStartup should be true (integration tests pass --skip-startup)"
+    script: |
+      return system.environment.args.skipStartup
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args.protocol - present in integration tests"
+    description: "protocol should be true (integration tests run in --protocol mode)"
+    script: |
+      return system.environment.args.protocol
+    expected_success: true
+    expected_result: "true"
+
+  # Flags NOT passed by integration tests should be absent
+  - name: "args.wsPort - absent when not passed"
+    description: "wsPort should not be defined when --ws-port is not passed"
+    script: |
+      return !defined(system.environment.args.wsPort)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args.verbose - absent when not passed"
+    description: "verbose should not be defined when --verbose is not passed"
+    script: |
+      return !defined(system.environment.args.verbose)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args.debug - absent when not passed"
+    description: "debug should not be defined when --debug is not passed"
+    script: |
+      return !defined(system.environment.args.debug)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "args.execute - absent in protocol mode"
+    description: "execute should not be defined (integration tests use --protocol, not -e)"
+    script: |
+      return !defined(system.environment.args.execute)
+    expected_success: true
+    expected_result: "true"


### PR DESCRIPTION
## Summary

- Populates `system.environment.args` subtable at startup so UserTalk scripts can inspect CLI flags
- Only flags actually passed on the command line appear; absence means not set
- Boolean flags → `true`, string flags → string value (Handle-based, no 255-char limit), integer flags → long

## Architecture

Uses a **callback pattern** for dependency inversion: Common defines a generic `env_args_populate_callback` type in `langinternal.h`. The CLI layer (`main.c`) registers its callback before `db_format_prepare_runtime()` runs, which calls `inittablestructure()` → `initenvironment()` → `initenvironment_args()`. Common never sees `cli_options_t`.

## Files changed

| File | Change |
|------|--------|
| `Common/headers/langinternal.h` | `env_args_populate_callback` typedef + `langenvironment_set_args_callback()` |
| `Common/source/langstartup.c` | `initenvironment_args()` creates subtable, delegates to callback |
| `frontier-cli/main.c` | `populate_environment_args()` callback + `assign_cstring_value()` helper |
| `frontier-cli/cli_utils.h` | Moved `#include "cli_parser.h"` to top |
| `tests/integration/test_cases/sys_environment_args.yaml` | 11 integration tests |

## Test plan

- [x] 302/302 unit tests pass
- [x] 11/11 new integration tests pass (subtable existence, type checks, presence/absence)
- [x] No new integration test failures
- [x] Manual smoke test: `--skip-startup`, `--system-root`, `defined()` for absent flags
- [ ] Manual smoke test: `--verbose`, `--batch`, `--ws-port` (not exercisable via integration runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)