### PR TITLE
fix: Check grabthreadglobals() return value at all call sites (#365)

### DIFF
--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -378,7 +378,10 @@ boolean db_format_prepare_runtime(void) {
     log_trace(LOG_COMP_STARTUP, "db_format_prepare_runtime: dbinitverbs completed successfully");
 #endif
 
-    grabthreadglobals();
+    if (!grabthreadglobals()) {
+        log_warn(LOG_COMP_STARTUP, "db_format_prepare_runtime: grabthreadglobals failed");
+        return false;
+    }
 
     g_db_format_runtime_initialized = true;
     return true;

--- a/Common/source/lang.c
+++ b/Common/source/lang.c
@@ -1369,7 +1369,7 @@ boolean langruncallbackwithparams (
 	/* Thread-safety wrapper - ENTRY */
 	if (!grabthreadglobals()) {
 		log_warn(LOG_COMP_LANG, "grabthreadglobals failed in langruncallbackwithparams");
-		return (false);
+		return (false); /* oppushoutline not yet called; skip cleanup */
 	}
 	oppushoutline(op_get_outlinedata());
 

--- a/Common/source/lang.c
+++ b/Common/source/lang.c
@@ -1221,7 +1221,10 @@ boolean langopruncallbackscripts (short idscript) {
 
 	if (getsystemtablescript (idscript, bsscript)) {
 
-		grabthreadglobals ();
+		if (!grabthreadglobals ()) {
+			log_warn(LOG_COMP_LANG, "grabthreadglobals failed in langopruncallbackscripts");
+			return (false);
+		}
 
 		oppushoutline (op_get_outlinedata()); /*7.0b10 PBS: make sure the current outline gets saved.*/
 
@@ -1364,7 +1367,10 @@ boolean langruncallbackwithparams (
 	initvalue(&vresult, novaluetype);
 
 	/* Thread-safety wrapper - ENTRY */
-	grabthreadglobals();
+	if (!grabthreadglobals()) {
+		log_warn(LOG_COMP_LANG, "grabthreadglobals failed in langruncallbackwithparams");
+		return (false);
+	}
 	oppushoutline(op_get_outlinedata());
 
 	/* Input validation - AFTER thread setup to ensure cleanup is called */
@@ -1498,8 +1504,11 @@ boolean langzoomobject (const bigstring bsobject) {
 	if (fl) {
 		
 		parsedialogstring (bsscript, (ptrstring) bsobject, nil, nil, nil, bsscript);
-		
-		grabthreadglobals ();
+
+		if (!grabthreadglobals ()) {
+			log_warn(LOG_COMP_LANG, "grabthreadglobals failed in langzoomobject");
+			return (false);
+		}
 
 		fl = langrunstringnoerror (bsscript, bsresult);
 

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -206,7 +206,11 @@ int tcp_process_callbacks(void) {
          * Thread globals needed for setaddressvalue/pushfunctionreference
          * which access ODB structures. */
 
-        grabthreadglobals();
+        if (!grabthreadglobals()) {
+            log_warn(LOG_COMP_LANG, "tcp_process_callbacks: grabthreadglobals failed for stream_id=%ld", item.stream_id);
+            processed++;
+            continue;
+        }
 
         /* Build callback address → function reference */
         tyvaluerecord addrval;

--- a/portable/runtime_stubs.h
+++ b/portable/runtime_stubs.h
@@ -91,7 +91,7 @@ long getoserror(void);
 void *getstringlist(void);
 void *getsystemerrorstring(long error);
 void *getsystemtablescript(const char *name);
-void grabthreadglobals(void);
+long grabthreadglobals(void);
 void hashassign(void *table, const char *key, void *value);
 void hashdelete(void *table, const char *key);
 void *hashgetiteminfo(void *table, const char *key);

--- a/portable/runtime_stubs_system.c
+++ b/portable/runtime_stubs_system.c
@@ -500,12 +500,13 @@ void *getstringlist(void) {
     return NULL;
 }
 
-void grabthreadglobals(void) {
+long grabthreadglobals(void) {
     /*
      * Grab thread globals
      */
     // TODO: Implement proper thread globals grabbing when we have the full structure
-    // For now, this is a minimal implementation
+    // For now, this is a minimal implementation returning success
+    return 1;
 }
 
 int iscurrentapplication(void) {

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Wed, 08 Apr 2026 02:26:19 GMT</dateCreated>
+    <dateCreated>Wed, 08 Apr 2026 03:51:47 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-08 at 02:26 UTC"/>
+      <outline text="Run: 2026-04-08 at 03:51 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>


### PR DESCRIPTION
## Summary

Fixes P0 crash risk: 5 callers of `grabthreadglobals()` in headless-compiled files ignored the return value, proceeding with uninitialized thread state on failure.

### Changes

- **`lang.c`** (3 sites): `langopruncallbackscripts`, `langruncallbackwithparams`, `langzoomobject` — return false on failure
- **`tcpverbs.c`**: `tcp_process_callbacks` — skip failed callback with continue
- **`db_format.c`**: `db_format_prepare_runtime` — return false without setting initialized flag
- **`portable/runtime_stubs.h`**: Fixed signature from `void` to `long` to match `threads.h`
- **`portable/runtime_stubs_system.c`**: Updated stub to return 1 (success)

Closes #365

## Test plan
- [x] 302/302 unit tests pass
- [x] Integration test failures unchanged (~12 pre-existing)
- [x] Portable stub signature matches Common/headers/threads.h

🤖 Generated with [Claude Code](https://claude.com/claude-code)