### PR TITLE
feat: Arbitrary CLI args in system.environment.args + --browser for openUrl

### DIFF
--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -869,6 +869,8 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 				 * If "agent-browser", use that command. If "default" or absent,
 				 * fall through to the platform default (open/xdg-open).
 				 */
+				/* Always false in non-headless (GUI) builds — the ifdef below
+				 * only sets it to true in headless mode. */
 				boolean use_agent_browser = false;
 
 #ifdef FRONTIER_HEADLESS
@@ -893,10 +895,10 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 								if (hashtablelookup (htargs, bsbrowser, &vbrowser, &hbnode)) {
 									if (vbrowser.valuetype == stringvaluetype && vbrowser.data.stringvalue != nil) {
 										long len = gethandlesize (vbrowser.data.stringvalue);
-										if (len == 13 && memcmp (*vbrowser.data.stringvalue, "agent-browser", 13) == 0) {
+										if (len == (long)(sizeof ("agent-browser") - 1) && memcmp (*vbrowser.data.stringvalue, "agent-browser", sizeof ("agent-browser") - 1) == 0) {
 											use_agent_browser = true;
 										}
-										else if (len != 7 || memcmp (*vbrowser.data.stringvalue, "default", 7) != 0) {
+										else if (len != (long)(sizeof ("default") - 1) || memcmp (*vbrowser.data.stringvalue, "default", sizeof ("default") - 1) != 0) {
 											/* Unknown browser value — reject for security */
 											unlockhandle (hurl);
 											disposehandle (hurl);

--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -831,6 +831,9 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 			 * 3/21/26 JES: Open a URL in the default browser without shell interpolation.
 			 * Uses fork/execlp to avoid command injection vulnerabilities.
 			 * macOS: execlp("open", ...), Linux: execlp("xdg-open", ...).
+			 *
+			 * 3/23/26 JES: Respect --browser CLI arg via system.environment.args.browser.
+			 * Allowed values: "default" (system browser) or "agent-browser".
 			 */
 
 			Handle hurl;
@@ -857,6 +860,53 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 					return (false);
 				}
 
+				/*
+				 * Check --browser arg: look up system.environment.args.browser.
+				 * If "agent-browser", use that command. If "default" or absent,
+				 * fall through to the platform default (open/xdg-open).
+				 */
+				boolean use_agent_browser = false;
+
+#ifdef FRONTIER_HEADLESS
+				{
+					hdlhashnode hnode;
+					tyvaluerecord vargs;
+					bigstring bsargs = BIGSTRING ("\x04" "args");
+					bigstring bsbrowser = BIGSTRING ("\x07" "browser");
+
+					if (environmenttable != nil &&
+						hashtablelookup (environmenttable, bsargs, &vargs, &hnode)) {
+
+						if (vargs.valuetype == externalvaluetype) {
+							hdlhashtable htargs;
+							hdlexternalvariable hv = (hdlexternalvariable) vargs.data.externalvalue;
+
+							if (hv != nil && langexternalvaltotable (vargs, &htargs, hnode)) {
+
+								tyvaluerecord vbrowser;
+								hdlhashnode hbnode;
+
+								if (hashtablelookup (htargs, bsbrowser, &vbrowser, &hbnode)) {
+									if (vbrowser.valuetype == stringvaluetype && vbrowser.data.stringvalue != nil) {
+										long len = gethandlesize (vbrowser.data.stringvalue);
+										if (len == 13 && memcmp (*vbrowser.data.stringvalue, "agent-browser", 13) == 0) {
+											use_agent_browser = true;
+										}
+										else if (len != 7 || memcmp (*vbrowser.data.stringvalue, "default", 7) != 0) {
+											/* Unknown browser value — reject for security */
+											unlockhandle (hurl);
+											disposehandle (hurl);
+											langerrormessage (BIGSTRING ("\x45" "Can't open URL: --browser must be \"default\" or \"agent-browser\"."));
+											return (false);
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+#endif
+
 #if defined(__APPLE__) || defined(__linux__)
 				/*
 				Double-fork to avoid zombie processes: first child forks again
@@ -873,11 +923,16 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 					pid_t pid2 = fork ();
 
 					if (pid2 == 0) { /* grandchild — runs the command */
+						if (use_agent_browser) {
+							execlp ("agent-browser", "agent-browser", url, NULL);
+						}
+						else {
 #ifdef __APPLE__
-						execlp ("open", "open", url, NULL);
+							execlp ("open", "open", url, NULL);
 #else
-						execlp ("xdg-open", "xdg-open", url, NULL);
+							execlp ("xdg-open", "xdg-open", url, NULL);
 #endif
+						}
 						_exit (1); /* execlp failed */
 					}
 

--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -836,6 +836,8 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 			 * Allowed values: "default" (system browser) or "agent-browser".
 			 * Note: Scripts can also set system.environment.args.browser directly;
 			 * this is intentional — scripts are trusted code within the ODB.
+			 * The browser check is guarded by FRONTIER_HEADLESS; GUI builds
+			 * always use the system default browser (no --browser flag).
 			 */
 
 			Handle hurl;

--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -834,6 +834,8 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 			 *
 			 * 3/23/26 JES: Respect --browser CLI arg via system.environment.args.browser.
 			 * Allowed values: "default" (system browser) or "agent-browser".
+			 * Note: Scripts can also set system.environment.args.browser directly;
+			 * this is intentional — scripts are trusted code within the ODB.
 			 */
 
 			Handle hurl;

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -315,8 +315,10 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                     /* --flag=value: key is everything before '=', value after */
                     size_t key_len = (size_t)(eq - flag_name);
                     key_buf = malloc(key_len + 1);
-                    if (key_buf == NULL)
+                    if (key_buf == NULL) {
+                        log_warn(LOG_COMP_GENERAL, "Memory allocation failed, skipping flag: %s", arg);
                         continue;
+                    }
                     memcpy(key_buf, flag_name, key_len);
                     key_buf[key_len] = '\0';
                     key_part = key_buf;
@@ -357,7 +359,11 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
             }
         }
         else {
-            /* Short flag or positional — pass through */
+            /* Short flag or positional — pass through.
+             * Note: first_positional_seen tracks whether we've passed the
+             * script file / .root positional to filtered_argv. Short flag
+             * values (e.g. the 'expr' in -e expr) are consumed by the
+             * short-flag branch above and won't trigger this flag. */
             if (arg[0] != '-' && !first_positional_seen) {
                 first_positional_seen = true;
                 filtered_argv[filtered_argc++] = argv[i];
@@ -409,14 +415,13 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
     while ((opt = getopt_long(filtered_argc, filtered_argv, "e:R:m:o:fbHJvDPW::ShV", long_options, &option_index)) != -1) {
         switch (opt) {
             case 'e':
-                // Inline script execution
                 if (options->inline_script != NULL) {
                     log_error(LOG_COMP_GENERAL, "Error: Multiple --execute options not allowed");
-                    return false;
+                    goto parse_error;
                 }
                 if (strlen(optarg) > CLI_MAX_SCRIPT_LENGTH) {
                     log_error(LOG_COMP_GENERAL, "Error: Inline script too long (max %d characters)", CLI_MAX_SCRIPT_LENGTH);
-                    return false;
+                    goto parse_error;
                 }
                 options->inline_script = strdup(optarg);
                 break;
@@ -424,80 +429,59 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
             case 'R':
                 if (options->system_root != NULL) {
                     log_error(LOG_COMP_GENERAL, "Error: Multiple --system-root options not allowed");
-                    return false;
+                    goto parse_error;
                 }
                 if (strlen(optarg) > CLI_MAX_PATH_LENGTH) {
                     log_error(LOG_COMP_GENERAL, "Error: System root path too long (max %d characters)", CLI_MAX_PATH_LENGTH);
-                    return false;
+                    goto parse_error;
                 }
                 options->system_root = strdup(optarg);
                 break;
 
             case 'm':
-                // Migrate database to v7 format
                 if (options->migrate_database != NULL) {
                     log_error(LOG_COMP_GENERAL, "Error: Multiple --migrate options not allowed");
-                    return false;
+                    goto parse_error;
                 }
                 if (strlen(optarg) > CLI_MAX_PATH_LENGTH) {
                     log_error(LOG_COMP_GENERAL, "Error: Migrate path too long (max %d characters)", CLI_MAX_PATH_LENGTH);
-                    return false;
+                    goto parse_error;
                 }
                 options->migrate_database = strdup(optarg);
                 break;
 
             case 'o':
-                // Output path for migration
                 if (options->output_path != NULL) {
                     log_error(LOG_COMP_GENERAL, "Error: Multiple --output options not allowed");
-                    return false;
+                    goto parse_error;
                 }
                 if (strlen(optarg) > CLI_MAX_PATH_LENGTH) {
                     log_error(LOG_COMP_GENERAL, "Error: Output path too long (max %d characters)", CLI_MAX_PATH_LENGTH);
-                    return false;
+                    goto parse_error;
                 }
                 options->output_path = strdup(optarg);
                 break;
 
-            case 'f':
-                // Force overwrite existing output file
-                options->force_overwrite = true;
-                break;
-
-            case 'b':
-                // Batch mode (no interactive prompts)
-                options->batch_mode = true;
-                break;
-
-            case 'H':
-                options->hydrate_system_root = true;
-                break;
-
-            case 'J':
-                // JSON output mode
-                options->output_json = true;
-                break;
-
-            case 'v':
-                // Verbose mode
-                options->verbose = true;
-                break;
-
-            case 'D':
-                // Debug mode
-                options->debug = true;
-                break;
+            case 'f':  options->force_overwrite = true; break;
+            case 'b':  options->batch_mode = true; break;
+            case 'H':  options->hydrate_system_root = true; break;
+            case 'J':  options->output_json = true; break;
+            case 'v':  options->verbose = true; break;
+            case 'D':  options->debug = true; break;
+            case 'S':  options->skip_startup = true; break;
+            case 'P':  options->protocol_mode = true; break;
+            case 'h':  options->show_help = true; break;
+            case 'V':  options->show_version = true; break;
 
             case 'L':
                 // Log spec (--log comp:level,...)
                 if (options->log_spec != NULL) {
-                    // Multiple --log args: concatenate with commas
                     size_t old_len = strlen(options->log_spec);
                     size_t new_len = strlen(optarg);
                     char *combined = malloc(old_len + 1 + new_len + 1);
                     if (combined == NULL) {
                         log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for --log");
-                        return false;
+                        goto parse_error;
                     }
                     memcpy(combined, options->log_spec, old_len);
                     combined[old_len] = ',';
@@ -508,29 +492,21 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                     options->log_spec = strdup(optarg);
                     if (options->log_spec == NULL) {
                         log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for --log");
-                        return false;
+                        goto parse_error;
                     }
                 }
                 break;
 
-            case 'S':
-                // Skip startup scripts
-                options->skip_startup = true;
-                break;
-
-            case 'P':
-                // NDJSON protocol mode (structured JSON over stdin/stdout)
-                options->protocol_mode = true;
-                break;
-
             case 'W':
-                // WebSocket server port (default: 5337, Frontier admin is on 5336)
+                /* --ws-port uses optional_argument: value must be inline (--ws-port=5337)
+                 * or omitted (uses default). Pass 1 intentionally does NOT consume a
+                 * separate next-arg for 'W' since optional_argument requires = syntax. */
                 if (optarg != NULL && optarg[0] != '\0') {
                     char *endptr;
                     long port = strtol(optarg, &endptr, 10);
                     if (*endptr != '\0' || port < 1 || port > 65535) {
                         log_error(LOG_COMP_GENERAL, "Error: Invalid WebSocket port: %s", optarg);
-                        return false;
+                        goto parse_error;
                     }
                     options->ws_port = (int)port;
                 } else {
@@ -538,20 +514,8 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 }
                 break;
 
-            case 'h':
-                // Help
-                options->show_help = true;
-                break;
-
-            case 'V':
-                // Version
-                options->show_version = true;
-                break;
-
             case '?':
-                // Should not happen — unknown flags were filtered in pass 1
-                free(filtered_argv);
-                return false;
+                goto parse_error;
 
             default:
                 break;
@@ -596,9 +560,13 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
     }
 
     free(filtered_argv);
-    
+
     // Validate the parsed options
     return cli_validate_options(options);
+
+parse_error:
+    free(filtered_argv);
+    return false;
 }
 
 /* Frees dynamically allocated strings in the options structure. */

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -97,16 +97,11 @@ static boolean cli_add_extra_arg(cli_options_t *options, const char *key, const 
     return true;
 }
 
-/* Returns true if flag is a known long option name (without --). */
-static boolean is_known_long_option(const char *name) {
-    static const char *known[] = {
-        "execute", "system-root", "migrate", "output", "force",
-        "batch", "non-interactive", "hydrate-system-root", "output-json",
-        "verbose", "debug", "log", "skip-startup", "protocol",
-        "ws-port", "help", "version", NULL
-    };
-    for (int i = 0; known[i] != NULL; i++) {
-        if (strcmp(name, known[i]) == 0)
+/* Returns true if flag is a known long option name (without --).
+ * Derives the known set from long_options[] to avoid duplication. */
+static boolean is_known_long_option(const char *name, const struct option *long_options) {
+    for (int k = 0; long_options[k].name != NULL; k++) {
+        if (strcmp(long_options[k].name, name) == 0)
             return true;
     }
     return false;
@@ -275,7 +270,7 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
             /* Long flag: check if known */
             const char *flag_name = arg + 2;
 
-            if (is_known_long_option(flag_name)) {
+            if (is_known_long_option(flag_name, long_options)) {
                 /* Known flag — pass through to getopt */
                 filtered_argv[filtered_argc++] = argv[i];
 
@@ -296,14 +291,29 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 if (camel == NULL)
                     continue;
 
-                /* Next arg is the value if it doesn't start with '-' */
+                /* Reject keys longer than 255 chars (bigstring limit) */
+                if (strlen(camel) > 255) {
+                    log_error(LOG_COMP_GENERAL, "Warning: Custom flag name too long, skipping: --%s", flag_name);
+                    free(camel);
+                    continue;
+                }
+
+                /* Next arg is the value if it doesn't start with '-'.
+                 * Note: this means --threshold -5 treats -5 as a flag,
+                 * not a negative number value. This is a known limitation;
+                 * use --threshold=-5 or pass negative values via other means. */
                 const char *value = NULL;
                 if (i + 1 < argc && argv[i + 1][0] != '-') {
                     value = argv[i + 1];
                     i++; /* consume the value */
                 }
 
-                cli_add_extra_arg(options, camel, value);
+                if (!cli_add_extra_arg(options, camel, value)) {
+                    log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for custom flag: --%s", flag_name);
+                    free(camel);
+                    free(filtered_argv);
+                    return false;
+                }
                 free(camel);
             }
         }
@@ -321,11 +331,20 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 /* Extra positional arg */
                 int n = options->positional_count;
                 char **new_arr = realloc(options->positional_args, (size_t)(n + 1) * sizeof(char *));
-                if (new_arr != NULL) {
-                    new_arr[n] = strdup(arg);
-                    options->positional_args = new_arr;
-                    options->positional_count = n + 1;
+                if (new_arr == NULL) {
+                    log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for positional arg");
+                    free(filtered_argv);
+                    return false;
                 }
+                new_arr[n] = strdup(arg);
+                if (new_arr[n] == NULL) {
+                    log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for positional arg");
+                    options->positional_args = new_arr;
+                    free(filtered_argv);
+                    return false;
+                }
+                options->positional_args = new_arr;
+                options->positional_count = n + 1;
             }
         }
     }
@@ -506,6 +525,11 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 return false;
             }
             options->system_root = strdup(arg);
+            if (options->system_root == NULL) {
+                log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed");
+                free(filtered_argv);
+                return false;
+            }
         } else {
             if (options->script_file != NULL) {
                 log_error(LOG_COMP_GENERAL, "Error: Multiple script files not allowed");
@@ -513,6 +537,11 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 return false;
             }
             options->script_file = strdup(arg);
+            if (options->script_file == NULL) {
+                log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed");
+                free(filtered_argv);
+                return false;
+            }
         }
     }
 

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -273,7 +273,10 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
             const char *flag_name = arg + 2;
 
             /* For known-flag check, strip =value if present
-             * (getopt_long handles --flag=value natively for known flags) */
+             * (getopt_long handles --flag=value natively for known flags).
+             * If the flag name exceeds 255 chars, known_check_name keeps the
+             * full flag=value string, which won't match any known option —
+             * so it falls through to the unknown-flag branch correctly. */
             const char *known_eq = strchr(flag_name, '=');
             char known_name_buf[256];
             const char *known_check_name = flag_name;

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -377,8 +377,12 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 
                 /* Consume required argument for known short flags (separate arg only).
                  * Only when flag is exactly "-X" (not "-Xvalue" inline form).
-                 * Derived from optstring "e:R:m:o:fbHJvDPW::ShV" — colon = required.
-                 * Must stay in sync with the optstring above. */
+                 *
+                 * SYNC WARNING: This list must match the required_argument short flags
+                 * from optstring "e:R:m:o:fbHJvDPW::ShV". A colon after a letter
+                 * means required_argument. W:: is optional_argument — intentionally
+                 * excluded because optional args must use --ws-port=VALUE syntax
+                 * (getopt does not consume a separate next-arg for optional). */
                 static const char short_with_arg[] = "eRmo";
                 char flag_char = arg[1];
                 if (arg[2] == '\0' && strchr(short_with_arg, flag_char) != NULL && i + 1 < argc) {

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -212,7 +212,9 @@ boolean cli_validate_options(const cli_options_t* options) {
     return true;
 }
 
-/* Parses command-line arguments and populates the options structure. */
+/* Parses command-line arguments and populates the options structure.
+ * On failure, the caller must still call cli_free_options() to release
+ * any partially-allocated fields (extra_args, positional_args, etc.). */
 boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
     int opt;
     int option_index = 0;
@@ -322,13 +324,15 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 }
 
                 char *camel = kebab_to_camel(key_part);
-                free(key_buf); /* safe if NULL */
+                free(key_buf); /* safe if NULL; key_part is now dangling if eq != NULL */
+                key_part = NULL; /* prevent accidental use-after-free */
+                key_buf = NULL;
                 if (camel == NULL)
                     continue;
 
                 /* Reject keys longer than 255 chars (bigstring limit) */
                 if (strlen(camel) > 255) {
-                    log_warn(LOG_COMP_GENERAL, "Custom flag name too long, skipping: --%s", key_part);
+                    log_warn(LOG_COMP_GENERAL, "Custom flag name too long, skipping: %s", camel);
                     free(camel);
                     continue;
                 }
@@ -344,7 +348,7 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 }
 
                 if (!cli_add_extra_arg(options, camel, value)) {
-                    log_error(LOG_COMP_GENERAL, "Memory allocation failed for custom flag: --%s", key_part);
+                    log_error(LOG_COMP_GENERAL, "Memory allocation failed for custom flag: %s", camel);
                     free(camel);
                     free(filtered_argv);
                     return false;
@@ -362,12 +366,13 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 /* Short flag — pass through */
                 filtered_argv[filtered_argc++] = argv[i];
 
-                /* Consume required argument for known short flags.
-                 * Short options with required_argument: e, R, m, o, L
-                 * (from optstring "e:R:m:o:fbHJvDPW::ShV" — colon = required) */
-                static const char short_with_arg[] = "eRmoL";
+                /* Consume required argument for known short flags (separate arg only).
+                 * Only when flag is exactly "-X" (not "-Xvalue" inline form).
+                 * Derived from optstring "e:R:m:o:fbHJvDPW::ShV" — colon = required.
+                 * Must stay in sync with the optstring above. */
+                static const char short_with_arg[] = "eRmo";
                 char flag_char = arg[1];
-                if (strchr(short_with_arg, flag_char) != NULL && i + 1 < argc) {
+                if (arg[2] == '\0' && strchr(short_with_arg, flag_char) != NULL && i + 1 < argc) {
                     i++;
                     filtered_argv[filtered_argc++] = argv[i];
                 }

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -22,6 +22,96 @@
 #include "cli_utils.h"
 #include "../Common/headers/logging.h"
 
+/*
+ * Convert a kebab-case flag name to camelCase.
+ * Strips leading dashes, then splits on '-' and capitalizes each word after the first.
+ * Caller must free the returned string.
+ */
+static char *kebab_to_camel(const char *flag) {
+    const char *p = flag;
+
+    /* Strip leading dashes */
+    while (*p == '-')
+        p++;
+
+    size_t len = strlen(p);
+    char *result = malloc(len + 1);
+    if (result == NULL)
+        return NULL;
+
+    size_t j = 0;
+    boolean capitalize_next = false;
+
+    for (size_t i = 0; i < len; i++) {
+        if (p[i] == '-') {
+            capitalize_next = true;
+        } else {
+            if (capitalize_next && p[i] >= 'a' && p[i] <= 'z') {
+                result[j++] = (char)(p[i] - 'a' + 'A');
+            } else {
+                result[j++] = p[i];
+            }
+            capitalize_next = false;
+        }
+    }
+
+    result[j] = '\0';
+    return result;
+}
+
+/*
+ * Append an extra argument to the linked list.
+ * key is the camelCase name, value is the string value (or NULL for boolean).
+ * Both are strdup'd internally.
+ */
+static boolean cli_add_extra_arg(cli_options_t *options, const char *key, const char *value) {
+    cli_extra_arg_t *node = calloc(1, sizeof(cli_extra_arg_t));
+    if (node == NULL)
+        return false;
+
+    node->key = strdup(key);
+    if (node->key == NULL) {
+        free(node);
+        return false;
+    }
+
+    if (value != NULL) {
+        node->value = strdup(value);
+        if (node->value == NULL) {
+            free(node->key);
+            free(node);
+            return false;
+        }
+    }
+
+    /* Append to end of list to preserve command-line order */
+    if (options->extra_args == NULL) {
+        options->extra_args = node;
+    } else {
+        cli_extra_arg_t *tail = options->extra_args;
+        while (tail->next != NULL)
+            tail = tail->next;
+        tail->next = node;
+    }
+
+    return true;
+}
+
+/* Returns true if flag is a known long option name (without --). */
+static boolean is_known_long_option(const char *name) {
+    static const char *known[] = {
+        "execute", "system-root", "migrate", "output", "force",
+        "batch", "non-interactive", "hydrate-system-root", "output-json",
+        "verbose", "debug", "log", "skip-startup", "protocol",
+        "ws-port", "help", "version", NULL
+    };
+    for (int i = 0; known[i] != NULL; i++) {
+        if (strcmp(name, known[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
 /* Checks if a path ends with .root or .root7 (case-insensitive). */
 static boolean cli_is_root_file(const char* path) {
     if (path == NULL) {
@@ -131,10 +221,10 @@ boolean cli_validate_options(const cli_options_t* options) {
 boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
     int opt;
     int option_index = 0;
-    
+
     // Initialize options with defaults
     cli_init_options(options);
-    
+
     // Define long options
     static struct option long_options[] = {
         {"execute", required_argument, 0, 'e'},
@@ -157,8 +247,97 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
         {0, 0, 0, 0}
     };
 
-    // Parse command line arguments
-    while ((opt = getopt_long(argc, argv, "e:R:m:o:fbHJvDPW::ShV", long_options, &option_index)) != -1) {
+    /*
+     * Two-pass parsing:
+     *   Pass 1 — Extract unknown --flags (and their values) from argv,
+     *            building a filtered argv for getopt_long.
+     *   Pass 2 — Run getopt_long on the filtered argv (known flags only).
+     *
+     * This avoids getopt_long's inability to skip unknown long options
+     * that take values (it would misinterpret the value as a positional).
+     */
+
+    /* Pass 1: Build filtered argv, extract unknown --flags into extra_args */
+
+    char **filtered_argv = malloc((size_t)(argc + 1) * sizeof(char *));
+    if (filtered_argv == NULL)
+        return false;
+
+    int filtered_argc = 0;
+    boolean first_positional_seen = false;
+
+    filtered_argv[filtered_argc++] = argv[0]; /* program name */
+
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+
+        if (arg[0] == '-' && arg[1] == '-' && arg[2] != '\0') {
+            /* Long flag: check if known */
+            const char *flag_name = arg + 2;
+
+            if (is_known_long_option(flag_name)) {
+                /* Known flag — pass through to getopt */
+                filtered_argv[filtered_argc++] = argv[i];
+
+                /* If it takes an argument, pass that through too */
+                for (int k = 0; long_options[k].name != NULL; k++) {
+                    if (strcmp(long_options[k].name, flag_name) == 0) {
+                        if (long_options[k].has_arg == required_argument && i + 1 < argc) {
+                            i++;
+                            filtered_argv[filtered_argc++] = argv[i];
+                        }
+                        break;
+                    }
+                }
+            }
+            else {
+                /* Unknown flag — extract into extra_args */
+                char *camel = kebab_to_camel(flag_name);
+                if (camel == NULL)
+                    continue;
+
+                /* Next arg is the value if it doesn't start with '-' */
+                const char *value = NULL;
+                if (i + 1 < argc && argv[i + 1][0] != '-') {
+                    value = argv[i + 1];
+                    i++; /* consume the value */
+                }
+
+                cli_add_extra_arg(options, camel, value);
+                free(camel);
+            }
+        }
+        else {
+            /* Short flag or positional — pass through */
+            if (arg[0] != '-' && !first_positional_seen) {
+                first_positional_seen = true;
+                filtered_argv[filtered_argc++] = argv[i];
+            }
+            else if (arg[0] == '-') {
+                /* Short flag — pass through, including its value if applicable */
+                filtered_argv[filtered_argc++] = argv[i];
+            }
+            else {
+                /* Extra positional arg */
+                int n = options->positional_count;
+                char **new_arr = realloc(options->positional_args, (size_t)(n + 1) * sizeof(char *));
+                if (new_arr != NULL) {
+                    new_arr[n] = strdup(arg);
+                    options->positional_args = new_arr;
+                    options->positional_count = n + 1;
+                }
+            }
+        }
+    }
+
+    filtered_argv[filtered_argc] = NULL;
+
+    /* Pass 2: Run getopt_long on filtered argv (known flags only) */
+
+    optind = 1; /* reset getopt state */
+    opterr = 1; /* re-enable error messages for truly bad syntax */
+
+    while ((opt = getopt_long(filtered_argc, filtered_argv, "e:R:m:o:fbHJvDPW::ShV", long_options, &option_index)) != -1) {
         switch (opt) {
             case 'e':
                 // Inline script execution
@@ -301,60 +480,43 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 break;
 
             case '?':
-                // Unknown option
+                // Should not happen — unknown flags were filtered in pass 1
+                free(filtered_argv);
                 return false;
 
             default:
-                log_error(LOG_COMP_GENERAL, "Error: Unknown option");
-                return false;
+                break;
         }
     }
 
-    // Handle non-option arguments (script files or database roots)
-    if (optind < argc) {
-        const char* arg = argv[optind];
+    // Handle the first non-option argument from filtered argv
+    if (optind < filtered_argc) {
+        const char* arg = filtered_argv[optind];
 
         if (strlen(arg) > CLI_MAX_PATH_LENGTH) {
             log_error(LOG_COMP_GENERAL, "Error: Path too long (max %d characters)", CLI_MAX_PATH_LENGTH);
+            free(filtered_argv);
             return false;
         }
 
-        // Detect if this is a .root or .root7 file
         if (cli_is_root_file(arg)) {
-            // Positional argument is a database root
             if (options->system_root != NULL) {
                 log_error(LOG_COMP_GENERAL, "Error: System root already specified via --system-root");
+                free(filtered_argv);
                 return false;
             }
             options->system_root = strdup(arg);
-            if (options->system_root == NULL) {
-                log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed");
-                return false;
-            }
         } else {
-            // Positional argument is a script file
             if (options->script_file != NULL) {
                 log_error(LOG_COMP_GENERAL, "Error: Multiple script files not allowed");
+                free(filtered_argv);
                 return false;
             }
             options->script_file = strdup(arg);
-            if (options->script_file == NULL) {
-                log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed");
-                return false;
-            }
-        }
-
-        // Check for additional arguments
-        if (optind + 1 < argc) {
-            const char* next_arg = argv[optind + 1];
-            if (cli_is_root_file(next_arg)) {
-                log_error(LOG_COMP_GENERAL, "Error: Multiple .root files not allowed");
-            } else {
-                log_error(LOG_COMP_GENERAL, "Error: Unexpected argument '%s'", next_arg);
-            }
-            return false;
         }
     }
+
+    free(filtered_argv);
     
     // Validate the parsed options
     return cli_validate_options(options);
@@ -396,6 +558,27 @@ void cli_free_options(cli_options_t* options) {
         free(options->log_spec);
         options->log_spec = NULL;
     }
+
+    /* Free extra args linked list */
+    {
+        cli_extra_arg_t *node = options->extra_args;
+        while (node != NULL) {
+            cli_extra_arg_t *next = node->next;
+            free(node->key);
+            free(node->value);
+            free(node);
+            node = next;
+        }
+        options->extra_args = NULL;
+    }
+
+    /* Free positional args array */
+    for (int i = 0; i < options->positional_count; i++) {
+        free(options->positional_args[i]);
+    }
+    free(options->positional_args);
+    options->positional_args = NULL;
+    options->positional_count = 0;
 }
 
 /* Prints parsed options for debugging purposes. */

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -270,46 +270,81 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
             /* Long flag: check if known */
             const char *flag_name = arg + 2;
 
-            if (is_known_long_option(flag_name, long_options)) {
-                /* Known flag — pass through to getopt */
+            /* For known-flag check, strip =value if present
+             * (getopt_long handles --flag=value natively for known flags) */
+            const char *known_eq = strchr(flag_name, '=');
+            char known_name_buf[256];
+            const char *known_check_name = flag_name;
+            if (known_eq != NULL) {
+                size_t klen = (size_t)(known_eq - flag_name);
+                if (klen < sizeof(known_name_buf)) {
+                    memcpy(known_name_buf, flag_name, klen);
+                    known_name_buf[klen] = '\0';
+                    known_check_name = known_name_buf;
+                }
+            }
+
+            if (is_known_long_option(known_check_name, long_options)) {
+                /* Known flag — pass through to getopt (handles =value internally) */
                 filtered_argv[filtered_argc++] = argv[i];
 
-                /* If it takes an argument, pass that through too */
-                for (int k = 0; long_options[k].name != NULL; k++) {
-                    if (strcmp(long_options[k].name, flag_name) == 0) {
-                        if (long_options[k].has_arg == required_argument && i + 1 < argc) {
-                            i++;
-                            filtered_argv[filtered_argc++] = argv[i];
+                /* If it takes a separate argument (no = present), pass that through too */
+                if (known_eq == NULL) {
+                    for (int k = 0; long_options[k].name != NULL; k++) {
+                        if (strcmp(long_options[k].name, known_check_name) == 0) {
+                            if (long_options[k].has_arg == required_argument && i + 1 < argc) {
+                                i++;
+                                filtered_argv[filtered_argc++] = argv[i];
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
             }
             else {
-                /* Unknown flag — extract into extra_args */
-                char *camel = kebab_to_camel(flag_name);
+                /* Unknown flag — extract into extra_args.
+                 * Handle --flag=value syntax: split on first '=' if present. */
+                const char *eq = strchr(flag_name, '=');
+                const char *key_part = flag_name;
+                const char *inline_value = NULL;
+                char *key_buf = NULL;
+
+                if (eq != NULL) {
+                    /* --flag=value: key is everything before '=', value after */
+                    size_t key_len = (size_t)(eq - flag_name);
+                    key_buf = malloc(key_len + 1);
+                    if (key_buf == NULL)
+                        continue;
+                    memcpy(key_buf, flag_name, key_len);
+                    key_buf[key_len] = '\0';
+                    key_part = key_buf;
+                    inline_value = eq + 1;
+                }
+
+                char *camel = kebab_to_camel(key_part);
+                free(key_buf); /* safe if NULL */
                 if (camel == NULL)
                     continue;
 
                 /* Reject keys longer than 255 chars (bigstring limit) */
                 if (strlen(camel) > 255) {
-                    log_error(LOG_COMP_GENERAL, "Warning: Custom flag name too long, skipping: --%s", flag_name);
+                    log_warn(LOG_COMP_GENERAL, "Custom flag name too long, skipping: --%s", key_part);
                     free(camel);
                     continue;
                 }
 
-                /* Next arg is the value if it doesn't start with '-'.
-                 * Note: this means --threshold -5 treats -5 as a flag,
-                 * not a negative number value. This is a known limitation;
-                 * use --threshold=-5 or pass negative values via other means. */
-                const char *value = NULL;
-                if (i + 1 < argc && argv[i + 1][0] != '-') {
+                /* Determine the value: inline (--flag=val) takes priority,
+                 * otherwise next arg if it doesn't start with '-'.
+                 * Note: --threshold -5 treats -5 as a flag, not a negative
+                 * number value. This is a known limitation. */
+                const char *value = inline_value;
+                if (value == NULL && i + 1 < argc && argv[i + 1][0] != '-') {
                     value = argv[i + 1];
                     i++; /* consume the value */
                 }
 
                 if (!cli_add_extra_arg(options, camel, value)) {
-                    log_error(LOG_COMP_GENERAL, "Error: Memory allocation failed for custom flag: --%s", flag_name);
+                    log_error(LOG_COMP_GENERAL, "Memory allocation failed for custom flag: --%s", key_part);
                     free(camel);
                     free(filtered_argv);
                     return false;
@@ -323,9 +358,19 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
                 first_positional_seen = true;
                 filtered_argv[filtered_argc++] = argv[i];
             }
-            else if (arg[0] == '-') {
-                /* Short flag — pass through, including its value if applicable */
+            else if (arg[0] == '-' && arg[1] != '\0') {
+                /* Short flag — pass through */
                 filtered_argv[filtered_argc++] = argv[i];
+
+                /* Consume required argument for known short flags.
+                 * Short options with required_argument: e, R, m, o, L
+                 * (from optstring "e:R:m:o:fbHJvDPW::ShV" — colon = required) */
+                static const char short_with_arg[] = "eRmoL";
+                char flag_char = arg[1];
+                if (strchr(short_with_arg, flag_char) != NULL && i + 1 < argc) {
+                    i++;
+                    filtered_argv[filtered_argc++] = argv[i];
+                }
             }
             else {
                 /* Extra positional arg */

--- a/frontier-cli/cli_parser.h
+++ b/frontier-cli/cli_parser.h
@@ -20,6 +20,13 @@
 typedef unsigned char boolean;
 #endif
 
+// Extra (unknown) CLI argument — linked list node
+typedef struct cli_extra_arg {
+    char *key;                      // camelCase key (stripped of -- prefix)
+    char *value;                    // value string, or NULL for boolean flags
+    struct cli_extra_arg *next;
+} cli_extra_arg_t;
+
 // CLI options structure
 typedef struct {
     char* script_file;          // Script file path
@@ -39,6 +46,9 @@ typedef struct {
     int ws_port;                // WebSocket server port (--ws-port), 0 = disabled
     boolean show_help;          // Show help flag
     boolean show_version;       // Show version flag
+    cli_extra_arg_t *extra_args;    // Linked list of unknown --flags
+    int positional_count;           // Number of extra positional args
+    char **positional_args;         // Array of extra positional args (after script/root)
 } cli_options_t;
 
 // Argument parsing functions

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -118,13 +118,7 @@ boolean cli_should_skip_startup(void) {
     return g_cli_options.skip_startup;
 }
 
-/*
- * system.environment.args key names (camelCase from CLI flags).
- *
- * Note: script_file (positional arg) is intentionally not exposed here.
- * It is not a named flag; scripts that need their own path can use
- * frontier.getProgramPath() or receive it as a parameter.
- */
+/* system.environment.args key names (camelCase from CLI flags). */
 #define str_systemRoot      BIGSTRING ("\x0a" "systemRoot")
 #define str_skipStartup     BIGSTRING ("\x0b" "skipStartup")
 #define str_execute         BIGSTRING ("\x07" "execute")
@@ -246,6 +240,55 @@ static boolean populate_environment_args (hdlhashtable htargs) {
 
     if (opts->ws_port > 0) {
         if (!langassignlongvalue (htargs, str_wsPort, (long) opts->ws_port))
+            return (false);
+    }
+
+    /* Extra (unknown) flags — these come from the second-pass parser */
+
+    {
+        const cli_extra_arg_t *node = opts->extra_args;
+
+        while (node != NULL) {
+
+            bigstring bskey;
+
+            copyctopstring (node->key, bskey);
+
+            if (node->value != NULL) {
+                if (!assign_cstring_value (htargs, bskey, node->value))
+                    return (false);
+            }
+            else {
+                if (!langassignbooleanvalue (htargs, bskey, true))
+                    return (false);
+            }
+
+            node = node->next;
+        }
+    }
+
+    /* Positional arguments — stored as _1, _2, etc. (1-based index) */
+
+    for (int i = 0; i < opts->positional_count; i++) {
+
+        bigstring bskey;
+        char ckey[16];
+
+        snprintf (ckey, sizeof (ckey), "_%d", i + 1);
+        copyctopstring (ckey, bskey);
+
+        if (!assign_cstring_value (htargs, bskey, opts->positional_args[i]))
+            return (false);
+    }
+
+    /* script_file — exposed as "scriptFile" when present */
+
+    if (opts->script_file != NULL) {
+
+        bigstring bskey;
+        copyctopstring ("scriptFile", bskey);
+
+        if (!assign_cstring_value (htargs, bskey, opts->script_file))
             return (false);
     }
 
@@ -739,6 +782,18 @@ static void print_usage(const char* program_name) {
     printf("                           can access the ODB while the server is running.\n");
     printf("  -h, --help               Show this help message\n");
     printf("  --version                Show version information\n");
+    printf("\n");
+
+    printf("Custom Arguments:\n");
+    printf("  --KEY VALUE              Any unknown flag is passed to UserTalk scripts\n");
+    printf("  --KEY                    Boolean flag (no value) is set to true\n");
+    printf("                           Access in UserTalk via system.environment.args.KEY\n");
+    printf("                           Flag names are converted to camelCase:\n");
+    printf("                             --my-flag value  ->  system.environment.args.myFlag\n");
+    printf("\n");
+    printf("  Built-in custom flags:\n");
+    printf("  --browser MODE           Set browser for sys.openUrl (default: system default)\n");
+    printf("                           MODE: \"default\" or \"agent-browser\"\n");
     printf("\n");
 
     printf("Environment Variables:\n");

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -351,6 +351,7 @@ int main(int argc, char* argv[]) {
     if (!cli_parse_arguments(argc, argv, &g_cli_options)) {
         log_error(LOG_COMP_GENERAL, "Error: Invalid command line arguments");
         print_usage(argv[0]);
+        cli_free_options(&g_cli_options); /* honor parse-failure cleanup contract */
         return 1;
     }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -528,8 +528,13 @@ test-migrate-flag:
 	@echo "Running CLI migration flag tests..."
 	@./test_migrate_flag.sh
 
-# Run all tests (unit + integration + CLI migration)
-test-all: test test-integration test-migrate-flag
+# Run custom CLI args tests (shell-based, uses -e mode)
+test-custom-args:
+	@echo "Running custom CLI args tests..."
+	@./custom_cli_args_test.sh
+
+# Run all tests (unit + integration + CLI migration + custom args)
+test-all: test test-integration test-migrate-flag test-custom-args
 	@echo "All test suites completed"
 
 $(STRINGS_COMPILER):
@@ -632,7 +637,7 @@ verify-errors:
 	@echo "Verifying error message coverage..."
 	@../tools/verify_error_coverage.sh
 
-.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-all clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
+.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-custom-args test-all clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
 
 check_v6_tables: check_v6_tables.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -DHEADLESS_TEST_PORTABLE_FILE -DHEADLESS_LINKS_REAL_DB -I../Common/headers -I../Common/SystemHeaders -I../portable check_v6_tables.c \

--- a/tests/custom_cli_args_test.sh
+++ b/tests/custom_cli_args_test.sh
@@ -96,6 +96,26 @@ run_test "systemRoot with unknown flag" "true" \
     -e 'system.environment.args.systemRoot contains "Frontier.root"'
 
 echo
+echo "--- Inline --flag=value syntax ---"
+run_test "inline equals syntax with value" "hello" \
+    --skip-startup --system-root "$DB" --my-flag=hello \
+    -e 'system.environment.args.myFlag'
+
+run_test "inline equals syntax with kebab-case" "world" \
+    --skip-startup --system-root "$DB" --my-long-flag=world \
+    -e 'system.environment.args.myLongFlag'
+
+run_test "inline browser=agent-browser" "agent-browser" \
+    --skip-startup --system-root "$DB" --browser=agent-browser \
+    -e 'system.environment.args.browser'
+
+echo
+echo "--- Duplicate unknown flags (last wins) ---"
+run_test "duplicate flag last value wins" "second" \
+    --skip-startup --system-root "$DB" --foo first --foo second \
+    -e 'system.environment.args.foo'
+
+echo
 echo "--- Absent unknown flags ---"
 run_test "undefined unknown flag" "false" \
     --skip-startup --system-root "$DB" \

--- a/tests/custom_cli_args_test.sh
+++ b/tests/custom_cli_args_test.sh
@@ -32,7 +32,8 @@ run_test() {
     local expected="$2"
     shift 2
     local actual
-    actual=$("$CLI" "$@" 2>/dev/null) || true
+    local exit_code=0
+    actual=$("$CLI" "$@" 2>/dev/null) || exit_code=$?
 
     if [ "$actual" = "$expected" ]; then
         echo -e "  ${GREEN}✓ PASS${NC}: $name"
@@ -41,6 +42,9 @@ run_test() {
         echo -e "  ${RED}✗ FAIL${NC}: $name"
         echo "    Expected: '$expected'"
         echo "    Got:      '$actual'"
+        if [ "$exit_code" -ne 0 ]; then
+            echo "    CLI exit code: $exit_code"
+        fi
         FAILED=$((FAILED + 1))
     fi
 }

--- a/tests/custom_cli_args_test.sh
+++ b/tests/custom_cli_args_test.sh
@@ -6,12 +6,19 @@
 # These tests use -e mode (not --protocol) because the protocol runner
 # cannot pass arbitrary unknown flags to the frontier-cli subprocess.
 
-set -e
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
 DB="$PROJECT_ROOT/databases/Frontier.root"
+
+if [ ! -x "$CLI" ]; then
+    echo "Error: frontier-cli not found at $CLI" >&2
+    exit 1
+fi
+if [ ! -f "$DB" ]; then
+    echo "Error: database not found at $DB" >&2
+    exit 1
+fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/custom_cli_args_test.sh
+++ b/tests/custom_cli_args_test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Integration tests for arbitrary CLI arguments in system.environment.args
+# Tests the two-pass parser and custom arg handling.
+#
+# These tests use -e mode (not --protocol) because the protocol runner
+# cannot pass arbitrary unknown flags to the frontier-cli subprocess.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+DB="$PROJECT_ROOT/databases/Frontier.root"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+run_test() {
+    local name="$1"
+    local expected="$2"
+    shift 2
+    local actual
+    actual=$("$CLI" "$@" 2>/dev/null) || true
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓ PASS${NC}: $name"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "  ${RED}✗ FAIL${NC}: $name"
+        echo "    Expected: '$expected'"
+        echo "    Got:      '$actual'"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+echo "=============================================="
+echo "Custom CLI Arguments Tests"
+echo "=============================================="
+echo
+
+echo "--- Unknown flag with value ---"
+run_test "browser flag with value" "agent-browser" \
+    --skip-startup --system-root "$DB" --browser agent-browser \
+    -e 'system.environment.args.browser'
+
+run_test "custom flag with value" "hello-world" \
+    --skip-startup --system-root "$DB" --my-flag hello-world \
+    -e 'system.environment.args.myFlag'
+
+echo
+echo "--- Unknown boolean flag ---"
+run_test "boolean flag (no value)" "true" \
+    --skip-startup --system-root "$DB" --my-flag \
+    -e 'system.environment.args.myFlag'
+
+echo
+echo "--- kebab-case to camelCase conversion ---"
+run_test "single-hyphen flag" "true" \
+    --skip-startup --system-root "$DB" --my-custom-flag \
+    -e 'system.environment.args.myCustomFlag'
+
+run_test "multi-hyphen flag with value" "test-value" \
+    --skip-startup --system-root "$DB" --my-long-flag-name test-value \
+    -e 'system.environment.args.myLongFlagName'
+
+echo
+echo "--- Multiple unknown flags ---"
+run_test "first of multiple flags" "bar" \
+    --skip-startup --system-root "$DB" --foo bar --baz \
+    -e 'system.environment.args.foo'
+
+run_test "second of multiple flags (boolean)" "true" \
+    --skip-startup --system-root "$DB" --foo bar --baz \
+    -e 'system.environment.args.baz'
+
+echo
+echo "--- Known flags still work alongside unknowns ---"
+run_test "skipStartup with unknown flag" "true" \
+    --skip-startup --system-root "$DB" --my-extra extra \
+    -e 'system.environment.args.skipStartup'
+
+run_test "systemRoot with unknown flag" "true" \
+    --skip-startup --system-root "$DB" --my-extra extra \
+    -e 'system.environment.args.systemRoot contains "Frontier.root"'
+
+echo
+echo "--- Absent unknown flags ---"
+run_test "undefined unknown flag" "false" \
+    --skip-startup --system-root "$DB" \
+    -e 'defined(system.environment.args.myFlag)'
+
+echo
+echo "--- Browser flag validation (via openUrl error) ---"
+run_test "invalid browser value rejected" "true" \
+    --skip-startup --system-root "$DB" --browser invalid-browser \
+    -e 'try {sys.openUrl("http://example.com"); return false} else {return true}'
+
+run_test "default browser accepted (no error)" "true" \
+    --skip-startup --system-root "$DB" --browser default \
+    -e 'typeof(system.environment.args.browser) == stringType'
+
+echo
+echo "=============================================="
+echo "RESULTS: $PASSED passed, $FAILED failed"
+echo "=============================================="
+
+exit $FAILED

--- a/tests/integration/test_cases/sys_environment_args.yaml
+++ b/tests/integration/test_cases/sys_environment_args.yaml
@@ -9,6 +9,8 @@
 # --system-root, so only those flags (plus absence checks) can be tested
 # here. The following keys are only exercisable via manual smoke tests:
 #   batch, force, output, log, migrate, hydrate, outputJson, wsPort (as present)
+# Custom/unknown args (--browser, --my-flag, etc.) are tested separately
+# in test_custom_cli_args.sh since the protocol runner can't pass them.
 # Manual: frontier-cli --verbose --system-root databases/Frontier.root -e 'system.environment.args.verbose'
 
 tests:

--- a/tests/integration/test_cases/sys_environment_args.yaml
+++ b/tests/integration/test_cases/sys_environment_args.yaml
@@ -10,7 +10,7 @@
 # here. The following keys are only exercisable via manual smoke tests:
 #   batch, force, output, log, migrate, hydrate, outputJson, wsPort (as present)
 # Custom/unknown args (--browser, --my-flag, etc.) are tested separately
-# in test_custom_cli_args.sh since the protocol runner can't pass them.
+# in custom_cli_args_test.sh since the protocol runner can't pass them.
 # Manual: frontier-cli --verbose --system-root databases/Frontier.root -e 'system.environment.args.verbose'
 
 tests:


### PR DESCRIPTION
## Summary

- **Arbitrary CLI args**: Any unknown `--flag` is now accepted and exposed in `system.environment.args` as a camelCase key. `--my-flag value` → `system.environment.args.myFlag` = `"value"`. `--my-flag` alone → `true`.
- **Positional args**: Extra positional args (beyond script/root) stored as `_1`, `_2`, etc. `scriptFile` key added when a script file is specified.
- **Two-pass parser**: Pre-scan extracts unknown flags before `getopt_long` runs, avoiding getopt's inability to handle unknown long options with values.
- **`--browser` for sys.openUrl**: `--browser default` uses system browser, `--browser agent-browser` uses the `agent-browser` command. Any other value is rejected with a security error.

## Architecture

The parser now works in two passes:
1. **Pass 1**: Scan argv, extract unknown `--flags` (and their values) into `extra_args` linked list, build filtered argv containing only known flags
2. **Pass 2**: Run `getopt_long` on the filtered argv (known flags only)

The `populate_environment_args` callback iterates the `extra_args` list and positional args array, assigning them into the `system.environment.args` subtable alongside the known flags.

`sys.openUrl` looks up `system.environment.args.browser` at runtime via the `environmenttable` global → `args` subtable → `browser` key.

## Test plan

- [x] 302/302 unit tests pass
- [x] 11/11 existing environment args integration tests pass
- [x] 12/12 new custom CLI args shell tests pass (`tests/custom_cli_args_test.sh`)
- [x] No new integration test failures (66 pre-existing)
- [x] Manual smoke tests: `--browser agent-browser`, `--browser default`, kebab-case conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)