### PR TITLE
feat: Call depth tracking, debug/clearBreakpoints, lock ordering docs

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -50,6 +50,12 @@ extern boolean langfastaddresstotable(hdlhashtable, bigstring, hdlhashtable *); 
 /*
  * Maximum number of concurrent debug threads.
  * Each slot holds a pointer to a debug state; NULL = unused.
+ *
+ * Lock ordering invariant: GIL → g_debug_mutex. All protocol handlers
+ * hold the GIL (acquired by protocol_handler.c before dispatch) and may
+ * then acquire g_debug_mutex. Never acquire the GIL while holding
+ * g_debug_mutex — this would deadlock. The debugger callback runs with
+ * the GIL held and acquires g_debug_mutex for breakpoint checks.
  */
 #define MAX_DEBUG_THREADS 16
 static tydebugstate *g_debug_threads[MAX_DEBUG_THREADS] = {0};
@@ -338,6 +344,12 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
         state->current_script[0] = '\0';
     }
 
+    /* Track call depth for step-over/step-out.
+     * Incremented on every function call entry, decremented on return.
+     * Used by the stepping logic: step-over stops when depth returns to
+     * the same level, step-out stops when depth decreases. */
+    atomic_fetch_add(&state->calldepth, 1);
+
     return true;
 }
 
@@ -363,6 +375,9 @@ static boolean debug_pop_sourcecode(void) {
     } else {
         state->current_script[0] = '\0';
     }
+
+    /* Decrement call depth (balanced with increment in push) */
+    atomic_fetch_sub(&state->calldepth, 1);
 
     return true;
 }
@@ -484,7 +499,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      * Step-out:  suspend when call depth decreases below step level */
     if (atomic_load(&state->flstepping) && flsteppable && !atomic_load(&state->flsuspended)) {
 
-        short diff = atomic_load(&state->calldepth) - atomic_load(&state->steplevel); /* calldepth always 0 — diff always 0 until call depth tracking is added */
+        short diff = atomic_load(&state->calldepth) - atomic_load(&state->steplevel);
         boolean flstop = false;
 
         switch (atomic_load(&state->stepdir)) {
@@ -1273,6 +1288,36 @@ void handle_debug_listbreakpoints(int id, const char *json_line, transport_t *tr
         free(json_str);
     }
     cJSON_Delete(resp);
+}
+
+/*
+ * debug/clearBreakpoints — Clear all session breakpoints.
+ */
+void handle_debug_clearbreakpoints(int id, const char *json_line, transport_t *transport) {
+
+    (void)json_line;
+
+    int cleared = 0;
+
+    pthread_mutex_lock(&g_debug_mutex);
+
+    for (int i = 0; i < MAX_BREAKPOINTS; i++) {
+        if (g_breakpoints[i].active) {
+            g_breakpoints[i].active = false;
+            cleared++;
+        }
+    }
+
+    atomic_store(&g_has_breakpoints, false);
+
+    pthread_mutex_unlock(&g_debug_mutex);
+
+    char resp[128];
+    snprintf(resp, sizeof(resp),
+             "{\"id\":%d,\"result\":{\"cleared\":%d},\"success\":true}", id, cleared);
+    transport->write_line(transport->ctx, resp, strlen(resp));
+
+    log_info(LOG_COMP_LANG, "debug: cleared %d breakpoints", cleared);
 }
 
 /* ========================================================================

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -455,7 +455,10 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
     /* Skip breakpoint check when stepping from the same line at the same depth —
      * the step should advance past the current breakpoint, not re-trigger it.
      * A recursive call at the same lnum but greater calldepth is NOT skipped,
-     * since the breakpoint should fire on re-entry at a different call level. */
+     * since the breakpoint should fire on re-entry at a different call level.
+     *
+     * The multiple atomic_load calls form a consistent snapshot because the
+     * callback runs with the GIL held — no other thread can modify these fields. */
     boolean flskipbreakpoint = (atomic_load(&state->flstepping) &&
                                 lnum == atomic_load(&state->lastlnum) &&
                                 atomic_load(&state->calldepth) == atomic_load(&state->steplevel));
@@ -1297,7 +1300,7 @@ void handle_debug_listbreakpoints(int id, const char *json_line, transport_t *tr
  */
 void handle_debug_clearbreakpoints(int id, const char *json_line, transport_t *transport) {
 
-    (void)json_line;
+    (void)json_line; /* no params to validate */
 
     int cleared = 0;
 

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -452,11 +452,13 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      *
      * Fast-path: g_has_breakpoints is checked with relaxed ordering to skip
      * the mutex entirely when no breakpoints are set (common case). */
-    /* Skip breakpoint check when stepping from the same line — the step should
-     * advance past the current breakpoint, not immediately re-trigger it.
-     * TODO: revisit when calldepth tracking is added — recursive calls could
-     * have the same lnum at a different depth, and the breakpoint should fire. */
-    boolean flskipbreakpoint = (atomic_load(&state->flstepping) && lnum == atomic_load(&state->lastlnum));
+    /* Skip breakpoint check when stepping from the same line at the same depth —
+     * the step should advance past the current breakpoint, not re-trigger it.
+     * A recursive call at the same lnum but greater calldepth is NOT skipped,
+     * since the breakpoint should fire on re-entry at a different call level. */
+    boolean flskipbreakpoint = (atomic_load(&state->flstepping) &&
+                                lnum == atomic_load(&state->lastlnum) &&
+                                atomic_load(&state->calldepth) == atomic_load(&state->steplevel));
 
     if (!flskipbreakpoint && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
         lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -376,8 +376,10 @@ static boolean debug_pop_sourcecode(void) {
         state->current_script[0] = '\0';
     }
 
-    /* Decrement call depth (balanced with increment in push) */
-    atomic_fetch_sub(&state->calldepth, 1);
+    /* Decrement call depth (balanced with increment in push).
+     * Guard against underflow from unbalanced interpreter error paths. */
+    if (atomic_load(&state->calldepth) > 0)
+        atomic_fetch_sub(&state->calldepth, 1);
 
     return true;
 }

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -99,10 +99,10 @@ typedef struct tydebugstate {
     atomic_int stepdir;              /* current step direction (debug_step_direction_t) */
     atomic_ulong lastlnum;           /* line number at last suspension */
     atomic_short steplevel;          /* call depth when step was initiated */
-    atomic_short calldepth;          /* current call depth — NOT YET IMPLEMENTED (#505).
-                                      * Stays 0, making step-over line-based only and
-                                      * step-out non-functional. Needs hook into function
-                                      * call entry/exit in the interpreter. */
+    atomic_short calldepth;          /* current call depth — 0 at top-level expression,
+                                      * incremented on function entry (push sourcecode),
+                                      * decremented on return (pop sourcecode). Used by
+                                      * step-over (same depth) and step-out (shallower). */
 
     /* Source tracking (Phase 3) — tracks which script is currently executing.
      * Updated by the push/pop sourcecode callbacks installed in debug_init().
@@ -131,6 +131,7 @@ void handle_debug_continue(int id, const char *json_line, transport_t *transport
 void handle_debug_kill(int id, const char *json_line, transport_t *transport);
 void handle_debug_pause(int id, const char *json_line, transport_t *transport);
 void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *transport);
+void handle_debug_clearbreakpoints(int id, const char *json_line, transport_t *transport);
 void handle_debug_listbreakpoints(int id, const char *json_line, transport_t *transport);
 void handle_debug_getlocals(int id, const char *json_line, transport_t *transport);
 void handle_debug_getsource(int id, const char *json_line, transport_t *transport);

--- a/frontier-cli/op_handler.c
+++ b/frontier-cli/op_handler.c
@@ -653,6 +653,8 @@ int op_dispatch(const char *json_line, size_t len, transport_t *transport) {
         handle_debug_setbreakpoint(id, json_line, transport);
     } else if (strcmp(op, "debug/listBreakpoints") == 0) {
         handle_debug_listbreakpoints(id, json_line, transport);
+    } else if (strcmp(op, "debug/clearBreakpoints") == 0) {
+        handle_debug_clearbreakpoints(id, json_line, transport);
     } else if (strcmp(op, "debug/getLocals") == 0) {
         handle_debug_getlocals(id, json_line, transport);
     } else if (strcmp(op, "debug/getSource") == 0) {

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -447,7 +447,60 @@ assert_test("setBreakpoint without line errors",
             any("line" in str(m).lower() for m in msgs if not m.get("success", True)),
             f"Messages: {msgs}")
 
-# --- Test 11: debug/getLocals + debug/getStack + debug/getSource ---
+# --- Test 11: debug/clearBreakpoints ---
+print()
+print("--- debug/clearBreakpoints ---")
+
+def test_clear_breakpoints(send):
+    # Set two breakpoints
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "foo.bar", "line": 1}})
+    time.sleep(0.3)
+    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "foo.bar", "line": 2}})
+    time.sleep(0.3)
+    # Clear all
+    send({"op": "debug/clearBreakpoints", "id": 3, "params": {}})
+    time.sleep(0.3)
+    # List should be empty
+    send({"op": "debug/listBreakpoints", "id": 4, "params": {}})
+    time.sleep(0.3)
+
+msgs = run_debug_session(test_clear_breakpoints)
+
+# Check clear returns count
+clear_msg = None
+for m in msgs:
+    if m.get("id") == 3 and m.get("result", {}).get("cleared") is not None:
+        clear_msg = m
+        break
+assert_test("clearBreakpoints returns count",
+            clear_msg is not None and clear_msg["result"]["cleared"] == 2,
+            f"Messages: {[m for m in msgs if m.get('id') == 3]}")
+
+# Check list is empty after clear
+list_msg = None
+for m in msgs:
+    if m.get("id") == 4 and m.get("result", {}).get("breakpoints") is not None:
+        list_msg = m
+        break
+assert_test("list empty after clearBreakpoints",
+            list_msg is not None and len(list_msg["result"]["breakpoints"]) == 0,
+            f"Messages: {[m for m in msgs if m.get('id') == 4]}")
+
+def test_clear_empty(send):
+    send({"op": "debug/clearBreakpoints", "id": 1, "params": {}})
+    time.sleep(0.3)
+
+msgs = run_debug_session(test_clear_empty)
+clear_msg = None
+for m in msgs:
+    if m.get("id") == 1 and m.get("result", {}).get("cleared") is not None:
+        clear_msg = m
+        break
+assert_test("clearBreakpoints with no breakpoints returns 0",
+            clear_msg is not None and clear_msg["result"]["cleared"] == 0,
+            f"Messages: {msgs}")
+
+# --- Test 12: debug/getLocals + debug/getStack + debug/getSource ---
 print()
 print("--- debug/getLocals + debug/getStack + debug/getSource ---")
 

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -242,6 +242,43 @@ if step_suspend:
                 step_line == 3,
                 f"Expected line 3, got {step_line}")
 
+# Step-over with calldepth: verify step-over skips into function calls
+def test_step_over_calldepth(send):
+    # Create a helper function and a caller that invokes it
+    send({"op": "script/eval", "id": 1, "params": {
+        "expression": 'new(scriptType, @system.temp.depthHelper); script.newScriptObject("return 99", @system.temp.depthHelper)'
+    }})
+    time.sleep(0.5)
+    send({"op": "script/eval", "id": 2, "params": {
+        "expression": 'new(scriptType, @system.temp.depthCaller); script.newScriptObject("local (a = system.temp.depthHelper())\\rreturn a", @system.temp.depthCaller)'
+    }})
+    time.sleep(0.5)
+    # Set breakpoint on line 1 of caller (the function call line)
+    send({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.depthCaller", "line": 1}})
+    time.sleep(0.3)
+    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.depthCaller()"}})
+    time.sleep(2)
+    # Continue past entry
+    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(2)
+    # Now at breakpoint on line 1 — step over should skip INTO depthHelper
+    # and stop at line 2 (return a) of depthCaller
+    send({"op": "debug/step", "id": 6, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
+    time.sleep(3)
+    send({"op": "debug/kill", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+
+msgs = run_debug_session(test_step_over_calldepth, timeout=25)
+step_suspend = find_msg(msgs, reason="step")
+assert_test("step-over with calldepth skips function call",
+            step_suspend is not None,
+            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
+if step_suspend:
+    step_line = step_suspend.get("params", {}).get("line")
+    assert_test("step-over returns to caller line 2",
+                step_line == 2,
+                f"Expected line 2, got {step_line}")
+
 def test_step_error_not_suspended(send):
     send({"op": "debug/run", "id": 1, "params": {"expression": "return 1"}})
     time.sleep(1)

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -261,8 +261,8 @@ def test_step_over_calldepth(send):
     # Continue past entry
     send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
     time.sleep(2)
-    # Now at breakpoint on line 1 — step over should skip INTO depthHelper
-    # and stop at line 2 (return a) of depthCaller
+    # Now at breakpoint on line 1 — step over should NOT enter depthHelper
+    # and should stop at line 2 (return a) of depthCaller
     send({"op": "debug/step", "id": 6, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
     time.sleep(3)
     send({"op": "debug/kill", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})


### PR DESCRIPTION
## Summary

Three debugger improvements addressing the top unactioned feedback items:

1. **Call depth tracking** — `push/pop sourcecode` callbacks now increment/decrement `calldepth` on function entry/exit. Enables proper step-over (stop at same depth when line changes) and step-out (stop when depth decreases below step level). Previously calldepth was always 0.

2. **`debug/clearBreakpoints`** — New protocol operation to clear all session breakpoints at once. Returns the count cleared. Useful for automation.

3. **Lock ordering documentation** — Added invariant comment: GIL → g_debug_mutex. Prevents future deadlocks.

## Protocol

```json
// Clear all breakpoints
{"op":"debug/clearBreakpoints","id":1,"params":{}}
// Response: {"id":1,"result":{"cleared":3},"success":true}
```

## Test plan

- [x] 302/302 unit tests pass
- [x] 38/38 debug protocol tests pass
- [x] Step-over test passes (advances from breakpointed line to next steppable line)
- [x] All existing Phase 1-4 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)