### PR TITLE
feat: Debugger Phase 3 — session breakpoints (set/clear/list/hit)

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -72,6 +72,7 @@ typedef struct {
 } debug_breakpoint_t;
 
 static debug_breakpoint_t g_breakpoints[MAX_BREAKPOINTS] = {0};
+static atomic_bool g_has_breakpoints = false; /* fast-path: skip mutex when no breakpoints set */
 
 /* ========================================================================
  * Reason string conversion
@@ -300,8 +301,12 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
                state->current_script, DEBUG_SCRIPT_PATH_MAX);
         state->script_stack_depth++;
     } else {
-        /* Stack overflow — track the imbalance so pop skips the corresponding restore */
+        /* Stack overflow — track the imbalance so pop skips the corresponding restore.
+         * Clear current_script to avoid false breakpoint matches: we can't save the
+         * caller's path, so it's safer to match nothing than to leave a stale path
+         * that persists into the caller after this frame returns. */
         state->script_stack_overflow++;
+        state->current_script[0] = '\0';
     }
 
     /* Build full dotted path from table + name */
@@ -418,8 +423,12 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      *
      * current_script is thread-local to the debug thread (written only by push/pop
      * callbacks on this same thread) — no lock needed. g_debug_mutex protects only
-     * the shared g_breakpoints array. */
-    if (lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
+     * the shared g_breakpoints array.
+     *
+     * Fast-path: g_has_breakpoints is checked with relaxed ordering to skip
+     * the mutex entirely when no breakpoints are set (common case). */
+    if (atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
+        lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
 
         boolean flbreakpoint = false;
 
@@ -1154,6 +1163,16 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
             }
         }
     }
+
+    /* Update fast-path flag: check if any breakpoints remain active */
+    boolean any_active = false;
+    for (int i = 0; i < MAX_BREAKPOINTS; i++) {
+        if (g_breakpoints[i].active) {
+            any_active = true;
+            break;
+        }
+    }
+    atomic_store(&g_has_breakpoints, any_active);
 
     pthread_mutex_unlock(&g_debug_mutex);
 

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -48,11 +48,15 @@ static pthread_mutex_t g_debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 static atomic_bool g_debug_thread_was_killed = false; /* set when a debug thread is killed mid-execution */
 
 /* ========================================================================
- * Session breakpoints (Phase 3)
+ * Breakpoints (Phase 3)
  *
  * Stored as (script_path, line) pairs in a global array. Protected by
- * g_debug_mutex. The debugger callback checks this list at each steppable
- * statement to determine if execution should suspend.
+ * g_debug_mutex. The debugger callback checks this list at each statement
+ * to determine if execution should suspend.
+ *
+ * Breakpoints persist for the lifetime of the process. They survive across
+ * multiple debug/run invocations and are only cleared by toggling them off
+ * via debug/setBreakpoint or when the process exits.
  *
  * Script paths use dotted notation without leading "@", e.g.
  * "mainResponder.respond". The path is matched against the current
@@ -1092,15 +1096,17 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     }
 
     const char *script = script_json->valuestring;
-    unsigned long line = (unsigned long)line_json->valuedouble;
+    double line_raw = line_json->valuedouble;
 
-    if (line == 0) {
+    if (line_raw < 1.0 || line_raw != (double)(unsigned long)line_raw) {
         char err[512];
-        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Line must be >= 1\"},\"success\":false}", id);
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Line must be a positive integer\"},\"success\":false}", id);
         transport->write_line(transport->ctx, err, strlen(err));
         cJSON_Delete(root);
         return;
     }
+
+    unsigned long line = (unsigned long)line_raw;
 
     /* Strip leading "@" if present — normalize to dotted path */
     if (script[0] == '@')

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -412,9 +412,13 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
     }
 
     /* Breakpoint check (Phase 3) — if not already suspended, check if there's
-     * a session breakpoint matching the current script and line number. Unlike
-     * stepping (which skips infrastructure nodes), breakpoints fire on any line
-     * including local declarations. Uses g_debug_mutex for thread safety. */
+     * a breakpoint matching the current script and line number. Unlike stepping
+     * (which skips infrastructure nodes), breakpoints fire on any line including
+     * local declarations.
+     *
+     * current_script is thread-local to the debug thread (written only by push/pop
+     * callbacks on this same thread) — no lock needed. g_debug_mutex protects only
+     * the shared g_breakpoints array. */
     if (lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
 
         boolean flbreakpoint = false;
@@ -1098,7 +1102,7 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     const char *script = script_json->valuestring;
     double line_raw = line_json->valuedouble;
 
-    if (line_raw < 1.0 || line_raw != (double)(unsigned long)line_raw) {
+    if (line_raw < 1.0 || line_raw > 1000000.0 || line_raw != (double)(unsigned long)line_raw) {
         char err[512];
         snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Line must be a positive integer\"},\"success\":false}", id);
         transport->write_line(transport->ctx, err, strlen(err));
@@ -1141,8 +1145,8 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     if (!cleared) {
         for (int i = 0; i < MAX_BREAKPOINTS; i++) {
             if (!g_breakpoints[i].active) {
-                strncpy(g_breakpoints[i].script, script, sizeof(g_breakpoints[i].script) - 1);
-                g_breakpoints[i].script[sizeof(g_breakpoints[i].script) - 1] = '\0';
+                /* strlen(script) < DEBUG_SCRIPT_PATH_MAX is guaranteed by the guard above */
+                memcpy(g_breakpoints[i].script, script, strlen(script) + 1);
                 g_breakpoints[i].line = line;
                 g_breakpoints[i].active = true;
                 set = true;

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -286,7 +286,7 @@ static void debug_send_completed(transport_t *transport, long threadid, boolean 
 
 static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, bigstring bsname) {
 
-    #pragma unused(hnode)
+    (void)hnode;
 
     if (hthreadglobals == nil)
         return true;

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -304,6 +304,8 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
             len = (int)sizeof(state->current_script) - 1;
         memcpy(state->current_script, bspath + 1, (size_t)len);
         state->current_script[len] = '\0';
+
+        log_debug(LOG_COMP_LANG, "debug: push source '%s' for thread %ld", state->current_script, state->threadid);
     }
 
     return true;
@@ -385,10 +387,13 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
         log_debug(LOG_COMP_LANG, "debug: thread %ld interrupted at line %ld", state->threadid, (long)lnum);
     }
 
-    /* Breakpoint check (Phase 3) — if not already suspended and on a steppable
-     * node, check if there's a session breakpoint matching the current script
-     * and line number. Uses g_debug_mutex for thread safety. */
-    if (flsteppable && lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
+    /* Breakpoint check (Phase 3) — if not already suspended, check if there's
+     * a session breakpoint matching the current script and line number. Unlike
+     * stepping (which skips infrastructure nodes), breakpoints can be set on any
+     * line including local declarations. Uses g_debug_mutex for thread safety. */
+    /* Breakpoint check applies to ALL nodes (not just steppable ones) — a user
+     * can set a breakpoint on any line including local declarations. */
+    if (lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
 
         boolean flbreakpoint = false;
 

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -295,6 +295,9 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
         memcpy(state->script_stack[state->script_stack_depth],
                state->current_script, DEBUG_SCRIPT_PATH_MAX);
         state->script_stack_depth++;
+    } else {
+        /* Stack overflow — track the imbalance so pop skips the corresponding restore */
+        state->script_stack_overflow++;
     }
 
     /* Build full dotted path from table + name */
@@ -329,8 +332,12 @@ static boolean debug_pop_sourcecode(void) {
     if (state == NULL || !state->fldebugmode)
         return true;
 
-    /* Restore caller's script path from the stack */
-    if (state->script_stack_depth > 0) {
+    /* Restore caller's script path from the stack.
+     * If we overflowed on push, consume the overflow counter instead
+     * of restoring — the saved path was never recorded. */
+    if (state->script_stack_overflow > 0) {
+        state->script_stack_overflow--;
+    } else if (state->script_stack_depth > 0) {
         state->script_stack_depth--;
         memcpy(state->current_script,
                state->script_stack[state->script_stack_depth], DEBUG_SCRIPT_PATH_MAX);
@@ -402,10 +409,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
     /* Breakpoint check (Phase 3) — if not already suspended, check if there's
      * a session breakpoint matching the current script and line number. Unlike
-     * stepping (which skips infrastructure nodes), breakpoints can be set on any
-     * line including local declarations. Uses g_debug_mutex for thread safety. */
-    /* Breakpoint check applies to ALL nodes (not just steppable ones) — a user
-     * can set a breakpoint on any line including local declarations. */
+     * stepping (which skips infrastructure nodes), breakpoints fire on any line
+     * including local declarations. Uses g_debug_mutex for thread safety. */
     if (lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
 
         boolean flbreakpoint = false;
@@ -1088,6 +1093,14 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
 
     const char *script = script_json->valuestring;
     unsigned long line = (unsigned long)line_json->valuedouble;
+
+    if (line == 0) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Line must be >= 1\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
 
     /* Strip leading "@" if present — normalize to dotted path */
     if (script[0] == '@')

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>  /* strcasecmp */
 #include <pthread.h>
 
 #include "../Common/headers/frontier.h"
@@ -311,9 +312,10 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
 
     /* Build full dotted path from table + name */
     bigstring bspath;
-    hdlwindowinfo hroot;
+    hdlwindowinfo hroot = NULL;
 
     if (langexternalgetfullpath(htable, bsname, bspath, &hroot)) {
+        (void)hroot; /* used only by langexternalgetfullpath, not needed here */
         /* Convert Pascal string to C string, store in debug state.
          * Path is like "mainResponder.respond" (no leading @). */
         int len = bspath[0];
@@ -437,7 +439,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
         for (int i = 0; i < MAX_BREAKPOINTS; i++) {
             if (g_breakpoints[i].active &&
                 g_breakpoints[i].line == lnum &&
-                strcmp(g_breakpoints[i].script, state->current_script) == 0) {
+                strcasecmp(g_breakpoints[i].script, state->current_script) == 0) {
                 flbreakpoint = true;
                 break;
             }
@@ -1143,7 +1145,7 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     for (int i = 0; i < MAX_BREAKPOINTS; i++) {
         if (g_breakpoints[i].active &&
             g_breakpoints[i].line == line &&
-            strcmp(g_breakpoints[i].script, script) == 0) {
+            strcasecmp(g_breakpoints[i].script, script) == 0) {
             g_breakpoints[i].active = false;
             cleared = true;
             break;

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -37,6 +37,9 @@
 extern hdlhashtable currenthashtable;
 extern hdltablestack hashtablestack;
 
+/* Needed for langexternalgetfullpath */
+#include "langexternal.h"
+
 /*
  * Maximum number of concurrent debug threads.
  * Each slot holds a pointer to a debug state; NULL = unused.
@@ -45,6 +48,28 @@ extern hdltablestack hashtablestack;
 static tydebugstate *g_debug_threads[MAX_DEBUG_THREADS] = {0};
 static pthread_mutex_t g_debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 static atomic_bool g_debug_thread_was_killed = false; /* set when a debug thread is killed mid-execution */
+
+/* ========================================================================
+ * Session breakpoints (Phase 3)
+ *
+ * Stored as (script_path, line) pairs in a global array. Protected by
+ * g_debug_mutex. The debugger callback checks this list at each steppable
+ * statement to determine if execution should suspend.
+ *
+ * Script paths use dotted notation without leading "@", e.g.
+ * "mainResponder.respond". The path is matched against the current
+ * script tracked via the push/pop sourcecode callbacks.
+ * ======================================================================== */
+
+#define MAX_BREAKPOINTS 256
+
+typedef struct {
+    char script[256];       /* dotted script path, e.g. "mainResponder.respond" */
+    unsigned long line;     /* 1-based line number */
+    boolean active;         /* is this slot in use? */
+} debug_breakpoint_t;
+
+static debug_breakpoint_t g_breakpoints[MAX_BREAKPOINTS] = {0};
 
 /* ========================================================================
  * Reason string conversion
@@ -248,6 +273,60 @@ static void debug_send_completed(transport_t *transport, long threadid, boolean 
 }
 
 /* ========================================================================
+ * Source tracking callbacks (Phase 3)
+ *
+ * Installed by debug_init() to replace the no-op sourcecode callbacks.
+ * These track the current script path in each debug thread's state,
+ * enabling breakpoint matching in the debugger callback.
+ * ======================================================================== */
+
+static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, bigstring bsname) {
+
+    #pragma unused(hnode)
+
+    if (hthreadglobals == nil)
+        return true;
+
+    tydebugstate *state = (tydebugstate *)((**hthreadglobals).param_reserved[0]);
+
+    if (state == NULL || !state->fldebugmode)
+        return true;
+
+    /* Build full dotted path from table + name */
+    bigstring bspath;
+    hdlwindowinfo hroot;
+
+    if (langexternalgetfullpath(htable, bsname, bspath, &hroot)) {
+        /* Convert Pascal string to C string, store in debug state.
+         * Path is like "mainResponder.respond" (no leading @). */
+        int len = bspath[0];
+        if (len >= (int)sizeof(state->current_script))
+            len = (int)sizeof(state->current_script) - 1;
+        memcpy(state->current_script, bspath + 1, (size_t)len);
+        state->current_script[len] = '\0';
+    }
+
+    return true;
+}
+
+static boolean debug_pop_sourcecode(void) {
+
+    if (hthreadglobals == nil)
+        return true;
+
+    tydebugstate *state = (tydebugstate *)((**hthreadglobals).param_reserved[0]);
+
+    if (state == NULL || !state->fldebugmode)
+        return true;
+
+    /* Clear current script — we're returning to the caller.
+     * The parent script's path will be restored by the next push. */
+    state->current_script[0] = '\0';
+
+    return true;
+}
+
+/* ========================================================================
  * Debugger callback — replaces cb_noop_treenode
  * ======================================================================== */
 
@@ -304,6 +383,40 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
         debug_send_suspended(state->transport, state->threadid, (long)lnum, DEBUG_REASON_INTERRUPTED);
         log_debug(LOG_COMP_LANG, "debug: thread %ld interrupted at line %ld", state->threadid, (long)lnum);
+    }
+
+    /* Breakpoint check (Phase 3) — if not already suspended and on a steppable
+     * node, check if there's a session breakpoint matching the current script
+     * and line number. Uses g_debug_mutex for thread safety. */
+    if (flsteppable && lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
+
+        boolean flbreakpoint = false;
+
+        pthread_mutex_lock(&g_debug_mutex);
+
+        for (int i = 0; i < MAX_BREAKPOINTS; i++) {
+            if (g_breakpoints[i].active &&
+                g_breakpoints[i].line == lnum &&
+                strcmp(g_breakpoints[i].script, state->current_script) == 0) {
+                flbreakpoint = true;
+                break;
+            }
+        }
+
+        pthread_mutex_unlock(&g_debug_mutex);
+
+        if (flbreakpoint) {
+            atomic_store(&state->lastlnum, lnum);
+
+            /* Clear stepping state if we were stepping — breakpoint takes priority */
+            atomic_store(&state->flstepping, false);
+            atomic_store(&state->stepdir, DEBUG_STEP_NONE);
+
+            atomic_store_explicit(&state->flsuspended, true, memory_order_seq_cst);
+            debug_send_suspended(state->transport, state->threadid, (long)lnum, DEBUG_REASON_BREAKPOINT);
+            log_debug(LOG_COMP_LANG, "debug: thread %ld hit breakpoint at %s line %ld",
+                      state->threadid, state->current_script, (long)lnum);
+        }
     }
 
     /* Stepping logic — check if we should suspend based on step direction.
@@ -408,6 +521,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 void debug_init(void) {
 
     langcallbacks.debuggercallback = &protocol_debugger_callback;
+    langcallbacks.pushsourcecodecallback = &debug_push_sourcecode;
+    langcallbacks.popsourcecodecallback = &debug_pop_sourcecode;
     log_info(LOG_COMP_GENERAL, "Protocol debugger initialized");
 }
 
@@ -902,4 +1017,173 @@ void handle_debug_pause(int id, const char *json_line, transport_t *transport) {
     transport->write_line(transport->ctx, resp, strlen(resp));
 
     cJSON_Delete(root);
+}
+
+/* ========================================================================
+ * Breakpoint protocol handlers (Phase 3)
+ * ======================================================================== */
+
+/*
+ * debug/setBreakpoint — Set or clear a session breakpoint.
+ *
+ * Toggle behavior: if a breakpoint already exists at the given script+line,
+ * it is cleared. Otherwise, a new breakpoint is set.
+ *
+ * Params:
+ *   script: dotted path (e.g. "mainResponder.respond") — no leading "@"
+ *   line:   1-based line number
+ *
+ * Returns:
+ *   action: "set" or "cleared"
+ *   script, line: echo back the breakpoint location
+ */
+void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *transport) {
+
+    cJSON *root = cJSON_Parse(json_line);
+
+    if (root == NULL) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Invalid JSON\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        return;
+    }
+
+    cJSON *params = cJSON_GetObjectItemCaseSensitive(root, "params");
+    cJSON *script_json = params ? cJSON_GetObjectItemCaseSensitive(params, "script") : NULL;
+    cJSON *line_json = params ? cJSON_GetObjectItemCaseSensitive(params, "line") : NULL;
+
+    if (!cJSON_IsString(script_json) || script_json->valuestring == NULL) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Missing 'script' in params\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    if (!cJSON_IsNumber(line_json)) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Missing 'line' in params\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    const char *script = script_json->valuestring;
+    unsigned long line = (unsigned long)line_json->valuedouble;
+
+    /* Strip leading "@" if present — normalize to dotted path */
+    if (script[0] == '@')
+        script++;
+
+    if (strlen(script) >= 256) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Script path too long\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    /* Toggle: check if breakpoint already exists */
+    boolean cleared = false;
+    boolean set = false;
+
+    pthread_mutex_lock(&g_debug_mutex);
+
+    /* First pass: check for existing breakpoint to toggle off */
+    for (int i = 0; i < MAX_BREAKPOINTS; i++) {
+        if (g_breakpoints[i].active &&
+            g_breakpoints[i].line == line &&
+            strcmp(g_breakpoints[i].script, script) == 0) {
+            g_breakpoints[i].active = false;
+            cleared = true;
+            break;
+        }
+    }
+
+    /* Second pass: if not clearing, find an empty slot to set */
+    if (!cleared) {
+        for (int i = 0; i < MAX_BREAKPOINTS; i++) {
+            if (!g_breakpoints[i].active) {
+                strncpy(g_breakpoints[i].script, script, sizeof(g_breakpoints[i].script) - 1);
+                g_breakpoints[i].script[sizeof(g_breakpoints[i].script) - 1] = '\0';
+                g_breakpoints[i].line = line;
+                g_breakpoints[i].active = true;
+                set = true;
+                break;
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&g_debug_mutex);
+
+    if (!cleared && !set) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Too many breakpoints (max %d)\"},\"success\":false}", id, MAX_BREAKPOINTS);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    /* Build response using cJSON to safely escape the script path */
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddNumberToObject(resp, "id", id);
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddStringToObject(result, "action", cleared ? "cleared" : "set");
+    cJSON_AddStringToObject(result, "script", script);
+    cJSON_AddNumberToObject(result, "line", (double)line);
+    cJSON_AddItemToObject(resp, "result", result);
+    cJSON_AddBoolToObject(resp, "success", 1);
+
+    char *json_str = cJSON_PrintUnformatted(resp);
+    if (json_str) {
+        transport->write_line(transport->ctx, json_str, strlen(json_str));
+        free(json_str);
+    }
+    cJSON_Delete(resp);
+
+    log_info(LOG_COMP_LANG, "debug: breakpoint %s at %s line %ld",
+             cleared ? "cleared" : "set", script, line);
+
+    cJSON_Delete(root);
+}
+
+/*
+ * debug/listBreakpoints — List all session breakpoints.
+ *
+ * Returns an array of {script, line} objects.
+ */
+void handle_debug_listbreakpoints(int id, const char *json_line, transport_t *transport) {
+
+    (void)json_line; /* no params needed */
+
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddNumberToObject(resp, "id", id);
+
+    cJSON *result = cJSON_CreateObject();
+    cJSON *bparray = cJSON_CreateArray();
+
+    pthread_mutex_lock(&g_debug_mutex);
+
+    for (int i = 0; i < MAX_BREAKPOINTS; i++) {
+        if (g_breakpoints[i].active) {
+            cJSON *bp = cJSON_CreateObject();
+            cJSON_AddStringToObject(bp, "script", g_breakpoints[i].script);
+            cJSON_AddNumberToObject(bp, "line", (double)g_breakpoints[i].line);
+            cJSON_AddStringToObject(bp, "type", "session");
+            cJSON_AddItemToArray(bparray, bp);
+        }
+    }
+
+    pthread_mutex_unlock(&g_debug_mutex);
+
+    cJSON_AddItemToObject(result, "breakpoints", bparray);
+    cJSON_AddItemToObject(resp, "result", result);
+    cJSON_AddBoolToObject(resp, "success", 1);
+
+    char *json_str = cJSON_PrintUnformatted(resp);
+    if (json_str) {
+        transport->write_line(transport->ctx, json_str, strlen(json_str));
+        free(json_str);
+    }
+    cJSON_Delete(resp);
 }

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -31,14 +31,12 @@
 #include "processinternal.h"
 #include "threadregistry.h"
 #include "headless_threading.h"
+#include "langexternal.h"
 #include "../third_party/cJSON/cJSON.h"
 
 /* Global: current hashtable and table stack (thread globals) */
 extern hdlhashtable currenthashtable;
 extern hdltablestack hashtablestack;
-
-/* Needed for langexternalgetfullpath */
-#include "langexternal.h"
 
 /*
  * Maximum number of concurrent debug threads.
@@ -64,9 +62,9 @@ static atomic_bool g_debug_thread_was_killed = false; /* set when a debug thread
 #define MAX_BREAKPOINTS 256
 
 typedef struct {
-    char script[256];       /* dotted script path, e.g. "mainResponder.respond" */
-    unsigned long line;     /* 1-based line number */
-    boolean active;         /* is this slot in use? */
+    char script[DEBUG_SCRIPT_PATH_MAX]; /* dotted script path, e.g. "mainResponder.respond" */
+    unsigned long line;                 /* 1-based line number */
+    boolean active;                     /* is this slot in use? */
 } debug_breakpoint_t;
 
 static debug_breakpoint_t g_breakpoints[MAX_BREAKPOINTS] = {0};
@@ -292,6 +290,13 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
     if (state == NULL || !state->fldebugmode)
         return true;
 
+    /* Save current script path on the stack before overwriting */
+    if (state->script_stack_depth < DEBUG_SCRIPT_STACK_MAX) {
+        memcpy(state->script_stack[state->script_stack_depth],
+               state->current_script, DEBUG_SCRIPT_PATH_MAX);
+        state->script_stack_depth++;
+    }
+
     /* Build full dotted path from table + name */
     bigstring bspath;
     hdlwindowinfo hroot;
@@ -300,12 +305,15 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
         /* Convert Pascal string to C string, store in debug state.
          * Path is like "mainResponder.respond" (no leading @). */
         int len = bspath[0];
-        if (len >= (int)sizeof(state->current_script))
-            len = (int)sizeof(state->current_script) - 1;
+        if (len >= DEBUG_SCRIPT_PATH_MAX)
+            len = DEBUG_SCRIPT_PATH_MAX - 1;
         memcpy(state->current_script, bspath + 1, (size_t)len);
         state->current_script[len] = '\0';
 
         log_debug(LOG_COMP_LANG, "debug: push source '%s' for thread %ld", state->current_script, state->threadid);
+    } else {
+        /* Path resolution failed — clear to avoid false breakpoint matches */
+        state->current_script[0] = '\0';
     }
 
     return true;
@@ -321,9 +329,14 @@ static boolean debug_pop_sourcecode(void) {
     if (state == NULL || !state->fldebugmode)
         return true;
 
-    /* Clear current script — we're returning to the caller.
-     * The parent script's path will be restored by the next push. */
-    state->current_script[0] = '\0';
+    /* Restore caller's script path from the stack */
+    if (state->script_stack_depth > 0) {
+        state->script_stack_depth--;
+        memcpy(state->current_script,
+               state->script_stack[state->script_stack_depth], DEBUG_SCRIPT_PATH_MAX);
+    } else {
+        state->current_script[0] = '\0';
+    }
 
     return true;
 }
@@ -1080,7 +1093,7 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     if (script[0] == '@')
         script++;
 
-    if (strlen(script) >= 256) {
+    if (strlen(script) >= DEBUG_SCRIPT_PATH_MAX) {
         char err[512];
         snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Script path too long\"},\"success\":false}", id);
         transport->write_line(transport->ctx, err, strlen(err));

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -64,6 +64,11 @@ typedef enum {
  * g_debug_mutex), use the pointer, then call debug_release_state.
  * The debug thread frees the struct only when refcount drops to 0.
  */
+
+/* Source tracking constants (used by tydebugstate and debug_breakpoint_t) */
+#define DEBUG_SCRIPT_PATH_MAX 256
+#define DEBUG_SCRIPT_STACK_MAX 32
+
 typedef struct tydebugstate {
     boolean fldebugmode;             /* not atomic: set once at registration (under GIL) before
                                       * thread starts, only read after. GIL provides ordering. */
@@ -95,11 +100,10 @@ typedef struct tydebugstate {
      * The callback reads current_script to match breakpoints.
      * Script path stack handles nested calls (A calls B): push saves path,
      * pop restores caller's path so breakpoints in A still fire after B returns. */
-    #define DEBUG_SCRIPT_PATH_MAX 256
-    #define DEBUG_SCRIPT_STACK_MAX 32
     char current_script[DEBUG_SCRIPT_PATH_MAX]; /* current script dotted path */
     char script_stack[DEBUG_SCRIPT_STACK_MAX][DEBUG_SCRIPT_PATH_MAX]; /* saved caller paths */
     short script_stack_depth;                   /* stack pointer (0 = empty) */
+    short script_stack_overflow;                /* push/pop balance when stack overflows */
 } tydebugstate, *ptrdebugstate;
 
 /*

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -92,8 +92,14 @@ typedef struct tydebugstate {
 
     /* Source tracking (Phase 3) — tracks which script is currently executing.
      * Updated by the push/pop sourcecode callbacks installed in debug_init().
-     * The callback reads this to match breakpoints against the current script. */
-    char current_script[256];        /* full dotted path, e.g. "mainResponder.respond" */
+     * The callback reads current_script to match breakpoints.
+     * Script path stack handles nested calls (A calls B): push saves path,
+     * pop restores caller's path so breakpoints in A still fire after B returns. */
+    #define DEBUG_SCRIPT_PATH_MAX 256
+    #define DEBUG_SCRIPT_STACK_MAX 32
+    char current_script[DEBUG_SCRIPT_PATH_MAX]; /* current script dotted path */
+    char script_stack[DEBUG_SCRIPT_STACK_MAX][DEBUG_SCRIPT_PATH_MAX]; /* saved caller paths */
+    short script_stack_depth;                   /* stack pointer (0 = empty) */
 } tydebugstate, *ptrdebugstate;
 
 /*

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -103,7 +103,7 @@ typedef struct tydebugstate {
     char current_script[DEBUG_SCRIPT_PATH_MAX]; /* current script dotted path */
     char script_stack[DEBUG_SCRIPT_STACK_MAX][DEBUG_SCRIPT_PATH_MAX]; /* saved caller paths */
     short script_stack_depth;                   /* stack pointer (0 = empty) */
-    short script_stack_overflow;                /* push/pop balance when stack overflows */
+    int script_stack_overflow;                  /* push/pop balance when stack overflows */
 } tydebugstate, *ptrdebugstate;
 
 /*

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -2,10 +2,12 @@
  * debug_handler.h - Protocol-based UserTalk debugger
  *
  * Provides debug/* protocol operations for headless script debugging:
- *   debug/run        — Run script in debug mode (non-blocking, spawns thread)
- *   debug/continue   — Resume suspended thread
- *   debug/kill       — Kill a debug thread
- *   debug/pause      — Interrupt a running thread
+ *   debug/run             — Run script in debug mode (non-blocking, spawns thread)
+ *   debug/continue        — Resume suspended thread
+ *   debug/kill            — Kill a debug thread
+ *   debug/pause           — Interrupt a running thread
+ *   debug/setBreakpoint   — Set or clear a breakpoint (Phase 3)
+ *   debug/listBreakpoints — List all breakpoints (Phase 3)
  *
  * The debugger replaces the headless no-op callback with a protocol-aware
  * callback that can suspend execution and wait for client commands.
@@ -87,6 +89,11 @@ typedef struct tydebugstate {
                                       * Stays 0, making step-over line-based only and
                                       * step-out non-functional. Needs hook into function
                                       * call entry/exit in the interpreter. */
+
+    /* Source tracking (Phase 3) — tracks which script is currently executing.
+     * Updated by the push/pop sourcecode callbacks installed in debug_init().
+     * The callback reads this to match breakpoints against the current script. */
+    char current_script[256];        /* full dotted path, e.g. "mainResponder.respond" */
 } tydebugstate, *ptrdebugstate;
 
 /*
@@ -104,6 +111,8 @@ void handle_debug_step(int id, const char *json_line, transport_t *transport);
 void handle_debug_continue(int id, const char *json_line, transport_t *transport);
 void handle_debug_kill(int id, const char *json_line, transport_t *transport);
 void handle_debug_pause(int id, const char *json_line, transport_t *transport);
+void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *transport);
+void handle_debug_listbreakpoints(int id, const char *json_line, transport_t *transport);
 
 /*
  * Release a reference to a debug state obtained from debug_get_state_for_thread.

--- a/frontier-cli/op_handler.c
+++ b/frontier-cli/op_handler.c
@@ -649,6 +649,10 @@ int op_dispatch(const char *json_line, size_t len, transport_t *transport) {
         handle_debug_kill(id, json_line, transport);
     } else if (strcmp(op, "debug/pause") == 0) {
         handle_debug_pause(id, json_line, transport);
+    } else if (strcmp(op, "debug/setBreakpoint") == 0) {
+        handle_debug_setbreakpoint(id, json_line, transport);
+    } else if (strcmp(op, "debug/listBreakpoints") == 0) {
+        handle_debug_listbreakpoints(id, json_line, transport);
     } else if (strcmp(op, "shutdown") == 0) {
         send_ack(id, transport);
         free(op);

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -254,6 +254,130 @@ def test_missing_expression(send):
 msgs = run_debug_session(test_missing_expression)
 assert_test("run with missing expression errors", any("expression" in str(m) for m in msgs), f"Messages: {msgs}")
 
+# --- Test 6: debug/setBreakpoint + debug/listBreakpoints ---
+print()
+print("--- debug/setBreakpoint + debug/listBreakpoints ---")
+
+def test_set_breakpoint(send):
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "mainResponder.respond", "line": 5}})
+    time.sleep(0.5)
+    send({"op": "debug/listBreakpoints", "id": 2, "params": {}})
+    time.sleep(0.5)
+
+msgs = run_debug_session(test_set_breakpoint)
+# Check setBreakpoint response
+set_msg = None
+for m in msgs:
+    if m.get("id") == 1 and m.get("result", {}).get("action") == "set":
+        set_msg = m
+        break
+assert_test("setBreakpoint returns action=set", set_msg is not None, f"Messages: {msgs}")
+
+# Check listBreakpoints response
+list_msg = None
+for m in msgs:
+    if m.get("id") == 2 and m.get("result", {}).get("breakpoints") is not None:
+        list_msg = m
+        break
+assert_test("listBreakpoints returns breakpoint array",
+            list_msg is not None and len(list_msg["result"]["breakpoints"]) > 0,
+            f"Messages: {msgs}")
+if list_msg:
+    bp = list_msg["result"]["breakpoints"][0]
+    assert_test("listed breakpoint has correct script",
+                bp.get("script") == "mainResponder.respond",
+                f"Breakpoint: {bp}")
+    assert_test("listed breakpoint has correct line",
+                bp.get("line") == 5,
+                f"Breakpoint: {bp}")
+
+# --- Test 7: breakpoint toggle (clear) ---
+print()
+print("--- breakpoint toggle (clear) ---")
+
+def test_toggle_breakpoint(send):
+    # Set a breakpoint
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "test.script", "line": 3}})
+    time.sleep(0.5)
+    # Set again to toggle off
+    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "test.script", "line": 3}})
+    time.sleep(0.5)
+    # List should be empty
+    send({"op": "debug/listBreakpoints", "id": 3, "params": {}})
+    time.sleep(0.5)
+
+msgs = run_debug_session(test_toggle_breakpoint)
+# Check first set
+set_msg = None
+for m in msgs:
+    if m.get("id") == 1 and m.get("result", {}).get("action") == "set":
+        set_msg = m
+        break
+assert_test("first set returns action=set", set_msg is not None, f"Messages: {msgs}")
+
+# Check toggle clears
+clear_msg = None
+for m in msgs:
+    if m.get("id") == 2 and m.get("result", {}).get("action") == "cleared":
+        clear_msg = m
+        break
+assert_test("second set returns action=cleared", clear_msg is not None, f"Messages: {msgs}")
+
+# Check list is empty
+list_msg = None
+for m in msgs:
+    if m.get("id") == 3 and m.get("result", {}).get("breakpoints") is not None:
+        list_msg = m
+        break
+assert_test("list after toggle is empty",
+            list_msg is not None and len(list_msg["result"]["breakpoints"]) == 0,
+            f"Messages: {msgs}")
+
+# --- Test 8: breakpoint with leading @ stripped ---
+print()
+print("--- breakpoint @ prefix handling ---")
+
+def test_breakpoint_at_prefix(send):
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "@system.compiler.start", "line": 1}})
+    time.sleep(0.5)
+    send({"op": "debug/listBreakpoints", "id": 2, "params": {}})
+    time.sleep(0.5)
+
+msgs = run_debug_session(test_breakpoint_at_prefix)
+list_msg = None
+for m in msgs:
+    if m.get("id") == 2 and m.get("result", {}).get("breakpoints") is not None:
+        list_msg = m
+        break
+if list_msg and len(list_msg["result"]["breakpoints"]) > 0:
+    assert_test("@ prefix stripped from script path",
+                list_msg["result"]["breakpoints"][0].get("script") == "system.compiler.start",
+                f"Breakpoint: {list_msg['result']['breakpoints'][0]}")
+else:
+    assert_test("@ prefix stripped from script path", False, f"Messages: {msgs}")
+
+# --- Test 9: breakpoint error cases ---
+print()
+print("--- breakpoint error cases ---")
+
+def test_breakpoint_missing_script(send):
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {"line": 5}})
+    time.sleep(0.5)
+
+msgs = run_debug_session(test_breakpoint_missing_script)
+assert_test("setBreakpoint without script errors",
+            any("script" in str(m).lower() for m in msgs if not m.get("success", True)),
+            f"Messages: {msgs}")
+
+def test_breakpoint_missing_line(send):
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "foo.bar"}})
+    time.sleep(0.5)
+
+msgs = run_debug_session(test_breakpoint_missing_line)
+assert_test("setBreakpoint without line errors",
+            any("line" in str(m).lower() for m in msgs if not m.get("success", True)),
+            f"Messages: {msgs}")
+
 print()
 print("=" * 46)
 print(f"RESULTS: {PASSED} passed, {FAILED} failed")

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -254,7 +254,49 @@ def test_missing_expression(send):
 msgs = run_debug_session(test_missing_expression)
 assert_test("run with missing expression errors", any("expression" in str(m) for m in msgs), f"Messages: {msgs}")
 
-# --- Test 6: debug/setBreakpoint + debug/listBreakpoints ---
+# --- Test 6: breakpoint hit during execution ---
+print()
+print("--- breakpoint hit during execution ---")
+
+def test_breakpoint_hit(send):
+    # Step 1: Create a test function in system.temp via script/eval
+    send({"op": "script/eval", "id": 1, "params": {
+        "expression": 'new(scriptType, @system.temp.bpTestFunc); script.newScriptObject("local (x = 1)\\rlocal (y = 2)\\rreturn (x + y)", @system.temp.bpTestFunc)'
+    }})
+    time.sleep(1)
+    # Step 2: Set a breakpoint on line 2 of bpTestFunc
+    send({"op": "debug/setBreakpoint", "id": 2, "params": {
+        "script": "system.temp.bpTestFunc", "line": 2
+    }})
+    time.sleep(0.5)
+    # Step 3: Run an expression that calls the function
+    send({"op": "debug/run", "id": 3, "params": {
+        "expression": "system.temp.bpTestFunc()"
+    }})
+    time.sleep(2)
+    # Step 4: Continue past initial entry suspension
+    send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(3)
+    # Step 5: At this point, should be suspended at breakpoint on line 2
+    # Kill to clean up
+    send({"op": "debug/kill", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+
+msgs = run_debug_session(test_breakpoint_hit, timeout=20)
+# Check that we got a breakpoint suspension
+bp_suspend = find_msg(msgs, reason="breakpoint")
+assert_test("breakpoint hit suspends thread",
+            bp_suspend is not None,
+            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended' or m.get('result', {}).get('action')]}")
+
+# If breakpoint was hit, verify it's on the right line
+if bp_suspend:
+    bp_line = bp_suspend.get("params", {}).get("line")
+    assert_test("breakpoint hit on correct line",
+                bp_line == 2,
+                f"Expected line 2, got {bp_line}")
+
+# --- Test 7: debug/setBreakpoint + debug/listBreakpoints ---
 print()
 print("--- debug/setBreakpoint + debug/listBreakpoints ---")
 

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -333,7 +333,7 @@ if list_msg:
                 bp.get("line") == 5,
                 f"Breakpoint: {bp}")
 
-# --- Test 7: breakpoint toggle (clear) ---
+# --- Test 8: breakpoint toggle (clear) ---
 print()
 print("--- breakpoint toggle (clear) ---")
 
@@ -375,7 +375,7 @@ assert_test("list after toggle is empty",
             list_msg is not None and len(list_msg["result"]["breakpoints"]) == 0,
             f"Messages: {msgs}")
 
-# --- Test 8: breakpoint with leading @ stripped ---
+# --- Test 9: breakpoint with leading @ stripped ---
 print()
 print("--- breakpoint @ prefix handling ---")
 
@@ -398,7 +398,7 @@ if list_msg and len(list_msg["result"]["breakpoints"]) > 0:
 else:
     assert_test("@ prefix stripped from script path", False, f"Messages: {msgs}")
 
-# --- Test 9: breakpoint error cases ---
+# --- Test 10: breakpoint error cases ---
 print()
 print("--- breakpoint error cases ---")
 


### PR DESCRIPTION
## Summary

Adds session-scoped breakpoint support to the UserTalk debugger (Phase 3):

- **`debug/setBreakpoint`** — Set or clear a breakpoint by script path + line number. Toggle behavior: setting at an existing location clears it.
- **`debug/listBreakpoints`** — List all active session breakpoints with script, line, and type.
- **Breakpoint hit detection** — Debugger callback checks breakpoints at every statement. When a matching breakpoint is found, the thread suspends with `reason:"breakpoint"`.

## Implementation

- **Breakpoint storage**: Global array of `(script_path, line)` pairs protected by `g_debug_mutex`. Session-scoped only (cleared when process exits).
- **Source tracking**: `langpushsourcecode`/`langpopsourcecode` callbacks track the current script path per debug thread in `tydebugstate.current_script`. Installed by `debug_init()`.
- **Path resolution**: Uses `langexternalgetfullpath()` to build dotted paths (e.g. `system.temp.bpTestFunc`) from the `(htable, bsname)` pair provided by the interpreter.
- **Breakpoint check**: Fires on ALL nodes (not just steppable ones) — users can set breakpoints on any line including local declarations.

## Protocol

```json
// Set breakpoint (toggle)
{"op":"debug/setBreakpoint","id":1,"params":{"script":"system.temp.myFunc","line":5}}
// Response: {"id":1,"result":{"action":"set","script":"system.temp.myFunc","line":5},"success":true}

// List breakpoints
{"op":"debug/listBreakpoints","id":2,"params":{}}
// Response: {"id":2,"result":{"breakpoints":[{"script":"system.temp.myFunc","line":5,"type":"session"}]},"success":true}
```

Leading `@` in script paths is automatically stripped for consistent matching.

## Test plan

- [x] 302/302 unit tests pass
- [x] 25/25 debug protocol tests pass (12 new breakpoint tests)
- [x] Breakpoint set/clear/list protocol operations verified
- [x] Toggle behavior (set then clear) verified
- [x] Leading `@` prefix stripping verified
- [x] Error cases (missing script, missing line) verified
- [x] End-to-end breakpoint hit: create function via script/eval, set breakpoint, run via debug/run, verify suspension with `reason:"breakpoint"` at correct line

🤖 Generated with [Claude Code](https://claude.com/claude-code)