### PR TITLE
refactor: Database audits — external_set_inmemory conversion (#201), 3 audits closed

### DIFF
--- a/Common/source/menuverbs.c
+++ b/Common/source/menuverbs.c
@@ -197,11 +197,7 @@ boolean menuverbinmemory_context (const db_context *ctx, hdlexternalvariable hva
 		return (false);
 	}
 
-	(**hv).variabledata = (long) hmenurecord;
-
-	(**hv).oldaddress = adr;
-
-	(**hv).flinmemory = true;
+	external_set_inmemory ((hdlexternalvariable) hv, (Handle) hmenurecord, adr);
 
 	(**hmenurecord).menurefcon = (long) hv; /*we can get from menu rec to variable rec*/
 

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -729,11 +729,7 @@ boolean opverbinmemory (const db_context *ctx, hdlexternalvariable hvariable) {
 	if (!fl)
 		return (false);
 
-	(**hv).flinmemory = true;
-
-	(**hv).variabledata = (long) ho; /*link into variable structure*/
-
-	(**hv).oldaddress = adr; /*last place this outline was stored*/
+	external_set_inmemory ((hdlexternalvariable) hv, (Handle) ho, adr);
 
 	opverbsetupoutline (ho, hv);
 

--- a/Common/source/pictverbs.c
+++ b/Common/source/pictverbs.c
@@ -260,11 +260,7 @@ boolean pictverbinmemory (const db_context *ctx, hdlexternalvariable hv) {
 	if (!fl)
 		return (false);
 
-	(**hv).flinmemory = true;
-
-	(**hv).variabledata = (long) hpict; /*link into variable structure*/
-
-	(**hv).oldaddress = adr; /*last place this pict was stored*/
+	external_set_inmemory ((hdlexternalvariable) hv, (Handle) hpict, adr);
 
 	(**hpict).pictrefcon = (long) hv; /*we can get from pict rec to variable rec*/
 

--- a/Common/source/tableexternal_common.c
+++ b/Common/source/tableexternal_common.c
@@ -484,26 +484,25 @@ boolean tableverbinmemory_common(const db_context *ctx, hdlexternalvariable hvar
         return false;
     }
 
-    (**hv).flinmemory = true;
-
-    (**hv).variabledata = (long) htable; /* link into variable structure */
-
     /* During migration/repack, clear oldaddress to force new allocation. */
     {
     db_format_mode current_mode = db_format_mode_current();
+    dbaddress effective_adr = adr;
+
     log_debug(LOG_COMP_TABLE, "tableverbinmemory before address assignment: adapter_repack=%d use_64bit=%d database=%p adr=0x%llx",
             (int)current_mode.adapter_repack, (int)current_mode.use_64bit_format,
             (void*)hdb, (unsigned long long)adr);
 
     if (current_mode.adapter_repack && hdb != nil) {
-        (**hv).oldaddress = nildbaddress;
-        log_debug(LOG_COMP_TABLE, "tableverbinmemory CLEARED oldaddress (adapter_repack) adr=0x%llx variabledata=0x%llx flinmemory=%d",
-                (unsigned long long)adr, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
-    } else {
-        (**hv).oldaddress = adr; /* last place this table was stored */
-        log_debug(LOG_COMP_TABLE, "tableverbinmemory SET oldaddress=0x%llx variabledata=0x%llx flinmemory=%d",
-                (unsigned long long)adr, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
+        effective_adr = nildbaddress;
+        log_debug(LOG_COMP_TABLE, "tableverbinmemory CLEARED oldaddress (adapter_repack) adr=0x%llx",
+                (unsigned long long)adr);
     }
+
+    external_set_inmemory ((hdlexternalvariable) hv, (Handle) htable, effective_adr);
+
+    log_debug(LOG_COMP_TABLE, "tableverbinmemory SET oldaddress=0x%llx variabledata=0x%llx flinmemory=%d",
+            (unsigned long long)(**hv).oldaddress, (unsigned long long)(**hv).variabledata, (int)(**hv).flinmemory);
     }
 
     if (log_enabled(LOG_LEVEL_TRACE, LOG_COMP_TABLE)) {

--- a/Common/source/wpverbs.c
+++ b/Common/source/wpverbs.c
@@ -807,15 +807,13 @@ boolean wpverbinmemory (const db_context *ctx, hdlexternalvariable h) {
 	if (!fl)
 		return (false);
 	
-	(**hv).flinmemory = true;
-	
+	external_set_inmemory ((hdlexternalvariable) hv, (Handle) hwp, adr);
+
 	(**hv).flpacked = false;
-	
-	(**hv).oldaddress = adr; /*last place this wp was stored*/
-	
+
 	(**hwp).fldirty = fldirty;
-	
-	wpverblinkvariable (hwp, hv); /*set up pointers to each other*/
+
+	(**hwp).wprefcon = (long) hv; /*set up pointer from wp rec to variable rec*/
 	
 	return (true);
 	} /*wpverbinmemory*/


### PR DESCRIPTION
Database audit results and one refactor:

- **#68**: ensure_database_v7 / db_format_mode_apply verified idempotent. Closed.
- **#69**: 64-bit promotion audit — no truncation bugs found. Closed.
- **#140**: db_context_guard audit — no issues in disposal paths. Closed.
- **#201**: Converted 5 verbinmemory sites to use external_set_inmemory() transition function.

Closes #201

Test plan:
- [x] 302/302 unit tests pass
- [x] Integration failures unchanged