### PR TITLE
feat: Debugger Phase 6 — watchpoints (set/clear/list/fire)

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -575,8 +575,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                 memcpy(bsname + 1, g_watchpoints[w].varname, (size_t)nlen);
 
                 tyvaluerecord val;
-                hdlhashnode hn;
-                if (!hashtablelookup(hlocals, bsname, &val, &hn))
+                hdlhashnode hn = nil;
+                if (!hashtablelookup(hlocals, bsname, &val, &hn))  /* hn unused — API requires it */
                     continue;
 
                 /* Get current value as string */

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -90,6 +90,32 @@ static debug_breakpoint_t g_breakpoints[MAX_BREAKPOINTS] = {0};
 static atomic_bool g_has_breakpoints = false; /* fast-path: skip mutex when no breakpoints set */
 
 /* ========================================================================
+ * Watchpoints (Phase 6)
+ *
+ * Watchpoints monitor a named variable and suspend when its value changes.
+ * The callback snapshots the variable's string representation on first
+ * encounter and compares on each subsequent callback. If the value differs,
+ * the thread suspends with reason "watchpoint" and reports old/new values.
+ *
+ * Like breakpoints, watchpoints persist for the lifetime of the process
+ * and are protected by g_debug_mutex.
+ * ======================================================================== */
+
+#define MAX_WATCHPOINTS 64
+#define DEBUG_VARNAME_MAX 64
+#define DEBUG_VALUE_MAX 256
+
+typedef struct {
+    char varname[DEBUG_VARNAME_MAX];    /* variable name to watch */
+    char last_value[DEBUG_VALUE_MAX];   /* last known value (string repr) */
+    boolean has_snapshot;               /* have we taken an initial snapshot? */
+    boolean active;                     /* is this slot in use? */
+} debug_watchpoint_t;
+
+static debug_watchpoint_t g_watchpoints[MAX_WATCHPOINTS] = {0};
+static atomic_bool g_has_watchpoints = false; /* fast-path */
+
+/* ========================================================================
  * Reason string conversion
  * ======================================================================== */
 
@@ -99,6 +125,7 @@ const char *debug_reason_string(debug_suspend_reason_t reason) {
         case DEBUG_REASON_INTERRUPTED: return "interrupted";
         case DEBUG_REASON_BREAKPOINT:  return "breakpoint";
         case DEBUG_REASON_STEP:        return "step";
+        case DEBUG_REASON_WATCHPOINT:  return "watchpoint";
         case DEBUG_REASON_ERROR:       return "error";
         default:                       return "unknown";
     }
@@ -461,9 +488,13 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      *
      * The multiple atomic_load calls form a consistent snapshot because the
      * callback runs with the GIL held — no other thread can modify these fields. */
-    boolean flskipbreakpoint = (atomic_load(&state->flstepping) &&
-                                lnum == atomic_load(&state->lastlnum) &&
-                                atomic_load(&state->calldepth) == atomic_load(&state->steplevel));
+    /* Skip breakpoint re-trigger on the same line we just suspended at.
+     * After any suspension (breakpoint, step, watchpoint), lastlnum records
+     * the suspension line. The callback may fire again for the same lnum
+     * (multiple AST nodes per source line) before advancing. Without this
+     * guard, the thread would immediately re-hit the same breakpoint.
+     * Once lnum changes (next source line), breakpoints fire normally again. */
+    boolean flskipbreakpoint = (lnum > 0 && lnum == atomic_load(&state->lastlnum));
 
     if (!flskipbreakpoint && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
         lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
@@ -494,6 +525,115 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
             debug_send_suspended(state->transport, state->threadid, (long)lnum, DEBUG_REASON_BREAKPOINT);
             log_debug(LOG_COMP_LANG, "debug: thread %ld hit breakpoint at %s line %ld",
                       state->threadid, state->current_script, (long)lnum);
+        }
+    }
+
+    /* Watchpoint check (Phase 6) — if not already suspended and watchpoints
+     * exist, check if any watched variable has changed value since last check.
+     * Uses string representation comparison (hashgetvaluestring) to avoid
+     * the dispose-both-inputs issue with EQvalue.
+     *
+     * Watchpoints fire on steppable nodes only (meaningful lines where values
+     * could have changed). */
+    if (atomic_load_explicit(&g_has_watchpoints, memory_order_relaxed) &&
+        flsteppable && !atomic_load(&state->flsuspended)) {
+
+        /* Get current local hash table — use the global currenthashtable
+         * (which is correct since we hold the GIL and own this thread's
+         * restored context) rather than reading from hglobals. */
+        hdlhashtable htable = currenthashtable;
+
+        /* Find the innermost local table */
+        hdlhashtable hlocals = nil;
+        hdlhashtable hwalk = htable;
+        while (hwalk != nil) {
+            if ((**hwalk).fllocaltable) {
+                hlocals = hwalk;
+                break;
+            }
+            hwalk = (**hwalk).prevhashtable;
+        }
+
+        if (hlocals != nil) {
+            pthread_mutex_lock(&g_debug_mutex);
+
+            for (int w = 0; w < MAX_WATCHPOINTS; w++) {
+                if (!g_watchpoints[w].active)
+                    continue;
+
+                /* Look up the variable by name */
+                bigstring bsname;
+                int nlen = (int)strlen(g_watchpoints[w].varname);
+                if (nlen > 255) nlen = 255;
+                bsname[0] = (unsigned char)nlen;
+                memcpy(bsname + 1, g_watchpoints[w].varname, (size_t)nlen);
+
+                tyvaluerecord val;
+                hdlhashnode hnode;
+                if (!hashtablelookup(hlocals, bsname, &val, &hnode))
+                    continue;
+
+                /* Get current value as string */
+                bigstring bsval;
+                if (!hashgetvaluestring(val, bsval))
+                    continue;
+
+                char cval[DEBUG_VALUE_MAX];
+                int vlen = bsval[0];
+                if (vlen >= DEBUG_VALUE_MAX) vlen = DEBUG_VALUE_MAX - 1;
+                memcpy(cval, bsval + 1, (size_t)vlen);
+                cval[vlen] = '\0';
+
+                if (!g_watchpoints[w].has_snapshot) {
+                    /* First encounter — save snapshot, don't trigger */
+                    memcpy(g_watchpoints[w].last_value, cval, (size_t)(vlen + 1));
+                    g_watchpoints[w].has_snapshot = true;
+                    continue;
+                }
+
+                /* Compare with last known value */
+                if (strcmp(g_watchpoints[w].last_value, cval) != 0) {
+                    /* Value changed! */
+                    char old_value[DEBUG_VALUE_MAX];
+                    memcpy(old_value, g_watchpoints[w].last_value, DEBUG_VALUE_MAX);
+                    memcpy(g_watchpoints[w].last_value, cval, (size_t)(vlen + 1));
+
+                    pthread_mutex_unlock(&g_debug_mutex);
+
+                    /* Clear stepping state — watchpoint takes priority */
+                    atomic_store(&state->flstepping, false);
+                    atomic_store(&state->stepdir, DEBUG_STEP_NONE);
+                    atomic_store(&state->lastlnum, lnum);
+
+                    /* Send watchpoint notification with old/new values */
+                    cJSON *notif = cJSON_CreateObject();
+                    cJSON_AddNullToObject(notif, "id");
+                    cJSON_AddStringToObject(notif, "op", "debug/suspended");
+                    cJSON *params = cJSON_CreateObject();
+                    cJSON_AddNumberToObject(params, "threadId", (double)state->threadid);
+                    cJSON_AddNumberToObject(params, "line", (double)lnum);
+                    cJSON_AddStringToObject(params, "reason", "watchpoint");
+                    cJSON_AddStringToObject(params, "variable", g_watchpoints[w].varname);
+                    cJSON_AddStringToObject(params, "oldValue", old_value);
+                    cJSON_AddStringToObject(params, "newValue", cval);
+                    cJSON_AddItemToObject(notif, "params", params);
+
+                    char *json_str = cJSON_PrintUnformatted(notif);
+                    if (json_str) {
+                        atomic_store_explicit(&state->flsuspended, true, memory_order_seq_cst);
+                        state->transport->write_line(state->transport->ctx, json_str, strlen(json_str));
+                        free(json_str);
+                    }
+                    cJSON_Delete(notif);
+
+                    log_debug(LOG_COMP_LANG, "debug: thread %ld watchpoint '%s' changed: '%s' -> '%s' at line %ld",
+                              state->threadid, g_watchpoints[w].varname, old_value, cval, (long)lnum);
+
+                    goto after_stepping; /* skip stepping logic, already suspended */
+                }
+            }
+
+            pthread_mutex_unlock(&g_debug_mutex);
         }
     }
 
@@ -552,6 +692,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
             log_debug(LOG_COMP_LANG, "debug: thread %ld step completed at line %ld", state->threadid, (long)lnum);
         }
     }
+
+after_stepping: /* label for watchpoint goto — skips stepping when watchpoint fires */
 
     /* Capture the thread globals handle in a local variable BEFORE releasing
      * the GIL. The global `hthreadglobals` is shared — other threads overwrite
@@ -1815,4 +1957,186 @@ void handle_debug_listthreads(int id, const char *json_line, transport_t *transp
         free(json_str);
     }
     cJSON_Delete(resp);
+}
+
+/* ========================================================================
+ * Watchpoint protocol handlers (Phase 6)
+ * ======================================================================== */
+
+/*
+ * debug/setWatchpoint — Set or clear a watchpoint on a variable.
+ *
+ * Toggle behavior: if a watchpoint already exists for the variable,
+ * it is cleared. Otherwise, a new watchpoint is set.
+ *
+ * Params:
+ *   variable: name of the variable to watch (e.g. "x", "msg")
+ */
+void handle_debug_setwatchpoint(int id, const char *json_line, transport_t *transport) {
+
+    cJSON *root = cJSON_Parse(json_line);
+
+    if (root == NULL) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Invalid JSON\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        return;
+    }
+
+    cJSON *params_json = cJSON_GetObjectItemCaseSensitive(root, "params");
+    cJSON *var_json = params_json ? cJSON_GetObjectItemCaseSensitive(params_json, "variable") : NULL;
+
+    if (!cJSON_IsString(var_json) || var_json->valuestring == NULL) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Missing 'variable' in params\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    const char *varname = var_json->valuestring;
+
+    if (strlen(varname) >= DEBUG_VARNAME_MAX) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Variable name too long\"},\"success\":false}", id);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    boolean cleared = false;
+    boolean set = false;
+
+    pthread_mutex_lock(&g_debug_mutex);
+
+    /* First pass: check for existing watchpoint to toggle off */
+    for (int i = 0; i < MAX_WATCHPOINTS; i++) {
+        if (g_watchpoints[i].active &&
+            strcmp(g_watchpoints[i].varname, varname) == 0) {
+            g_watchpoints[i].active = false;
+            cleared = true;
+            break;
+        }
+    }
+
+    /* Second pass: if not clearing, find an empty slot */
+    if (!cleared) {
+        for (int i = 0; i < MAX_WATCHPOINTS; i++) {
+            if (!g_watchpoints[i].active) {
+                memcpy(g_watchpoints[i].varname, varname, strlen(varname) + 1);
+                g_watchpoints[i].has_snapshot = false;
+                g_watchpoints[i].last_value[0] = '\0';
+                g_watchpoints[i].active = true;
+                set = true;
+                break;
+            }
+        }
+    }
+
+    /* Update fast-path flag */
+    boolean any_active = false;
+    for (int i = 0; i < MAX_WATCHPOINTS; i++) {
+        if (g_watchpoints[i].active) {
+            any_active = true;
+            break;
+        }
+    }
+    atomic_store(&g_has_watchpoints, any_active);
+
+    pthread_mutex_unlock(&g_debug_mutex);
+
+    if (!cleared && !set) {
+        char err[512];
+        snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Too many watchpoints (max %d)\"},\"success\":false}", id, MAX_WATCHPOINTS);
+        transport->write_line(transport->ctx, err, strlen(err));
+        cJSON_Delete(root);
+        return;
+    }
+
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddNumberToObject(resp, "id", id);
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddStringToObject(result, "action", cleared ? "cleared" : "set");
+    cJSON_AddStringToObject(result, "variable", varname);
+    cJSON_AddItemToObject(resp, "result", result);
+    cJSON_AddBoolToObject(resp, "success", 1);
+
+    char *json_str = cJSON_PrintUnformatted(resp);
+    if (json_str) {
+        transport->write_line(transport->ctx, json_str, strlen(json_str));
+        free(json_str);
+    }
+    cJSON_Delete(resp);
+
+    log_info(LOG_COMP_LANG, "debug: watchpoint %s on '%s'",
+             cleared ? "cleared" : "set", varname);
+
+    cJSON_Delete(root);
+}
+
+/*
+ * debug/listWatchpoints — List all active watchpoints.
+ */
+void handle_debug_listwatchpoints(int id, const char *json_line, transport_t *transport) {
+
+    (void)json_line; /* no params to validate */
+
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddNumberToObject(resp, "id", id);
+
+    cJSON *result = cJSON_CreateObject();
+    cJSON *wparray = cJSON_CreateArray();
+
+    pthread_mutex_lock(&g_debug_mutex);
+
+    for (int i = 0; i < MAX_WATCHPOINTS; i++) {
+        if (g_watchpoints[i].active) {
+            cJSON *wp = cJSON_CreateObject();
+            cJSON_AddStringToObject(wp, "variable", g_watchpoints[i].varname);
+            if (g_watchpoints[i].has_snapshot)
+                cJSON_AddStringToObject(wp, "lastValue", g_watchpoints[i].last_value);
+            cJSON_AddItemToArray(wparray, wp);
+        }
+    }
+
+    pthread_mutex_unlock(&g_debug_mutex);
+
+    cJSON_AddItemToObject(result, "watchpoints", wparray);
+    cJSON_AddItemToObject(resp, "result", result);
+    cJSON_AddBoolToObject(resp, "success", 1);
+
+    char *json_str = cJSON_PrintUnformatted(resp);
+    if (json_str) {
+        transport->write_line(transport->ctx, json_str, strlen(json_str));
+        free(json_str);
+    }
+    cJSON_Delete(resp);
+}
+
+/*
+ * debug/clearWatchpoints — Clear all watchpoints.
+ */
+void handle_debug_clearwatchpoints(int id, const char *json_line, transport_t *transport) {
+
+    (void)json_line; /* no params to validate */
+
+    int cleared_count = 0;
+
+    pthread_mutex_lock(&g_debug_mutex);
+
+    for (int i = 0; i < MAX_WATCHPOINTS; i++) {
+        if (g_watchpoints[i].active) {
+            g_watchpoints[i].active = false;
+            cleared_count++;
+        }
+    }
+
+    atomic_store(&g_has_watchpoints, false);
+
+    pthread_mutex_unlock(&g_debug_mutex);
+
+    char resp[128];
+    snprintf(resp, sizeof(resp),
+             "{\"id\":%d,\"result\":{\"cleared\":%d},\"success\":true}", id, cleared_count);
+    transport->write_line(transport->ctx, resp, strlen(resp));
 }

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -488,13 +488,19 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
      *
      * The multiple atomic_load calls form a consistent snapshot because the
      * callback runs with the GIL held — no other thread can modify these fields. */
-    /* Skip breakpoint re-trigger on the same line we just suspended at.
-     * After any suspension (breakpoint, step, watchpoint), lastlnum records
-     * the suspension line. The callback may fire again for the same lnum
-     * (multiple AST nodes per source line) before advancing. Without this
-     * guard, the thread would immediately re-hit the same breakpoint.
-     * Once lnum changes (next source line), breakpoints fire normally again. */
-    boolean flskipbreakpoint = (lnum > 0 && lnum == atomic_load(&state->lastlnum));
+    /* Skip breakpoint re-trigger on the same line we just resumed from.
+     * After any suspension, flskipaliasline is set. While true, breakpoints
+     * at lastlnum are skipped (multiple AST nodes per source line). Once the
+     * line number changes (next source line), the flag is cleared and
+     * breakpoints fire normally — including if a loop returns to lastlnum. */
+    boolean flskipbreakpoint = false;
+    if (state->flskipaliasline && lnum > 0) {
+        if (lnum == atomic_load(&state->lastlnum)) {
+            flskipbreakpoint = true;
+        } else {
+            state->flskipaliasline = false; /* line changed — re-enable breakpoints */
+        }
+    }
 
     if (!flskipbreakpoint && atomic_load_explicit(&g_has_breakpoints, memory_order_relaxed) &&
         lnum > 0 && !atomic_load(&state->flsuspended) && state->current_script[0] != '\0') {
@@ -569,8 +575,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                 memcpy(bsname + 1, g_watchpoints[w].varname, (size_t)nlen);
 
                 tyvaluerecord val;
-                hdlhashnode hnode;
-                if (!hashtablelookup(hlocals, bsname, &val, &hnode))
+                hdlhashnode hn;
+                if (!hashtablelookup(hlocals, bsname, &val, &hn))
                     continue;
 
                 /* Get current value as string */
@@ -593,9 +599,11 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
                 /* Compare with last known value */
                 if (strcmp(g_watchpoints[w].last_value, cval) != 0) {
-                    /* Value changed! */
+                    /* Value changed! Copy all needed data before releasing mutex */
                     char old_value[DEBUG_VALUE_MAX];
+                    char fired_varname[DEBUG_VARNAME_MAX];
                     memcpy(old_value, g_watchpoints[w].last_value, DEBUG_VALUE_MAX);
+                    memcpy(fired_varname, g_watchpoints[w].varname, DEBUG_VARNAME_MAX);
                     memcpy(g_watchpoints[w].last_value, cval, (size_t)(vlen + 1));
 
                     pthread_mutex_unlock(&g_debug_mutex);
@@ -609,14 +617,14 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                     cJSON *notif = cJSON_CreateObject();
                     cJSON_AddNullToObject(notif, "id");
                     cJSON_AddStringToObject(notif, "op", "debug/suspended");
-                    cJSON *params = cJSON_CreateObject();
-                    cJSON_AddNumberToObject(params, "threadId", (double)state->threadid);
-                    cJSON_AddNumberToObject(params, "line", (double)lnum);
-                    cJSON_AddStringToObject(params, "reason", "watchpoint");
-                    cJSON_AddStringToObject(params, "variable", g_watchpoints[w].varname);
-                    cJSON_AddStringToObject(params, "oldValue", old_value);
-                    cJSON_AddStringToObject(params, "newValue", cval);
-                    cJSON_AddItemToObject(notif, "params", params);
+                    cJSON *wp_params = cJSON_CreateObject();
+                    cJSON_AddNumberToObject(wp_params, "threadId", (double)state->threadid);
+                    cJSON_AddNumberToObject(wp_params, "line", (double)lnum);
+                    cJSON_AddStringToObject(wp_params, "reason", "watchpoint");
+                    cJSON_AddStringToObject(wp_params, "variable", fired_varname);
+                    cJSON_AddStringToObject(wp_params, "oldValue", old_value);
+                    cJSON_AddStringToObject(wp_params, "newValue", cval);
+                    cJSON_AddItemToObject(notif, "params", wp_params);
 
                     char *json_str = cJSON_PrintUnformatted(notif);
                     if (json_str) {
@@ -627,7 +635,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                     cJSON_Delete(notif);
 
                     log_debug(LOG_COMP_LANG, "debug: thread %ld watchpoint '%s' changed: '%s' -> '%s' at line %ld",
-                              state->threadid, g_watchpoints[w].varname, old_value, cval, (long)lnum);
+                              state->threadid, fired_varname, old_value, cval, (long)lnum);
 
                     goto after_stepping; /* skip stepping logic, already suspended */
                 }
@@ -1068,6 +1076,7 @@ void handle_debug_continue(int id, const char *json_line, transport_t *transport
     /* Clear any stepping state — continue means run freely */
     atomic_store(&state->flstepping, false);
     atomic_store(&state->stepdir, DEBUG_STEP_NONE);
+    state->flskipaliasline = true; /* skip re-trigger at same line on resume */
 
     atomic_store(&state->flsuspended, false);
     debug_release_state(state);
@@ -1153,6 +1162,7 @@ void handle_debug_step(int id, const char *json_line, transport_t *transport) {
     atomic_store(&state->stepdir, (int)dir);
     atomic_store(&state->steplevel, atomic_load(&state->calldepth));
     /* lastlnum already set from the last suspension point */
+    state->flskipaliasline = true; /* skip re-trigger at same line on resume */
 
     /* Resume the thread — it will execute until the stepping condition is met */
     atomic_store_explicit(&state->flsuspended, false, memory_order_seq_cst);

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -37,6 +37,7 @@ typedef enum {
     DEBUG_REASON_INTERRUPTED,  /* suspended via debug/pause */
     DEBUG_REASON_BREAKPOINT,   /* suspended at breakpoint (Phase 3) */
     DEBUG_REASON_STEP,         /* suspended after step (Phase 2) */
+    DEBUG_REASON_WATCHPOINT,   /* suspended on watchpoint value change (Phase 6) */
     DEBUG_REASON_ERROR         /* suspended on error (future) */
 } debug_suspend_reason_t;
 
@@ -137,6 +138,9 @@ void handle_debug_getlocals(int id, const char *json_line, transport_t *transpor
 void handle_debug_getsource(int id, const char *json_line, transport_t *transport);
 void handle_debug_getstack(int id, const char *json_line, transport_t *transport);
 void handle_debug_listthreads(int id, const char *json_line, transport_t *transport);
+void handle_debug_setwatchpoint(int id, const char *json_line, transport_t *transport);
+void handle_debug_listwatchpoints(int id, const char *json_line, transport_t *transport);
+void handle_debug_clearwatchpoints(int id, const char *json_line, transport_t *transport);
 
 /*
  * Release a reference to a debug state obtained from debug_get_state_for_thread.

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -99,6 +99,8 @@ typedef struct tydebugstate {
     atomic_bool flstepping;          /* stepping mode active */
     atomic_int stepdir;              /* current step direction (debug_step_direction_t) */
     atomic_ulong lastlnum;           /* line number at last suspension */
+    boolean flskipaliasline;         /* skip breakpoints at lastlnum until line changes;
+                                      * set on resume, cleared when lnum != lastlnum */
     atomic_short steplevel;          /* call depth when step was initiated */
     atomic_short calldepth;          /* current call depth — 0 at top-level expression,
                                       * incremented on function entry (push sourcecode),

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -100,7 +100,10 @@ typedef struct tydebugstate {
     atomic_int stepdir;              /* current step direction (debug_step_direction_t) */
     atomic_ulong lastlnum;           /* line number at last suspension */
     boolean flskipaliasline;         /* skip breakpoints at lastlnum until line changes;
-                                      * set on resume, cleared when lnum != lastlnum */
+                                      * set on resume, cleared when lnum != lastlnum.
+                                      * Not atomic: written by protocol handler (under GIL)
+                                      * and read by debug thread callback (under GIL).
+                                      * Safe because only one thread holds the GIL at a time. */
     atomic_short steplevel;          /* call depth when step was initiated */
     atomic_short calldepth;          /* current call depth — 0 at top-level expression,
                                       * incremented on function entry (push sourcecode),

--- a/frontier-cli/op_handler.c
+++ b/frontier-cli/op_handler.c
@@ -663,6 +663,12 @@ int op_dispatch(const char *json_line, size_t len, transport_t *transport) {
         handle_debug_getstack(id, json_line, transport);
     } else if (strcmp(op, "debug/listThreads") == 0) {
         handle_debug_listthreads(id, json_line, transport);
+    } else if (strcmp(op, "debug/setWatchpoint") == 0) {
+        handle_debug_setwatchpoint(id, json_line, transport);
+    } else if (strcmp(op, "debug/listWatchpoints") == 0) {
+        handle_debug_listwatchpoints(id, json_line, transport);
+    } else if (strcmp(op, "debug/clearWatchpoints") == 0) {
+        handle_debug_clearwatchpoints(id, json_line, transport);
     } else if (strcmp(op, "shutdown") == 0) {
         send_ack(id, transport);
         free(op);

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -723,6 +723,104 @@ assert_test("both threads completed",
             len(completions) >= 2,
             f"Completions: {completions}")
 
+# --- Test 15: watchpoint set/list/clear ---
+print()
+print("--- watchpoint set/list/clear ---")
+
+def test_watchpoint_ops(send):
+    send({"op": "debug/setWatchpoint", "id": 1, "params": {"variable": "x"}})
+    time.sleep(0.3)
+    send({"op": "debug/setWatchpoint", "id": 2, "params": {"variable": "y"}})
+    time.sleep(0.3)
+    send({"op": "debug/listWatchpoints", "id": 3, "params": {}})
+    time.sleep(0.3)
+    # Toggle x off
+    send({"op": "debug/setWatchpoint", "id": 4, "params": {"variable": "x"}})
+    time.sleep(0.3)
+    send({"op": "debug/listWatchpoints", "id": 5, "params": {}})
+    time.sleep(0.3)
+    # Clear all
+    send({"op": "debug/clearWatchpoints", "id": 6, "params": {}})
+    time.sleep(0.3)
+
+msgs = run_debug_session(test_watchpoint_ops)
+
+set_msg = None
+for m in msgs:
+    if m.get("id") == 1 and m.get("result", {}).get("action") == "set":
+        set_msg = m
+        break
+assert_test("setWatchpoint returns action=set", set_msg is not None, f"Messages: {msgs}")
+
+list1 = None
+for m in msgs:
+    if m.get("id") == 3 and m.get("result", {}).get("watchpoints") is not None:
+        list1 = m
+        break
+assert_test("listWatchpoints shows 2 watchpoints",
+            list1 is not None and len(list1["result"]["watchpoints"]) == 2,
+            f"Messages: {[m for m in msgs if m.get('id') == 3]}")
+
+toggle_msg = None
+for m in msgs:
+    if m.get("id") == 4 and m.get("result", {}).get("action") == "cleared":
+        toggle_msg = m
+        break
+assert_test("setWatchpoint toggle clears", toggle_msg is not None, f"Messages: {msgs}")
+
+list2 = None
+for m in msgs:
+    if m.get("id") == 5 and m.get("result", {}).get("watchpoints") is not None:
+        list2 = m
+        break
+assert_test("listWatchpoints shows 1 after toggle",
+            list2 is not None and len(list2["result"]["watchpoints"]) == 1,
+            f"Messages: {[m for m in msgs if m.get('id') == 5]}")
+
+clear_msg = None
+for m in msgs:
+    if m.get("id") == 6 and m.get("result", {}).get("cleared") is not None:
+        clear_msg = m
+        break
+assert_test("clearWatchpoints returns count",
+            clear_msg is not None and clear_msg["result"]["cleared"] == 1,
+            f"Messages: {[m for m in msgs if m.get('id') == 6]}")
+
+# --- Test 16: watchpoint fires on value change ---
+print()
+print("--- watchpoint fires on value change ---")
+
+def test_watchpoint_fire(send):
+    send({"op": "debug/setWatchpoint", "id": 1, "params": {"variable": "x"}})
+    time.sleep(0.3)
+    send({"op": "debug/run", "id": 2, "params": {"expression": "local (x = 1); x = x + 10; return x"}})
+    time.sleep(2)
+    # Continue past entry — watchpoint should fire when x changes
+    send({"op": "debug/continue", "id": 3, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(3)
+    # Kill
+    send({"op": "debug/kill", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+
+msgs = run_debug_session(test_watchpoint_fire, timeout=20)
+
+wp_suspend = find_msg(msgs, reason="watchpoint")
+assert_test("watchpoint fires on value change",
+            wp_suspend is not None,
+            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
+
+if wp_suspend:
+    params = wp_suspend.get("params", {})
+    assert_test("watchpoint reports variable name",
+                params.get("variable") == "x",
+                f"Params: {params}")
+    assert_test("watchpoint reports old value",
+                params.get("oldValue") == "1",
+                f"Params: {params}")
+    assert_test("watchpoint reports new value",
+                params.get("newValue") == "11",
+                f"Params: {params}")
+
 print()
 print("=" * 46)
 print(f"RESULTS: {PASSED} passed, {FAILED} failed")


### PR DESCRIPTION
## Summary

Adds watchpoint support to the UserTalk debugger (Phase 6). Watchpoints monitor a named variable and suspend execution when its value changes, reporting old and new values.

## Protocol

```json
// Set watchpoint
{"op":"debug/setWatchpoint","id":1,"params":{"variable":"x"}}
// Response: {"id":1,"result":{"action":"set","variable":"x"},"success":true}

// Watchpoint fires — unsolicited notification
{"id":null,"op":"debug/suspended","params":{
  "threadId":3,"line":1,"reason":"watchpoint",
  "variable":"x","oldValue":"1","newValue":"11"
}}
```

## Implementation

- String-comparison model: snapshots `hashgetvaluestring` output on first encounter, compares on each subsequent steppable callback. Avoids the EQvalue dispose-both-inputs issue.
- Fast-path: `g_has_watchpoints` atomic flag skips mutex when no watchpoints set.
- Uses live `currenthashtable` (correct under GIL) for variable lookup in the callback.
- Also fixes breakpoint re-trigger after continue (not just stepping).

## Test plan

- [x] 302/302 unit tests pass
- [x] 57/57 debug protocol tests pass (9 new watchpoint tests)
- [x] Watchpoint set/toggle/list/clear protocol operations verified
- [x] End-to-end: watchpoint fires when variable changes, reports correct old/new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)