### PR TITLE
fix: Batch P1 fixes — opinitcallbacks, startup braces, memory leak, Pascal logging

### DIFF
--- a/Common/headers/op.h
+++ b/Common/headers/op.h
@@ -453,6 +453,8 @@ typedef struct tyoutlinerecord {
 	
 	boolean fldisposewhenpopped: 1; //true if an attempt was made to dispose outline while pushed
 
+	boolean flcallbacksinited: 1; //true after opinitcallbacks has run; prevents re-initialization
+
 	boolean flhtml; /*7.0b28 PBS: true if outline is in WYSIWYG HTML mode.*/
 	
 	unsigned long timevisi; /*the time for the next scheduled visi check*/

--- a/Common/source/db.c
+++ b/Common/source/db.c
@@ -416,7 +416,7 @@ static void debug_dberror (short errnum, int line, boolean flthrow) {
 
 	DBTRACKERGETFILENAME (bsfile);
 	
-	sprintf (str, "%s | %s [db.c,%ld]", stringbaseaddress (bsfile), stringbaseaddress (bs), line);
+	sprintf (str, "%.*s | %.*s [db.c,%ld]", (int)bsfile[0], (const char *)(bsfile + 1), (int)bs[0], (const char *)(bs + 1), line);
 
 	DB_MSG_1 (str);
 
@@ -440,7 +440,7 @@ static boolean debug_dbseteof (long eof, long line) {
 			
 			DBTRACKERGETFILENAME (bsfile);
 			
-			sprintf (str, "%s | WARNING -- Growing database from %ld to %ld bytes. [db.c,%ld]", stringbaseaddress (bsfile), oldeof, eof, line);
+			sprintf (str, "%.*s | WARNING -- Growing database from %ld to %ld bytes. [db.c,%ld]", (int)bsfile[0], (const char *)(bsfile + 1), oldeof, eof, line);
 
 			DB_MSG_1 (str);
 			}
@@ -4304,7 +4304,7 @@ static boolean dbflushreleasestack_impl (void) {
 
 				texthandletostring (info.file, bsfile);
 
-				sprintf (str, "dbrelease failed for address %ld, type %ld, line %ld in %s.", info.adr, info.id, info.line, stringbaseaddress (bsfile));
+				sprintf (str, "dbrelease failed for address %ld, type %ld, line %ld in %.*s.", info.adr, info.id, info.line, (int)bsfile[0], (const char *)(bsfile + 1));
 				
 				DB_MSG_2 (str);
 				}

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -415,7 +415,7 @@ static boolean odberror (boolean flresult) {
 
 	odbgeterror (bserror);
 
-	log_error(LOG_COMP_DB, "odberror: ODB engine error: %s", stringbaseaddress(bserror));
+	log_error(LOG_COMP_DB, "odberror: ODB engine error: %.*s", (int)bserror[0], (const char *)(bserror + 1));
 
 	langerrormessage (bserror);
 
@@ -705,7 +705,7 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 	}
 
 	filespectopath(&odbrec.fs, bspath);
-	log_debug(LOG_COMP_DB, "dbopenverb: path=%s", stringbaseaddress(bspath));
+	log_debug(LOG_COMP_DB, "dbopenverb: path=%.*s", (int)bspath[0], (const char *)(bspath + 1));
 
 	flnextparamislast = true;
 
@@ -775,7 +775,7 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 				bigstring bs;
 
 				getfsfile (&odbrec.fs, bs);
-				log_error(LOG_COMP_DB, "dbopenverb: database already open: %s", stringbaseaddress(bs));
+				log_error(LOG_COMP_DB, "dbopenverb: database already open: %.*s", (int)bs[0], (const char *)(bs + 1));
 				lang2paramerror (dbalreadyopenederror, bsfunctionname, bs);
 				return (false);
 			}

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -2152,7 +2152,7 @@ static boolean hashresolvevalue_context (const db_context *ctx, hdlhashtable hta
 #if defined(FRONTIER_HEADLESS)
 			bigstring bspathtemp;
 			copyheapstring ((hdlstring) (**hn).val.data.addressvalue, bspathtemp);
-			log_debug(LOG_COMP_HASH, "hashresolvevalue: failed to encode path entry %s", stringbaseaddress (bspathtemp));
+			log_debug(LOG_COMP_HASH, "hashresolvevalue: failed to encode path entry %.*s", (int)bspathtemp[0], (const char *)(bspathtemp + 1));
 #endif
 			return (false);
         }
@@ -2161,7 +2161,7 @@ static boolean hashresolvevalue_context (const db_context *ctx, hdlhashtable hta
 			bigstring bspathtemp;
 			hdlhashtable hresolved = nil;
 			if (getaddressvalue ((**hn).val, &hresolved, bspathtemp)) {
-				log_debug(LOG_COMP_HASH, "hashresolvevalue: resolved %s -> table=%p", stringbaseaddress (bspathtemp), (void *) hresolved);
+				log_debug(LOG_COMP_HASH, "hashresolvevalue: resolved %.*s -> table=%p", (int)bspathtemp[0], (const char *)(bspathtemp + 1), (void *) hresolved);
 			}
 		}
 #endif

--- a/Common/source/langops.c
+++ b/Common/source/langops.c
@@ -413,7 +413,7 @@ boolean langfindsymbol (const bigstring bs, hdlhashtable *htable, hdlhashnode *h
 
 				*htable = h;
 
-				log_trace(LOG_COMP_EVAL, "langfindsymbol hit %s table=%p node=%p", stringbaseaddress(bs), (void *)h, (void *)*hnode);
+				log_trace(LOG_COMP_EVAL, "langfindsymbol hit %.*s table=%p node=%p", (int)bs[0], (const char *)(bs + 1), (void *)h, (void *)*hnode);
 				return (true);
 				}
 			
@@ -433,7 +433,7 @@ boolean langfindsymbol (const bigstring bs, hdlhashtable *htable, hdlhashnode *h
 					return (false);
 
 #if defined(FRONTIER_HEADLESS)
-				log_trace(LOG_COMP_EVAL, "langfindsymbol with slot=%d table=%p name=%s", (int)n, (void *)hwith, stringbaseaddress(bswith));
+				log_trace(LOG_COMP_EVAL, "langfindsymbol with slot=%d table=%p name=%.*s", (int)n, (void *)hwith, (int)bswith[0], (const char *)(bswith + 1));
 #endif
 				
 				if (!isemptystring (bswith)) { // not encoded as expected
@@ -450,7 +450,7 @@ boolean langfindsymbol (const bigstring bs, hdlhashtable *htable, hdlhashnode *h
 					*htable = hwith;
 					
 #if defined(FRONTIER_HEADLESS)
-					log_trace(LOG_COMP_EVAL, "langfindsymbol with hit %s table=%p node=%p", stringbaseaddress(bs), (void *)hwith, (void *)*hnode);
+					log_trace(LOG_COMP_EVAL, "langfindsymbol with hit %.*s table=%p node=%p", (int)bs[0], (const char *)(bs + 1), (void *)hwith, (void *)*hnode);
 #endif
 					return (true);
 					}

--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -4676,10 +4676,12 @@ boolean evaluatereadonlyparam (hdltreenode hparam, tyvaluerecord *vparam) {
 			
 			if (!getaddressvalue (val, &htable, bs))
 				return (false);
-			
+
+			disposevaluerecord (val, false); /*#355: val was a temporary from evaluatetree; dispose now that address is extracted*/
+
 			if (htable == nil)
 				langsearchpathlookup (bs, &htable);
-			
+
 			break;
 		
 		default:

--- a/Common/source/opinit.c
+++ b/Common/source/opinit.c
@@ -191,18 +191,25 @@ void opinitcallbacks (hdloutlinerecord houtline) {
 	
 	/*
 	5.0a25 dmb: default cmdclickcallback needs to return false now
-	
+
 	5.0.2b16 dmb: default postfontchangecallback is opseteditbufferrect
-	
+
 	5.1.5 dmb: ...now, it's oppostfontchange
+
+	2026-04-03 JES: idempotency guard — skip if callbacks already initialized.
+	Calling this on an outline with specialized callbacks (menu, script)
+	silently replaces them, leading to segfaults. See issue #397.
 	*/
-	
+
 #if !fljustpacking
 
 		register hdloutlinerecord ho = houtline;
 
+		if ((**ho).flcallbacksinited) /*already initialized — don't overwrite specialized callbacks*/
+			return;
 
-		
+		(**ho).flcallbacksinited = true;
+
 		(**ho).setscrollbarsroutine = &opdefaultsetscrollbars;
 		
 		// (**ho).getlinedisplayinfocallback = (opgetlineinfocallback) &truenoop;

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -605,8 +605,8 @@ boolean opverbinmemory (const db_context *ctx, hdlexternalvariable hvariable) {
 
 		ho = (hdloutlinerecord) (**hv).variabledata;
 
-		if (ho != nil && ((**ho).preexpandcallback == NULL || (**ho).caneditcallback == NULL))
-			opinitcallbacks (ho); /*opinitcallbacks is NOT idempotent — only call when callbacks are uninitialized*/
+		if (ho != nil)
+			opinitcallbacks (ho); /*now idempotent via flcallbacksinited flag — safe to call unconditionally*/
 
 		return (true);
 	}

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Wed, 08 Apr 2026 03:51:47 GMT</dateCreated>
+    <dateCreated>Thu, 09 Apr 2026 08:49:07 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-08 at 03:51 UTC"/>
+      <outline text="Run: 2026-04-09 at 08:49 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -342,7 +342,7 @@ static boolean filemenu_open(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
     filespectopath(&odbrec.fs, bspath);
     safenullterminate(bspath);
-    log_debug(LOG_COMP_DB, "filemenu_open: opening %s", stringbaseaddress(bspath));
+    log_debug(LOG_COMP_DB, "filemenu_open: opening %.*s", (int)bspath[0], (const char *)(bspath + 1));
 
     /* Check if already open in hodblist */
     if (hodblist != nil) {
@@ -358,7 +358,7 @@ static boolean filemenu_open(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
     /* Open the OS file */
     if (!openfile(&odbrec.fs, &odbrec.fref, odbrec.flreadonly)) {
-        log_verb_error(LOG_COMP_DB, "filemenu_open: openfile failed for %s", stringbaseaddress(bspath));
+        log_verb_error(LOG_COMP_DB, "filemenu_open: openfile failed for %.*s", (int)bspath[0], (const char *)(bspath + 1));
         langerrormessage(PSTRING("\x1f", "Can't open: file does not exist"));
         return false;
     }
@@ -418,7 +418,7 @@ static boolean filemenu_open(hdltreenode hparam1, tyvaluerecord *vreturned) {
         Handle hrootvar = odbGetRootVariable(odbrec.odb);
 
         if (hrootvar == nil) {
-            log_debug(LOG_COMP_DB, "filemenu_open: odbGetRootVariable returned nil for %s", stringbaseaddress(bspath));
+            log_debug(LOG_COMP_DB, "filemenu_open: odbGetRootVariable returned nil for %.*s", (int)bspath[0], (const char *)(bspath + 1));
         }
 
         if (hrootvar != nil) {
@@ -431,8 +431,8 @@ static boolean filemenu_open(hdltreenode hparam1, tyvaluerecord *vreturned) {
                 /* Non-fatal: database is still open in hodblist */
             }
             else {
-                log_debug(LOG_COMP_DB, "filemenu_open: mounted in system.compiler.files as '%s'",
-                          stringbaseaddress(bspath));
+                log_debug(LOG_COMP_DB, "filemenu_open: mounted in system.compiler.files as '%.*s'",
+                          (int)bspath[0], (const char *)(bspath + 1));
             }
         }
     }
@@ -456,7 +456,7 @@ static boolean filemenu_close_guestdb(hdlodbrecord hodb) {
 
     filespectopath(&(**hodb).fs, bspath);
     safenullterminate(bspath);
-    log_debug(LOG_COMP_DB, "filemenu_close_guestdb: closing %s", stringbaseaddress(bspath));
+    log_debug(LOG_COMP_DB, "filemenu_close_guestdb: closing %.*s", (int)bspath[0], (const char *)(bspath + 1));
 
     /* Close the ODB file first — use context guard to protect system root globals */
     {
@@ -512,7 +512,7 @@ static boolean filemenu_close(tyvaluerecord *vreturned) {
         return true;  /* No target set - nothing to close */
     }
 
-    log_debug(LOG_COMP_DB, "filemenu_close: target='%s'", stringbaseaddress(bstargetname));
+    log_debug(LOG_COMP_DB, "filemenu_close: target='%.*s'", (int)bstargetname[0], (const char *)(bstargetname + 1));
 
     /* Check if target is in system.compiler.files (i.e., it's a guest database) */
     if (filewindowtable == nil || htargettable != filewindowtable) {
@@ -624,7 +624,7 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
     filespectopath(&fsdest, bsdest);
     safenullterminate(bsdest);
-    log_debug(LOG_COMP_DB, "filemenu_saveas: destination=%s", stringbaseaddress(bsdest));
+    log_debug(LOG_COMP_DB, "filemenu_saveas: destination=%.*s", (int)bsdest[0], (const char *)(bsdest + 1));
 
     /* Determine source database: check current target */
     {
@@ -638,7 +638,7 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
             htargettable == filewindowtable) {
 
             /* Target is in system.compiler.files → guest database */
-            log_debug(LOG_COMP_DB, "filemenu_saveas: target is guest db '%s'", stringbaseaddress(bstargetname));
+            log_debug(LOG_COMP_DB, "filemenu_saveas: target is guest db '%.*s'", (int)bstargetname[0], (const char *)(bstargetname + 1));
 
             /* Find the guest DB in hodblist */
             if (hodblist == nil) {
@@ -729,7 +729,7 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
         fin = fopen(stringbaseaddress(bssource), "rb");
 
         if (fin == NULL) {
-            log_verb_error(LOG_COMP_DB, "filemenu_saveas: can't open source %s", stringbaseaddress(bssource));
+            log_verb_error(LOG_COMP_DB, "filemenu_saveas: can't open source %.*s", (int)bssource[0], (const char *)(bssource + 1));
             langerrormessage(PSTRING("\x22", "Can't save: can't read source file"));
             return false;
         }
@@ -738,7 +738,7 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
         if (fout == NULL) {
             fclose(fin);
-            log_verb_error(LOG_COMP_DB, "filemenu_saveas: can't create destination %s", stringbaseaddress(bsdest));
+            log_verb_error(LOG_COMP_DB, "filemenu_saveas: can't create destination %.*s", (int)bsdest[0], (const char *)(bsdest + 1));
             langerrormessage(PSTRING("\x21", "Can't save: can't create new file"));
             return false;
         }
@@ -767,7 +767,7 @@ static boolean filemenu_saveas(hdltreenode hparam1, tyvaluerecord *vreturned) {
         fclose(fout);
     }
 
-    log_debug(LOG_COMP_DB, "filemenu_saveas: successfully copied to %s", stringbaseaddress(bsdest));
+    log_debug(LOG_COMP_DB, "filemenu_saveas: successfully copied to %.*s", (int)bsdest[0], (const char *)(bsdest + 1));
 
     return setbooleanvalue(true, vreturned);
 }
@@ -821,7 +821,7 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
     filespectopath(&fs, bspath);
     safenullterminate(bspath);
-    log_debug(LOG_COMP_DB, "filemenu_new: creating new database at %s", stringbaseaddress(bspath));
+    log_debug(LOG_COMP_DB, "filemenu_new: creating new database at %.*s", (int)bspath[0], (const char *)(bspath + 1));
 
     /* Check if file already exists - don't overwrite.
      * fileexists() returns true if the file exists, false otherwise.
@@ -829,7 +829,7 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
     {
         boolean flfolder = false;
         if (fileexists(&fs, &flfolder)) {
-            log_verb_error(LOG_COMP_DB, "filemenu_new: file already exists at %s", stringbaseaddress(bspath));
+            log_verb_error(LOG_COMP_DB, "filemenu_new: file already exists at %.*s", (int)bspath[0], (const char *)(bspath + 1));
             langerrormessage(PSTRING("\x29", "Can't create: file already exists at path"));
             return false;
         }
@@ -837,7 +837,7 @@ static boolean filemenu_new(hdltreenode hparam1, tyvaluerecord *vreturned) {
 
     /* Create the new file */
     if (!opennewfile(&fs, 'LAND', 'ROOT', &fnum)) {
-        log_verb_error(LOG_COMP_DB, "filemenu_new: opennewfile failed for %s", stringbaseaddress(bspath));
+        log_verb_error(LOG_COMP_DB, "filemenu_new: opennewfile failed for %.*s", (int)bspath[0], (const char *)(bspath + 1));
         langerrormessage(PSTRING("\x27", "Can't create: failed to create new file"));
         return false;
     }

--- a/tests/headless_op_verbs.c
+++ b/tests/headless_op_verbs.c
@@ -348,7 +348,7 @@ static boolean opvisitall_callback(hdlheadrecord hnode, ptrvoid refcon) {
     /* Call the callback script */
     if (!langrunscript(ctx->scriptname, NULL, NULL, &vreturned)) {
         /* Log callback failure to help with debugging */
-        log_warn(LOG_COMP_OP, "op.visitall callback script failed: %s", stringbaseaddress(ctx->scriptname));
+        log_warn(LOG_COMP_OP, "op.visitall callback script failed: %.*s", (int)ctx->scriptname[0], (const char *)(ctx->scriptname + 1));
         oppopoutline();
         return false;
     }

--- a/usertalk_scripts/Frontier.root/system/startup/startupScript.ut
+++ b/usertalk_scripts/Frontier.root/system/startup/startupScript.ut
@@ -202,7 +202,7 @@ if user.prefs.firstRootRun { //license agreement, finish cleanup on user's machi
 			proxyInit ();
 			if user.prefs.serialNumber != "" and not (string.lower (user.prefs.serialNumber) contains "trial") {
 				rootUpdates.init ();
-				rootUpdates.getCurrent ("Frontier")}}}};
+				rootUpdates.getCurrent ("Frontier")}}};
 	fileMenu.save ()}; //save after finishInstall so user.databases entries persist
 
 system.menus.buildMenuBar ();


### PR DESCRIPTION
## Summary

Four independent P1 bug fixes batched into one PR:

### #397: opinitcallbacks is not idempotent
Added `flcallbacksinited` flag to `tyoutlinerecord`. `opinitcallbacks()` now checks the flag and returns early if callbacks are already initialized, preventing silent overwrite of specialized callbacks (menu, script outlines).

### #465: Startup script brace-matching bug
Fixed extra closing brace on line 205 of `startupScript.ut` (`}}}};` → `}}};`). The extra brace closed the `if user.prefs.firstRootRun` block prematurely, making the second `fileMenu.save()` at line 206 unreachable.

### #355: Memory leak in evaluatereadonlyparam
Added `disposevaluerecord(val, false)` after `getaddressvalue` in the `dereferenceop` case. The temporary value from `evaluatetree` was never disposed.

### #339: Pascal string logging garbage characters
Replaced all 22 `%s` + `stringbaseaddress(bs)` patterns with `%.*s` + `(int)bs[0]` across 6 files. The `%.*s` precision specifier uses the Pascal string length byte to stop reading at the correct position.

Closes #397, closes #465, closes #355, closes #339

## Test plan
- [x] 302/302 unit tests pass
- [x] Integration test failures unchanged (10 pre-existing)
- [x] Build succeeds with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)