### PR TITLE
refactor: Eliminate global efptable — static isolation with accessors (#292)

### DIFF
--- a/Common/headers/tablestructure.h
+++ b/Common/headers/tablestructure.h
@@ -148,7 +148,12 @@ extern hdlhashtable internaltable;
 
 extern hdlhashtable systemtable;
 
-extern hdlhashtable efptable;
+/* Issue #292: efptable is module-private in tablestructure.c.
+   Use get_efptable()/set_efptable() for access. The macro below
+   provides backward compatibility for read sites. */
+extern hdlhashtable get_efptable(void);
+extern void set_efptable(hdlhashtable);
+#define efptable (get_efptable())
 
 extern hdlhashtable langtable;
 

--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -341,11 +341,6 @@ boolean db_format_prepare_runtime(void) {
     }
     log_trace(LOG_COMP_STARTUP, "db_format_prepare_runtime: opattributesinitverbs completed successfully");
 
-    /* Save reference to headless-created efptable before database loading */
-    extern void save_headless_efptable(void);  /* Forward declaration */
-    save_headless_efptable();
-    log_debug(LOG_COMP_STARTUP, "db_format_prepare_runtime: saved headless efptable reference");
-
     /* Link system table structure to make processors accessible via system.compiler.kernel.* */
     log_trace(LOG_COMP_STARTUP, "db_format_prepare_runtime: linking system table structure");
     if (!linksystemtablestructure(roottable)) {

--- a/Common/source/langstartup.c
+++ b/Common/source/langstartup.c
@@ -719,8 +719,12 @@ boolean inittablestructure (void) {
 	if (!tablenewsystemtable (htable, nameinternaltable, &internaltable))
 		goto error;
 	
-	if (!tablenewsystemtable (internaltable, nameefptable, &efptable))
-		goto error;
+	{
+		hdlhashtable hefp;
+		if (!tablenewsystemtable (internaltable, nameefptable, &hefp))
+			goto error;
+		set_efptable (hefp);
+	}
 	
 	if (!tablenewsystemtable (internaltable, namelangtable, &langtable))
 		goto error;
@@ -762,7 +766,8 @@ boolean inittablestructure (void) {
 	
 	disposehashtable (htable, false);
 	
-	internaltable = efptable = langtable = runtimestacktable = semaphoretable = threadtable = filewindowtable = environmenttable = nil;
+	internaltable = langtable = runtimestacktable = semaphoretable = threadtable = filewindowtable = environmenttable = nil;
+	set_efptable (nil);
 	
 	return (false);
 	} /*inittablestructure*/

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -116,23 +116,19 @@ hdlhashtable systemtable = nil;
 
 hdlhashtable internaltable = nil;
 
-hdlhashtable efptable = nil;
+/* Issue #292: efptable is module-private static with accessor functions.
+   Processor table is shared, read-only state (created once at startup).
+   The compatibility macro in tablestructure.h (#define efptable (get_efptable()))
+   means all read sites work unchanged. Only write sites use set_efptable(). */
+static hdlhashtable s_efptable = nil;
 
-#if defined(FRONTIER_HEADLESS)
-/* 2026-01-12 Codex: Save reference to headless-created efptable before database loading.
-   When database is loaded, efptable gets overwritten with tokenvaluetype entries from database.
-   We need to preserve the original headless-created table with working valueroutines. */
-static hdlhashtable headless_efptable_original = nil;
-
-void save_headless_efptable(void) {
-    headless_efptable_original = efptable;
-    log_debug(LOG_COMP_LANG, "save_headless_efptable: saved efptable=%p", (void*)efptable);
+hdlhashtable get_efptable(void) {
+    return s_efptable;
 }
 
-hdlhashtable get_headless_efptable(void) {
-    return headless_efptable_original;
+void set_efptable(hdlhashtable ht) {
+    s_efptable = ht;
 }
-#endif
 
 hdlhashtable langtable = nil;
 

--- a/Common/source/tablestructure.c
+++ b/Common/source/tablestructure.c
@@ -126,6 +126,7 @@ hdlhashtable get_efptable(void) {
     return s_efptable;
 }
 
+/* Should only be called during startup initialization (inittablestructure). */
 void set_efptable(hdlhashtable ht) {
     s_efptable = ht;
 }
@@ -1208,7 +1209,7 @@ boolean cleartablestructureglobals (void) {
 	
 	internaltable = nil;
 	
-	efptable = nil;
+	set_efptable (nil);
 	
 	langtable = nil;
 	

--- a/planning/architectural_decision_records/ADR-008-processor-table-lifecycle-workaround.md
+++ b/planning/architectural_decision_records/ADR-008-processor-table-lifecycle-workaround.md
@@ -1,10 +1,10 @@
 # ADR-008: Processor Table Lifecycle Workaround
 
-**Status**: `[IMPLEMENTED]` - Temporary workaround in place (proper fix deferred to Phase 6+, PR #291)
-**Date**: 2026-01-12
+**Status**: `[SUPERSEDED]` - Workaround removed. Global efptable eliminated via static isolation with accessor functions (Issue #292).
+**Date**: 2026-01-12 (superseded 2026-04-15)
 **Author**: System Architect
 **Relates to**: Issue #135 (Collaborative ODB), ADR-005 (Thread-Safety)
-**Note**: TEMPORARY SOLUTION - will be replaced with explicit processor context in Phase 6+
+**Superseded by**: Issue #292 — efptable converted from extern global to module-private static with `get_efptable()`/`set_efptable()` accessor functions and backward-compatible `#define efptable (get_efptable())` macro. The `save_headless_efptable()`/`get_headless_efptable()` workaround was dead code (caller removed in Issue #352) and has been deleted.
 
 ## Executive Summary
 

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,27 +1,31 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 2086 tests: 1896 pass (90%) 190 skip (9%)</title>
-    <dateCreated>Tue, 14 Apr 2026 07:45:49 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2227 tests: 2031 pass (91%) 196 skip (8%)</title>
+    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-14 at 07:45 UTC"/>
-      <outline text="Results: 28 passed (80%), 1 skipped (3%), 6 failed (17%)"/>
-      <outline text="Duration: 0.1s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 2086 tests (1896 active, 190 marked skip) across 61 categories"/>
+      <outline text="Run: 2026-04-16 at 06:57 UTC"/>
+      <outline text="Results: 1955 passed (89%), 196 skipped (9%), 58 failed (3%)"/>
+      <outline text="Duration: 35.2s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 2227 tests (2031 active, 196 marked skip) across 66 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
     <outline text="Callback Database (callback_database) - 29 tests: 29 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_database.opml"/>
     <outline text="Callback Tcp (callback_tcp) - 20 tests: 20 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/callback_tcp.opml"/>
+    <outline text="Control Flow (control_flow) - 27 tests: 27 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/control_flow.opml"/>
     <outline text="Db Migration (db_migration) - 7 tests: 3 pass (42%) 4 skip (57%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/db_migration.opml"/>
     <outline text="Db Verbs (db_verbs) - 35 tests: 35 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/db_verbs.opml"/>
     <outline text="Dialog Verbs (dialog_verbs) - 41 tests: 41 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dialog_verbs.opml"/>
     <outline text="Dist Stability (dist_stability) - 7 tests: 7 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/dist_stability.opml"/>
     <outline text="Efp Introspection (efp_introspection) - 14 tests: 14 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efp_introspection.opml"/>
+    <outline text="Efptable Stability (efptable_stability) - 9 tests: 9 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/efptable_stability.opml"/>
+    <outline text="Error Handling Extended (error_handling_extended) - 37 tests: 37 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/error_handling_extended.opml"/>
     <outline text="Error Recovery Concurrency Tests (error_recovery_concurrency_tests) - 13 tests: 13 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/error_recovery_concurrency_tests.opml"/>
     <outline text="File Dialog Verbs (file_dialog_verbs) - 14 tests: 13 pass (92%) 1 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_dialog_verbs.opml"/>
+    <outline text="File Path Security (file_path_security) - 35 tests: 29 pass (82%) 6 skip (17%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_path_security.opml"/>
     <outline text="File Verbs (file_verbs) - 84 tests: 78 pass (92%) 6 skip (7%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/file_verbs.opml"/>
     <outline text="Filemenu Verbs (filemenu_verbs) - 35 tests: 34 pass (97%) 1 skip (2%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/filemenu_verbs.opml"/>
     <outline text="Frontier Verbs (frontier_verbs) - 23 tests: 23 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/frontier_verbs.opml"/>
@@ -50,6 +54,7 @@
     <outline text="Runtime Parameter State (runtime_parameter_state) - 17 tests: 17 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/runtime_parameter_state.opml"/>
     <outline text="Script Processor Verbs (script_processor_verbs) - 43 tests: 7 pass (16%) 36 skip (83%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/script_processor_verbs.opml"/>
     <outline text="String Isvalidurl (string_isvalidurl) - 12 tests: 12 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/string_isvalidurl.opml"/>
+    <outline text="String Ops Extended (string_ops_extended) - 33 tests: 33 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/string_ops_extended.opml"/>
     <outline text="String Verb Resolution Fix (string_verb_resolution_fix) - 51 tests: 41 pass (80%) 10 skip (19%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/string_verb_resolution_fix.opml"/>
     <outline text="String Verbs (string_verbs) - 25 tests: 25 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/string_verbs.opml"/>
     <outline text="Sys Environment Args (sys_environment_args) - 11 tests: 11 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/sys_environment_args.opml"/>

--- a/reports/integration_tests/control_flow.opml
+++ b/reports/integration_tests/control_flow.opml
@@ -1,0 +1,403 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Control Flow (control_flow) - 27 tests: 27 pass (100%)</title>
+    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="if - true branch - if with true condition executes body">
+      <outline text="Metadata">
+        <outline text="expected_result: yes"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if true">
+          <outline text="return &quot;yes&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if/else - false takes else branch - if with false condition executes else body">
+      <outline text="Metadata">
+        <outline text="expected_result: no"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if false">
+          <outline text="return &quot;yes&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;no&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if/else - numeric comparison - if with numeric comparison">
+      <outline text="Metadata">
+        <outline text="expected_result: big"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 10)"/>
+        <outline text="if x &gt; 5">
+          <outline text="return &quot;big&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;small&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if/else/if - first branch - Nested if/else takes first matching branch">
+      <outline text="Metadata">
+        <outline text="expected_result: one"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 1)"/>
+        <outline text="if x == 1">
+          <outline text="return &quot;one&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="if x == 2">
+            <outline text="return &quot;two&quot;}"/>
+          </outline>
+          <outline text="else">
+            <outline text="return &quot;other&quot;}}"/>
+          </outline>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if/else/if - middle branch - Nested if/else takes second branch">
+      <outline text="Metadata">
+        <outline text="expected_result: two"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 2)"/>
+        <outline text="if x == 1">
+          <outline text="return &quot;one&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="if x == 2">
+            <outline text="return &quot;two&quot;}"/>
+          </outline>
+          <outline text="else">
+            <outline text="return &quot;other&quot;}}"/>
+          </outline>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if/else/if - fallthrough to else - Nested if/else falls to final else">
+      <outline text="Metadata">
+        <outline text="expected_result: other"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 99)"/>
+        <outline text="if x == 1">
+          <outline text="return &quot;one&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="if x == 2">
+            <outline text="return &quot;two&quot;}"/>
+          </outline>
+          <outline text="else">
+            <outline text="return &quot;other&quot;}}"/>
+          </outline>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="for - count to 5 - for i = 1 to 5 accumulates sum">
+      <outline text="Metadata">
+        <outline text="expected_result: 15"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sum = 0)"/>
+        <outline text="for i = 1 to 5">
+          <outline text="sum = sum + i}"/>
+        </outline>
+        <outline text="return sum"/>
+      </outline>
+    </outline>
+    <outline text="for - single iteration - for i = 1 to 1 executes exactly once">
+      <outline text="Metadata">
+        <outline text="expected_result: 1"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (count = 0)"/>
+        <outline text="for i = 1 to 1">
+          <outline text="count = count + 1}"/>
+        </outline>
+        <outline text="return count"/>
+      </outline>
+    </outline>
+    <outline text="for - zero iterations when start &gt; end - for i = 5 to 1 executes zero times">
+      <outline text="Metadata">
+        <outline text="expected_result: 0"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (count = 0)"/>
+        <outline text="for i = 5 to 1">
+          <outline text="count = count + 1}"/>
+        </outline>
+        <outline text="return count"/>
+      </outline>
+    </outline>
+    <outline text="for..in - iterate table items - for..in iterates over address items in a table">
+      <outline text="Metadata">
+        <outline text="expected_result: 6"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (t); new(tableType, @t)"/>
+        <outline text="t.a = 1; t.b = 2; t.c = 3"/>
+        <outline text="local (sum = 0)"/>
+        <outline text="local (adr)"/>
+        <outline text="for adr in @t">
+          <outline text="sum = sum + adr^}"/>
+        </outline>
+        <outline text="return sum"/>
+      </outline>
+    </outline>
+    <outline text="while - count to 5 - while loop counting to 5">
+      <outline text="Metadata">
+        <outline text="expected_result: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (i = 0)"/>
+        <outline text="while i &lt; 5">
+          <outline text="i = i + 1}"/>
+        </outline>
+        <outline text="return i"/>
+      </outline>
+    </outline>
+    <outline text="while - false condition never executes - while with initially false condition">
+      <outline text="Metadata">
+        <outline text="expected_result: 0"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 0)"/>
+        <outline text="while false">
+          <outline text="x = 99}"/>
+        </outline>
+        <outline text="return x"/>
+      </outline>
+    </outline>
+    <outline text="loop/break - exit on condition - loop with conditional break">
+      <outline text="Metadata">
+        <outline text="expected_result: 3"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (i = 0)"/>
+        <outline text="loop">
+          <outline text="i = i + 1"/>
+          <outline text="if i == 3">
+            <outline text="break}}"/>
+          </outline>
+        </outline>
+        <outline text="return i"/>
+      </outline>
+    </outline>
+    <outline text="loop/break - immediate break - loop that breaks immediately">
+      <outline text="Metadata">
+        <outline text="expected_result: 0"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 0)"/>
+        <outline text="loop">
+          <outline text="break}"/>
+        </outline>
+        <outline text="return x"/>
+      </outline>
+    </outline>
+    <outline text="case - match first - case matches first value">
+      <outline text="Metadata">
+        <outline text="expected_result: fruit"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = &quot;apple&quot;)"/>
+        <outline text="case x">
+          <outline text="&quot;apple&quot;">
+            <outline text="return &quot;fruit&quot;}"/>
+          </outline>
+          <outline text="&quot;carrot&quot;">
+            <outline text="return &quot;vegetable&quot;}}"/>
+          </outline>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="case - match second - case matches second value">
+      <outline text="Metadata">
+        <outline text="expected_result: vegetable"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = &quot;carrot&quot;)"/>
+        <outline text="case x">
+          <outline text="&quot;apple&quot;">
+            <outline text="return &quot;fruit&quot;}"/>
+          </outline>
+          <outline text="&quot;carrot&quot;">
+            <outline text="return &quot;vegetable&quot;}}"/>
+          </outline>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="case - numeric values - case with numeric matching">
+      <outline text="Metadata">
+        <outline text="expected_result: two"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 2)"/>
+        <outline text="case x">
+          <outline text="1">
+            <outline text="return &quot;one&quot;}"/>
+          </outline>
+          <outline text="2">
+            <outline text="return &quot;two&quot;}"/>
+          </outline>
+          <outline text="3">
+            <outline text="return &quot;three&quot;}}"/>
+          </outline>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="nested for loops - Nested for loops multiply iterations">
+      <outline text="Metadata">
+        <outline text="expected_result: 12"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (count = 0)"/>
+        <outline text="for i = 1 to 3">
+          <outline text="for j = 1 to 4">
+            <outline text="count = count + 1}}"/>
+          </outline>
+        </outline>
+        <outline text="return count"/>
+      </outline>
+    </outline>
+    <outline text="nested while loops - Nested while loops">
+      <outline text="Metadata">
+        <outline text="expected_result: 6"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sum = 0)"/>
+        <outline text="local (i = 0)"/>
+        <outline text="while i &lt; 3">
+          <outline text="local (j = 0)"/>
+          <outline text="while j &lt; 2">
+            <outline text="sum = sum + 1"/>
+            <outline text="j = j + 1}"/>
+          </outline>
+          <outline text="i = i + 1}"/>
+        </outline>
+        <outline text="return sum"/>
+      </outline>
+    </outline>
+    <outline text="return from for loop - return inside a for loop exits immediately">
+      <outline text="Metadata">
+        <outline text="expected_result: found 3"/>
+      </outline>
+      <outline text="Script">
+        <outline text="for i = 1 to 10">
+          <outline text="if i == 3">
+            <outline text="return &quot;found &quot; + i}}"/>
+          </outline>
+        </outline>
+        <outline text="return &quot;not found&quot;"/>
+      </outline>
+    </outline>
+    <outline text="return from while loop - return inside a while loop exits immediately">
+      <outline text="Metadata">
+        <outline text="expected_result: 5"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (i = 0)"/>
+        <outline text="while true">
+          <outline text="i = i + 1"/>
+          <outline text="if i == 5">
+            <outline text="return i}}"/>
+          </outline>
+        </outline>
+        <outline text="return 0"/>
+      </outline>
+    </outline>
+    <outline text="try/else - no error passes through - try block with no error skips else">
+      <outline text="Metadata">
+        <outline text="expected_result: ok"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (result = &quot;ok&quot;)"/>
+        <outline text="try">
+          <outline text="local (x = 1 + 1)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="result = &quot;error&quot;}"/>
+        </outline>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="try/else - error caught and recovered - try/else catches error and allows recovery">
+      <outline text="Metadata">
+        <outline text="expected_result: caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (result = &quot;&quot;)"/>
+        <outline text="try">
+          <outline text="scriptError(&quot;boom&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="result = &quot;caught&quot;}"/>
+        </outline>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="try/else - in loop continues after catch - try/else inside a loop allows iteration to continue">
+      <outline text="Metadata">
+        <outline text="expected_result: 2"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (errors = 0)"/>
+        <outline text="for i = 1 to 5">
+          <outline text="try">
+            <outline text="if (i == 3) or (i == 5)">
+              <outline text="scriptError(&quot;bad&quot;)}}"/>
+            </outline>
+          </outline>
+          <outline text="else">
+            <outline text="errors = errors + 1}}"/>
+          </outline>
+        </outline>
+        <outline text="return errors"/>
+      </outline>
+    </outline>
+    <outline text="if - and condition - if with and operator">
+      <outline text="Metadata">
+        <outline text="expected_result: in range"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 5)"/>
+        <outline text="if (x &gt; 3) and (x &lt; 10)">
+          <outline text="return &quot;in range&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;out of range&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if - or condition - if with or operator">
+      <outline text="Metadata">
+        <outline text="expected_result: match"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 1)"/>
+        <outline text="if (x == 1) or (x == 2)">
+          <outline text="return &quot;match&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;no match&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="if - not condition - if with not operator">
+      <outline text="Metadata">
+        <outline text="expected_result: negated"/>
+      </outline>
+      <outline text="Script">
+        <outline text="if not false">
+          <outline text="return &quot;negated&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/efptable_stability.opml
+++ b/reports/integration_tests/efptable_stability.opml
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Efptable Stability (efptable_stability) - 9 tests: 9 pass (100%)</title>
+    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="efptable stability - file.exists works after guest db open - Open StartupTasks.root as a guest database, then verify file.exists()&#10;still dispatches correctly. If efptable were clobbered by database&#10;loading, this would fail with a nil valueroutine.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath, true)"/>
+        <outline text="return file.exists(&quot;/tmp&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - string.mid works after guest db open - Verify string processor dispatch after opening a guest database.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: world"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath, true)"/>
+        <outline text="return string.mid(&quot;hello world&quot;, 7, 5)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - string.length works after guest db open - Verify string.length() dispatch after database loading.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: 4"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath, true)"/>
+        <outline text="return string.length(&quot;test&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - clock.now works after guest db open - Verify clock processor dispatch after database loading.&#10;clock.now() returns a date; we verify it's defined (non-nil).&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath, true)"/>
+        <outline text="return defined(clock.now())"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - file.exists works after db.new - Create a fresh database via db.new(), then verify file processor&#10;dispatch still works. No db.close() — the process exits after each&#10;test and the harness cleans up tmp files.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_efp_stability.root&quot;)"/>
+        <outline text="if file.exists(dbPath)">
+          <outline text="file.delete(dbPath)}"/>
+        </outline>
+        <outline text="db.new(dbPath)"/>
+        <outline text="return file.exists(&quot;/tmp&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - string.mid works after db.new - Create a fresh database via db.new(), then verify string processor&#10;dispatch still works.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: cd"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local(dbPath = tmpDir + &quot;/&quot; + &quot;test_efp_stability2.root&quot;)"/>
+        <outline text="if file.exists(dbPath)">
+          <outline text="file.delete(dbPath)}"/>
+        </outline>
+        <outline text="db.new(dbPath)"/>
+        <outline text="return string.mid(&quot;abcdef&quot;, 3, 2)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - parentOf(string.mid) after guest db open - Verify that parentOf() introspection returns database path (not&#10;EFP internal path) after opening a guest database.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: system.verbs.builtins.string"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath, true)"/>
+        <outline text="return parentOf(string.mid)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - defined(file.exists) after guest db open - Verify defined() still resolves processor verbs after database loading.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath, true)"/>
+        <outline text="return defined(file.exists)"/>
+      </outline>
+    </outline>
+    <outline text="efptable stability - dispatch survives multiple guest db opens - Open two different guest databases in sequence, then verify&#10;processor dispatch still works. Tests that repeated database&#10;lifecycle operations don't degrade efptable state.&#10;">
+      <outline text="Metadata">
+        <outline text="expected_result: 10"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (sysdir = file.folderFromPath(Frontier.getFilePath()))"/>
+        <outline text="local (guestpath1 = sysdir + &quot;StartupTasks.root&quot;)"/>
+        <outline text="local (guestpath2 = sysdir + &quot;test.root&quot;)"/>
+        <outline text="if not file.exists(guestpath1)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="if not file.exists(guestpath2)">
+          <outline text="return &quot;skip&quot;}"/>
+        </outline>
+        <outline text="fileMenu.open(guestpath1, true)"/>
+        <outline text="fileMenu.open(guestpath2, true)"/>
+        <outline text="return string.length(&quot;cycle test&quot;)"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/error_handling_extended.opml
+++ b/reports/integration_tests/error_handling_extended.opml
@@ -1,0 +1,522 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Error Handling Extended (error_handling_extended) - 37 tests: 37 pass (100%)</title>
+    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="lang.scriptError - custom message is thrown - lang.scriptError() should cause script failure with custom message">
+      <outline text="Metadata">
+        <outline text="expected_success: False"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.scriptError(&quot;custom failure message&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="lang.scriptError - empty string message - lang.scriptError with empty string still triggers error">
+      <outline text="Metadata">
+        <outline text="expected_success: False"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.scriptError(&quot;&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="lang.scriptError - message with special characters - lang.scriptError preserves special characters in message">
+      <outline text="Metadata">
+        <outline text="expected_result: error: value=42, path=/foo/bar"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;error: value=42, path=/foo/bar&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="lang.scriptError - long message preserved - lang.scriptError preserves longer messages through tryError">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (msg = &quot;This is a longer error message that tests whether the full text is preserved through the try/else mechanism&quot;)"/>
+        <outline text="try">
+          <outline text="lang.scriptError(msg)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError == msg}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="try/else - tryError captures lang.scriptError message - tryError in else block contains the lang.scriptError string">
+      <outline text="Metadata">
+        <outline text="expected_result: captured message"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;captured message&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="try/else - tryError type is string - tryError should be a string value">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;test&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return typeOf(tryError) == stringType}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="try/else - else block can use tryError in expressions - tryError can be used in string operations within else block">
+      <outline text="Metadata">
+        <outline text="expected_result: caught: the error"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;the error&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;caught: &quot; + tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="try/else - tryError with contains operator - tryError can be tested with contains operator">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;file not found: /tmp/test.txt&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError contains &quot;not found&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="nested try - inner catches, outer succeeds - Inner try/else handles error, outer try sees no error">
+      <outline text="Metadata">
+        <outline text="expected_result: inner caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (result = &quot;none&quot;)"/>
+        <outline text="try">
+          <outline text="try">
+            <outline text="lang.scriptError(&quot;inner error&quot;)}"/>
+          </outline>
+          <outline text="else">
+            <outline text="result = &quot;inner caught&quot;}}"/>
+          </outline>
+        </outline>
+        <outline text="else">
+          <outline text="result = &quot;outer caught&quot;}"/>
+        </outline>
+        <outline text="return result"/>
+      </outline>
+    </outline>
+    <outline text="nested try - inner rethrows to outer - Inner else can rethrow via lang.scriptError to outer try">
+      <outline text="Metadata">
+        <outline text="expected_result: rethrown: original"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="try">
+            <outline text="lang.scriptError(&quot;original&quot;)}"/>
+          </outline>
+          <outline text="else">
+            <outline text="lang.scriptError(&quot;rethrown: &quot; + tryError)}}"/>
+          </outline>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="nested try - three levels deep - Three levels of try/else nesting work correctly">
+      <outline text="Metadata">
+        <outline text="expected_result: level 1: level 2: level 3"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="try">
+            <outline text="try">
+              <outline text="lang.scriptError(&quot;level 3&quot;)}"/>
+            </outline>
+            <outline text="else">
+              <outline text="lang.scriptError(&quot;level 2: &quot; + tryError)}}"/>
+            </outline>
+          </outline>
+          <outline text="else">
+            <outline text="lang.scriptError(&quot;level 1: &quot; + tryError)}}"/>
+          </outline>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="nested try - inner succeeds, outer catches different error - Inner try succeeds, error after inner try caught by outer">
+      <outline text="Metadata">
+        <outline text="expected_result: after inner"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="try">
+            <outline text="local (x = 1 + 1)}"/>
+          </outline>
+          <outline text="else">
+            <outline text="return &quot;should not reach&quot;}"/>
+          </outline>
+          <outline text="lang.scriptError(&quot;after inner&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="nested try - each level has independent tryError - Each else block gets its own tryError value">
+      <outline text="Metadata">
+        <outline text="expected_result: inner msg|outer msg"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (innerMsg = &quot;&quot;)"/>
+        <outline text="try">
+          <outline text="try">
+            <outline text="lang.scriptError(&quot;inner msg&quot;)}"/>
+          </outline>
+          <outline text="else">
+            <outline text="innerMsg = tryError"/>
+            <outline text="lang.scriptError(&quot;outer msg&quot;)}}"/>
+          </outline>
+        </outline>
+        <outline text="else">
+          <outline text="return innerMsg + &quot;|&quot; + tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="error propagation - division by zero propagates through expression - Division by zero in sub-expression propagates to enclosing try">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (a = 5)"/>
+          <outline text="local (b = 0)"/>
+          <outline text="local (c = a + (10 / b))}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError contains &quot;divide&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="error propagation - undefined name propagates - Undefined name error propagates through nested expression">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = 1 + noSuchThing)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError contains &quot;noSuchThing&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="error propagation - lang.scriptError in conditional - Error thrown inside conditional branch propagates to try/else">
+      <outline text="Metadata">
+        <outline text="expected_result: conditional error"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = 5)"/>
+          <outline text="if x &gt; 3">
+            <outline text="lang.scriptError(&quot;conditional error&quot;)}}"/>
+          </outline>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="error recovery - code after try/else executes - Execution continues normally after a try/else block">
+      <outline text="Metadata">
+        <outline text="expected_result: caught and after"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = &quot;before&quot;)"/>
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;oops&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="x = &quot;caught&quot;}"/>
+        </outline>
+        <outline text="local (y = x + &quot; and after&quot;)"/>
+        <outline text="return y"/>
+      </outline>
+    </outline>
+    <outline text="error recovery - multiple try/else blocks in sequence - Multiple sequential try/else blocks each handle independently">
+      <outline text="Metadata">
+        <outline text="expected_result: 12"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (log = &quot;&quot;)"/>
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;first&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="log = log + &quot;1&quot;}"/>
+        </outline>
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;second&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="log = log + &quot;2&quot;}"/>
+        </outline>
+        <outline text="try">
+          <outline text="local (x = 1)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="log = log + &quot;3&quot;}"/>
+        </outline>
+        <outline text="return log"/>
+      </outline>
+    </outline>
+    <outline text="error recovery - loop continues after try/else - Loop iteration continues after error is caught">
+      <outline text="Metadata">
+        <outline text="expected_result: 1"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (count = 0)"/>
+        <outline text="local (i)"/>
+        <outline text="for i = 1 to 5">
+          <outline text="try">
+            <outline text="if i == 3">
+              <outline text="lang.scriptError(&quot;skip 3&quot;)}}"/>
+            </outline>
+          </outline>
+          <outline text="else">
+            <outline text="count = count + 1}}"/>
+          </outline>
+        </outline>
+        <outline text="return count"/>
+      </outline>
+    </outline>
+    <outline text="error recovery - variable assignment in else persists - Variables modified in else block retain their values">
+      <outline text="Metadata">
+        <outline text="expected_result: error: fail"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (status = &quot;ok&quot;)"/>
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;fail&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="status = &quot;error: &quot; + tryError}"/>
+        </outline>
+        <outline text="return status"/>
+      </outline>
+    </outline>
+    <outline text="error recovery - accumulate results across errors - Can accumulate results across multiple try/else in a loop">
+      <outline text="Metadata">
+        <outline text="expected_result: 2|2"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (errors = 0)"/>
+        <outline text="local (successes = 0)"/>
+        <outline text="local (i)"/>
+        <outline text="for i = 1 to 4">
+          <outline text="try">
+            <outline text="if (i % 2) == 0">
+              <outline text="lang.scriptError(&quot;even&quot;)}"/>
+            </outline>
+            <outline text="successes = successes + 1}"/>
+          </outline>
+          <outline text="else">
+            <outline text="errors = errors + 1}}"/>
+          </outline>
+        </outline>
+        <outline text="return successes + &quot;|&quot; + errors"/>
+      </outline>
+    </outline>
+    <outline text="division by zero - integer - Integer division by zero is caught by try/else">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = 10 / 0)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return tryError contains &quot;divide&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="division by zero - uncaught causes failure - Division by zero without try/else causes script failure">
+      <outline text="Metadata">
+        <outline text="expected_success: False"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = 1 / 0)"/>
+      </outline>
+    </outline>
+    <outline text="division by zero - in expression - Division by zero in complex expression is caught">
+      <outline text="Metadata">
+        <outline text="expected_result: caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = (10 + 5) / (3 - 3))}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;caught&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="division by zero - modulo by zero - Modulo by zero triggers error">
+      <outline text="Metadata">
+        <outline text="expected_result: caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = 10 % 0)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;caught&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="type coercion - string plus boolean coerces - UserTalk coerces boolean to string for concatenation">
+      <outline text="Metadata">
+        <outline text="expected_result: hellotrue"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return &quot;hello&quot; + true"/>
+      </outline>
+    </outline>
+    <outline text="type coercion - string multiply errors - Multiplying string by number triggers error (no coercion path)">
+      <outline text="Metadata">
+        <outline text="expected_result: caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = &quot;abc&quot; * 2)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;caught&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="type coercion - string minus coerces silently - UserTalk string minus number does not error (unusual coercion)">
+      <outline text="Metadata">
+        <outline text="expected_result: abc"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (x = &quot;abc&quot; - 1)"/>
+        <outline text="return x"/>
+      </outline>
+    </outline>
+    <outline text="type coercion - boolean multiply is logical - Boolean multiplication acts as logical AND in UserTalk">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return true * false"/>
+      </outline>
+    </outline>
+    <outline text="type coercion - numeric string concatenation - Adding two numeric strings concatenates (string context wins)">
+      <outline text="Metadata">
+        <outline text="expected_result: 34"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return &quot;3&quot; + &quot;4&quot;"/>
+      </outline>
+    </outline>
+    <outline text="undefined variable - access causes error - Referencing undefined variable causes script failure">
+      <outline text="Metadata">
+        <outline text="expected_success: False"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return undefinedVariable"/>
+      </outline>
+    </outline>
+    <outline text="undefined variable - caught by try/else - Undefined variable access caught in try/else">
+      <outline text="Metadata">
+        <outline text="expected_result: caught"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="local (x = noSuchVariable)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;caught&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="undefined variable - defined() returns false - defined() properly reports undefined variables">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return defined(neverDefinedVar)"/>
+      </outline>
+    </outline>
+    <outline text="undefined variable - defined() returns true for local - defined() properly reports defined local variables">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (myVar = 42)"/>
+        <outline text="return defined(myVar)"/>
+      </outline>
+    </outline>
+    <outline text="try with no error - else not executed - When try body succeeds, else is skipped entirely">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (entered = false)"/>
+        <outline text="try">
+          <outline text="local (x = 42)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="entered = true}"/>
+        </outline>
+        <outline text="return entered"/>
+      </outline>
+    </outline>
+    <outline text="try/else - return from else exits function - Return statement in else block exits the enclosing scope">
+      <outline text="Metadata">
+        <outline text="expected_result: from else"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="lang.scriptError(&quot;test&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;from else&quot;}"/>
+        </outline>
+        <outline text="return &quot;after try&quot;"/>
+      </outline>
+    </outline>
+    <outline text="try/else - return from try body exits function - Return from successful try body exits the enclosing scope">
+      <outline text="Metadata">
+        <outline text="expected_result: from try"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="return &quot;from try&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;from else&quot;}"/>
+        </outline>
+        <outline text="return &quot;after try&quot;"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/file_path_security.opml
+++ b/reports/integration_tests/file_path_security.opml
@@ -1,0 +1,415 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>File Path Security (file_path_security) - 35 tests: 29 pass (82%) 6 skip (17%)</title>
+    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="path traversal - file.exists with ../ is safe - file.exists on path with ../ should not crash or expose info">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/../../../etc/passwd&quot;)"/>
+        <outline text="return typeOf(file.exists(path)) == booleanType"/>
+      </outline>
+    </outline>
+    <outline text="path traversal - multiple ../ segments - Path with many ../ segments handled safely">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (path = &quot;/tmp/a/b/c/../../../../etc/shadow&quot;)"/>
+        <outline text="return typeOf(file.exists(path)) == booleanType"/>
+      </outline>
+    </outline>
+    <outline text="path traversal - ../ in middle of path - Embedded ../ in path is handled safely">
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/subdir/../testfile_traversal.txt&quot;)"/>
+        <outline text="try">
+          <outline text="file.writeWholeFile(path, &quot;test&quot;)"/>
+          <outline text="local (exists = file.exists(path))"/>
+          <outline text="file.delete(path)"/>
+          <outline text="return &quot;handled&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="path traversal - file.new with ../ parent escape - Creating file via ../ traversal handled safely">
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/../traversal_test_security.txt&quot;)"/>
+        <outline text="try">
+          <outline text="file.new(path)"/>
+          <outline text="if file.exists(path)">
+            <outline text="file.delete(path)}"/>
+          </outline>
+          <outline text="return &quot;created&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="empty path - file.exists should handle safely - Empty string path should return false or error, not crash">
+      <outline text="Metadata">
+        <outline text="skip: BUG: Empty path causes process crash — not catchable by try/else"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="return file.exists(&quot;&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;error caught&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="empty path - file.new should reject - Creating file with empty path should fail safely">
+      <outline text="Metadata">
+        <outline text="skip: BUG: Empty path causes process crash — not catchable by try/else"/>
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.new(&quot;&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="empty path - file.readWholeFile should reject - Reading file with empty path should fail safely">
+      <outline text="Metadata">
+        <outline text="skip: BUG: Empty path causes process crash — not catchable by try/else"/>
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.readWholeFile(&quot;&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="empty path - file.writeWholeFile should reject - Writing file with empty path should fail safely">
+      <outline text="Metadata">
+        <outline text="skip: BUG: Empty path causes process crash — not catchable by try/else"/>
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.writeWholeFile(&quot;&quot;, &quot;data&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="empty path - file.delete should reject - Deleting with empty path should fail safely">
+      <outline text="Metadata">
+        <outline text="skip: BUG: Empty path causes process crash — not catchable by try/else"/>
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.delete(&quot;&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="long path - 900 char filename - Very long filename (900 chars) — tests OS limits">
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (longName = string.filledString(&quot;a&quot;, 900))"/>
+        <outline text="local (path = tmpDir + &quot;/&quot; + longName + &quot;.txt&quot;)"/>
+        <outline text="try">
+          <outline text="file.new(path)"/>
+          <outline text="local (exists = file.exists(path))"/>
+          <outline text="if exists">
+            <outline text="file.delete(path)}"/>
+          </outline>
+          <outline text="return &quot;handled&quot;}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="long path - deeply nested directories - Path with many directory levels should fail gracefully">
+      <outline text="Script">
+        <outline text="local (path = &quot;/tmp&quot;)"/>
+        <outline text="local (i)"/>
+        <outline text="for i = 1 to 50">
+          <outline text="path = path + &quot;/dir&quot; + i}"/>
+        </outline>
+        <outline text="path = path + &quot;/file.txt&quot;"/>
+        <outline text="try">
+          <outline text="return file.exists(path)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;error handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="special chars - spaces in filename - File operations with spaces in paths">
+      <outline text="Metadata">
+        <outline text="skip: BUG: Spaces in filenames cause process crash in headless mode"/>
+        <outline text="expected_result: content"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/file with spaces.txt&quot;)"/>
+        <outline text="file.writeWholeFile(path, &quot;content&quot;)"/>
+        <outline text="local (data = file.readWholeFile(path))"/>
+        <outline text="file.delete(path)"/>
+        <outline text="return string(data)"/>
+      </outline>
+    </outline>
+    <outline text="special chars - dots in filename - Multiple dots in filename handled correctly">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/file.name.with.dots.txt&quot;)"/>
+        <outline text="file.writeWholeFile(path, &quot;dots&quot;)"/>
+        <outline text="local (exists = file.exists(path))"/>
+        <outline text="file.delete(path)"/>
+        <outline text="return exists"/>
+      </outline>
+    </outline>
+    <outline text="special chars - hyphen and underscore - Hyphens and underscores in paths work correctly">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/test-file_name-2.txt&quot;)"/>
+        <outline text="file.writeWholeFile(path, &quot;test&quot;)"/>
+        <outline text="local (exists = file.exists(path))"/>
+        <outline text="file.delete(path)"/>
+        <outline text="return exists"/>
+      </outline>
+    </outline>
+    <outline text="special chars - single dot path is safe - Single dot path handled safely (refers to current directory)">
+      <outline text="Script">
+        <outline text="try">
+          <outline text="return typeOf(file.exists(&quot;.&quot;)) == booleanType}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;error handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="special chars - double dot path is safe - Double dot path handled safely (refers to parent directory)">
+      <outline text="Script">
+        <outline text="try">
+          <outline text="return typeOf(file.exists(&quot;..&quot;)) == booleanType}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;error handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="special chars - numeric filename - All-numeric filename works correctly">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/12345&quot;)"/>
+        <outline text="file.writeWholeFile(path, &quot;numeric&quot;)"/>
+        <outline text="local (exists = file.exists(path))"/>
+        <outline text="file.delete(path)"/>
+        <outline text="return exists"/>
+      </outline>
+    </outline>
+    <outline text="special chars - leading dot (hidden file) - Leading dot (hidden file) works correctly">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/.hidden_test_file&quot;)"/>
+        <outline text="file.writeWholeFile(path, &quot;hidden&quot;)"/>
+        <outline text="local (exists = file.exists(path))"/>
+        <outline text="file.delete(path)"/>
+        <outline text="return exists"/>
+      </outline>
+    </outline>
+    <outline text="file.exists - non-existent file returns false - file.exists should return false for missing files, not error">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="return file.exists(tmpDir + &quot;/absolutely_does_not_exist_xyz123.txt&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="file.exists - non-existent deep path returns false - file.exists on path with missing parent dirs returns false">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.exists(&quot;/tmp/nonexistent_dir_xyz/subdir/file.txt&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="file.exists - non-existent volume returns false - file.exists on path starting with non-existent mount point returns false">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.exists(&quot;/nonexistent_volume_xyz/test.txt&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="file.exists - very long nonexistent path returns false - file.exists on long nonexistent path returns false safely">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (path = &quot;/tmp/&quot; + string.filledString(&quot;x&quot;, 200) + &quot;/file.txt&quot;)"/>
+        <outline text="return file.exists(path)"/>
+      </outline>
+    </outline>
+    <outline text="absolute path - root path exists - Root filesystem path should exist">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.exists(&quot;/&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="absolute path - /tmp exists - /tmp directory should exist on all POSIX systems">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.exists(&quot;/tmp&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="absolute path - write and verify existence - Full absolute path write creates file that exists">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (tmpDir = &quot;{FRONTIER_TEST_TMP_DIR}&quot;)"/>
+        <outline text="local (path = tmpDir + &quot;/absolute_path_test.txt&quot;)"/>
+        <outline text="file.writeWholeFile(path, &quot;absolute&quot;)"/>
+        <outline text="local (exists = file.exists(path))"/>
+        <outline text="file.delete(path)"/>
+        <outline text="return exists"/>
+      </outline>
+    </outline>
+    <outline text="fileFromPath - path with ../ segments - fileFromPath handles ../ in path without crashing">
+      <outline text="Metadata">
+        <outline text="expected_result: passwd"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.fileFromPath(&quot;/tmp/../etc/passwd&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="folderFromPath - path with ../ segments - folderFromPath handles ../ in path without crashing">
+      <outline text="Metadata">
+        <outline text="expected_result: /tmp/../etc/"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.folderFromPath(&quot;/tmp/../etc/passwd&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="fileFromPath - empty string is safe - fileFromPath with empty string should not crash">
+      <outline text="Script">
+        <outline text="try">
+          <outline text="return file.fileFromPath(&quot;&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;error handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="folderFromPath - empty string is safe - folderFromPath with empty string should not crash">
+      <outline text="Script">
+        <outline text="try">
+          <outline text="return file.folderFromPath(&quot;&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;error handled&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="fileFromPath - just a slash - fileFromPath on root slash returns slash">
+      <outline text="Metadata">
+        <outline text="expected_result: /"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.fileFromPath(&quot;/&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="folderFromPath - just a slash - folderFromPath on root slash returns root">
+      <outline text="Metadata">
+        <outline text="expected_result: /"/>
+      </outline>
+      <outline text="Script">
+        <outline text="return file.folderFromPath(&quot;/&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="restricted path - cannot write to root - Writing to / should fail with permission error">
+      <outline text="Metadata">
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.writeWholeFile(&quot;/test_security_write.txt&quot;, &quot;data&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="restricted path - cannot delete system files - Deleting system paths should fail safely">
+      <outline text="Metadata">
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.delete(&quot;/etc/hosts&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="restricted path - cannot create file in /etc - Creating files in system directories should fail">
+      <outline text="Metadata">
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.new(&quot;/etc/frontier_security_test.txt&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+    <outline text="restricted path - cannot overwrite system file - Overwriting system file should fail">
+      <outline text="Metadata">
+        <outline text="expected_result: rejected"/>
+      </outline>
+      <outline text="Script">
+        <outline text="try">
+          <outline text="file.writeWholeFile(&quot;/etc/hosts&quot;, &quot;malicious data&quot;)}"/>
+        </outline>
+        <outline text="else">
+          <outline text="return &quot;rejected&quot;}"/>
+        </outline>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/string_ops_extended.opml
+++ b/reports/integration_tests/string_ops_extended.opml
@@ -1,0 +1,277 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>String Ops Extended (string_ops_extended) - 33 tests: 33 pass (100%)</title>
+    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="string.replaceAll - basic replacement - Replace all occurrences of a substring">
+      <outline text="Metadata">
+        <outline text="expected_result: hi world hi"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.replaceAll(&quot;hello world hello&quot;, &quot;hello&quot;, &quot;hi&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.replaceAll - no match - replaceAll with no matching substring returns original">
+      <outline text="Metadata">
+        <outline text="expected_result: hello world"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.replaceAll(&quot;hello world&quot;, &quot;xyz&quot;, &quot;abc&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.replaceAll - replace with empty - Replace substring with empty string (deletion)">
+      <outline text="Metadata">
+        <outline text="expected_result: hello"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.replaceAll(&quot;hello world&quot;, &quot; world&quot;, &quot;&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.nthField - comma separated first - Extract first field from comma-separated string">
+      <outline text="Metadata">
+        <outline text="expected_result: apple"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.nthField(&quot;apple,banana,cherry&quot;, &quot;,&quot;, 1)"/>
+      </outline>
+    </outline>
+    <outline text="string.nthField - comma separated middle - Extract middle field">
+      <outline text="Metadata">
+        <outline text="expected_result: banana"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.nthField(&quot;apple,banana,cherry&quot;, &quot;,&quot;, 2)"/>
+      </outline>
+    </outline>
+    <outline text="string.nthField - comma separated last - Extract last field">
+      <outline text="Metadata">
+        <outline text="expected_result: cherry"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.nthField(&quot;apple,banana,cherry&quot;, &quot;,&quot;, 3)"/>
+      </outline>
+    </outline>
+    <outline text="string.nthField - space delimiter - Extract field using space delimiter">
+      <outline text="Metadata">
+        <outline text="expected_result: two"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.nthField(&quot;one two three&quot;, &quot; &quot;, 2)"/>
+      </outline>
+    </outline>
+    <outline text="string.countFields - comma separated - Count comma-separated fields">
+      <outline text="Metadata">
+        <outline text="expected_result: 4"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.countFields(&quot;a,b,c,d&quot;, &quot;,&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.countFields - single field - String with no delimiter has one field">
+      <outline text="Metadata">
+        <outline text="expected_result: 1"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.countFields(&quot;hello&quot;, &quot;,&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.countFields - empty string - Empty string has one field (the empty string itself)">
+      <outline text="Metadata">
+        <outline text="expected_result: 1"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.countFields(&quot;&quot;, &quot;,&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.insert - at beginning - Insert string at beginning (position 0)">
+      <outline text="Metadata">
+        <outline text="expected_result: hello world"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.insert(&quot;hello &quot;, &quot;world&quot;, 0)"/>
+      </outline>
+    </outline>
+    <outline text="string.insert - in middle - Insert character in the middle">
+      <outline text="Metadata">
+        <outline text="expected_result: hello"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.insert(&quot;l&quot;, &quot;helo&quot;, 3)"/>
+      </outline>
+    </outline>
+    <outline text="string.delete - from middle - Delete characters from middle of string">
+      <outline text="Metadata">
+        <outline text="expected_result: hello"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.delete(&quot;hello world&quot;, 6, 6)"/>
+      </outline>
+    </outline>
+    <outline text="string.delete - from beginning - Delete characters from beginning">
+      <outline text="Metadata">
+        <outline text="expected_result: llo"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.delete(&quot;hello&quot;, 1, 2)"/>
+      </outline>
+    </outline>
+    <outline text="contains - substring found - String contains substring via operator">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;hello world&quot; contains &quot;world&quot;"/>
+      </outline>
+    </outline>
+    <outline text="contains - substring not found - String does not contain substring">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;hello world&quot; contains &quot;xyz&quot;"/>
+      </outline>
+    </outline>
+    <outline text="contains - empty substring - Empty substring not found by contains operator">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;hello&quot; contains &quot;&quot;"/>
+      </outline>
+    </outline>
+    <outline text="string inequality - different strings - Different strings are not equal">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;hello&quot; != &quot;world&quot;"/>
+      </outline>
+    </outline>
+    <outline text="string inequality - same strings - Same strings are equal, != returns false">
+      <outline text="Metadata">
+        <outline text="expected_result: false"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;hello&quot; != &quot;hello&quot;"/>
+      </outline>
+    </outline>
+    <outline text="concatenation - string and number - Concatenating string with number coerces to string">
+      <outline text="Metadata">
+        <outline text="expected_result: count: 42"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;count: &quot; + 42"/>
+      </outline>
+    </outline>
+    <outline text="concatenation - empty strings - Concatenating empty strings">
+      <outline text="Metadata">
+        <outline text="expected_result: hello"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;&quot; + &quot;&quot; + &quot;hello&quot; + &quot;&quot;"/>
+      </outline>
+    </outline>
+    <outline text="concatenation - multi-step - Building a string incrementally">
+      <outline text="Metadata">
+        <outline text="expected_result: 123"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local (s = &quot;&quot;)"/>
+        <outline text="for i = 1 to 3">
+          <outline text="s = s + lang.string(i)}"/>
+        </outline>
+        <outline text="return s"/>
+      </outline>
+    </outline>
+    <outline text="empty string - length - Empty string has length 0">
+      <outline text="Metadata">
+        <outline text="expected_result: 0"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.length(&quot;&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="empty string - upper - Upper of empty string is empty">
+      <outline text="Metadata">
+        <outline text="expected_result: "/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.upper(&quot;&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="empty string - equality - Two empty strings are equal">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="&quot;&quot; == &quot;&quot;"/>
+      </outline>
+    </outline>
+    <outline text="string.upper - mixed case - Upper on mixed case string">
+      <outline text="Metadata">
+        <outline text="expected_result: HELLO WORLD"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.upper(&quot;Hello World&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.lower - mixed case - Lower on mixed case string">
+      <outline text="Metadata">
+        <outline text="expected_result: hello world"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.lower(&quot;Hello World&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.upper - already uppercase - Upper on already uppercase string">
+      <outline text="Metadata">
+        <outline text="expected_result: HELLO"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.upper(&quot;HELLO&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.lower - already lowercase - Lower on already lowercase string">
+      <outline text="Metadata">
+        <outline text="expected_result: hello"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.lower(&quot;hello&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.mid - single character - Extract single character via mid">
+      <outline text="Metadata">
+        <outline text="expected_result: l"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.mid(&quot;hello&quot;, 3, 1)"/>
+      </outline>
+    </outline>
+    <outline text="string.mid - entire string - Extract entire string via mid">
+      <outline text="Metadata">
+        <outline text="expected_result: hello"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.mid(&quot;hello&quot;, 1, 5)"/>
+      </outline>
+    </outline>
+    <outline text="string.patternMatch - at beginning - Pattern found at beginning returns 1">
+      <outline text="Metadata">
+        <outline text="expected_result: 1"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.patternMatch(&quot;hello&quot;, &quot;hello world&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="string.patternMatch - empty pattern - Empty pattern match returns 0 (no match)">
+      <outline text="Metadata">
+        <outline text="expected_result: 0"/>
+      </outline>
+      <outline text="Script">
+        <outline text="string.patternMatch(&quot;&quot;, &quot;hello&quot;)"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Thu, 16 Apr 2026 05:12:47 GMT</dateCreated>
+    <dateCreated>Thu, 16 Apr 2026 05:32:14 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-16 at 05:12 UTC"/>
+      <outline text="Run: 2026-04-16 at 05:32 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Thu, 16 Apr 2026 00:43:16 GMT</dateCreated>
+    <dateCreated>Thu, 16 Apr 2026 05:12:47 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-16 at 00:43 UTC"/>
+      <outline text="Run: 2026-04-16 at 05:12 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -664,14 +664,20 @@ def _run_file_worker(args: tuple) -> dict:
         shutil.copy2(system_root, worker_db_path)
         worker_system_root = worker_db_path
 
-        # Copy guest databases only for tests that need them (avoids
-        # unnecessary I/O overhead for the majority of test workers).
-        if os.path.basename(yaml_path) == 'guest_db_externals.yaml':
+        # Copy sibling .root files and Guest Databases/ for tests that
+        # open guest databases. Files that use fileMenu.open() or reference
+        # paths relative to Frontier.getFilePath() need these alongside the
+        # copied system root.
+        NEEDS_GUEST_DBS = {'guest_db_externals.yaml', 'efptable_stability.yaml'}
+        if os.path.basename(yaml_path) in NEEDS_GUEST_DBS:
             src_dir = os.path.dirname(system_root)
-            for guest_file in ['StartupTasks.root']:
-                guest_src = os.path.join(src_dir, guest_file)
-                if os.path.isfile(guest_src):
-                    shutil.copy2(guest_src, os.path.join(worker_tmp, guest_file))
+            # Copy sibling .root files (StartupTasks.root, test.root, etc.)
+            for sibling in os.listdir(src_dir):
+                if sibling.endswith('.root') and sibling != os.path.basename(system_root):
+                    sibling_src = os.path.join(src_dir, sibling)
+                    if os.path.isfile(sibling_src):
+                        shutil.copy2(sibling_src, os.path.join(worker_tmp, sibling))
+            # Copy Guest Databases/ directory tree
             guest_db_dir = os.path.join(src_dir, 'Guest Databases')
             if os.path.isdir(guest_db_dir):
                 worker_guest_dir = os.path.join(worker_tmp, 'Guest Databases')

--- a/tests/integration/test_cases/efptable_stability.yaml
+++ b/tests/integration/test_cases/efptable_stability.yaml
@@ -1,0 +1,169 @@
+# Integration tests for efptable stability across database operations
+#
+# CONTEXT: Issue #292 — efptable refactored from extern global to module-private
+# static with accessor functions. These tests verify that processor verb dispatch
+# continues to work correctly after database loading operations, which historically
+# could clobber the efptable global with stale tokenvaluetype entries.
+#
+# The key scenario: open a guest database, then verify that kernel verbs
+# (file.*, string.*, clock.*, etc.) still dispatch correctly via their
+# valueroutine callbacks.
+#
+# These tests complement efp_introspection.yaml (which tests parentOf/typeOf/
+# defined resolution) by focusing specifically on verb DISPATCH after database
+# state changes.
+
+tests:
+  # ========================================================================
+  # SECTION 1: Processor dispatch after guest database open
+  # ========================================================================
+  # Open a guest database and verify processor verbs still work.
+  # This catches the historical bug where database loading overwrites
+  # efptable with tokenvaluetype entries (no valueroutine callbacks).
+
+  - name: "efptable stability - file.exists works after guest db open"
+    description: |
+      Open StartupTasks.root as a guest database, then verify file.exists()
+      still dispatches correctly. If efptable were clobbered by database
+      loading, this would fail with a nil valueroutine.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      return file.exists("/tmp")
+    expected_success: true
+    expected_result: "true"
+
+  - name: "efptable stability - string.mid works after guest db open"
+    description: |
+      Verify string processor dispatch after opening a guest database.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      return string.mid("hello world", 7, 5)
+    expected_success: true
+    expected_result: "world"
+
+  - name: "efptable stability - string.length works after guest db open"
+    description: |
+      Verify string.length() dispatch after database loading.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      return string.length("test")
+    expected_success: true
+    expected_result: "4"
+
+  - name: "efptable stability - clock.now works after guest db open"
+    description: |
+      Verify clock processor dispatch after database loading.
+      clock.now() returns a date; we verify it's defined (non-nil).
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      return defined(clock.now())
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # SECTION 2: Processor dispatch after db.new (fresh database creation)
+  # ========================================================================
+  # Creating a new database exercises a different code path than opening
+  # an existing one. Verify processor dispatch is unaffected.
+
+  - name: "efptable stability - file.exists works after db.new"
+    description: |
+      Create a fresh database via db.new(), then verify file processor
+      dispatch still works. No db.close() — the process exits after each
+      test and the harness cleans up tmp files.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "test_efp_stability.root");
+      if file.exists(dbPath) {
+        file.delete(dbPath)};
+      db.new(dbPath);
+      return file.exists("/tmp")
+    expected_success: true
+    expected_result: "true"
+
+  - name: "efptable stability - string.mid works after db.new"
+    description: |
+      Create a fresh database via db.new(), then verify string processor
+      dispatch still works.
+    script: |
+      local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
+      local(dbPath = tmpDir + "/" + "test_efp_stability2.root");
+      if file.exists(dbPath) {
+        file.delete(dbPath)};
+      db.new(dbPath);
+      return string.mid("abcdef", 3, 2)
+    expected_success: true
+    expected_result: "cd"
+
+  # ========================================================================
+  # SECTION 3: Introspection stability after database operations
+  # ========================================================================
+  # parentOf() and defined() also depend on efptable resolution.
+  # Verify they work correctly after database state changes.
+
+  - name: "efptable stability - parentOf(string.mid) after guest db open"
+    description: |
+      Verify that parentOf() introspection returns database path (not
+      EFP internal path) after opening a guest database.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      return parentOf(string.mid)
+    expected_success: true
+    expected_result: "system.verbs.builtins.string"
+
+  - name: "efptable stability - defined(file.exists) after guest db open"
+    description: |
+      Verify defined() still resolves processor verbs after database loading.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath = sysdir + "StartupTasks.root");
+      if not file.exists(guestpath) {
+        return "skip"};
+      fileMenu.open(guestpath, true);
+      return defined(file.exists)
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # SECTION 4: Multiple database operations in sequence
+  # ========================================================================
+  # Open multiple databases in sequence and verify dispatch survives all of them.
+
+  - name: "efptable stability - dispatch survives multiple guest db opens"
+    description: |
+      Open two different guest databases in sequence, then verify
+      processor dispatch still works. Tests that repeated database
+      lifecycle operations don't degrade efptable state.
+    script: |
+      local (sysdir = file.folderFromPath(Frontier.getFilePath()));
+      local (guestpath1 = sysdir + "StartupTasks.root");
+      local (guestpath2 = sysdir + "test.root");
+      if not file.exists(guestpath1) {
+        return "skip"};
+      if not file.exists(guestpath2) {
+        return "skip"};
+      fileMenu.open(guestpath1, true);
+      fileMenu.open(guestpath2, true);
+      return string.length("cycle test")
+    expected_success: true
+    expected_result: "10"


### PR DESCRIPTION
## Summary

- Converts extern `hdlhashtable efptable` global to module-private static with `get_efptable()`/`set_efptable()` accessor functions
- Backward-compatible `#define efptable (get_efptable())` macro means all read sites unchanged
- Removes dead ADR-008 workaround code (`save_headless_efptable`, `get_headless_efptable`, `headless_efptable_original`)
- Marks ADR-008 as superseded

**This is the last P0 architecture launch blocker.** Closes #292.

## Design Rationale

Unlike `currenthashtable` (which varies per-thread), `efptable` is **shared, read-only state** — all threads use the same processor table, created once at startup. Making it per-thread would add complexity for no benefit.

Additionally, efptable is accessed during early bootstrap before `hthreadglobals` is initialized (same bootstrap constraint as `hashtablestack` — ADR-009). A TLS macro would crash during startup.

Static isolation with accessor functions:
- Eliminates the `extern` global (no more uncontrolled write access)
- No bootstrap risk (plain static, not thread-local)
- Stepping stone for future `system_context` struct migration

## Files Changed (4 production + 1 ADR)

| File | Change |
|------|--------|
| `Common/source/tablestructure.c` | Global → static + accessor functions, remove dead workaround |
| `Common/headers/tablestructure.h` | extern → accessor prototypes + compatibility macro |
| `Common/source/langstartup.c` | Fix 2 write sites to use `set_efptable()` |
| `Common/source/db_format.c` | Remove dead `save_headless_efptable()` call |
| `planning/.../ADR-008-*.md` | Mark as superseded |

## Test plan

- [x] Build: `make -C frontier-cli` — clean build, 0 errors
- [x] Unit tests: `./tools/run_headless_tests.sh` — 302/302 pass
- [x] Integration tests: `cd tests && make test-integration` — 1946/2200 pass (58 pre-existing failures, 0 new)
- [x] Smoke tests: `file.exists("/tmp")` → true, `string.mid("hello", 2, 3)` → "ell", `parentOf(string.mid)` → "system.verbs.builtins.string"
- [x] Verify no remaining extern: `grep -rn 'extern.*efptable[^_]'` shows only accessor prototypes and `nameefptable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)