### PR TITLE
fix: Data-loss risks — duplicate open guard, fread size, migration lock

### DIFF
--- a/Common/headers/langinternal.h
+++ b/Common/headers/langinternal.h
@@ -209,6 +209,7 @@
 #define sqliteopenerror 163 // 2006-03-17 gewirtz
 #define sqlitedberror 164 // 2006-03-17 gewirtz
 #define sqlitecompileerror 165 // 2007-10-11 creedon
+#define dbalreadyopenederror 166 // 2026-04-03 JES: #270 prevent duplicate db opens
 
 
 #define langstacklist 137

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2434,7 +2434,13 @@ static void migration_lock_release(int fd, const char *lock_path) {
 /*  migration_lock_wait -- wait for another process to finish migration.
  *
  *  Polls every 500ms for up to 30 seconds.
- *  Returns true if the lock was released within the timeout. */
+ *  Returns true if the lock was released within the timeout.
+ *
+ *  GIL note: this may block while holding the GIL, but it only runs
+ *  during db.open() (not during script evaluation). In the headless
+ *  build, db.open is typically called during startup before any
+ *  concurrent scripts are running. The inter-process race this guards
+ *  against (two processes migrating the same file) is rare. */
 
 static boolean migration_lock_wait(const char *lock_path) {
 

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2379,7 +2379,9 @@ cleanup:
 
 static int migration_lock_acquire(const char *db_path, char *lock_path, size_t lock_path_size) {
 
-    snprintf(lock_path, lock_path_size, "%s%s", db_path, MIGRATION_LOCK_SUFFIX);
+    int n = snprintf(lock_path, lock_path_size, "%s%s", db_path, MIGRATION_LOCK_SUFFIX);
+    if (n < 0 || (size_t)n >= lock_path_size)
+        return -2; /* path too long */
 
     /* Try atomic creation. */
     int fd = open(lock_path, O_CREAT | O_EXCL | O_WRONLY, 0600);

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2401,10 +2401,13 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
          * .root as v6 or missing; in that case, fall through to re-migrate. */
         FILE *fp_check = fopen(db_path, "rb");
         if (fp_check) {
+            /* Read with byte-count to handle v7 files smaller than sizeof(tydatabaserecord).
+             * Issue #264: v7 databases may be only 90 bytes (sizeof(tydatabaserecord_64)). */
             tydatabaserecord header_check;
-            boolean header_ok = fread(&header_check, sizeof header_check, 1, fp_check) == 1;
+            memset(&header_check, 0, sizeof header_check);
+            size_t check_bytes = fread(&header_check, 1, sizeof header_check, fp_check);
             fclose(fp_check);
-            if (header_ok && !db_format_is_v6_header(&header_check)) {
+            if (check_bytes >= sizeof(tydatabaserecord_64) && !db_format_is_v6_header(&header_check)) {
                 /* Confirmed v7 -- return db_path as the output */
                 if (output_path && output_path_size > 0) {
                     strncpy(output_path, db_path, output_path_size);
@@ -2463,10 +2466,13 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
         snprintf(legacy_root7_path, sizeof legacy_root7_path, "%s7", db_path);
         FILE *fp_legacy = fopen(legacy_root7_path, "rb");
         if (fp_legacy) {
+            /* Read with byte-count to handle v7 files smaller than sizeof(tydatabaserecord).
+             * Issue #264: v7 databases may be only 90 bytes (sizeof(tydatabaserecord_64)). */
             tydatabaserecord header_v7;
-            boolean header_ok = fread(&header_v7, sizeof header_v7, 1, fp_legacy) == 1;
+            memset(&header_v7, 0, sizeof header_v7);
+            size_t legacy_bytes = fread(&header_v7, 1, sizeof header_v7, fp_legacy);
             fclose(fp_legacy);
-            if (header_ok && !db_format_is_v6_header(&header_v7)) {
+            if (legacy_bytes >= sizeof(tydatabaserecord_64) && !db_format_is_v6_header(&header_v7)) {
                 /* Legacy .root7 file exists and is valid v7 */
 #if defined(FRONTIER_HEADLESS)
                 log_info(LOG_COMP_DB,
@@ -2490,11 +2496,17 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
     if (!fp)
         return false;
 
+    /* Read the header using a union that covers both v6 (118 bytes) and v7 (90 bytes).
+     * v7 databases created by db.new() may be only 90 bytes on disk, so reading
+     * sizeof(tydatabaserecord) = 118 bytes as a single fread item would fail.
+     * Instead, read byte-by-byte up to the larger size and accept partial reads
+     * as long as we got at least the v7 header size (90 bytes). Issue #264. */
     tydatabaserecord header;
-    boolean ok = fread(&header, sizeof header, 1, fp) == 1;
+    memset(&header, 0, sizeof header);
+    size_t bytes_read = fread(&header, 1, sizeof header, fp);
     fclose(fp);
-    if (!ok)
-        return false;
+    if (bytes_read < sizeof(tydatabaserecord_64))
+        return false;  /* Too small for even the v7 header */
 
     if (!detect_database_format(&header))
         return false;

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2669,10 +2669,10 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
             fclose(fp_recheck);
 
             if (recheck_bytes >= sizeof(tydatabaserecord_64) && !db_format_is_v6_header(&recheck_header)) {
-                /* Other process completed migration successfully. */
-                db_format_mode recheck_mode = {true, false};
-                db_format_mode_apply(&recheck_mode);
-
+                /* Other process completed migration successfully.
+                 * Don't call db_format_mode_apply here — consistent with the
+                 * existing fast-return path at line 2509 which also skips it.
+                 * The caller (dbopenverb) handles mode setup after open. */
                 if (output_path && output_path_size > 0) {
                     strncpy(output_path, db_path, output_path_size);
                     if (output_path_size > 0)

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -20,6 +20,9 @@
 #include <errno.h>
 #if !defined(_WIN32)
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 
 #include "logging.h"  /* Phase 2D: fprintf migration */
@@ -2359,6 +2362,100 @@ cleanup:
     return ok;
 }
 
+/* ---- Migration lock file helpers (issue #271: TOCTOU race prevention) ---- */
+
+#if !defined(_WIN32)
+
+#define MIGRATION_LOCK_SUFFIX ".migrating"
+#define MIGRATION_LOCK_STALE_SECONDS (5 * 60)  /* 5 minutes */
+#define MIGRATION_LOCK_POLL_MS 500
+#define MIGRATION_LOCK_TIMEOUT_MS 30000
+
+/*  migration_lock_acquire -- atomically create lock file for migration.
+ *
+ *  Returns the fd (>= 0) on success.
+ *  Returns -1 if another process holds the lock (caller should wait/retry).
+ *  Returns -2 on unexpected error. */
+
+static int migration_lock_acquire(const char *db_path, char *lock_path, size_t lock_path_size) {
+
+    snprintf(lock_path, lock_path_size, "%s%s", db_path, MIGRATION_LOCK_SUFFIX);
+
+    /* Try atomic creation. */
+    int fd = open(lock_path, O_CREAT | O_EXCL | O_WRONLY, 0600);
+
+    if (fd >= 0)
+        return fd;  /* Lock acquired. */
+
+    if (errno != EEXIST)
+        return -2;  /* Unexpected error. */
+
+    /* Lock file exists -- check if it is stale (older than 5 minutes). */
+    struct stat st;
+
+    if (stat(lock_path, &st) == 0) {
+        time_t now = time(NULL);
+
+        if (now - st.st_mtime > MIGRATION_LOCK_STALE_SECONDS) {
+#if defined(FRONTIER_HEADLESS)
+            log_warn(LOG_COMP_DB,
+                "migration_lock_acquire: removing stale lock file %s (age %ld seconds)",
+                lock_path, (long)(now - st.st_mtime));
+#endif
+            unlink(lock_path);
+
+            /* Retry once after removing stale lock. */
+            fd = open(lock_path, O_CREAT | O_EXCL | O_WRONLY, 0600);
+
+            if (fd >= 0)
+                return fd;
+
+            if (errno != EEXIST)
+                return -2;
+        }
+    }
+
+    return -1;  /* Another process holds the lock. */
+}
+
+/*  migration_lock_release -- remove the lock file and close the fd. */
+
+static void migration_lock_release(int fd, const char *lock_path) {
+
+    if (fd >= 0)
+        close(fd);
+
+    if (lock_path && lock_path[0] != '\0')
+        unlink(lock_path);
+}
+
+/*  migration_lock_wait -- wait for another process to finish migration.
+ *
+ *  Polls every 500ms for up to 30 seconds.
+ *  Returns true if the lock was released within the timeout. */
+
+static boolean migration_lock_wait(const char *lock_path) {
+
+    int elapsed_ms = 0;
+
+    while (elapsed_ms < MIGRATION_LOCK_TIMEOUT_MS) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = MIGRATION_LOCK_POLL_MS * 1000000L;
+        nanosleep(&ts, NULL);
+
+        elapsed_ms += MIGRATION_LOCK_POLL_MS;
+
+        /* Check if the lock file has been removed. */
+        if (access(lock_path, F_OK) != 0)
+            return true;  /* Lock released -- migration completed. */
+    }
+
+    return false;  /* Timeout. */
+}
+
+#endif /* !_WIN32 */
+
 boolean migrate_32bit_to_64bit(const char *db_path) {
     return migrate_internal(db_path, NULL);
 }
@@ -2525,8 +2622,94 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
         return true;
     }
 
+    /* Issue #271: TOCTOU race prevention — acquire a lock file before migrating
+     * so that concurrent processes cannot both attempt migration simultaneously. */
+
+#if !defined(_WIN32)
+    {
+        char lock_path[1024];
+        int lock_fd = migration_lock_acquire(db_path, lock_path, sizeof lock_path);
+
+        if (lock_fd == -2) {
+            /* Unexpected error creating lock file. */
+#if defined(FRONTIER_HEADLESS)
+            log_error(LOG_COMP_DB,
+                "ensure_database_v7: cannot create migration lock file %s: %s",
+                lock_path, strerror(errno));
+#endif
+            return false;
+        }
+
+        if (lock_fd == -1) {
+            /* Another process is migrating — wait for it to finish. */
+#if defined(FRONTIER_HEADLESS)
+            log_info(LOG_COMP_DB,
+                "ensure_database_v7: migration in progress by another process, waiting...");
+#endif
+
+            if (!migration_lock_wait(lock_path)) {
+#if defined(FRONTIER_HEADLESS)
+                log_error(LOG_COMP_DB,
+                    "ensure_database_v7: timed out waiting for migration lock %s", lock_path);
+#endif
+                return false;
+            }
+
+            /* Other process finished — re-read the header to see if it migrated. */
+            FILE *fp_recheck = fopen(db_path, "rb");
+
+            if (!fp_recheck)
+                return false;
+
+            tydatabaserecord recheck_header;
+            memset(&recheck_header, 0, sizeof recheck_header);
+            size_t recheck_bytes = fread(&recheck_header, 1, sizeof recheck_header, fp_recheck);
+            fclose(fp_recheck);
+
+            if (recheck_bytes >= sizeof(tydatabaserecord_64) && !db_format_is_v6_header(&recheck_header)) {
+                /* Other process completed migration successfully. */
+                db_format_mode recheck_mode = {true, false};
+                db_format_mode_apply(&recheck_mode);
+
+                if (output_path && output_path_size > 0) {
+                    strncpy(output_path, db_path, output_path_size);
+                    if (output_path_size > 0)
+                        output_path[output_path_size - 1] = '\0';
+                }
+
+                if (migrated)
+                    *migrated = true;
+
+                return true;
+            }
+
+            /* Other process did not leave a valid v7 file — fall through to migrate ourselves.
+             * We need to acquire the lock first. */
+            lock_fd = migration_lock_acquire(db_path, lock_path, sizeof lock_path);
+
+            if (lock_fd < 0) {
+#if defined(FRONTIER_HEADLESS)
+                log_error(LOG_COMP_DB,
+                    "ensure_database_v7: cannot acquire migration lock after wait: %s",
+                    strerror(errno));
+#endif
+                return false;
+            }
+        }
+
+        /* We hold the lock — perform migration. */
+        boolean migrate_ok = migrate_internal(db_path, NULL);
+
+        migration_lock_release(lock_fd, lock_path);
+
+        if (!migrate_ok)
+            return false;
+    }
+#else
+    /* Windows: no lock file support yet — migrate without locking. */
     if (!migrate_internal(db_path, NULL))
         return false;
+#endif
 
     /* Migration succeeded; return path to new v7 file */
     if (output_path && output_path_size > 0) {

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -768,6 +768,23 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 		}
 	}
 
+	/* #270: Check if database is already in the open database list.
+	 * Opening the same file twice causes concurrent write corruption. */
+	{
+		hdlodbrecord h;
+
+		for (h = (**hodblist).hnext; h != nil; h = (**h).hnext) {
+			if (equalfilespecs (&(**h).fs, &odbrec.fs)) {
+				bigstring bs;
+
+				getfsfile (&odbrec.fs, bs);
+				log_warn(LOG_COMP_DB, "dbopenverb: database already open: %s", stringbaseaddress(bs));
+				lang2paramerror (dbalreadyopenederror, bsfunctionname, bs);
+				return (false);
+			}
+		}
+	}
+
 	w = shellfindfilewindow ( &odbrec.fs );
 
 	if (w != nil) {

--- a/resources/strings/langerrorlist.yaml
+++ b/resources/strings/langerrorlist.yaml
@@ -494,6 +494,9 @@ langerrorlist:
   - id: sqlitecompileerror
     index: 165
     text: "Can't compile query ^0."
+  - id: dbalreadyopenederror
+    index: 166
+    text: "Can't call ^0 because the database ^1 is already open."
 
 tablestringlist:
   - id: system_table_type

--- a/tests/integration/test_cases/db_verbs.yaml
+++ b/tests/integration/test_cases/db_verbs.yaml
@@ -579,3 +579,23 @@ tests:
       return v
     expected_success: true
     expected_result: "hello264"
+
+  - name: "Issue #270 - duplicate open returns error"
+    description: "Opening an already-open database returns an error instead of creating a second handle"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "test_issue270_dupopen.root");
+      if file.exists(dbPath) {file.delete(dbPath)};
+      db.new(dbPath);
+      db.open(dbPath, false);
+      try {
+        db.open(dbPath, false);
+        db.close(dbPath);
+        file.delete(dbPath);
+        return false};
+      else {
+        db.close(dbPath);
+        file.delete(dbPath);
+        return true}
+    expected_success: true
+    expected_result: "true"

--- a/tests/integration/test_cases/db_verbs.yaml
+++ b/tests/integration/test_cases/db_verbs.yaml
@@ -538,3 +538,44 @@ tests:
       return ok and v7Exists and rootExists
     expected_success: true
     expected_result: "true"
+
+  # ========================================================================
+  # Regression test for Issue #264: db.close() + db.open() in same script
+  # ========================================================================
+
+  - name: "Issue #264 - close and reopen in same script"
+    description: "db.new/open/close/reopen must not segfault (Issue #264)"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "test_issue264.root");
+      if file.exists(dbPath) {file.delete(dbPath)};
+      db.new(dbPath);
+      db.open(dbPath, false);
+      db.close(dbPath);
+      local(ok = db.open(dbPath, false));
+      db.close(dbPath);
+      file.delete(dbPath);
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  - name: "Issue #264 - multiple close/reopen cycles with data persistence"
+    description: "Data persists across multiple close/reopen cycles in same script"
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "test_issue264_persist.root");
+      if file.exists(dbPath) {file.delete(dbPath)};
+      db.new(dbPath);
+      db.open(dbPath, false);
+      db.setvalue(dbPath, "testkey", "hello264");
+      db.save(dbPath);
+      db.close(dbPath);
+      db.open(dbPath, false);
+      local(v = db.getvalue(dbPath, "testkey"));
+      db.close(dbPath);
+      db.open(dbPath, false);
+      db.close(dbPath);
+      file.delete(dbPath);
+      return v
+    expected_success: true
+    expected_result: "hello264"


### PR DESCRIPTION
## Summary

Three data-loss fixes from the issue triage (highest priority items):

### #270: Prevent duplicate database opens
`dbopenverb()` now searches `hodblist` for an already-open database before calling `odbopenfile()`. Returns a clear error ("database is already open") instead of creating a second write handle to the same file, which would cause concurrent write corruption.

### #264: Fix db.close() + db.open() segfault
The `fread` in `ensure_database_v7()` used `sizeof(tydatabaserecord)` (118 bytes) as a single item, but v7 databases created by `db.new()` are only 90 bytes on disk (`sizeof(tydatabaserecord_64)`). Changed to byte-by-byte reads with `memset` zero-initialization and a minimum-size check to accept both v6 and v7 headers.

### #271: TOCTOU race in auto-migration
Added lock file mechanism using `O_CREAT|O_EXCL` for atomic creation. A second process attempting migration sees the lock, waits up to 30 seconds, then re-reads the header (migration completed by the first process). Stale lock detection (5 minute timeout) handles crashed processes.

Closes #264, closes #270, closes #271

## Test plan
- [x] 302/302 unit tests pass
- [x] 2 new regression tests for db.close+db.open cycle
- [x] Duplicate open returns error instead of creating second handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)