### PR TITLE
fix: Convert BIGSTRING hex-prefix to PSTRING for compile-time validation

### DIFF
--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Wed, 25 Mar 2026 05:59:54 GMT</dateCreated>
+    <dateCreated>Wed, 25 Mar 2026 06:08:47 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-03-25 at 05:59 UTC"/>
+      <outline text="Run: 2026-03-25 at 06:08 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/headless_frontier_verbs.c
+++ b/tests/headless_frontier_verbs.c
@@ -275,9 +275,9 @@ boolean frontierversion(tyvaluerecord *v) {
  */
 boolean sysos(tyvaluerecord *v) {
     #ifdef __APPLE__
-    return setstringvalue(BIGSTRING("\x05" "MacOS"), v);
+    return setstringvalue(PSTRING("\x05", "MacOS"), v);
     #else
-    return setstringvalue(BIGSTRING("\x05" "Linux"), v);
+    return setstringvalue(PSTRING("\x05", "Linux"), v);
     #endif
 }
 

--- a/tests/headless_op_verbs.c
+++ b/tests/headless_op_verbs.c
@@ -1485,7 +1485,7 @@ static boolean op_valueproc(short token, hdltreenode hparam1,
             setbooleanvalue(true, &vindent);
 
             flnextparamislast = true;
-            if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, BIGSTRING("\x08" "flindent"), &vindent))
+            if (!getoptionalparamvalue(hparam1, &ctconsumed, &ctpositional, PSTRING("\x08", "flindent"), &vindent))
                 return false;
 
             oppushoutline(ho);

--- a/tests/headless_window_verbs.c
+++ b/tests/headless_window_verbs.c
@@ -201,19 +201,19 @@ static boolean window_valueproc(short token, hdltreenode hparam1,
                     copyctopstring(inputpath, bsinputpath);
 
                     if (saved_errno == ENOENT) {
-                        copystring(BIGSTRING("\x14" "Can't check window \""), bserrmsg);
+                        copystring(PSTRING("\x14", "Can't check window \""), bserrmsg);
                         pushstring(bsinputpath, bserrmsg);
-                        pushstring(BIGSTRING("\x16" "\": file does not exist"), bserrmsg);
+                        pushstring(PSTRING("\x16", "\": file does not exist"), bserrmsg);
                     }
                     else if (saved_errno == EACCES) {
-                        copystring(BIGSTRING("\x14" "Can't check window \""), bserrmsg);
+                        copystring(PSTRING("\x14", "Can't check window \""), bserrmsg);
                         pushstring(bsinputpath, bserrmsg);
-                        pushstring(BIGSTRING("\x14" "\": permission denied"), bserrmsg);
+                        pushstring(PSTRING("\x14", "\": permission denied"), bserrmsg);
                     }
                     else {
-                        copystring(BIGSTRING("\x14" "Can't check window \""), bserrmsg);
+                        copystring(PSTRING("\x14", "Can't check window \""), bserrmsg);
                         pushstring(bsinputpath, bserrmsg);
-                        pushstring(BIGSTRING("\x19" "\": path resolution failed"), bserrmsg);
+                        pushstring(PSTRING("\x19", "\": path resolution failed"), bserrmsg);
                     }
 
                     langerrormessage(bserrmsg);

--- a/tests/headless_xml_verbs.c
+++ b/tests/headless_xml_verbs.c
@@ -68,19 +68,19 @@ static boolean xmldecodeentities_headless(Handle htext) {
     */
 
     /* Decode &quot; -> " */
-    if (!replaceallinhandle(BIGSTRING("\x06" "&quot;"), BIGSTRING("\x01" "\""), htext))
+    if (!replaceallinhandle(PSTRING("\x06", "&quot;"), PSTRING("\x01", "\""), htext))
         return false;
 
     /* Decode &lt; -> < */
-    if (!replaceallinhandle(BIGSTRING("\x04" "&lt;"), BIGSTRING("\x01" "<"), htext))
+    if (!replaceallinhandle(PSTRING("\x04", "&lt;"), PSTRING("\x01", "<"), htext))
         return false;
 
     /* Decode &gt; -> > */
-    if (!replaceallinhandle(BIGSTRING("\x04" "&gt;"), BIGSTRING("\x01" ">"), htext))
+    if (!replaceallinhandle(PSTRING("\x04", "&gt;"), PSTRING("\x01", ">"), htext))
         return false;
 
     /* Decode &amp; -> & (MUST be last to avoid partial decoding) */
-    if (!replaceallinhandle(BIGSTRING("\x05" "&amp;"), BIGSTRING("\x01" "&"), htext))
+    if (!replaceallinhandle(PSTRING("\x05", "&amp;"), PSTRING("\x01", "&"), htext))
         return false;
 
     return true;
@@ -566,8 +566,8 @@ static boolean xml_valueproc(short token, hdltreenode hparam1,
             /* If value is a table, try to get /pcdata or /contents (GUI: langxml.c:3305-3307) */
             if (langexternalvaltotable(val, &ht, hnode)) {
                 log_trace(LOG_COMP_LANG, "xml.getvalue: value is table, checking for /pcdata or /contents");
-                if (!hashtablelookup(ht, BIGSTRING("\x07/pcdata"), &val, &hnode))
-                    hashtablelookup(ht, BIGSTRING("\x09/contents"), &val, &hnode);
+                if (!hashtablelookup(ht, PSTRING("\x07", "/pcdata"), &val, &hnode))
+                    hashtablelookup(ht, PSTRING("\x09", "/contents"), &val, &hnode);
             }
 
             log_trace(LOG_COMP_LANG, "xml.getvalue: exit (success)");


### PR DESCRIPTION
## Summary

- Convert all `BIGSTRING("\xNN" "string")` patterns to `PSTRING("\xNN", "string")` in headless verb files
- PSTRING uses `_Static_assert` to verify the hex length byte matches the string length at compile time
- This conversion caught and **fixed 5 pre-existing wrong length bytes** in `headless_filemenu_verbs.c`:
  - `"Can't open: invalid database file"` — was `\x22` (34), correct is `\x21` (33)
  - `"Can't create: file already exists at path"` — was `\x27` (39), correct is `\x29` (41)
  - `"Can't create: failed to create new file"` — was `\x24` (36), correct is `\x27` (39)
  - `"Can't create: failed to initialize database"` — was `\x29` (41), correct is `\x2b` (43)
  - `"fileMenu.save requires 0 or 1 parameters (path)"` — was `\x2c` (44), correct is `\x2f` (47)

## Files changed

- `tests/headless_filemenu_verbs.c` — 22 conversions + 5 length fixes
- `tests/headless_frontier_verbs.c` — 2 conversions
- `tests/headless_op_verbs.c` — 1 conversion
- `tests/headless_window_verbs.c` — 6 conversions
- `tests/headless_xml_verbs.c` — 6 conversions (including xml entity decode pairs)

## What was NOT changed

- `BIGSTRING("\p...")` patterns (Pascal string syntax, not hex prefix)
- `BIGSTRING("\x00")` — zero-length empty string, no string body to separate
- Files outside `tests/headless_*_verbs.c`

## Test plan

- [x] Build with `make -C frontier-cli` — all `_Static_assert` checks pass (this IS the primary test)
- [x] Run `./tools/run_headless_tests.sh` — 302/302 unit tests pass
- [x] Pre-commit hook verified all 1085 Pascal string lengths across 52 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)