### PR TITLE
feat: Add make clean-root target for pre-release cleanup

### DIFF
--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -360,14 +360,16 @@ dist: $(TARGET)
 # Run userland.cleanRoot against the dist copy of Frontier.root.
 # This strips runtime state (user.databases, scheduler tasks, serial numbers, etc.)
 # while preserving all scripts and verbs. The source databases/Virgin.root is NOT modified.
+# Note: cleanRoot also produces dist/Virgin.root as a side artifact (via FileMenu.saveCopy).
 # Use before shipping: make dist && make clean-root
 clean-root: dist
 	@echo "Running userland.cleanRoot on dist/Frontier.root..."
 	@echo '{"op":"script/eval","id":1,"params":{"expression":"userland.cleanRoot()"}}' \
 		| $(DIST_DIR)/frontier-cli --protocol --system-root $(DIST_DIR)/Frontier.root 2>&1 \
+		| tee /tmp/frontier-cleanroot.log \
 		| grep -q '"success":true' \
 		&& echo "cleanRoot completed successfully." \
-		|| (echo "ERROR: cleanRoot failed. Check dist/Frontier.root." && exit 1)
+		|| (echo "ERROR: cleanRoot failed. Output:" && cat /tmp/frontier-cleanroot.log && exit 1)
 
 dist-clean:
 	rm -rf $(DIST_DIR)

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -366,10 +366,15 @@ clean-root: dist
 	@echo "Running userland.cleanRoot on dist/Frontier.root..."
 	@echo '{"op":"script/eval","id":1,"params":{"expression":"userland.cleanRoot()"}}' \
 		| $(DIST_DIR)/frontier-cli --protocol --system-root $(DIST_DIR)/Frontier.root 2>&1 \
-		| tee /tmp/frontier-cleanroot.log \
-		| grep -q '"success":true' \
-		&& echo "cleanRoot completed successfully." \
-		|| (echo "ERROR: cleanRoot failed. Output:" && cat /tmp/frontier-cleanroot.log && exit 1)
+		| tee $(DIST_DIR)/cleanroot.log > /dev/null; \
+	if grep -q '"success":true' $(DIST_DIR)/cleanroot.log; then \
+		echo "cleanRoot completed successfully."; \
+		rm -f $(DIST_DIR)/cleanroot.log; \
+	else \
+		echo "ERROR: cleanRoot failed. Output:"; \
+		cat $(DIST_DIR)/cleanroot.log; \
+		exit 1; \
+	fi
 
 dist-clean:
 	rm -rf $(DIST_DIR)

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -357,7 +357,19 @@ dist: $(TARGET)
 	@echo "Distribution created in $(DIST_DIR)/"
 	@echo "Run with: ./dist/frontier-cli --system-root dist/Frontier.root"
 
+# Run userland.cleanRoot against the dist copy of Frontier.root.
+# This strips runtime state (user.databases, scheduler tasks, serial numbers, etc.)
+# while preserving all scripts and verbs. The source databases/Virgin.root is NOT modified.
+# Use before shipping: make dist && make clean-root
+clean-root: dist
+	@echo "Running userland.cleanRoot on dist/Frontier.root..."
+	@echo '{"op":"script/eval","id":1,"params":{"expression":"userland.cleanRoot()"}}' \
+		| $(DIST_DIR)/frontier-cli --protocol --system-root $(DIST_DIR)/Frontier.root 2>&1 \
+		| grep -q '"success":true' \
+		&& echo "cleanRoot completed successfully." \
+		|| (echo "ERROR: cleanRoot failed. Check dist/Frontier.root." && exit 1)
+
 dist-clean:
 	rm -rf $(DIST_DIR)
 
-.PHONY: all build clean strings_generated kernel_verbs_generated check-paige-cache dist dist-clean validate-bigstrings
+.PHONY: all build clean strings_generated kernel_verbs_generated check-paige-cache dist dist-clean clean-root validate-bigstrings


### PR DESCRIPTION
## Summary

Adds `make clean-root` Makefile target that runs `userland.cleanRoot` via protocol against `dist/Frontier.root`. This strips runtime state (user.databases, scheduler tasks, serial numbers, etc.) while preserving all scripts and verbs.

Reproduces the pre-release workflow used at UserLand to ship clean Frontier.root files.

## Usage

```bash
make -C frontier-cli clean-root    # builds dist first, then cleans
```

The source `databases/Virgin.root` is NOT modified — only `dist/Frontier.root` is cleaned.

## Test plan

- [x] `make clean-root` runs to completion
- [x] `user.databases` absent in cleaned dist/Frontier.root
- [x] 302/302 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)