### PR TITLE
feat: Debugger Phase 7 — conditional breakpoints

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -79,11 +79,17 @@ static atomic_bool g_debug_thread_was_killed = false; /* set when a debug thread
  * ======================================================================== */
 
 #define MAX_BREAKPOINTS 256
+#define DEBUG_VALUE_MAX 256  /* shared: breakpoint conditions + watchpoint values */
 
 typedef struct {
     char script[DEBUG_SCRIPT_PATH_MAX]; /* dotted script path, e.g. "mainResponder.respond" */
     unsigned long line;                 /* 1-based line number */
     boolean active;                     /* is this slot in use? */
+    char condition[DEBUG_VALUE_MAX];    /* optional condition expression (Phase 7).
+                                         * Empty string = unconditional breakpoint.
+                                         * Simple format: "varname op value" where op is
+                                         * ==, !=, >, <, >=, <=. Evaluated against locals
+                                         * when breakpoint line is reached. */
 } debug_breakpoint_t;
 
 static debug_breakpoint_t g_breakpoints[MAX_BREAKPOINTS] = {0};
@@ -103,7 +109,6 @@ static atomic_bool g_has_breakpoints = false; /* fast-path: skip mutex when no b
 
 #define MAX_WATCHPOINTS 64
 #define DEBUG_VARNAME_MAX 64
-#define DEBUG_VALUE_MAX 256
 
 typedef struct {
     char varname[DEBUG_VARNAME_MAX];    /* variable name to watch */
@@ -509,16 +514,118 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
         pthread_mutex_lock(&g_debug_mutex);
 
+        /* Find matching breakpoint and copy its condition (if any) */
+        char bp_condition[DEBUG_VALUE_MAX] = {0};
+
         for (int i = 0; i < MAX_BREAKPOINTS; i++) {
             if (g_breakpoints[i].active &&
                 g_breakpoints[i].line == lnum &&
                 strcasecmp(g_breakpoints[i].script, state->current_script) == 0) {
                 flbreakpoint = true;
+                memcpy(bp_condition, g_breakpoints[i].condition, DEBUG_VALUE_MAX);
                 break;
             }
         }
 
         pthread_mutex_unlock(&g_debug_mutex);
+
+        /* Evaluate condition if present (Phase 7).
+         * Simple format: "varname op value" where op is ==, !=, >, <, >=, <=.
+         * Compares string representation of the variable against expected value.
+         * Numeric comparison used when both sides parse as numbers. */
+        if (flbreakpoint && bp_condition[0] != '\0') {
+            boolean cond_met = false;
+
+            /* Parse: find operator (check two-char ops before one-char) */
+            char *op_pos = NULL;
+            int op_len = 0;
+            enum { OP_EQ, OP_NE, OP_GE, OP_LE, OP_GT, OP_LT } op_type = OP_EQ;
+
+            if ((op_pos = strstr(bp_condition, "==")) != NULL) { op_len = 2; op_type = OP_EQ; }
+            else if ((op_pos = strstr(bp_condition, "!=")) != NULL) { op_len = 2; op_type = OP_NE; }
+            else if ((op_pos = strstr(bp_condition, ">=")) != NULL) { op_len = 2; op_type = OP_GE; }
+            else if ((op_pos = strstr(bp_condition, "<=")) != NULL) { op_len = 2; op_type = OP_LE; }
+            else if ((op_pos = strstr(bp_condition, ">")) != NULL) { op_len = 1; op_type = OP_GT; }
+            else if ((op_pos = strstr(bp_condition, "<")) != NULL) { op_len = 1; op_type = OP_LT; }
+
+            if (op_pos != NULL) {
+                *op_pos = '\0';
+                char *varname = bp_condition;
+                char *expected = op_pos + op_len;
+
+                /* Trim whitespace */
+                while (*varname == ' ') varname++;
+                char *vend = op_pos - 1;
+                while (vend > varname && *vend == ' ') *vend-- = '\0';
+                while (*expected == ' ') expected++;
+                char *eend = expected + strlen(expected) - 1;
+                while (eend > expected && *eend == ' ') *eend-- = '\0';
+
+                /* Strip quotes from expected value */
+                size_t elen = strlen(expected);
+                if (elen >= 2 && expected[0] == '"' && expected[elen-1] == '"') {
+                    expected[elen-1] = '\0';
+                    expected++;
+                }
+
+                /* Look up variable in locals */
+                hdlhashtable hlocals_cond = nil;
+                hdlhashtable hwalk_cond = currenthashtable;
+                while (hwalk_cond != nil) {
+                    if ((**hwalk_cond).fllocaltable) { hlocals_cond = hwalk_cond; break; }
+                    hwalk_cond = (**hwalk_cond).prevhashtable;
+                }
+
+                if (hlocals_cond != nil) {
+                    bigstring bsname;
+                    int nlen = (int)strlen(varname);
+                    if (nlen > 255) nlen = 255;
+                    bsname[0] = (unsigned char)nlen;
+                    memcpy(bsname + 1, varname, (size_t)nlen);
+
+                    tyvaluerecord cond_val;
+                    hdlhashnode hn_cond = nil;
+                    if (hashtablelookup(hlocals_cond, bsname, &cond_val, &hn_cond)) {
+                        bigstring bsval;
+                        if (hashgetvaluestring(cond_val, bsval)) {
+                            char actual[DEBUG_VALUE_MAX];
+                            int avlen = bsval[0];
+                            if (avlen >= DEBUG_VALUE_MAX) avlen = DEBUG_VALUE_MAX - 1;
+                            memcpy(actual, bsval + 1, (size_t)avlen);
+                            actual[avlen] = '\0';
+
+                            /* Try numeric comparison first */
+                            char *endp1, *endp2;
+                            double da = strtod(actual, &endp1);
+                            double de = strtod(expected, &endp2);
+                            if (*endp1 == '\0' && *endp2 == '\0') {
+                                switch (op_type) {
+                                    case OP_EQ: cond_met = (da == de); break;
+                                    case OP_NE: cond_met = (da != de); break;
+                                    case OP_GE: cond_met = (da >= de); break;
+                                    case OP_LE: cond_met = (da <= de); break;
+                                    case OP_GT: cond_met = (da > de); break;
+                                    case OP_LT: cond_met = (da < de); break;
+                                }
+                            } else {
+                                int cmp = strcmp(actual, expected);
+                                switch (op_type) {
+                                    case OP_EQ: cond_met = (cmp == 0); break;
+                                    case OP_NE: cond_met = (cmp != 0); break;
+                                    case OP_GE: cond_met = (cmp >= 0); break;
+                                    case OP_LE: cond_met = (cmp <= 0); break;
+                                    case OP_GT: cond_met = (cmp > 0); break;
+                                    case OP_LT: cond_met = (cmp < 0); break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!cond_met)
+                flbreakpoint = false; /* condition not met — skip */
+        }
 
         if (flbreakpoint) {
             atomic_store(&state->lastlnum, lnum);
@@ -1292,6 +1399,7 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     cJSON *params = cJSON_GetObjectItemCaseSensitive(root, "params");
     cJSON *script_json = params ? cJSON_GetObjectItemCaseSensitive(params, "script") : NULL;
     cJSON *line_json = params ? cJSON_GetObjectItemCaseSensitive(params, "line") : NULL;
+    cJSON *cond_json = params ? cJSON_GetObjectItemCaseSensitive(params, "condition") : NULL;
 
     if (!cJSON_IsString(script_json) || script_json->valuestring == NULL) {
         char err[512];
@@ -1358,6 +1466,13 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
                 /* strlen(script) < DEBUG_SCRIPT_PATH_MAX is guaranteed by the guard above */
                 memcpy(g_breakpoints[i].script, script, strlen(script) + 1);
                 g_breakpoints[i].line = line;
+                g_breakpoints[i].condition[0] = '\0'; /* default: unconditional */
+                if (cJSON_IsString(cond_json) && cond_json->valuestring != NULL) {
+                    size_t clen = strlen(cond_json->valuestring);
+                    if (clen >= DEBUG_VALUE_MAX) clen = DEBUG_VALUE_MAX - 1;
+                    memcpy(g_breakpoints[i].condition, cond_json->valuestring, clen);
+                    g_breakpoints[i].condition[clen] = '\0';
+                }
                 g_breakpoints[i].active = true;
                 set = true;
                 break;
@@ -1392,6 +1507,8 @@ void handle_debug_setbreakpoint(int id, const char *json_line, transport_t *tran
     cJSON_AddStringToObject(result, "action", cleared ? "cleared" : "set");
     cJSON_AddStringToObject(result, "script", script);
     cJSON_AddNumberToObject(result, "line", (double)line);
+    if (!cleared && cJSON_IsString(cond_json) && cond_json->valuestring != NULL)
+        cJSON_AddStringToObject(result, "condition", cond_json->valuestring);
     cJSON_AddItemToObject(resp, "result", result);
     cJSON_AddBoolToObject(resp, "success", 1);
 
@@ -1431,6 +1548,8 @@ void handle_debug_listbreakpoints(int id, const char *json_line, transport_t *tr
             cJSON_AddStringToObject(bp, "script", g_breakpoints[i].script);
             cJSON_AddNumberToObject(bp, "line", (double)g_breakpoints[i].line);
             cJSON_AddStringToObject(bp, "type", "session");
+            if (g_breakpoints[i].condition[0] != '\0')
+                cJSON_AddStringToObject(bp, "condition", g_breakpoints[i].condition);
             cJSON_AddItemToArray(bparray, bp);
         }
     }

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -587,7 +587,10 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
                     tyvaluerecord cond_val;
                     hdlhashnode hn_cond = nil;
-                    if (hashtablelookup(hlocals_cond, bsname, &cond_val, &hn_cond)) {
+                    if (!hashtablelookup(hlocals_cond, bsname, &cond_val, &hn_cond)) {
+                        log_warn(LOG_COMP_LANG, "debug: condition variable '%s' not found in locals at line %ld",
+                                 varname, (long)lnum);
+                    } else {
                         bigstring bsval;
                         if (hashgetvaluestring(cond_val, bsval)) {
                             char actual[DEBUG_VALUE_MAX];

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -535,6 +535,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
          * Numeric comparison used when both sides parse as numbers. */
         if (flbreakpoint && bp_condition[0] != '\0') {
             boolean cond_met = false;
+            boolean cond_evaluated = false; /* did we actually evaluate the condition? */
             char bp_condition_orig[DEBUG_VALUE_MAX]; /* preserve for logging before parse mutates */
             memcpy(bp_condition_orig, bp_condition, DEBUG_VALUE_MAX);
 
@@ -599,6 +600,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                             memcpy(actual, bsval + 1, (size_t)avlen);
                             actual[avlen] = '\0';
 
+                            cond_evaluated = true;
+
                             /* Try numeric comparison first */
                             char *endp1, *endp2;
                             double da = strtod(actual, &endp1);
@@ -626,11 +629,15 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                         }
                     }
                 }
+            } else {
+                log_warn(LOG_COMP_LANG, "debug: unparseable condition '%s' at line %ld (expected: varname op value)",
+                         bp_condition_orig, (long)lnum);
             }
 
             if (!cond_met) {
-                log_debug(LOG_COMP_LANG, "debug: conditional breakpoint at line %ld skipped (condition '%s' not met)",
-                          (long)lnum, bp_condition_orig);
+                if (cond_evaluated)
+                    log_debug(LOG_COMP_LANG, "debug: conditional breakpoint at line %ld skipped (condition '%s' evaluated to false)",
+                              (long)lnum, bp_condition_orig);
                 flbreakpoint = false;
             }
         }

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -623,8 +623,11 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                 }
             }
 
-            if (!cond_met)
-                flbreakpoint = false; /* condition not met — skip */
+            if (!cond_met) {
+                log_debug(LOG_COMP_LANG, "debug: conditional breakpoint at line %ld skipped (condition '%s' not met)",
+                          (long)lnum, bp_condition);
+                flbreakpoint = false;
+            }
         }
 
         if (flbreakpoint) {

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -579,7 +579,10 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                     hwalk_cond = (**hwalk_cond).prevhashtable;
                 }
 
-                if (hlocals_cond != nil) {
+                if (hlocals_cond == nil) {
+                    log_warn(LOG_COMP_LANG, "debug: no local scope for condition '%s' at line %ld",
+                             bp_condition_orig, (long)lnum);
+                } else {
                     bigstring bsname;
                     int nlen = (int)strlen(varname);
                     if (nlen > 255) nlen = 255;

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -535,6 +535,8 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
          * Numeric comparison used when both sides parse as numbers. */
         if (flbreakpoint && bp_condition[0] != '\0') {
             boolean cond_met = false;
+            char bp_condition_orig[DEBUG_VALUE_MAX]; /* preserve for logging before parse mutates */
+            memcpy(bp_condition_orig, bp_condition, DEBUG_VALUE_MAX);
 
             /* Parse: find operator (check two-char ops before one-char) */
             char *op_pos = NULL;
@@ -625,7 +627,7 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
             if (!cond_met) {
                 log_debug(LOG_COMP_LANG, "debug: conditional breakpoint at line %ld skipped (condition '%s' not met)",
-                          (long)lnum, bp_condition);
+                          (long)lnum, bp_condition_orig);
                 flbreakpoint = false;
             }
         }

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -821,6 +821,54 @@ if wp_suspend:
                 params.get("newValue") == "11",
                 f"Params: {params}")
 
+# --- Test 17: conditional breakpoints (Phase 7) ---
+print()
+print("--- conditional breakpoints ---")
+
+def test_conditional_bp(send):
+    send({"op": "script/eval", "id": 1, "params": {
+        "expression": 'new(scriptType, @system.temp.condTest); script.newScriptObject("local (x = 1)\\rx = x + 10\\rreturn x", @system.temp.condTest)'
+    }})
+    time.sleep(1)
+    # Conditional breakpoint on line 1: x > 5 (won't fire, x=1)
+    send({"op": "debug/setBreakpoint", "id": 2, "params": {
+        "script": "system.temp.condTest", "line": 1, "condition": "x > 5"
+    }})
+    time.sleep(0.3)
+    # Conditional breakpoint on line 3: x > 5 (will fire, x=11)
+    send({"op": "debug/setBreakpoint", "id": 3, "params": {
+        "script": "system.temp.condTest", "line": 3, "condition": "x > 5"
+    }})
+    time.sleep(0.3)
+    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.condTest()"}})
+    time.sleep(2)
+    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(3)
+    send({"op": "debug/kill", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+
+msgs = run_debug_session(test_conditional_bp, timeout=20)
+
+# Should have suspended at line 3 (condition met), not line 1
+bp_suspensions = [m for m in msgs if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "breakpoint"]
+assert_test("conditional breakpoint fires only when condition met",
+            len(bp_suspensions) == 1,
+            f"Breakpoint suspensions: {bp_suspensions}")
+if bp_suspensions:
+    assert_test("conditional breakpoint fires at correct line",
+                bp_suspensions[0].get("params", {}).get("line") == 3,
+                f"Line: {bp_suspensions[0].get('params', {}).get('line')}")
+
+# Verify condition in setBreakpoint response
+set_with_cond = None
+for m in msgs:
+    if m.get("id") == 2 and m.get("result", {}).get("condition"):
+        set_with_cond = m
+        break
+assert_test("setBreakpoint response includes condition",
+            set_with_cond is not None and set_with_cond["result"]["condition"] == "x > 5",
+            f"Messages: {[m for m in msgs if m.get('id') == 2]}")
+
 print()
 print("=" * 46)
 print(f"RESULTS: {PASSED} passed, {FAILED} failed")


### PR DESCRIPTION
## Summary

Extends `debug/setBreakpoint` with optional conditional evaluation (Phase 7). Breakpoints with a condition only suspend execution when the condition is true.

## Protocol

```json
// Set conditional breakpoint
{"op":"debug/setBreakpoint","id":1,"params":{
  "script":"system.temp.myFunc","line":5,"condition":"x > 10"
}}

// Condition shown in list
{"op":"debug/listBreakpoints","id":2,"params":{}}
// Response includes "condition" field when set
```

## Condition Format

Simple expression: `varname op value` where op is `==`, `!=`, `>`, `<`, `>=`, `<=`.

- Looks up the variable in the innermost local scope
- Converts to string representation via `hashgetvaluestring`
- Numeric comparison when both sides parse as numbers; string comparison otherwise
- No condition = unconditional breakpoint (backward compatible)
- Unknown variable or unparseable condition: logged and skipped (breakpoint does not fire)

## Known Limitations

- Conditions only check the innermost local scope (not enclosing scopes or globals)
- Expression format is simple `varname op value` — not full UserTalk evaluation

## Test plan

- [x] 302/302 unit tests pass
- [x] 60/60 debug protocol tests pass (3 new conditional breakpoint tests)
- [x] Conditional breakpoint skipped when condition not met (x=1, condition x>5)
- [x] Conditional breakpoint fires when condition met (x=11, condition x>5)
- [x] Condition included in setBreakpoint and listBreakpoints responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)