### PR TITLE
fix: P2 correctness — scope expansion, stack lines, trim UB, tests

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -346,6 +346,7 @@ static boolean debug_push_sourcecode(hdlhashtable htable, hdlhashnode hnode, big
     if (state->script_stack_depth < DEBUG_SCRIPT_STACK_MAX) {
         memcpy(state->script_stack[state->script_stack_depth],
                state->current_script, DEBUG_SCRIPT_PATH_MAX);
+        state->script_stack_lines[state->script_stack_depth] = atomic_load(&state->lastlnum);
         state->script_stack_depth++;
     } else {
         /* Stack overflow — track the imbalance so pop skips the corresponding restore.
@@ -556,13 +557,18 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                 char *varname = bp_condition;
                 char *expected = op_pos + op_len;
 
-                /* Trim whitespace */
+                /* Trim whitespace (guard against op at position 0) */
                 while (*varname == ' ') varname++;
-                char *vend = op_pos - 1;
-                while (vend > varname && *vend == ' ') *vend-- = '\0';
+                if (op_pos > bp_condition) {
+                    char *vend = op_pos - 1;
+                    while (vend > varname && *vend == ' ') *vend-- = '\0';
+                }
                 while (*expected == ' ') expected++;
-                char *eend = expected + strlen(expected) - 1;
-                while (eend > expected && *eend == ' ') *eend-- = '\0';
+                size_t explen = strlen(expected);
+                if (explen > 0) {
+                    char *eend = expected + explen - 1;
+                    while (eend > expected && *eend == ' ') *eend-- = '\0';
+                }
 
                 /* Strip quotes from expected value */
                 size_t elen = strlen(expected);
@@ -571,63 +577,63 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                     expected++;
                 }
 
-                /* Look up variable in locals */
-                hdlhashtable hlocals_cond = nil;
+                /* Look up variable — walk the full hash table chain (locals,
+                 * enclosing scopes, globals) not just innermost local. */
+                bigstring bsname;
+                int nlen = (int)strlen(varname);
+                if (nlen > 255) nlen = 255;
+                bsname[0] = (unsigned char)nlen;
+                memcpy(bsname + 1, varname, (size_t)nlen);
+
+                tyvaluerecord cond_val;
+                hdlhashnode hn_cond = nil;
+                boolean found_var = false;
+
                 hdlhashtable hwalk_cond = currenthashtable;
                 while (hwalk_cond != nil) {
-                    if ((**hwalk_cond).fllocaltable) { hlocals_cond = hwalk_cond; break; }
+                    if (hashtablelookup(hwalk_cond, bsname, &cond_val, &hn_cond)) {
+                        found_var = true;
+                        break;
+                    }
                     hwalk_cond = (**hwalk_cond).prevhashtable;
                 }
 
-                if (hlocals_cond == nil) {
-                    log_warn(LOG_COMP_LANG, "debug: no local scope for condition '%s' at line %ld",
-                             bp_condition_orig, (long)lnum);
+                if (!found_var) {
+                    log_warn(LOG_COMP_LANG, "debug: condition variable '%s' not found at line %ld",
+                             varname, (long)lnum);
                 } else {
-                    bigstring bsname;
-                    int nlen = (int)strlen(varname);
-                    if (nlen > 255) nlen = 255;
-                    bsname[0] = (unsigned char)nlen;
-                    memcpy(bsname + 1, varname, (size_t)nlen);
+                    bigstring bsval;
+                    if (hashgetvaluestring(cond_val, bsval)) {
+                        char actual[DEBUG_VALUE_MAX];
+                        int avlen = bsval[0];
+                        if (avlen >= DEBUG_VALUE_MAX) avlen = DEBUG_VALUE_MAX - 1;
+                        memcpy(actual, bsval + 1, (size_t)avlen);
+                        actual[avlen] = '\0';
 
-                    tyvaluerecord cond_val;
-                    hdlhashnode hn_cond = nil;
-                    if (!hashtablelookup(hlocals_cond, bsname, &cond_val, &hn_cond)) {
-                        log_warn(LOG_COMP_LANG, "debug: condition variable '%s' not found in locals at line %ld",
-                                 varname, (long)lnum);
-                    } else {
-                        bigstring bsval;
-                        if (hashgetvaluestring(cond_val, bsval)) {
-                            char actual[DEBUG_VALUE_MAX];
-                            int avlen = bsval[0];
-                            if (avlen >= DEBUG_VALUE_MAX) avlen = DEBUG_VALUE_MAX - 1;
-                            memcpy(actual, bsval + 1, (size_t)avlen);
-                            actual[avlen] = '\0';
+                        cond_evaluated = true;
 
-                            cond_evaluated = true;
-
-                            /* Try numeric comparison first */
-                            char *endp1, *endp2;
-                            double da = strtod(actual, &endp1);
-                            double de = strtod(expected, &endp2);
-                            if (*endp1 == '\0' && *endp2 == '\0') {
-                                switch (op_type) {
-                                    case OP_EQ: cond_met = (da == de); break;
-                                    case OP_NE: cond_met = (da != de); break;
-                                    case OP_GE: cond_met = (da >= de); break;
-                                    case OP_LE: cond_met = (da <= de); break;
-                                    case OP_GT: cond_met = (da > de); break;
-                                    case OP_LT: cond_met = (da < de); break;
-                                }
-                            } else {
-                                int cmp = strcmp(actual, expected);
-                                switch (op_type) {
-                                    case OP_EQ: cond_met = (cmp == 0); break;
-                                    case OP_NE: cond_met = (cmp != 0); break;
-                                    case OP_GE: cond_met = (cmp >= 0); break;
-                                    case OP_LE: cond_met = (cmp <= 0); break;
-                                    case OP_GT: cond_met = (cmp > 0); break;
-                                    case OP_LT: cond_met = (cmp < 0); break;
-                                }
+                        /* Try numeric comparison first */
+                        char *endp1, *endp2;
+                        double da = strtod(actual, &endp1);
+                        double de = strtod(expected, &endp2);
+                        if (*endp1 == '\0' && *endp2 == '\0') {
+                            switch (op_type) {
+                                case OP_EQ: cond_met = (da == de); break;
+                                case OP_NE: cond_met = (da != de); break;
+                                case OP_GE: cond_met = (da >= de); break;
+                                case OP_LE: cond_met = (da <= de); break;
+                                case OP_GT: cond_met = (da > de); break;
+                                case OP_LT: cond_met = (da < de); break;
+                            }
+                        } else {
+                            int cmp = strcmp(actual, expected);
+                            switch (op_type) {
+                                case OP_EQ: cond_met = (cmp == 0); break;
+                                case OP_NE: cond_met = (cmp != 0); break;
+                                case OP_GE: cond_met = (cmp >= 0); break;
+                                case OP_LE: cond_met = (cmp <= 0); break;
+                                case OP_GT: cond_met = (cmp > 0); break;
+                                case OP_LT: cond_met = (cmp < 0); break;
                             }
                         }
                     }
@@ -669,30 +675,17 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
     if (atomic_load_explicit(&g_has_watchpoints, memory_order_relaxed) &&
         flsteppable && !atomic_load(&state->flsuspended)) {
 
-        /* Get current local hash table — use the global currenthashtable
-         * (which is correct since we hold the GIL and own this thread's
-         * restored context) rather than reading from hglobals. */
-        hdlhashtable htable = currenthashtable;
-
-        /* Find the innermost local table */
-        hdlhashtable hlocals = nil;
-        hdlhashtable hwalk = htable;
-        while (hwalk != nil) {
-            if ((**hwalk).fllocaltable) {
-                hlocals = hwalk;
-                break;
-            }
-            hwalk = (**hwalk).prevhashtable;
-        }
-
-        if (hlocals != nil) {
+        /* Use currenthashtable (correct under GIL) as starting point.
+         * Walk the full chain (locals, enclosing scopes, globals) for
+         * each watched variable — not just the innermost local table. */
+        if (currenthashtable != nil) {
             pthread_mutex_lock(&g_debug_mutex);
 
             for (int w = 0; w < MAX_WATCHPOINTS; w++) {
                 if (!g_watchpoints[w].active)
                     continue;
 
-                /* Look up the variable by name */
+                /* Look up the variable by name — walk full scope chain */
                 bigstring bsname;
                 int nlen = (int)strlen(g_watchpoints[w].varname);
                 if (nlen > 255) nlen = 255;
@@ -701,7 +694,16 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
 
                 tyvaluerecord val;
                 hdlhashnode hn = nil;
-                if (!hashtablelookup(hlocals, bsname, &val, &hn))  /* hn unused — API requires it */
+                boolean found_wp_var = false;
+                hdlhashtable hwalk = currenthashtable;
+                while (hwalk != nil) {
+                    if (hashtablelookup(hwalk, bsname, &val, &hn)) {
+                        found_wp_var = true;
+                        break;
+                    }
+                    hwalk = (**hwalk).prevhashtable;
+                }
+                if (!found_wp_var)
                     continue;
 
                 /* Get current value as string */
@@ -1802,6 +1804,8 @@ void handle_debug_getstack(int id, const char *json_line, transport_t *transport
             cJSON *frame = cJSON_CreateObject();
             cJSON_AddNumberToObject(frame, "level", i + 1);
             cJSON_AddStringToObject(frame, "script", state->script_stack[i]);
+            if (state->script_stack_lines[i] > 0)
+                cJSON_AddNumberToObject(frame, "line", (double)state->script_stack_lines[i]);
             cJSON_AddItemToArray(frames, frame);
         }
     }

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -117,6 +117,7 @@ typedef struct tydebugstate {
      * pop restores caller's path so breakpoints in A still fire after B returns. */
     char current_script[DEBUG_SCRIPT_PATH_MAX]; /* current script dotted path */
     char script_stack[DEBUG_SCRIPT_STACK_MAX][DEBUG_SCRIPT_PATH_MAX]; /* saved caller paths */
+    unsigned long script_stack_lines[DEBUG_SCRIPT_STACK_MAX]; /* saved caller line numbers */
     short script_stack_depth;                   /* stack pointer (0 = empty) */
     int script_stack_overflow;                  /* push/pop balance when stack overflows */
 } tydebugstate, *ptrdebugstate;

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -901,6 +901,67 @@ assert_test("setBreakpoint response includes condition",
             set_with_cond is not None and set_with_cond["result"]["condition"] == "x > 5",
             f"Messages: {[m for m in msgs if m.get('id') == 2]}")
 
+# --- Test 18: listBreakpoints includes condition ---
+print()
+print("--- listBreakpoints condition field ---")
+
+def test_list_bp_condition(send):
+    send({"op": "debug/setBreakpoint", "id": 1, "params": {
+        "script": "test.cond", "line": 1, "condition": "y == 0"
+    }})
+    time.sleep(0.3)
+    send({"op": "debug/listBreakpoints", "id": 2, "params": {}})
+    time.sleep(0.3)
+
+msgs = run_debug_session(test_list_bp_condition)
+list_msg = None
+for m in msgs:
+    if m.get("id") == 2 and m.get("result", {}).get("breakpoints"):
+        list_msg = m
+        break
+if list_msg and len(list_msg["result"]["breakpoints"]) > 0:
+    assert_test("listBreakpoints includes condition",
+                list_msg["result"]["breakpoints"][0].get("condition") == "y == 0",
+                f"Breakpoints: {list_msg['result']['breakpoints']}")
+else:
+    assert_test("listBreakpoints includes condition", False, f"Messages: {msgs}")
+
+# --- Test 19: breakpoint fires on each function re-entry ---
+print()
+print("--- breakpoint re-entry ---")
+
+def test_reentry_bp(send):
+    # inner function called twice by outer — breakpoint should fire both times
+    send({"op": "script/eval", "id": 1, "params": {
+        "expression": 'new(scriptType, @system.temp.bpInner); script.newScriptObject("return true", @system.temp.bpInner)'
+    }})
+    time.sleep(0.5)
+    send({"op": "script/eval", "id": 2, "params": {
+        "expression": 'new(scriptType, @system.temp.bpOuter); script.newScriptObject("local (a = system.temp.bpInner())\\rlocal (b = system.temp.bpInner())\\rreturn (a and b)", @system.temp.bpOuter)'
+    }})
+    time.sleep(0.5)
+    send({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.bpInner", "line": 1}})
+    time.sleep(0.3)
+    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.bpOuter()"}})
+    time.sleep(2)
+    # Continue past entry
+    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+    # Should hit breakpoint on first call to bpInner
+    send({"op": "debug/continue", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+    # Should hit breakpoint on second call to bpInner
+    send({"op": "debug/continue", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(2)
+    send({"op": "debug/kill", "id": 8, "params": {"threadId": FIRST_DEBUG_TID}})
+    time.sleep(1)
+
+msgs = run_debug_session(test_reentry_bp, timeout=25)
+bp_hits = [m for m in msgs if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "breakpoint"]
+assert_test("breakpoint fires on each function entry",
+            len(bp_hits) >= 2,
+            f"Breakpoint hits: {len(bp_hits)}, Messages: {bp_hits}")
+
 print()
 print("=" * 46)
 print(f"RESULTS: {PASSED} passed, {FAILED} failed")


### PR DESCRIPTION
## Summary

Priority 2 correctness fixes from the debugger gap plan:

1. **Variable scope expansion** — Watchpoints and conditional breakpoints now walk the full hash table chain (locals → enclosing scopes → globals) instead of only the innermost local table. Eliminates silent failures when watching or conditioning on outer-scope or global variables.

2. **Outer stack frame line numbers** — `debug/getStack` now includes `line` for all frames, not just the innermost. The push callback saves `lastlnum` alongside each script path.

3. **Condition trim UB** — Guards `op_pos - 1` and `eend` pointers against pointing before the array on edge-case empty operands.

4. **Missing tests** — `listBreakpoints` condition field verification, breakpoint re-entry test (inner function called twice, breakpoint fires both times).

## Test plan

- [x] 302/302 unit tests pass
- [x] 63/63 debug protocol tests pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)