### PR TITLE
fix: Address PR #520 review feedback — GIL yield + 5 minor fixes

### DIFF
--- a/Common/headers/db_format.h
+++ b/Common/headers/db_format.h
@@ -16,6 +16,11 @@
 #include "db.h"
 #include "lang.h" /* for hdlhashtable */
 
+/* Path buffer size for database file paths (lock files, backup paths, etc.) */
+#ifndef DB_PATH_MAX
+#define DB_PATH_MAX 1024
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -74,7 +74,7 @@ static boolean g_db_format_runtime_headless = false;
  * Written ONLY by migrate_internal() — stores the v7 output path.
  * Callers should read it immediately after migrate_32bit_to_64bit() or
  * ensure_database_v7(). */
-static _Thread_local char last_migration_output_path[1024];
+static _Thread_local char last_migration_output_path[DB_PATH_MAX];
 
 /* Thread-local buffer holding the path to the most recent backup file.
  * Written ONLY by create_root_backup() — stores the timestamped backup path.
@@ -83,7 +83,7 @@ static _Thread_local char last_migration_output_path[1024];
  * _Thread_local: safe under the GIL threading model (ADR-014) where
  * create_root_backup() callers read this value immediately in the same
  * call stack. See last_migration_output_path comment for details. */
-static _Thread_local char last_backup_output_path[1024];
+static _Thread_local char last_backup_output_path[DB_PATH_MAX];
 static boolean g_legacy_adapter_active = false;
 static boolean g_legacy_adapter_force_repack = false;
 static boolean g_legacy_adapter_mode_locked = false; /* Prevents v7->v6 downgrades during migration */
@@ -257,10 +257,7 @@ typedef off_t db_trace_off_t;
 #define DB_TRACE_PATH_MAX 512
 #define DB_TRACE_EXTERNAL_TABLE_ID 3  /* tyexternalid order: outline, wp, head, table */
 
-/* Path buffer size for database file paths (matches dbverbs.c) */
-#ifndef DB_PATH_MAX
-#define DB_PATH_MAX 1024
-#endif
+/* DB_PATH_MAX is defined in db_format.h */
 
 typedef struct db_trace_context db_trace_context;
 
@@ -1433,7 +1430,7 @@ boolean create_root_backup(const char *original_path) {
 
     last_backup_output_path[0] = '\0';
 
-    char backup_path[1024];
+    char backup_path[DB_PATH_MAX];
     time_t now = time(NULL);
     struct tm *tm_info = localtime(&now);
 
@@ -1885,9 +1882,9 @@ static boolean migrate_internal(const char *db_path, const char *explicit_output
     uint16_t cancoon_flags = 0;
     uint16_t cancoon_primary = 0;
     db_format_mode entry_mode = db_format_mode_current();
-    char output_path[1024];
-    char backup_path[1024];  /* v6 backup: e.g., Frontier.v6.root */
-    char temp_path[1024];
+    char output_path[DB_PATH_MAX];
+    char backup_path[DB_PATH_MAX];  /* v6 backup: e.g., Frontier.v6.root */
+    char temp_path[DB_PATH_MAX];
     temp_path[0] = '\0';
     backup_path[0] = '\0';
     bigstring bspath;
@@ -2496,7 +2493,7 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
     /* Check if a .v6.root backup exists from a previous migration.
      * If "Frontier.v6.root" exists alongside "Frontier.root", the .root file
      * is already v7 from a prior migration -- use it directly. */
-    char v6_backup_path[1024];
+    char v6_backup_path[DB_PATH_MAX];
     if (!db_format_derive_v6_backup_path(db_path, v6_backup_path, sizeof v6_backup_path))
         return false;
 
@@ -2574,7 +2571,7 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
          * TODO (2026-03-22): Remove this fallback once all users have migrated away from .root7.
          * Note: advisory log only fires in headless builds; non-headless users get no warning.
          * When adding GUI support, surface this via the GUI notification channel. */
-        char legacy_root7_path[1024];
+        char legacy_root7_path[DB_PATH_MAX];
         snprintf(legacy_root7_path, sizeof legacy_root7_path, "%s7", db_path);
         FILE *fp_legacy = fopen(legacy_root7_path, "rb");
         if (fp_legacy) {

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -257,6 +257,11 @@ typedef off_t db_trace_off_t;
 #define DB_TRACE_PATH_MAX 512
 #define DB_TRACE_EXTERNAL_TABLE_ID 3  /* tyexternalid order: outline, wp, head, table */
 
+/* Path buffer size for database file paths (matches dbverbs.c) */
+#ifndef DB_PATH_MAX
+#define DB_PATH_MAX 1024
+#endif
+
 typedef struct db_trace_context db_trace_context;
 
 /* Forward declarations for helper routines used by the tracing instrumentation */
@@ -2436,11 +2441,8 @@ static void migration_lock_release(int fd, const char *lock_path) {
  *  Polls every 500ms for up to 30 seconds.
  *  Returns true if the lock was released within the timeout.
  *
- *  GIL note: this may block while holding the GIL, but it only runs
- *  during db.open() (not during script evaluation). In the headless
- *  build, db.open is typically called during startup before any
- *  concurrent scripts are running. The inter-process race this guards
- *  against (two processes migrating the same file) is rare. */
+ *  Yields the GIL via langbackgroundtask() between polls so other
+ *  UserTalk threads can run during the wait. */
 
 static boolean migration_lock_wait(const char *lock_path) {
 
@@ -2450,9 +2452,13 @@ static boolean migration_lock_wait(const char *lock_path) {
         struct timespec ts;
         ts.tv_sec = 0;
         ts.tv_nsec = MIGRATION_LOCK_POLL_MS * 1000000L;
-        nanosleep(&ts, NULL);
+
+        while (nanosleep(&ts, &ts) != 0 && errno == EINTR)
+            ;  /* Retry on signal interruption. */
 
         elapsed_ms += MIGRATION_LOCK_POLL_MS;
+
+        langbackgroundtask(false);  /* Yield GIL to other threads. */
 
         /* Check if the lock file has been removed. */
         if (access(lock_path, F_OK) != 0)
@@ -2624,8 +2630,7 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
         /* Already v7 - return original path */
         if (output_path && output_path_size > 0) {
             strncpy(output_path, db_path, output_path_size);
-            if (output_path_size > 0)
-                output_path[output_path_size - 1] = '\0';
+            output_path[output_path_size - 1] = '\0';
         }
         return true;
     }
@@ -2635,7 +2640,7 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
 
 #if !defined(_WIN32)
     {
-        char lock_path[1024];
+        char lock_path[DB_PATH_MAX];
         int lock_fd = migration_lock_acquire(db_path, lock_path, sizeof lock_path);
 
         if (lock_fd == -2) {
@@ -2681,8 +2686,7 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
                  * The caller (dbopenverb) handles mode setup after open. */
                 if (output_path && output_path_size > 0) {
                     strncpy(output_path, db_path, output_path_size);
-                    if (output_path_size > 0)
-                        output_path[output_path_size - 1] = '\0';
+                    output_path[output_path_size - 1] = '\0';
                 }
 
                 if (migrated)
@@ -2692,7 +2696,9 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
             }
 
             /* Other process did not leave a valid v7 file — fall through to migrate ourselves.
-             * We need to acquire the lock first. */
+             * We need to acquire the lock first. No second wait if this fails — the
+             * race-within-a-race (two processes both waited, both try to acquire) is
+             * extremely unlikely, and failing fast is safer than infinite retry. */
             lock_fd = migration_lock_acquire(db_path, lock_path, sizeof lock_path);
 
             if (lock_fd < 0) {

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2458,7 +2458,8 @@ static boolean migration_lock_wait(const char *lock_path) {
 
         elapsed_ms += MIGRATION_LOCK_POLL_MS;
 
-        langbackgroundtask(false);  /* Yield GIL to other threads. */
+        if (!langbackgroundtask(false))  /* Yield GIL; honor abort/cancel. */
+            return false;
 
         /* Check if the lock file has been removed. */
         if (access(lock_path, F_OK) != 0)

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2664,7 +2664,7 @@ boolean ensure_database_v7(const char *db_path, boolean *migrated, char *output_
             if (!migration_lock_wait(lock_path)) {
 #if defined(FRONTIER_HEADLESS)
                 log_error(LOG_COMP_DB,
-                    "ensure_database_v7: timed out waiting for migration lock %s", lock_path);
+                    "ensure_database_v7: migration lock wait failed (timeout or abort) %s", lock_path);
 #endif
                 return false;
             }

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -61,10 +61,7 @@
 #include "db_format.h" /* migration helpers */
 #include "db.h" /* odb_context_guard */
 
-/* Path buffer size - macOS typically supports up to 1024 byte paths */
-#ifndef DB_PATH_MAX
-#define DB_PATH_MAX 1024
-#endif
+/* DB_PATH_MAX is defined in db_format.h */
 
 /* Database file extension length */
 #define ROOT_EXTENSION_LEN 5   /* ".root" */

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -778,7 +778,7 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 				bigstring bs;
 
 				getfsfile (&odbrec.fs, bs);
-				log_warn(LOG_COMP_DB, "dbopenverb: database already open: %s", stringbaseaddress(bs));
+				log_error(LOG_COMP_DB, "dbopenverb: database already open: %s", stringbaseaddress(bs));
 				lang2paramerror (dbalreadyopenederror, bsfunctionname, bs);
 				return (false);
 			}


### PR DESCRIPTION
## Summary

Follow-up to #520 (data-loss risks). Addresses all 6 items flagged across 3 rounds of bot review that were merged without resolution.

- **[P1] GIL yield in migration_lock_wait** — Added `langbackgroundtask(false)` call in the poll loop so other UserTalk threads can run during the up-to-30s wait. Previously a bare `nanosleep` would freeze all threads.
- **[P2] EINTR handling** — `nanosleep` now retries on signal interruption instead of silently undercounting elapsed time.
- **[P2] Dead code removal** — Removed 2 redundant `if (output_path_size > 0)` checks where the outer condition already guarantees it.
- **[P2] Named constant** — `lock_path[1024]` → `lock_path[DB_PATH_MAX]` for consistency with dbverbs.c.
- **[P2] Asymmetry comment** — Documented why post-wait re-acquire intentionally does not retry (failing fast is safer than infinite loop).
- **[P2] Log level** — `log_warn` → `log_error` for duplicate-open guard (consistency with other return-false paths in dbopenverb).

## Test plan
- [x] Unit tests: 302/302 passing
- [x] Integration tests: same pre-existing failures as clean develop (string.isValidUrl, thread.callscript, REPL /list, dialog.notify — none related to this change)
- [x] Build succeeds (universal binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)