### PR TITLE
feat: Migrate currenthashtable from global to thread-local storage (#262)

### DIFF
--- a/Common/headers/lang.h
+++ b/Common/headers/lang.h
@@ -720,7 +720,7 @@ extern byte bstrue [];
 
 extern byte bsfalse [];
 
-extern hdlhashtable currenthashtable; /*langhash.c*/
+/* currenthashtable is now a thread-local macro defined in processinternal.h (ADR-005) */
 
 extern hdltablestack hashtablestack;
 

--- a/Common/headers/processinternal.h
+++ b/Common/headers/processinternal.h
@@ -290,6 +290,9 @@ typedef struct tythreadglobals {
 #define fllanghashassignprotect ((**hthreadglobals).fllanghashassignprotect)
 #define fllangexternalvalueprotect ((**hthreadglobals).fllangexternalvalueprotect)
 
+/* ADR-005: Current hash table (Phase 3 migration — replaces C global in langhash.c) */
+#define currenthashtable ((**hthreadglobals).hcurrenthashtable)
+
 /* WP selection state (thread-local via GIL, matching ADR-005 macro pattern) */
 #define wp_sel_start ((**hthreadglobals).wp_sel_start)
 #define wp_sel_end ((**hthreadglobals).wp_sel_end)

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -31,6 +31,7 @@
 #include "memory.h"
 #include "strings.h"
 #include "lang.h"
+#include "processinternal.h"  /* currenthashtable macro (ADR-005) */
 #include "tablestructure.h"
 #include "kernelverbs.h"  /* For targetinitverbs() declaration */
 #include "tableinternal.h"

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -767,7 +767,7 @@ static void diskvalue_to_value_v7(const tydiskvaluedata_v7 *disk, tyvaluerecord 
 	}
 }
 
-hdlhashtable currenthashtable = nil;
+/* currenthashtable is now a thread-local macro defined in processinternal.h (ADR-005) */
 
 /* ADR-009: Thread-local hash table stack migration (Phase 3A)
  * Field added to tythreadglobals, saved/restored in copythreadglobals/swapinthreadglobals.

--- a/Common/source/process.c
+++ b/Common/source/process.c
@@ -1485,7 +1485,7 @@ void copythreadglobals (hdlthreadglobals hglobals) {
 		
 		(**hg).hprocess = currentprocess;
 		
-		(**hg).htable = currenthashtable;
+		(**hg).hcurrenthashtable = (**hthreadglobals).hcurrenthashtable;
 		
 		(**hg).flthreadkilled = flthreadkilled;
 		
@@ -1635,7 +1635,7 @@ void swapinthreadglobals (hdlthreadglobals hglobals) {
 	
 	processstack = (**hg).processstack;
 	
-	currenthashtable = (**hg).htable;
+	(**hthreadglobals).hcurrenthashtable = (**hg).hcurrenthashtable;
 	
 	langcallbacks = (**hg).langcallbacks;
 		

--- a/frontier-cli/cli_executor.c
+++ b/frontier-cli/cli_executor.c
@@ -9,6 +9,7 @@
 #include "cli_executor.h"
 #include "cli_json_output.h"
 #include "repl_output.h"  /* For kMacRomanHighToUnicode, putc_utf8 */
+#include "../Common/headers/processinternal.h"  /* currenthashtable macro (ADR-005) */
 
 /* 2025-12-08 Codex: Route long inline CLI scripts through langrunhandle so compiled evals return results without bogus empty verb names. */
 
@@ -107,7 +108,6 @@ boolean cli_execute_compiled_script(usertalk_execution_t* execution) {
     size_t len = strlen(execution->script_source);
 
 #if defined(FRONTIER_HEADLESS)
-    extern hdlhashtable currenthashtable;
     cli_log_debug("before execute currenthashtable=%p", (void *)currenthashtable);
 #endif
 

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -37,8 +37,7 @@
 #include "db_format.h"
 #include "../third_party/cJSON/cJSON.h"
 
-/* Global: current hashtable and table stack (thread globals) */
-extern hdlhashtable currenthashtable;
+/* Global: table stack (thread globals) — currenthashtable is now a macro in processinternal.h */
 extern hdltablestack hashtablestack;
 extern hdlhashtable roottable;
 

--- a/frontier-cli/headless_scripts_loader.c
+++ b/frontier-cli/headless_scripts_loader.c
@@ -49,7 +49,7 @@ extern boolean scriptbuildtree (Handle htext, long signature, hdltreenode *hcode
 extern boolean langruncode (hdltreenode htree, hdlhashtable hcontext, tyvaluerecord *vreturned);
 extern boolean pushhashtable (hdlhashtable);
 extern boolean pophashtable (void);
-extern hdlhashtable currenthashtable;
+/* currenthashtable is now a macro in processinternal.h (ADR-005) */
 extern hdlhashtable roottable;
 
 /* External declaration for langrunhandletraperror - runs scripts like REPL does */

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Tue, 14 Apr 2026 07:45:44 GMT</dateCreated>
+    <dateCreated>Wed, 15 Apr 2026 19:54:49 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-14 at 07:45 UTC"/>
+      <outline text="Run: 2026-04-15 at 19:54 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/file_verb_tests.c
+++ b/tests/file_verb_tests.c
@@ -6,6 +6,7 @@
 #include "memory.h"
 #include "strings.h"
 #include "lang.h"
+#include "processinternal.h"  /* currenthashtable macro (ADR-005) */
 #include "tablestructure.h"
 #include "langexternal.h"
 #include "kernelverbs.h"


### PR DESCRIPTION
## Summary

Migrates `currenthashtable` from a C global variable to thread-local storage via `tythreadglobals.hcurrenthashtable`. This is the **keystone architectural change** (#262) that unblocks the remaining global state elimination work (#274, #292, #296).

### Approach

Uses the ADR-005 macro pattern — a `#define currenthashtable ((**hthreadglobals).hcurrenthashtable)` transparently redirects all ~135 access sites across 27 files with **zero call-site changes**.

### Changes (10 files, 14 lines net)

- `processinternal.h`: Added `#define currenthashtable` macro
- `lang.h`: Removed `extern` declaration
- `langhash.c`: Removed global variable
- `process.c`: Updated `copythreadglobals`/`swapinthreadglobals` to use `hcurrenthashtable` directly
- `debug_handler.c`, `cli_executor.c`, `headless_scripts_loader.c`: Removed `extern` declarations
- `db_format.c`, `file_verb_tests.c`: Added `processinternal.h` include

### Safety

- Bootstrap-safe: `currenthashtable` is never accessed before `hthreadglobals` is initialized
- GIL-safe: only one thread accesses the value at a time
- Verified with table create/modify/delete round-trip through TLS path

Closes #262

## Test plan
- [x] 302/302 unit tests pass
- [x] Integration failures unchanged
- [x] Manual verification: table operations through TLS macro