### PR TITLE
fix: P3 polish — cJSON consistency, float comment, hglobals docs

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -617,6 +617,9 @@ static boolean protocol_debugger_callback(hdltreenode hnode) {
                         double da = strtod(actual, &endp1);
                         double de = strtod(expected, &endp2);
                         if (*endp1 == '\0' && *endp2 == '\0') {
+                            /* Exact floating-point comparison — appropriate for
+                             * integer values stored as doubles (the common case).
+                             * Use string comparison for epsilon-sensitive floats. */
                             switch (op_type) {
                                 case OP_EQ: cond_met = (da == de); break;
                                 case OP_NE: cond_met = (da != de); break;
@@ -1610,10 +1613,18 @@ void handle_debug_clearbreakpoints(int id, const char *json_line, transport_t *t
 
     pthread_mutex_unlock(&g_debug_mutex);
 
-    char resp[128];
-    snprintf(resp, sizeof(resp),
-             "{\"id\":%d,\"result\":{\"cleared\":%d},\"success\":true}", id, cleared);
-    transport->write_line(transport->ctx, resp, strlen(resp));
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddNumberToObject(resp, "id", id);
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(result, "cleared", cleared);
+    cJSON_AddItemToObject(resp, "result", result);
+    cJSON_AddBoolToObject(resp, "success", 1);
+    char *json_str = cJSON_PrintUnformatted(resp);
+    if (json_str) {
+        transport->write_line(transport->ctx, json_str, strlen(json_str));
+        free(json_str);
+    }
+    cJSON_Delete(resp);
 
     log_info(LOG_COMP_LANG, "debug: cleared %d breakpoints", cleared);
 }
@@ -2286,8 +2297,16 @@ void handle_debug_clearwatchpoints(int id, const char *json_line, transport_t *t
 
     pthread_mutex_unlock(&g_debug_mutex);
 
-    char resp[128];
-    snprintf(resp, sizeof(resp),
-             "{\"id\":%d,\"result\":{\"cleared\":%d},\"success\":true}", id, cleared_count);
-    transport->write_line(transport->ctx, resp, strlen(resp));
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddNumberToObject(resp, "id", id);
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(result, "cleared", cleared_count);
+    cJSON_AddItemToObject(resp, "result", result);
+    cJSON_AddBoolToObject(resp, "success", 1);
+    char *json_str = cJSON_PrintUnformatted(resp);
+    if (json_str) {
+        transport->write_line(transport->ctx, json_str, strlen(json_str));
+        free(json_str);
+    }
+    cJSON_Delete(resp);
 }

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -83,12 +83,10 @@ typedef struct tydebugstate {
     transport_t *transport;          /* for sending notifications back to client */
     long threadid;                   /* this thread's ID */
     pthread_t pthread_id;            /* POSIX thread ID for pthread_join */
-    void *hglobals;                  /* hdlthreadglobals — thread globals handle.
-                                      * Safe to read when thread is suspended (not
-                                      * touching globals while in nanosleep). Used by
-                                      * debug/getLocals to access the suspended
-                                      * thread's hash tables. Cast to hdlthreadglobals
-                                      * in debug_handler.c. */
+    void *hglobals;                  /* hdlthreadglobals (processinternal.h) — void* to
+                                      * avoid pulling that header into this one. Cast to
+                                      * hdlthreadglobals in debug_handler.c. Safe to read
+                                      * when thread is suspended (in nanosleep). */
 
     /* Stepping state (Phase 2) — written by handle_debug_step on main thread,
      * read by protocol_debugger_callback on debug thread. Access is GIL-ordered


### PR DESCRIPTION
## Summary

Priority 3 polish fixes from the debugger gap plan:

- **cJSON consistency**: `clearBreakpoints` and `clearWatchpoints` now use cJSON for response serialization, matching all other handlers (was manual snprintf)
- **Float comparison comment**: Documents that exact `==` is appropriate for integer-as-double values in condition evaluation
- **hglobals comment cleanup**: Clearer explanation of why `void*` is used (avoids processinternal.h include)

## Test plan

- [x] 302/302 unit tests pass
- [x] 63/63 debug protocol tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)