### PR TITLE
feat: P1 usability — event-driven test harness, script loading from disk

### DIFF
--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -34,6 +34,7 @@
 #include "headless_threading.h"
 #include "langexternal.h"
 #include "op.h"
+#include "db_format.h"
 #include "../third_party/cJSON/cJSON.h"
 
 /* Global: current hashtable and table stack (thread globals) */
@@ -45,6 +46,8 @@ extern hdlhashtable roottable;
  * header declaration. Used by debug/getSource for script path resolution
  * and outline-to-text conversion. */
 extern boolean opgetlangtext(hdloutlinerecord, boolean, Handle *);  /* oplangtext.c */
+extern boolean opverbinmemory(const struct db_context *, hdlexternalvariable);  /* opverbs.c */
+extern void db_context_init(struct db_context *);  /* db_format.c */
 extern boolean langfastaddresstotable(hdlhashtable, bigstring, hdlhashtable *);  /* langops.c */
 
 /*
@@ -1947,16 +1950,20 @@ void handle_debug_getsource(int id, const char *json_line, transport_t *transpor
     if (val.valuetype == externalvaluetype) {
         hdlexternalvariable hv = (hdlexternalvariable)val.data.externalvalue;
 
-        /* Scripts must be in memory to extract source. Compiled/run scripts are
-         * always loaded. Scripts never accessed in this session may still be on
-         * disk — loading requires db context work deferred to a follow-up. */
+        /* Load from database if not yet in memory */
         if (!(**hv).flinmemory) {
-            char err[512];
-            snprintf(err, sizeof(err),
-                     "{\"id\":%d,\"error\":{\"message\":\"Script not loaded in memory (try running it first)\"},\"success\":false}", id);
-            transport->write_line(transport->ctx, err, strlen(err));
-            cJSON_Delete(root);
-            return;
+            db_context ctx;
+            db_context_init(&ctx);
+            if ((**hv).hdatabase != nil)
+                ctx.database = (**hv).hdatabase;
+            if (!opverbinmemory(&ctx, hv)) {
+                char err[512];
+                snprintf(err, sizeof(err),
+                         "{\"id\":%d,\"error\":{\"message\":\"Failed to load script from database\"},\"success\":false}", id);
+                transport->write_line(transport->ctx, err, strlen(err));
+                cJSON_Delete(root);
+                return;
+            }
         }
 
         hdloutlinerecord houtline = (hdloutlinerecord)(**hv).variabledata;

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -48,6 +48,8 @@ extern hdlhashtable roottable;
 extern boolean opgetlangtext(hdloutlinerecord, boolean, Handle *);  /* oplangtext.c */
 extern boolean opverbinmemory(const struct db_context *, hdlexternalvariable);  /* opverbs.c */
 extern void db_context_init(struct db_context *);  /* db_format.c */
+extern void db_context_init_legacy_read(struct db_context *, hdldatabaserecord);  /* db_format.c */
+extern boolean db_format_is_legacy_db(hdldatabaserecord);  /* db_format.c */
 extern boolean langfastaddresstotable(hdlhashtable, bigstring, hdlhashtable *);  /* langops.c */
 
 /*
@@ -1950,12 +1952,17 @@ void handle_debug_getsource(int id, const char *json_line, transport_t *transpor
     if (val.valuetype == externalvaluetype) {
         hdlexternalvariable hv = (hdlexternalvariable)val.data.externalvalue;
 
-        /* Load from database if not yet in memory */
+        /* Load from database if not yet in memory.
+         * Use format-aware context to handle both v6 and v7 databases. */
         if (!(**hv).flinmemory) {
             db_context ctx;
-            db_context_init(&ctx);
-            if ((**hv).hdatabase != nil)
-                ctx.database = (**hv).hdatabase;
+            if ((**hv).hdatabase != nil && db_format_is_legacy_db((**hv).hdatabase)) {
+                db_context_init_legacy_read(&ctx, (**hv).hdatabase);
+            } else {
+                db_context_init(&ctx);
+                if ((**hv).hdatabase != nil)
+                    ctx.database = (**hv).hdatabase;
+            }
             if (!opverbinmemory(&ctx, hv)) {
                 char err[512];
                 snprintf(err, sizeof(err),

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -621,9 +621,9 @@ print("--- multi-thread debugging ---")
 with DebugSession(timeout=20) as s:
     # Launch two debug threads
     resp1 = s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
-    entry1 = s.wait_for_notification(reason="entry")
+    entry1 = s.wait_for_notification(reason="entry")  # sync: wait for thread 1 to suspend
     resp2 = s.send_and_wait({"op": "debug/run", "id": 2, "params": {"expression": "return 2+2"}})
-    entry2 = s.wait_for_notification(reason="entry")
+    entry2 = s.wait_for_notification(reason="entry")  # sync: wait for thread 2 to suspend
 
     # Extract actual thread IDs from responses
     t1_tid = resp1.get("result", {}).get("threadId") if resp1 else None

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -3,7 +3,8 @@
 # Integration tests for debug/* protocol operations
 # Tests the debugger MVP: debug/run, debug/continue, debug/kill, debug/pause
 #
-# Uses Python to handle the interactive protocol (parse threadId from responses).
+# Uses Python with an event-driven DebugSession class that reads responses
+# via a background thread instead of time.sleep() delays.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -23,7 +24,7 @@ export DEBUG_TEST_CLI="$CLI"
 export DEBUG_TEST_DB="$DB"
 
 python3 << 'PYEOF'
-import subprocess, json, sys, time, os
+import subprocess, json, sys, os, threading, time
 
 CLI = os.environ["DEBUG_TEST_CLI"]
 DB = os.environ["DEBUG_TEST_DB"]
@@ -34,50 +35,123 @@ GREEN = "\033[0;32m"
 RED = "\033[0;31m"
 NC = "\033[0m"
 
-def run_debug_session(commands_fn, timeout=15):
-    """Run a debug protocol session. commands_fn receives a send function.
-    All stdout output is collected after the process exits."""
-    proc = subprocess.Popen(
-        [CLI, "--protocol", "--skip-startup", "--system-root", DB],
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True, bufsize=1
-    )
+# ---------------------------------------------------------------------------
+# DebugSession — event-driven protocol session
+# ---------------------------------------------------------------------------
 
-    def send(msg):
+class DebugSession:
+    """Manages a frontier-cli --protocol session with a background reader thread."""
+
+    def __init__(self, timeout=15):
+        self.timeout = timeout
+        self.messages = []
+        self._lock = threading.Lock()
+        self._new_msg = threading.Event()
+        self._proc = subprocess.Popen(
+            [CLI, "--protocol", "--skip-startup", "--system-root", DB],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, bufsize=1
+        )
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self):
+        """Background thread: read stdout line-by-line, parse JSON, append to messages."""
+        try:
+            for line in self._proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                    with self._lock:
+                        self.messages.append(msg)
+                    self._new_msg.set()
+                except json.JSONDecodeError:
+                    pass
+        except (ValueError, OSError):
+            # stdout closed
+            pass
+
+    def send(self, msg):
+        """Send a JSON message to stdin and flush."""
         if isinstance(msg, dict):
             msg = json.dumps(msg)
-        proc.stdin.write(msg + "\n")
-        proc.stdin.flush()
-        time.sleep(0.5)
+        try:
+            self._proc.stdin.write(msg + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError):
+            pass
 
-    try:
-        commands_fn(send)
-        send({"op": "shutdown", "id": 999})
-        time.sleep(1)
-    except BrokenPipeError:
-        print(f"  [debug] BrokenPipeError during session", file=sys.stderr)
-    except Exception as e:
-        print(f"  Session error: {e}", file=sys.stderr)
+    def wait_for(self, predicate, timeout=None):
+        """Block until a message matching predicate appears or timeout expires.
+        Returns the matching message, or None on timeout."""
+        if timeout is None:
+            timeout = self.timeout
+        deadline = time.monotonic() + timeout
+        # Track how many messages we've already checked
+        checked = 0
+        while True:
+            with self._lock:
+                # Only check new messages since last check
+                for i in range(checked, len(self.messages)):
+                    if predicate(self.messages[i]):
+                        return self.messages[i]
+                checked = len(self.messages)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            # Wait for new message signal, then re-check
+            self._new_msg.clear()
+            self._new_msg.wait(timeout=min(0.05, remaining))
 
-    # Read all output
-    try:
-        proc.stdin.close()
-        stdout, _ = proc.communicate(timeout=15)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        stdout, _ = proc.communicate()
-    except BrokenPipeError:
-        stdout = ""
+    def send_and_wait(self, msg, match_id=None, timeout=None):
+        """Send a message and wait for its response (matched by id)."""
+        if match_id is None and isinstance(msg, dict):
+            match_id = msg.get("id")
+        self.send(msg)
+        if match_id is not None:
+            return self.wait_for(lambda m: m.get("id") == match_id, timeout=timeout)
+        return None
 
-    messages = []
-    for line in stdout.strip().split("\n"):
-        if line:
-            try:
-                messages.append(json.loads(line))
-            except json.JSONDecodeError:
-                pass
+    def wait_for_notification(self, op=None, reason=None, timeout=None):
+        """Wait for an unsolicited notification matching op and/or reason."""
+        # Small delay to let the process produce the notification
+        time.sleep(0.1)
+        def pred(m):
+            if op is not None and m.get("op") != op:
+                return False
+            if reason is not None and m.get("params", {}).get("reason") != reason:
+                return False
+            return True
+        return self.wait_for(pred, timeout=timeout)
 
-    return messages
+    def close(self):
+        """Send shutdown and clean up the process."""
+        try:
+            self.send({"op": "shutdown", "id": 999})
+        except (BrokenPipeError, OSError):
+            pass
+        try:
+            self._proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass
+        try:
+            self._proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def assert_test(name, passed, detail=""):
     global PASSED, FAILED
@@ -111,6 +185,7 @@ def find_msg(messages, **kwargs):
             return m
     return None
 
+
 print("=" * 46)
 print("Debug Protocol Tests")
 print("=" * 46)
@@ -121,23 +196,14 @@ print()
 # We validate this assumption explicitly in the first test.
 FIRST_DEBUG_TID = 3
 
-def get_actual_tid(msgs):
-    """Extract actual threadId from debug/run response."""
-    for m in msgs:
-        if m.get("id") == 1 and m.get("result", {}).get("threadId"):
-            return m["result"]["threadId"]
-    return None
-
 # --- Test 0: verify thread ID assumption ---
 print("--- thread ID validation ---")
-def test_tid_check(send):
-    send({"op": "debug/run", "id": 1, "params": {"expression": "return 1"}})
-    time.sleep(1)
-    send({"op": "debug/kill", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
 
-msgs = run_debug_session(test_tid_check)
-actual_tid = get_actual_tid(msgs)
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 1"}})
+    actual_tid = resp.get("result", {}).get("threadId") if resp else None
+    s.send_and_wait({"op": "debug/kill", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
+
 assert_test(
     f"first debug thread gets ID {FIRST_DEBUG_TID}",
     actual_tid == FIRST_DEBUG_TID,
@@ -151,468 +217,349 @@ if actual_tid is not None and actual_tid != FIRST_DEBUG_TID:
 print()
 print("--- debug/run + debug/continue ---")
 
-def test_run_continue(send):
-    send({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
-    time.sleep(2)
-    send({"op": "debug/continue", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
+    assert_test("run returns threadId",
+                resp is not None and resp.get("result", {}).get("threadId") is not None,
+                f"Response: {resp}")
 
-msgs = run_debug_session(test_run_continue)
-assert_test("run returns threadId", any(m.get("result", {}).get("threadId") for m in msgs if m.get("id") == 1),
-            f"Messages: {msgs}")
-assert_test("suspended at entry", find_msg(msgs, reason="entry") is not None, f"Messages: {msgs}")
-assert_test("completed successfully", find_msg(msgs, op="debug/completed") is not None, f"Messages: {msgs}")
+    entry = s.wait_for_notification(reason="entry")
+    assert_test("suspended at entry", entry is not None, f"Messages: {s.messages}")
+
+    s.send_and_wait({"op": "debug/continue", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
+
+    completed = s.wait_for_notification(op="debug/completed")
+    assert_test("completed successfully", completed is not None, f"Messages: {s.messages}")
 
 # --- Test 2: debug/run + debug/kill ---
 print()
 print("--- debug/run + debug/kill ---")
-def test_run_kill(send):
-    send({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
-    time.sleep(2)
-    send({"op": "debug/kill", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
 
-msgs = run_debug_session(test_run_kill)
-assert_test("kill returns killed status", find_msg(msgs, status="killed") is not None, f"Messages: {msgs}")
-assert_test("completed with failure", any(m.get("op") == "debug/completed" for m in msgs), f"Messages: {msgs}")
+with DebugSession() as s:
+    s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
+    s.wait_for_notification(reason="entry")
+    resp = s.send_and_wait({"op": "debug/kill", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
+    assert_test("kill returns killed status",
+                resp is not None and resp.get("result", {}).get("status") == "killed",
+                f"Response: {resp}")
+
+    completed = s.wait_for_notification(op="debug/completed")
+    assert_test("completed with failure", completed is not None, f"Messages: {s.messages}")
 
 # --- Test 3: debug/pause ---
 print()
 print("--- debug/pause on running thread ---")
-def test_pause(send):
-    send({"op": "debug/run", "id": 1, "params": {"expression": "local (i); for i = 1 to 1000000 {i = i}; return true"}})
-    time.sleep(1)
-    send({"op": "debug/continue", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-    send({"op": "debug/pause", "id": 3, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
-    send({"op": "debug/kill", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
 
-msgs = run_debug_session(test_pause)
-assert_test("pause sends interrupting", find_msg(msgs, status="interrupting") is not None, f"Messages: {msgs}")
-assert_test("suspended with interrupted reason", find_msg(msgs, reason="interrupted") is not None, f"Messages: {msgs}")
+with DebugSession() as s:
+    s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "local (i); for i = 1 to 1000000 {i = i}; return true"}})
+    s.wait_for_notification(reason="entry")
+    s.send_and_wait({"op": "debug/continue", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
+    resp = s.send_and_wait({"op": "debug/pause", "id": 3, "params": {"threadId": FIRST_DEBUG_TID}})
+    assert_test("pause sends interrupting",
+                resp is not None and resp.get("result", {}).get("status") == "interrupting",
+                f"Response: {resp}")
+
+    interrupted = s.wait_for_notification(reason="interrupted")
+    assert_test("suspended with interrupted reason", interrupted is not None, f"Messages: {s.messages}")
+
+    s.send_and_wait({"op": "debug/kill", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
 
 # --- Test 4: debug/step ---
 print()
 print("--- debug/step ---")
-def test_step_into(send):
-    # Simple expression — step into from entry should stop at the return statement
-    send({"op": "debug/run", "id": 1, "params": {"expression": "return 42"}})
-    time.sleep(1)
-    # Suspended at entry — step into (should stop at first steppable statement)
-    send({"op": "debug/step", "id": 2, "params": {"threadId": FIRST_DEBUG_TID, "direction": "into"}})
-    time.sleep(2)
 
-msgs = run_debug_session(test_step_into)
-assert_test("step into suspends at next statement",
-            find_msg(msgs, reason="step") is not None,
-            f"Messages: {msgs}")
+with DebugSession() as s:
+    s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 42"}})
+    s.wait_for_notification(reason="entry")
+    s.send_and_wait({"op": "debug/step", "id": 2, "params": {"threadId": FIRST_DEBUG_TID, "direction": "into"}})
+
+    step = s.wait_for_notification(reason="step")
+    assert_test("step into suspends at next statement", step is not None, f"Messages: {s.messages}")
 
 # Step-over test — previously crashed due to #505 (hthreadglobals overwrite
 # during GIL yield). Fixed by capturing hthreadglobals in a local variable.
-def test_step_over(send):
-    send({"op": "script/eval", "id": 1, "params": {
+with DebugSession(timeout=20) as s:
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.stepOverTest); script.newScriptObject("local (x = 1)\\rlocal (y = 2)\\rreturn (x + y)", @system.temp.stepOverTest)'
     }})
-    time.sleep(1)
-    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "system.temp.stepOverTest", "line": 1}})
-    time.sleep(0.5)
-    send({"op": "debug/run", "id": 3, "params": {"expression": "system.temp.stepOverTest()"}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "system.temp.stepOverTest", "line": 1}})
+    s.send_and_wait({"op": "debug/run", "id": 3, "params": {"expression": "system.temp.stepOverTest()"}})
+    s.wait_for_notification(reason="entry")
     # Continue past entry
-    send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
+    # Wait for breakpoint hit
+    bp_hit = s.wait_for_notification(reason="breakpoint")
     # Suspended at breakpoint on line 1 — step over to next steppable line (line 3)
-    send({"op": "debug/step", "id": 5, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/step", "id": 5, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
+    step_suspend = s.wait_for_notification(reason="step")
+    assert_test("step-over suspends at next line",
+                step_suspend is not None,
+                f"Messages: {[m for m in s.messages if m.get('op') == 'debug/suspended']}")
+    if step_suspend:
+        step_line = step_suspend.get("params", {}).get("line")
+        # Line 2 is a local declaration (non-steppable), so step-over advances to line 3
+        assert_test("step-over advances past locals to line 3",
+                    step_line == 3,
+                    f"Expected line 3, got {step_line}")
     # Kill to clean up
-    send({"op": "debug/kill", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_step_over, timeout=20)
-step_suspend = find_msg(msgs, reason="step")
-assert_test("step-over suspends at next line",
-            step_suspend is not None,
-            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
-if step_suspend:
-    step_line = step_suspend.get("params", {}).get("line")
-    # Line 2 is a local declaration (non-steppable), so step-over advances to line 3
-    assert_test("step-over advances past locals to line 3",
-                step_line == 3,
-                f"Expected line 3, got {step_line}")
+    s.send_and_wait({"op": "debug/kill", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
 
 # Step-over with calldepth: verify step-over skips into function calls
-def test_step_over_calldepth(send):
-    # Create a helper function and a caller that invokes it
-    send({"op": "script/eval", "id": 1, "params": {
+with DebugSession(timeout=25) as s:
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.depthHelper); script.newScriptObject("return 99", @system.temp.depthHelper)'
     }})
-    time.sleep(0.5)
-    send({"op": "script/eval", "id": 2, "params": {
+    s.send_and_wait({"op": "script/eval", "id": 2, "params": {
         "expression": 'new(scriptType, @system.temp.depthCaller); script.newScriptObject("local (a = system.temp.depthHelper())\\rreturn a", @system.temp.depthCaller)'
     }})
-    time.sleep(0.5)
     # Set breakpoint on line 1 of caller (the function call line)
-    send({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.depthCaller", "line": 1}})
-    time.sleep(0.3)
-    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.depthCaller()"}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.depthCaller", "line": 1}})
+    s.send_and_wait({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.depthCaller()"}})
+    s.wait_for_notification(reason="entry")
     # Continue past entry
-    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    s.wait_for_notification(reason="breakpoint")
     # Now at breakpoint on line 1 — step over should NOT enter depthHelper
     # and should stop at line 2 (return a) of depthCaller
-    send({"op": "debug/step", "id": 6, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
-    time.sleep(3)
-    send({"op": "debug/kill", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_step_over_calldepth, timeout=25)
-step_suspend = find_msg(msgs, reason="step")
-assert_test("step-over with calldepth skips function call",
-            step_suspend is not None,
-            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
-if step_suspend:
-    step_line = step_suspend.get("params", {}).get("line")
-    assert_test("step-over returns to caller line 2",
-                step_line == 2,
-                f"Expected line 2, got {step_line}")
+    s.send_and_wait({"op": "debug/step", "id": 6, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
+    step_suspend = s.wait_for_notification(reason="step")
+    assert_test("step-over with calldepth skips function call",
+                step_suspend is not None,
+                f"Messages: {[m for m in s.messages if m.get('op') == 'debug/suspended']}")
+    if step_suspend:
+        step_line = step_suspend.get("params", {}).get("line")
+        assert_test("step-over returns to caller line 2",
+                    step_line == 2,
+                    f"Expected line 2, got {step_line}")
+    s.send_and_wait({"op": "debug/kill", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
 
 # Step-out: step into a function, then step-out to return to caller
-def test_step_out(send):
-    # Reuse depthHelper and depthCaller from earlier test (or create fresh)
-    send({"op": "script/eval", "id": 1, "params": {
+with DebugSession(timeout=25) as s:
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.outHelper); script.newScriptObject("local (r = 77)\\rreturn r", @system.temp.outHelper)'
     }})
-    time.sleep(0.5)
-    send({"op": "script/eval", "id": 2, "params": {
+    s.send_and_wait({"op": "script/eval", "id": 2, "params": {
         "expression": 'new(scriptType, @system.temp.outCaller); script.newScriptObject("local (a = system.temp.outHelper())\\rreturn a", @system.temp.outCaller)'
     }})
-    time.sleep(0.5)
     # Set breakpoint inside outHelper (line 1: local r = 77)
-    send({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.outHelper", "line": 1}})
-    time.sleep(0.3)
-    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.outCaller()"}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.outHelper", "line": 1}})
+    s.send_and_wait({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.outCaller()"}})
+    s.wait_for_notification(reason="entry")
     # Continue past entry
-    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    s.wait_for_notification(reason="breakpoint")
     # Now suspended inside outHelper at line 1 — step out to return to outCaller
-    send({"op": "debug/step", "id": 6, "params": {"threadId": FIRST_DEBUG_TID, "direction": "out"}})
-    time.sleep(3)
-    # Should be suspended back in outCaller
-    send({"op": "debug/kill", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    s.send_and_wait({"op": "debug/step", "id": 6, "params": {"threadId": FIRST_DEBUG_TID, "direction": "out"}})
+    step_suspend = s.wait_for_notification(reason="step")
+    assert_test("step-out returns to caller",
+                step_suspend is not None,
+                f"Messages: {[m for m in s.messages if m.get('op') == 'debug/suspended']}")
+    s.send_and_wait({"op": "debug/kill", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
 
-msgs = run_debug_session(test_step_out, timeout=25)
-step_suspend = find_msg(msgs, reason="step")
-assert_test("step-out returns to caller",
-            step_suspend is not None,
-            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
-
-def test_step_error_not_suspended(send):
-    send({"op": "debug/run", "id": 1, "params": {"expression": "return 1"}})
-    time.sleep(1)
+# Step error: not suspended
+with DebugSession() as s:
+    s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 1"}})
+    s.wait_for_notification(reason="entry")
     # Continue first (thread is now running)
-    send({"op": "debug/continue", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/continue", "id": 2, "params": {"threadId": FIRST_DEBUG_TID}})
+    # Wait for completion so thread is gone
+    s.wait_for_notification(op="debug/completed")
     # Try to step — should fail because thread completed
-    send({"op": "debug/step", "id": 3, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_step_error_not_suspended)
-assert_test("step on non-suspended thread errors",
-            any("not suspended" in str(m) or "No debug thread" in str(m) for m in msgs),
-            f"Messages: {msgs}")
+    resp = s.send_and_wait({"op": "debug/step", "id": 3, "params": {"threadId": FIRST_DEBUG_TID, "direction": "over"}})
+    assert_test("step on non-suspended thread errors",
+                resp is not None and ("not suspended" in str(resp) or "No debug thread" in str(resp)),
+                f"Response: {resp}")
 
 # --- Test 5: error cases ---
 print()
 print("--- error cases ---")
-def test_invalid_continue(send):
-    send({"op": "debug/continue", "id": 1, "params": {"threadId": 999}})
-    time.sleep(1)
 
-msgs = run_debug_session(test_invalid_continue)
-assert_test("continue with invalid threadId errors", any("No debug thread" in str(m) for m in msgs), f"Messages: {msgs}")
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/continue", "id": 1, "params": {"threadId": 999}})
+    assert_test("continue with invalid threadId errors",
+                resp is not None and "No debug thread" in str(resp),
+                f"Response: {resp}")
 
-def test_invalid_kill(send):
-    send({"op": "debug/kill", "id": 1, "params": {"threadId": 999}})
-    time.sleep(1)
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/kill", "id": 1, "params": {"threadId": 999}})
+    assert_test("kill with invalid threadId errors",
+                resp is not None and "No debug thread" in str(resp),
+                f"Response: {resp}")
 
-msgs = run_debug_session(test_invalid_kill)
-assert_test("kill with invalid threadId errors", any("No debug thread" in str(m) for m in msgs), f"Messages: {msgs}")
-
-def test_missing_expression(send):
-    send({"op": "debug/run", "id": 1, "params": {}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_missing_expression)
-assert_test("run with missing expression errors", any("expression" in str(m) for m in msgs), f"Messages: {msgs}")
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/run", "id": 1, "params": {}})
+    assert_test("run with missing expression errors",
+                resp is not None and "expression" in str(resp),
+                f"Response: {resp}")
 
 # --- Test 6: breakpoint hit during execution ---
 print()
 print("--- breakpoint hit during execution ---")
 
-def test_breakpoint_hit(send):
+with DebugSession(timeout=20) as s:
     # Step 1: Create a test function in system.temp via script/eval
-    send({"op": "script/eval", "id": 1, "params": {
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.bpTestFunc); script.newScriptObject("local (x = 1)\\rlocal (y = 2)\\rreturn (x + y)", @system.temp.bpTestFunc)'
     }})
-    time.sleep(1)
     # Step 2: Set a breakpoint on line 2 of bpTestFunc
-    send({"op": "debug/setBreakpoint", "id": 2, "params": {
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 2, "params": {
         "script": "system.temp.bpTestFunc", "line": 2
     }})
-    time.sleep(0.5)
     # Step 3: Run an expression that calls the function
-    send({"op": "debug/run", "id": 3, "params": {
+    s.send_and_wait({"op": "debug/run", "id": 3, "params": {
         "expression": "system.temp.bpTestFunc()"
     }})
-    time.sleep(2)
+    s.wait_for_notification(reason="entry")
     # Step 4: Continue past initial entry suspension
-    send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(3)
-    # Step 5: At this point, should be suspended at breakpoint on line 2
+    s.send_and_wait({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
+    # Step 5: Should be suspended at breakpoint on line 2
+    bp_suspend = s.wait_for_notification(reason="breakpoint")
+    assert_test("breakpoint hit suspends thread", bp_suspend is not None,
+                f"Messages: {[m for m in s.messages if m.get('op') == 'debug/suspended' or m.get('result', {}).get('action')]}")
+
+    # If breakpoint was hit, verify it's on the right line
+    if bp_suspend:
+        bp_line = bp_suspend.get("params", {}).get("line")
+        assert_test("breakpoint hit on correct line",
+                    bp_line == 2,
+                    f"Expected line 2, got {bp_line}")
     # Kill to clean up
-    send({"op": "debug/kill", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_breakpoint_hit, timeout=20)
-# Check that we got a breakpoint suspension
-bp_suspend = find_msg(msgs, reason="breakpoint")
-assert_test("breakpoint hit suspends thread",
-            bp_suspend is not None,
-            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended' or m.get('result', {}).get('action')]}")
-
-# If breakpoint was hit, verify it's on the right line
-if bp_suspend:
-    bp_line = bp_suspend.get("params", {}).get("line")
-    assert_test("breakpoint hit on correct line",
-                bp_line == 2,
-                f"Expected line 2, got {bp_line}")
+    s.send_and_wait({"op": "debug/kill", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
 
 # --- Test 7: debug/setBreakpoint + debug/listBreakpoints ---
 print()
 print("--- debug/setBreakpoint + debug/listBreakpoints ---")
 
-def test_set_breakpoint(send):
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "mainResponder.respond", "line": 5}})
-    time.sleep(0.5)
-    send({"op": "debug/listBreakpoints", "id": 2, "params": {}})
-    time.sleep(0.5)
+with DebugSession() as s:
+    set_resp = s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "mainResponder.respond", "line": 5}})
+    assert_test("setBreakpoint returns action=set",
+                set_resp is not None and set_resp.get("result", {}).get("action") == "set",
+                f"Response: {set_resp}")
 
-msgs = run_debug_session(test_set_breakpoint)
-# Check setBreakpoint response
-set_msg = None
-for m in msgs:
-    if m.get("id") == 1 and m.get("result", {}).get("action") == "set":
-        set_msg = m
-        break
-assert_test("setBreakpoint returns action=set", set_msg is not None, f"Messages: {msgs}")
-
-# Check listBreakpoints response
-list_msg = None
-for m in msgs:
-    if m.get("id") == 2 and m.get("result", {}).get("breakpoints") is not None:
-        list_msg = m
-        break
-assert_test("listBreakpoints returns breakpoint array",
-            list_msg is not None and len(list_msg["result"]["breakpoints"]) > 0,
-            f"Messages: {msgs}")
-if list_msg:
-    bp = list_msg["result"]["breakpoints"][0]
-    assert_test("listed breakpoint has correct script",
-                bp.get("script") == "mainResponder.respond",
-                f"Breakpoint: {bp}")
-    assert_test("listed breakpoint has correct line",
-                bp.get("line") == 5,
-                f"Breakpoint: {bp}")
+    list_resp = s.send_and_wait({"op": "debug/listBreakpoints", "id": 2, "params": {}})
+    assert_test("listBreakpoints returns breakpoint array",
+                list_resp is not None and list_resp.get("result", {}).get("breakpoints") is not None and len(list_resp["result"]["breakpoints"]) > 0,
+                f"Response: {list_resp}")
+    if list_resp and list_resp.get("result", {}).get("breakpoints"):
+        bp = list_resp["result"]["breakpoints"][0]
+        assert_test("listed breakpoint has correct script",
+                    bp.get("script") == "mainResponder.respond",
+                    f"Breakpoint: {bp}")
+        assert_test("listed breakpoint has correct line",
+                    bp.get("line") == 5,
+                    f"Breakpoint: {bp}")
 
 # --- Test 8: breakpoint toggle (clear) ---
 print()
 print("--- breakpoint toggle (clear) ---")
 
-def test_toggle_breakpoint(send):
+with DebugSession() as s:
     # Set a breakpoint
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "test.script", "line": 3}})
-    time.sleep(0.5)
+    set_resp = s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "test.script", "line": 3}})
+    assert_test("first set returns action=set",
+                set_resp is not None and set_resp.get("result", {}).get("action") == "set",
+                f"Response: {set_resp}")
+
     # Set again to toggle off
-    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "test.script", "line": 3}})
-    time.sleep(0.5)
+    toggle_resp = s.send_and_wait({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "test.script", "line": 3}})
+    assert_test("second set returns action=cleared",
+                toggle_resp is not None and toggle_resp.get("result", {}).get("action") == "cleared",
+                f"Response: {toggle_resp}")
+
     # List should be empty
-    send({"op": "debug/listBreakpoints", "id": 3, "params": {}})
-    time.sleep(0.5)
-
-msgs = run_debug_session(test_toggle_breakpoint)
-# Check first set
-set_msg = None
-for m in msgs:
-    if m.get("id") == 1 and m.get("result", {}).get("action") == "set":
-        set_msg = m
-        break
-assert_test("first set returns action=set", set_msg is not None, f"Messages: {msgs}")
-
-# Check toggle clears
-clear_msg = None
-for m in msgs:
-    if m.get("id") == 2 and m.get("result", {}).get("action") == "cleared":
-        clear_msg = m
-        break
-assert_test("second set returns action=cleared", clear_msg is not None, f"Messages: {msgs}")
-
-# Check list is empty
-list_msg = None
-for m in msgs:
-    if m.get("id") == 3 and m.get("result", {}).get("breakpoints") is not None:
-        list_msg = m
-        break
-assert_test("list after toggle is empty",
-            list_msg is not None and len(list_msg["result"]["breakpoints"]) == 0,
-            f"Messages: {msgs}")
+    list_resp = s.send_and_wait({"op": "debug/listBreakpoints", "id": 3, "params": {}})
+    assert_test("list after toggle is empty",
+                list_resp is not None and list_resp.get("result", {}).get("breakpoints") is not None and len(list_resp["result"]["breakpoints"]) == 0,
+                f"Response: {list_resp}")
 
 # --- Test 9: breakpoint with leading @ stripped ---
 print()
 print("--- breakpoint @ prefix handling ---")
 
-def test_breakpoint_at_prefix(send):
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "@system.compiler.start", "line": 1}})
-    time.sleep(0.5)
-    send({"op": "debug/listBreakpoints", "id": 2, "params": {}})
-    time.sleep(0.5)
-
-msgs = run_debug_session(test_breakpoint_at_prefix)
-list_msg = None
-for m in msgs:
-    if m.get("id") == 2 and m.get("result", {}).get("breakpoints") is not None:
-        list_msg = m
-        break
-if list_msg and len(list_msg["result"]["breakpoints"]) > 0:
-    assert_test("@ prefix stripped from script path",
-                list_msg["result"]["breakpoints"][0].get("script") == "system.compiler.start",
-                f"Breakpoint: {list_msg['result']['breakpoints'][0]}")
-else:
-    assert_test("@ prefix stripped from script path", False, f"Messages: {msgs}")
+with DebugSession() as s:
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "@system.compiler.start", "line": 1}})
+    list_resp = s.send_and_wait({"op": "debug/listBreakpoints", "id": 2, "params": {}})
+    if list_resp and list_resp.get("result", {}).get("breakpoints") and len(list_resp["result"]["breakpoints"]) > 0:
+        assert_test("@ prefix stripped from script path",
+                    list_resp["result"]["breakpoints"][0].get("script") == "system.compiler.start",
+                    f"Breakpoint: {list_resp['result']['breakpoints'][0]}")
+    else:
+        assert_test("@ prefix stripped from script path", False, f"Response: {list_resp}")
 
 # --- Test 10: breakpoint error cases ---
 print()
 print("--- breakpoint error cases ---")
 
-def test_breakpoint_missing_script(send):
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {"line": 5}})
-    time.sleep(0.5)
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {"line": 5}})
+    assert_test("setBreakpoint without script errors",
+                resp is not None and not resp.get("success", True) and "script" in str(resp).lower(),
+                f"Response: {resp}")
 
-msgs = run_debug_session(test_breakpoint_missing_script)
-assert_test("setBreakpoint without script errors",
-            any("script" in str(m).lower() for m in msgs if not m.get("success", True)),
-            f"Messages: {msgs}")
-
-def test_breakpoint_missing_line(send):
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "foo.bar"}})
-    time.sleep(0.5)
-
-msgs = run_debug_session(test_breakpoint_missing_line)
-assert_test("setBreakpoint without line errors",
-            any("line" in str(m).lower() for m in msgs if not m.get("success", True)),
-            f"Messages: {msgs}")
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "foo.bar"}})
+    assert_test("setBreakpoint without line errors",
+                resp is not None and not resp.get("success", True) and "line" in str(resp).lower(),
+                f"Response: {resp}")
 
 # --- Test 11: debug/clearBreakpoints ---
 print()
 print("--- debug/clearBreakpoints ---")
 
-def test_clear_breakpoints(send):
+with DebugSession() as s:
     # Set two breakpoints
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "foo.bar", "line": 1}})
-    time.sleep(0.3)
-    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "foo.bar", "line": 2}})
-    time.sleep(0.3)
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {"script": "foo.bar", "line": 1}})
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "foo.bar", "line": 2}})
     # Clear all
-    send({"op": "debug/clearBreakpoints", "id": 3, "params": {}})
-    time.sleep(0.3)
-    # List should be empty
-    send({"op": "debug/listBreakpoints", "id": 4, "params": {}})
-    time.sleep(0.3)
+    clear_resp = s.send_and_wait({"op": "debug/clearBreakpoints", "id": 3, "params": {}})
+    assert_test("clearBreakpoints returns count",
+                clear_resp is not None and clear_resp.get("result", {}).get("cleared") == 2,
+                f"Response: {clear_resp}")
 
-msgs = run_debug_session(test_clear_breakpoints)
+    # List should be empty after clear
+    list_resp = s.send_and_wait({"op": "debug/listBreakpoints", "id": 4, "params": {}})
+    assert_test("list empty after clearBreakpoints",
+                list_resp is not None and list_resp.get("result", {}).get("breakpoints") is not None and len(list_resp["result"]["breakpoints"]) == 0,
+                f"Response: {list_resp}")
 
-# Check clear returns count
-clear_msg = None
-for m in msgs:
-    if m.get("id") == 3 and m.get("result", {}).get("cleared") is not None:
-        clear_msg = m
-        break
-assert_test("clearBreakpoints returns count",
-            clear_msg is not None and clear_msg["result"]["cleared"] == 2,
-            f"Messages: {[m for m in msgs if m.get('id') == 3]}")
-
-# Check list is empty after clear
-list_msg = None
-for m in msgs:
-    if m.get("id") == 4 and m.get("result", {}).get("breakpoints") is not None:
-        list_msg = m
-        break
-assert_test("list empty after clearBreakpoints",
-            list_msg is not None and len(list_msg["result"]["breakpoints"]) == 0,
-            f"Messages: {[m for m in msgs if m.get('id') == 4]}")
-
-def test_clear_empty(send):
-    send({"op": "debug/clearBreakpoints", "id": 1, "params": {}})
-    time.sleep(0.3)
-
-msgs = run_debug_session(test_clear_empty)
-clear_msg = None
-for m in msgs:
-    if m.get("id") == 1 and m.get("result", {}).get("cleared") is not None:
-        clear_msg = m
-        break
-assert_test("clearBreakpoints with no breakpoints returns 0",
-            clear_msg is not None and clear_msg["result"]["cleared"] == 0,
-            f"Messages: {msgs}")
+with DebugSession() as s:
+    clear_resp = s.send_and_wait({"op": "debug/clearBreakpoints", "id": 1, "params": {}})
+    assert_test("clearBreakpoints with no breakpoints returns 0",
+                clear_resp is not None and clear_resp.get("result", {}).get("cleared") == 0,
+                f"Response: {clear_resp}")
 
 # --- Test 12: debug/getLocals + debug/getStack + debug/getSource ---
 print()
 print("--- debug/getLocals + debug/getStack + debug/getSource ---")
 
-def test_inspection(send):
+with DebugSession(timeout=25) as s:
     # Create a test function with locals
-    send({"op": "script/eval", "id": 1, "params": {
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.inspectTest); script.newScriptObject("local (x = 42)\\rlocal (msg = \\"hello\\")\\rreturn (x)", @system.temp.inspectTest)'
     }})
-    time.sleep(1)
     # Set breakpoint on line 3
-    send({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "system.temp.inspectTest", "line": 3}})
-    time.sleep(0.5)
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 2, "params": {"script": "system.temp.inspectTest", "line": 3}})
     # Run in debug mode
-    send({"op": "debug/run", "id": 3, "params": {"expression": "system.temp.inspectTest()"}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/run", "id": 3, "params": {"expression": "system.temp.inspectTest()"}})
+    s.wait_for_notification(reason="entry")
     # Continue past entry
-    send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
+    # Wait for breakpoint
+    s.wait_for_notification(reason="breakpoint")
     # Now suspended at breakpoint — test inspection
-    send({"op": "debug/getLocals", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-    send({"op": "debug/getStack", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-    send({"op": "debug/getSource", "id": 7, "params": {"script": "system.temp.inspectTest", "threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    locals_resp = s.send_and_wait({"op": "debug/getLocals", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
+    stack_resp = s.send_and_wait({"op": "debug/getStack", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
+    source_resp = s.send_and_wait({"op": "debug/getSource", "id": 7, "params": {"script": "system.temp.inspectTest", "threadId": FIRST_DEBUG_TID}})
     # Kill to clean up
-    send({"op": "debug/kill", "id": 8, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_inspection, timeout=25)
+    s.send_and_wait({"op": "debug/kill", "id": 8, "params": {"threadId": FIRST_DEBUG_TID}})
 
 # Check getLocals
-locals_msg = None
-for m in msgs:
-    if m.get("id") == 5 and m.get("result", {}).get("locals") is not None:
-        locals_msg = m
-        break
 assert_test("getLocals returns locals array",
-            locals_msg is not None,
-            f"Messages: {[m for m in msgs if m.get('id') == 5]}")
+            locals_resp is not None and locals_resp.get("result", {}).get("locals") is not None,
+            f"Response: {locals_resp}")
 
-if locals_msg:
-    locals_list = locals_msg["result"]["locals"]
+if locals_resp and locals_resp.get("result", {}).get("locals") is not None:
+    locals_list = locals_resp["result"]["locals"]
     local_names = [l["name"] for l in locals_list]
     assert_test("getLocals contains x",
                 "x" in local_names,
@@ -627,33 +574,23 @@ if locals_msg:
                 f"x_local: {x_local}")
 
 # Check getStack
-stack_msg = None
-for m in msgs:
-    if m.get("id") == 6 and m.get("result", {}).get("frames") is not None:
-        stack_msg = m
-        break
 assert_test("getStack returns frames",
-            stack_msg is not None and len(stack_msg["result"]["frames"]) > 0,
-            f"Messages: {[m for m in msgs if m.get('id') == 6]}")
+            stack_resp is not None and stack_resp.get("result", {}).get("frames") is not None and len(stack_resp["result"]["frames"]) > 0,
+            f"Response: {stack_resp}")
 
-if stack_msg:
-    frames = stack_msg["result"]["frames"]
+if stack_resp and stack_resp.get("result", {}).get("frames"):
+    frames = stack_resp["result"]["frames"]
     assert_test("getStack has inspectTest frame",
                 any("inspectTest" in f.get("script", "") for f in frames),
                 f"Frames: {frames}")
 
 # Check getSource
-source_msg = None
-for m in msgs:
-    if m.get("id") == 7 and m.get("result", {}).get("lines") is not None:
-        source_msg = m
-        break
 assert_test("getSource returns lines",
-            source_msg is not None and len(source_msg["result"]["lines"]) >= 3,
-            f"Messages: {[m for m in msgs if m.get('id') == 7]}")
+            source_resp is not None and source_resp.get("result", {}).get("lines") is not None and len(source_resp["result"]["lines"]) >= 3,
+            f"Response: {source_resp}")
 
-if source_msg:
-    lines = source_msg["result"]["lines"]
+if source_resp and source_resp.get("result", {}).get("lines"):
+    lines = source_resp["result"]["lines"]
     assert_test("getSource line 3 is current",
                 any(l.get("current") for l in lines if l.get("num") == 3),
                 f"Lines: {lines}")
@@ -665,224 +602,159 @@ if source_msg:
 print()
 print("--- inspection error cases ---")
 
-def test_getlocals_not_suspended(send):
-    send({"op": "debug/getLocals", "id": 1, "params": {"threadId": 999}})
-    time.sleep(0.5)
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/getLocals", "id": 1, "params": {"threadId": 999}})
+    assert_test("getLocals with invalid threadId errors",
+                resp is not None and "No debug thread" in str(resp),
+                f"Response: {resp}")
 
-msgs = run_debug_session(test_getlocals_not_suspended)
-assert_test("getLocals with invalid threadId errors",
-            any("No debug thread" in str(m) for m in msgs),
-            f"Messages: {msgs}")
-
-def test_getsource_missing_script(send):
-    send({"op": "debug/getSource", "id": 1, "params": {}})
-    time.sleep(0.5)
-
-msgs = run_debug_session(test_getsource_missing_script)
-assert_test("getSource without script errors",
-            any("script" in str(m).lower() for m in msgs if not m.get("success", True)),
-            f"Messages: {msgs}")
+with DebugSession() as s:
+    resp = s.send_and_wait({"op": "debug/getSource", "id": 1, "params": {}})
+    assert_test("getSource without script errors",
+                resp is not None and not resp.get("success", True) and "script" in str(resp).lower(),
+                f"Response: {resp}")
 
 # --- Test 14: multi-thread debugging (Phase 5) ---
 print()
 print("--- multi-thread debugging ---")
 
-def test_multi_thread(send):
+with DebugSession(timeout=20) as s:
     # Launch two debug threads
-    send({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
-    time.sleep(1)
-    send({"op": "debug/run", "id": 2, "params": {"expression": "return 2+2"}})
-    time.sleep(1)
+    resp1 = s.send_and_wait({"op": "debug/run", "id": 1, "params": {"expression": "return 1+1"}})
+    entry1 = s.wait_for_notification(reason="entry")
+    resp2 = s.send_and_wait({"op": "debug/run", "id": 2, "params": {"expression": "return 2+2"}})
+    entry2 = s.wait_for_notification(reason="entry")
+
+    # Extract actual thread IDs from responses
+    t1_tid = resp1.get("result", {}).get("threadId") if resp1 else None
+    t2_tid = resp2.get("result", {}).get("threadId") if resp2 else None
+
+    assert_test("two threads started with different IDs",
+                t1_tid is not None and t2_tid is not None and t1_tid != t2_tid,
+                f"t1={t1_tid}, t2={t2_tid}")
+
+    # Both should have entry suspensions
+    entry_suspensions = [m for m in s.messages if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "entry"]
+    assert_test("both threads suspended at entry",
+                len(entry_suspensions) >= 2,
+                f"Entry suspensions: {entry_suspensions}")
+
     # List threads — should show both
-    send({"op": "debug/listThreads", "id": 3, "params": {}})
-    time.sleep(0.5)
-    # Continue first thread, keep second suspended.
-    # Thread IDs are sequential from the allocator; we use FIRST_DEBUG_TID
-    # (validated in Test 0) and +1 since we can't read responses mid-session.
-    send({"op": "debug/continue", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    list1_resp = s.send_and_wait({"op": "debug/listThreads", "id": 3, "params": {}})
+    assert_test("listThreads shows 2 threads",
+                list1_resp is not None and list1_resp.get("result", {}).get("threads") is not None and len(list1_resp["result"]["threads"]) == 2,
+                f"Response: {list1_resp}")
+
+    # Continue first thread
+    s.send_and_wait({"op": "debug/continue", "id": 4, "params": {"threadId": t1_tid}})
+    s.wait_for_notification(op="debug/completed")
+
     # List again — should show only second thread
-    send({"op": "debug/listThreads", "id": 5, "params": {}})
-    time.sleep(0.5)
+    list2_resp = s.send_and_wait({"op": "debug/listThreads", "id": 5, "params": {}})
+    assert_test("listThreads shows 1 thread after first completes",
+                list2_resp is not None and list2_resp.get("result", {}).get("threads") is not None and len(list2_resp["result"]["threads"]) == 1,
+                f"Response: {list2_resp}")
+
     # Continue second thread
-    send({"op": "debug/continue", "id": 6, "params": {"threadId": FIRST_DEBUG_TID + 1}})
-    time.sleep(1)
+    s.send_and_wait({"op": "debug/continue", "id": 6, "params": {"threadId": t2_tid}})
+    s.wait_for_notification(op="debug/completed")
 
-msgs = run_debug_session(test_multi_thread, timeout=20)
-
-# Extract actual thread IDs from responses (don't assume FIRST_DEBUG_TID + 1)
-t1_tid = None
-t2_tid = None
-for m in msgs:
-    if m.get("id") == 1 and m.get("result", {}).get("threadId"):
-        t1_tid = m["result"]["threadId"]
-    if m.get("id") == 2 and m.get("result", {}).get("threadId"):
-        t2_tid = m["result"]["threadId"]
-
-assert_test("two threads started with different IDs",
-            t1_tid is not None and t2_tid is not None and t1_tid != t2_tid,
-            f"t1={t1_tid}, t2={t2_tid}")
-
-# Both should have entry suspensions
-entry_suspensions = [m for m in msgs if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "entry"]
-assert_test("both threads suspended at entry",
-            len(entry_suspensions) >= 2,
-            f"Entry suspensions: {entry_suspensions}")
-
-# listThreads should have shown 2 threads initially
-list1 = None
-for m in msgs:
-    if m.get("id") == 3 and m.get("result", {}).get("threads") is not None:
-        list1 = m
-        break
-assert_test("listThreads shows 2 threads",
-            list1 is not None and len(list1["result"]["threads"]) == 2,
-            f"Messages: {[m for m in msgs if m.get('id') == 3]}")
-
-# After first thread completes, listThreads should show 1 thread
-list2 = None
-for m in msgs:
-    if m.get("id") == 5 and m.get("result", {}).get("threads") is not None:
-        list2 = m
-        break
-assert_test("listThreads shows 1 thread after first completes",
-            list2 is not None and len(list2["result"]["threads"]) == 1,
-            f"Messages: {[m for m in msgs if m.get('id') == 5]}")
-
-# Both should have completed
-completions = [m for m in msgs if m.get("op") == "debug/completed"]
-assert_test("both threads completed",
-            len(completions) >= 2,
-            f"Completions: {completions}")
+    # Both should have completed
+    completions = [m for m in s.messages if m.get("op") == "debug/completed"]
+    assert_test("both threads completed",
+                len(completions) >= 2,
+                f"Completions: {completions}")
 
 # --- Test 15: watchpoint set/list/clear ---
 print()
 print("--- watchpoint set/list/clear ---")
 
-def test_watchpoint_ops(send):
-    send({"op": "debug/setWatchpoint", "id": 1, "params": {"variable": "x"}})
-    time.sleep(0.3)
-    send({"op": "debug/setWatchpoint", "id": 2, "params": {"variable": "y"}})
-    time.sleep(0.3)
-    send({"op": "debug/listWatchpoints", "id": 3, "params": {}})
-    time.sleep(0.3)
+with DebugSession() as s:
+    set_resp = s.send_and_wait({"op": "debug/setWatchpoint", "id": 1, "params": {"variable": "x"}})
+    assert_test("setWatchpoint returns action=set",
+                set_resp is not None and set_resp.get("result", {}).get("action") == "set",
+                f"Response: {set_resp}")
+
+    s.send_and_wait({"op": "debug/setWatchpoint", "id": 2, "params": {"variable": "y"}})
+
+    list1_resp = s.send_and_wait({"op": "debug/listWatchpoints", "id": 3, "params": {}})
+    assert_test("listWatchpoints shows 2 watchpoints",
+                list1_resp is not None and list1_resp.get("result", {}).get("watchpoints") is not None and len(list1_resp["result"]["watchpoints"]) == 2,
+                f"Response: {list1_resp}")
+
     # Toggle x off
-    send({"op": "debug/setWatchpoint", "id": 4, "params": {"variable": "x"}})
-    time.sleep(0.3)
-    send({"op": "debug/listWatchpoints", "id": 5, "params": {}})
-    time.sleep(0.3)
+    toggle_resp = s.send_and_wait({"op": "debug/setWatchpoint", "id": 4, "params": {"variable": "x"}})
+    assert_test("setWatchpoint toggle clears",
+                toggle_resp is not None and toggle_resp.get("result", {}).get("action") == "cleared",
+                f"Response: {toggle_resp}")
+
+    list2_resp = s.send_and_wait({"op": "debug/listWatchpoints", "id": 5, "params": {}})
+    assert_test("listWatchpoints shows 1 after toggle",
+                list2_resp is not None and list2_resp.get("result", {}).get("watchpoints") is not None and len(list2_resp["result"]["watchpoints"]) == 1,
+                f"Response: {list2_resp}")
+
     # Clear all
-    send({"op": "debug/clearWatchpoints", "id": 6, "params": {}})
-    time.sleep(0.3)
-
-msgs = run_debug_session(test_watchpoint_ops)
-
-set_msg = None
-for m in msgs:
-    if m.get("id") == 1 and m.get("result", {}).get("action") == "set":
-        set_msg = m
-        break
-assert_test("setWatchpoint returns action=set", set_msg is not None, f"Messages: {msgs}")
-
-list1 = None
-for m in msgs:
-    if m.get("id") == 3 and m.get("result", {}).get("watchpoints") is not None:
-        list1 = m
-        break
-assert_test("listWatchpoints shows 2 watchpoints",
-            list1 is not None and len(list1["result"]["watchpoints"]) == 2,
-            f"Messages: {[m for m in msgs if m.get('id') == 3]}")
-
-toggle_msg = None
-for m in msgs:
-    if m.get("id") == 4 and m.get("result", {}).get("action") == "cleared":
-        toggle_msg = m
-        break
-assert_test("setWatchpoint toggle clears", toggle_msg is not None, f"Messages: {msgs}")
-
-list2 = None
-for m in msgs:
-    if m.get("id") == 5 and m.get("result", {}).get("watchpoints") is not None:
-        list2 = m
-        break
-assert_test("listWatchpoints shows 1 after toggle",
-            list2 is not None and len(list2["result"]["watchpoints"]) == 1,
-            f"Messages: {[m for m in msgs if m.get('id') == 5]}")
-
-clear_msg = None
-for m in msgs:
-    if m.get("id") == 6 and m.get("result", {}).get("cleared") is not None:
-        clear_msg = m
-        break
-assert_test("clearWatchpoints returns count",
-            clear_msg is not None and clear_msg["result"]["cleared"] == 1,
-            f"Messages: {[m for m in msgs if m.get('id') == 6]}")
+    clear_resp = s.send_and_wait({"op": "debug/clearWatchpoints", "id": 6, "params": {}})
+    assert_test("clearWatchpoints returns count",
+                clear_resp is not None and clear_resp.get("result", {}).get("cleared") == 1,
+                f"Response: {clear_resp}")
 
 # --- Test 16: watchpoint fires on value change ---
 print()
 print("--- watchpoint fires on value change ---")
 
-def test_watchpoint_fire(send):
-    send({"op": "debug/setWatchpoint", "id": 1, "params": {"variable": "x"}})
-    time.sleep(0.3)
-    send({"op": "debug/run", "id": 2, "params": {"expression": "local (x = 1); x = x + 10; return x"}})
-    time.sleep(2)
+with DebugSession(timeout=20) as s:
+    s.send_and_wait({"op": "debug/setWatchpoint", "id": 1, "params": {"variable": "x"}})
+    s.send_and_wait({"op": "debug/run", "id": 2, "params": {"expression": "local (x = 1); x = x + 10; return x"}})
+    s.wait_for_notification(reason="entry")
     # Continue past entry — watchpoint should fire when x changes
-    send({"op": "debug/continue", "id": 3, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(3)
+    s.send_and_wait({"op": "debug/continue", "id": 3, "params": {"threadId": FIRST_DEBUG_TID}})
+
+    wp_suspend = s.wait_for_notification(reason="watchpoint")
+    assert_test("watchpoint fires on value change",
+                wp_suspend is not None,
+                f"Messages: {[m for m in s.messages if m.get('op') == 'debug/suspended']}")
+
+    if wp_suspend:
+        params = wp_suspend.get("params", {})
+        assert_test("watchpoint reports variable name",
+                    params.get("variable") == "x",
+                    f"Params: {params}")
+        assert_test("watchpoint reports old value",
+                    params.get("oldValue") == "1",
+                    f"Params: {params}")
+        assert_test("watchpoint reports new value",
+                    params.get("newValue") == "11",
+                    f"Params: {params}")
+
     # Kill
-    send({"op": "debug/kill", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
-
-msgs = run_debug_session(test_watchpoint_fire, timeout=20)
-
-wp_suspend = find_msg(msgs, reason="watchpoint")
-assert_test("watchpoint fires on value change",
-            wp_suspend is not None,
-            f"Messages: {[m for m in msgs if m.get('op') == 'debug/suspended']}")
-
-if wp_suspend:
-    params = wp_suspend.get("params", {})
-    assert_test("watchpoint reports variable name",
-                params.get("variable") == "x",
-                f"Params: {params}")
-    assert_test("watchpoint reports old value",
-                params.get("oldValue") == "1",
-                f"Params: {params}")
-    assert_test("watchpoint reports new value",
-                params.get("newValue") == "11",
-                f"Params: {params}")
+    s.send_and_wait({"op": "debug/kill", "id": 4, "params": {"threadId": FIRST_DEBUG_TID}})
 
 # --- Test 17: conditional breakpoints (Phase 7) ---
 print()
 print("--- conditional breakpoints ---")
 
-def test_conditional_bp(send):
-    send({"op": "script/eval", "id": 1, "params": {
+with DebugSession(timeout=20) as s:
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.condTest); script.newScriptObject("local (x = 1)\\rx = x + 10\\rreturn x", @system.temp.condTest)'
     }})
-    time.sleep(1)
     # Conditional breakpoint on line 1: x > 5 (won't fire, x=1)
-    send({"op": "debug/setBreakpoint", "id": 2, "params": {
+    set_with_cond = s.send_and_wait({"op": "debug/setBreakpoint", "id": 2, "params": {
         "script": "system.temp.condTest", "line": 1, "condition": "x > 5"
     }})
-    time.sleep(0.3)
     # Conditional breakpoint on line 3: x > 5 (will fire, x=11)
-    send({"op": "debug/setBreakpoint", "id": 3, "params": {
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 3, "params": {
         "script": "system.temp.condTest", "line": 3, "condition": "x > 5"
     }})
-    time.sleep(0.3)
-    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.condTest()"}})
-    time.sleep(2)
-    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(3)
-    send({"op": "debug/kill", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    s.send_and_wait({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.condTest()"}})
+    s.wait_for_notification(reason="entry")
+    s.send_and_wait({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
 
-msgs = run_debug_session(test_conditional_bp, timeout=20)
+    bp_suspend = s.wait_for_notification(reason="breakpoint")
+    # Collect all breakpoint suspensions to verify only one fired
+    s.send_and_wait({"op": "debug/kill", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
 
-# Should have suspended at line 3 (condition met), not line 1
-bp_suspensions = [m for m in msgs if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "breakpoint"]
+bp_suspensions = [m for m in s.messages if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "breakpoint"]
 assert_test("conditional breakpoint fires only when condition met",
             len(bp_suspensions) == 1,
             f"Breakpoint suspensions: {bp_suspensions}")
@@ -892,72 +764,55 @@ if bp_suspensions:
                 f"Line: {bp_suspensions[0].get('params', {}).get('line')}")
 
 # Verify condition in setBreakpoint response
-set_with_cond = None
-for m in msgs:
-    if m.get("id") == 2 and m.get("result", {}).get("condition"):
-        set_with_cond = m
-        break
 assert_test("setBreakpoint response includes condition",
-            set_with_cond is not None and set_with_cond["result"]["condition"] == "x > 5",
-            f"Messages: {[m for m in msgs if m.get('id') == 2]}")
+            set_with_cond is not None and set_with_cond.get("result", {}).get("condition") == "x > 5",
+            f"Response: {set_with_cond}")
 
 # --- Test 18: listBreakpoints includes condition ---
 print()
 print("--- listBreakpoints condition field ---")
 
-def test_list_bp_condition(send):
-    send({"op": "debug/setBreakpoint", "id": 1, "params": {
+with DebugSession() as s:
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 1, "params": {
         "script": "test.cond", "line": 1, "condition": "y == 0"
     }})
-    time.sleep(0.3)
-    send({"op": "debug/listBreakpoints", "id": 2, "params": {}})
-    time.sleep(0.3)
-
-msgs = run_debug_session(test_list_bp_condition)
-list_msg = None
-for m in msgs:
-    if m.get("id") == 2 and m.get("result", {}).get("breakpoints"):
-        list_msg = m
-        break
-if list_msg and len(list_msg["result"]["breakpoints"]) > 0:
-    assert_test("listBreakpoints includes condition",
-                list_msg["result"]["breakpoints"][0].get("condition") == "y == 0",
-                f"Breakpoints: {list_msg['result']['breakpoints']}")
-else:
-    assert_test("listBreakpoints includes condition", False, f"Messages: {msgs}")
+    list_resp = s.send_and_wait({"op": "debug/listBreakpoints", "id": 2, "params": {}})
+    if list_resp and list_resp.get("result", {}).get("breakpoints") and len(list_resp["result"]["breakpoints"]) > 0:
+        assert_test("listBreakpoints includes condition",
+                    list_resp["result"]["breakpoints"][0].get("condition") == "y == 0",
+                    f"Breakpoints: {list_resp['result']['breakpoints']}")
+    else:
+        assert_test("listBreakpoints includes condition", False, f"Response: {list_resp}")
 
 # --- Test 19: breakpoint fires on each function re-entry ---
 print()
 print("--- breakpoint re-entry ---")
 
-def test_reentry_bp(send):
+with DebugSession(timeout=25) as s:
     # inner function called twice by outer — breakpoint should fire both times
-    send({"op": "script/eval", "id": 1, "params": {
+    s.send_and_wait({"op": "script/eval", "id": 1, "params": {
         "expression": 'new(scriptType, @system.temp.bpInner); script.newScriptObject("return true", @system.temp.bpInner)'
     }})
-    time.sleep(0.5)
-    send({"op": "script/eval", "id": 2, "params": {
+    s.send_and_wait({"op": "script/eval", "id": 2, "params": {
         "expression": 'new(scriptType, @system.temp.bpOuter); script.newScriptObject("local (a = system.temp.bpInner())\\rlocal (b = system.temp.bpInner())\\rreturn (a and b)", @system.temp.bpOuter)'
     }})
-    time.sleep(0.5)
-    send({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.bpInner", "line": 1}})
-    time.sleep(0.3)
-    send({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.bpOuter()"}})
-    time.sleep(2)
+    s.send_and_wait({"op": "debug/setBreakpoint", "id": 3, "params": {"script": "system.temp.bpInner", "line": 1}})
+    s.send_and_wait({"op": "debug/run", "id": 4, "params": {"expression": "system.temp.bpOuter()"}})
+    s.wait_for_notification(reason="entry")
     # Continue past entry
-    send({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    s.send_and_wait({"op": "debug/continue", "id": 5, "params": {"threadId": FIRST_DEBUG_TID}})
     # Should hit breakpoint on first call to bpInner
-    send({"op": "debug/continue", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    s.wait_for_notification(reason="breakpoint")
+    s.send_and_wait({"op": "debug/continue", "id": 6, "params": {"threadId": FIRST_DEBUG_TID}})
     # Should hit breakpoint on second call to bpInner
-    send({"op": "debug/continue", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(2)
-    send({"op": "debug/kill", "id": 8, "params": {"threadId": FIRST_DEBUG_TID}})
-    time.sleep(1)
+    s.wait_for_notification(reason="breakpoint")
+    s.send_and_wait({"op": "debug/continue", "id": 7, "params": {"threadId": FIRST_DEBUG_TID}})
+    # Wait for completion or kill
+    completed = s.wait_for_notification(op="debug/completed", timeout=5)
+    if not completed:
+        s.send_and_wait({"op": "debug/kill", "id": 8, "params": {"threadId": FIRST_DEBUG_TID}})
 
-msgs = run_debug_session(test_reentry_bp, timeout=25)
-bp_hits = [m for m in msgs if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "breakpoint"]
+bp_hits = [m for m in s.messages if m.get("op") == "debug/suspended" and m.get("params", {}).get("reason") == "breakpoint"]
 assert_test("breakpoint fires on each function entry",
             len(bp_hits) >= 2,
             f"Breakpoint hits: {len(bp_hits)}, Messages: {bp_hits}")


### PR DESCRIPTION
## Summary

Priority 1 usability fixes from the debugger gap plan:

### 1. Event-driven test harness (#498)

Complete rewrite of the debug protocol test framework. The old harness sent all commands blind with `time.sleep()` delays and collected responses after process exit. The new harness:

- **`DebugSession` class** with background stdout reader thread
- **`send_and_wait(msg, id, timeout)`** — sends and blocks until response with matching id
- **`wait_for_notification(op, reason, timeout)`** — blocks until matching unsolicited notification
- **Context manager** for automatic cleanup
- **No `time.sleep()` in test logic** — only 50ms polling in the wait loop
- All 63 assertions preserved with identical test names

### 2. Script loading from disk

`debug/getSource` now calls `opverbinmemory()` to load scripts from the database when they aren't yet in memory, instead of returning an error. Constructs a `db_context` from the external variable's database handle.

## Test plan

- [x] 302/302 unit tests pass
- [x] 63/63 debug protocol tests pass (all converted to event-driven harness)
- [x] Tests run faster (no 2-3s sleeps between commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)