### PR TITLE
fix: Resolve #505 — step-over/step-out suspension crash

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -429,7 +429,11 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      *
      * Fast-path: g_has_breakpoints is checked with relaxed ordering to skip
      * the mutex entirely when no breakpoints are set (common case). */
-    if (atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
+    /* Skip breakpoint check when stepping from the same line — the step should
+     * advance past the current breakpoint, not immediately re-trigger it. */
+    boolean flskip_bp = (atomic_load(&state->flstepping) && lnum == atomic_load(&state->lastlnum));
+
+    if (!flskip_bp && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
         lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
 
         boolean flbreakpoint = false;
@@ -517,17 +521,25 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
         }
     }
 
+    /* Capture the thread globals handle in a local variable BEFORE releasing
+     * the GIL. The global `hthreadglobals` is shared — other threads overwrite
+     * it when they restore their own context. Using the global after reacquiring
+     * the GIL would restore the WRONG thread's state (e.g., the main thread's
+     * currenthashtable instead of this debug thread's), causing the
+     * hlocals != currenthashtable assertion in evaluatelist. (#505) */
+    hdlthreadglobals my_hglobals = hthreadglobals;
+
     /* Suspension loop — yields GIL so protocol handler can process commands */
     while (atomic_load(&state->flsuspended)) {
 
         if (atomic_load(&state->flkill)) {
-            if (hthreadglobals != nil)
-                (**hthreadglobals).flthreadkilled = true;
+            if (my_hglobals != nil)
+                (**my_hglobals).flthreadkilled = true;
             return false;
         }
 
         /* Save thread globals, release GIL, sleep, reacquire, restore */
-        headless_save_threadglobals(hthreadglobals);
+        headless_save_threadglobals(my_hglobals);
         pthread_mutex_unlock(&frontier_gil);
 
         /* Sleep 10ms — other threads (including protocol handler) can run */
@@ -535,7 +547,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
         nanosleep(&ts, NULL);
 
         pthread_mutex_lock(&frontier_gil);
-        headless_restore_threadglobals(hthreadglobals);
+        headless_restore_threadglobals(my_hglobals);
     }
 
     /* Check kill flag after loop exit — handle_debug_kill sets flkill=true
@@ -548,8 +560,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      * with success=false, then cleans up. The callback does NOT send
      * debug/completed — that's always the thread entry's responsibility. */
     if (atomic_load(&state->flkill)) {
-        if (hthreadglobals != nil)
-            (**hthreadglobals).flthreadkilled = true;
+        if (my_hglobals != nil)
+            (**my_hglobals).flthreadkilled = true;
         return false;
     }
 

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -430,7 +430,9 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      * Fast-path: g_has_breakpoints is checked with relaxed ordering to skip
      * the mutex entirely when no breakpoints are set (common case). */
     /* Skip breakpoint check when stepping from the same line — the step should
-     * advance past the current breakpoint, not immediately re-trigger it. */
+     * advance past the current breakpoint, not immediately re-trigger it.
+     * TODO: revisit when calldepth tracking is added — recursive calls could
+     * have the same lnum at a different depth, and the breakpoint should fire. */
     boolean flskipbreakpoint = (atomic_load(&state->flstepping) && lnum == atomic_load(&state->lastlnum));
 
     if (!flskipbreakpoint && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -431,9 +431,9 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      * the mutex entirely when no breakpoints are set (common case). */
     /* Skip breakpoint check when stepping from the same line — the step should
      * advance past the current breakpoint, not immediately re-trigger it. */
-    boolean flskip_bp = (atomic_load(&state->flstepping) && lnum == atomic_load(&state->lastlnum));
+    boolean flskipbreakpoint = (atomic_load(&state->flstepping) && lnum == atomic_load(&state->lastlnum));
 
-    if (!flskip_bp && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
+    if (!flskipbreakpoint && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
         lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
 
         boolean flbreakpoint = false;
@@ -474,7 +474,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      * Step-out:  suspend when call depth decreases below step level */
     if (atomic_load(&state->flstepping) && flsteppable && !atomic_load(&state->flsuspended)) {
 
-        short diff = atomic_load(&state->calldepth) - atomic_load(&state->steplevel); /* calldepth always 0 in Phase 2 (#505) — diff always 0 */
+        short diff = atomic_load(&state->calldepth) - atomic_load(&state->steplevel); /* calldepth always 0 — diff always 0 until call depth tracking is added */
         boolean flstop = false;
 
         switch (atomic_load(&state->stepdir)) {

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -223,7 +223,7 @@ def test_step_over(send):
     # Continue past entry
     send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
     time.sleep(2)
-    # Suspended at breakpoint on line 1 — step over to line 2
+    # Suspended at breakpoint on line 1 — step over to next steppable line (line 3)
     send({"op": "debug/step", "id": 5, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
     time.sleep(2)
     # Kill to clean up

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -209,11 +209,38 @@ assert_test("step into suspends at next statement",
             find_msg(msgs, reason="step") is not None,
             f"Messages: {msgs}")
 
-# Note: step-over and step-out have a known issue where the GIL yield in the
-# suspension loop corrupts runtime state, causing an abort after resume.
-# Step-into works because it stops at the very next callback without yielding.
-# Step-over/out are implemented in the protocol but need a fix to the
-# suspension-loop save/restore pattern. See issue filed for tracking.
+# Step-over test — previously crashed due to #505 (hthreadglobals overwrite
+# during GIL yield). Fixed by capturing hthreadglobals in a local variable.
+def test_step_over(send):
+    send({"op": "script/eval", "id": 1, "params": {
+        "expression": 'new(scriptType, @system.temp.stepOverTest); script.newScriptObject("local (x = 1)\\rlocal (y = 2)\\rreturn (x + y)", @system.temp.stepOverTest)'
+    }})
+    time.sleep(1)
+    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "system.temp.stepOverTest", "line": 1}})
+    time.sleep(0.5)
+    send({"op": "debug/run", "id": 3, "params": {"expression": "system.temp.stepOverTest()"}})
+    time.sleep(2)
+    # Continue past entry
+    send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(2)
+    # Suspended at breakpoint on line 1 — step over to line 2
+    send({"op": "debug/step", "id": 5, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
+    time.sleep(2)
+    # Kill to clean up
+    send({"op": "debug/kill", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+
+msgs = run_debug_session(test_step_over, timeout=20)
+step_suspend = find_msg(msgs, reason="step")
+assert_test("step-over suspends at next line",
+            step_suspend is not None,
+            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
+if step_suspend:
+    step_line = step_suspend.get("params", {}).get("line")
+    # Line 2 is a local declaration (non-steppable), so step-over advances to line 3
+    assert_test("step-over advances past locals to line 3",
+                step_line == 3,
+                f"Expected line 3, got {step_line}")
 
 def test_step_error_not_suspended(send):
     send({"op": "debug/run", "id": 1, "params": {"expression": "return 1"}})


### PR DESCRIPTION
## Summary

Fixes #505 — step-over and step-out crashed with an assertion failure (`hlocals != currenthashtable`) after resuming from a debugger suspension.

## Root Cause

The suspension loop in `protocol_debugger_callback` used the **global** `hthreadglobals` for save/restore around GIL yields:

```c
headless_save_threadglobals(hthreadglobals);   // save debug thread's state
pthread_mutex_unlock(&frontier_gil);           // release GIL
nanosleep(&ts, NULL);                          // sleep — main thread runs here
pthread_mutex_lock(&frontier_gil);             // reacquire GIL
headless_restore_threadglobals(hthreadglobals); // BUG: now points to main thread's handle
```

While the debug thread sleeps, the main thread overwrites `hthreadglobals` with its own handle. On reacquire, the debug thread restores the **wrong** thread's `currenthashtable`, causing the assertion in `evaluatelist`.

The entry suspension in `debug_thread_entry` was immune because it used a local variable (`params->hglobals`).

## Fix

Capture `hthreadglobals` in a local variable before the suspension loop:

```c
hdlthreadglobals my_hglobals = hthreadglobals;  // capture before GIL release

while (atomic_load(&state->flsuspended)) {
    headless_save_threadglobals(my_hglobals);    // local — immune to overwrites
    pthread_mutex_unlock(&frontier_gil);
    nanosleep(&ts, NULL);
    pthread_mutex_lock(&frontier_gil);
    headless_restore_threadglobals(my_hglobals); // correct thread's state
}
```

Also fixes breakpoint re-triggering during step-over: when stepping from a breakpointed line, the breakpoint check now skips the current line to let the step advance.

## Test plan

- [x] 302/302 unit tests pass
- [x] 27/27 debug protocol tests pass (2 new: step-over from breakpoint)
- [x] Step-over from breakpointed line advances to next steppable line
- [x] No crash on step-over resume (previously SIGABRT)
- [x] All existing Phase 1-3 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)