### PR TITLE
feat: YAML-level metadata flags for integration test runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,8 @@ Use those rules as mandatory baseline guidance.
 Cross-agent test requirements (including integration test expectations for verb changes) now live in `docs/AI_SHARED_GUIDELINES.md`.
 For Frontier-specific test patterns and command details, also see `docs/TESTING_GUIDE.md`.
 
+**Integration test file metadata**: New test files that open guest databases must set `needs_guest_dbs: true` at the YAML root level. Tests with port conflicts or REPL dependencies must set `sequential: true`. See `docs/TESTING_GUIDE.md` "File-Level Metadata" for details.
+
 ---
 
 ## Architectural Anti-Patterns

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -93,6 +93,16 @@ Minimum expectations:
 - Cleanup of `system.temp` objects is unnecessary (the table is non-persistent and recreated fresh each run), but acceptable for clarity.
 - **NEVER use `new(tableType, @workspace)` or `new(tableType, @workspace.something)`** — this creates persistent tables in workspace that pollute the database across test runs and cause flaky tests. Always use `new(tableType, @system.temp.something)` instead.
 
+### Integration test parallel/sequential rules
+
+The test runner executes YAML files across parallel workers by default. Some tests need special treatment — use file-level YAML metadata flags:
+
+- **`sequential: true`** — Required when tests bind to TCP/UDP ports, use REPL stdin (`interactive_steps`), or depend on process-level side effects between tests in the same file.
+- **`needs_guest_dbs: true`** — Required when tests call `fileMenu.open()` to open guest databases, or reference sibling `.root` files relative to `Frontier.getFilePath()`.
+- **`protocol_mode: false`** — Required when tests may block waiting for UI interaction or need a fresh process per test case.
+
+See `docs/TESTING_GUIDE.md` "File-Level Metadata" for full documentation.
+
 ## ODB Script Editing
 
 When modifying UserTalk scripts in `.root` databases, follow `docs/ODB_SCRIPT_EDITING.md`. Key rules:

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -220,6 +220,25 @@ tests:
 - `timeout`: Per-test timeout in seconds (default: 10)
 - `description`: Human-readable test description
 
+### File-Level Metadata
+
+Test YAML files support optional top-level keys that control how the runner executes them. These go at the root of the YAML file, before the `tests:` array:
+
+```yaml
+sequential: true       # Run in main process, not parallel worker
+needs_guest_dbs: true  # Copy sibling .root files + Guest Databases/ to worker
+
+tests:
+  - name: "my test"
+    script: '...'
+```
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `sequential` | `false` | When `true`, file runs in the main process sequentially (not in a parallel worker). Use for tests with port conflicts, shared resources, or REPL stdin dependencies. |
+| `needs_guest_dbs` | `false` | When `true`, the runner copies sibling `.root` files and `Guest Databases/` into the worker's temp directory. Use for tests that call `fileMenu.open()` or reference paths relative to `Frontier.getFilePath()`. |
+| `protocol_mode` | `true` | When `false`, the runner skips the NDJSON protocol executor and spawns a new process per test. Use for tests that block or need special process behavior. |
+
 ### Test Path Placeholders
 
 For portable file path handling in test scripts, use the `{FRONTIER_TEST_TMP_DIR}` placeholder instead of hardcoded paths:

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2227 tests: 2031 pass (91%) 196 skip (8%)</title>
-    <dateCreated>Thu, 16 Apr 2026 06:57:16 GMT</dateCreated>
+    <dateCreated>Thu, 16 Apr 2026 07:25:55 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-16 at 06:57 UTC"/>
-      <outline text="Results: 1955 passed (89%), 196 skipped (9%), 58 failed (3%)"/>
-      <outline text="Duration: 35.2s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-04-16 at 07:24 UTC"/>
+      <outline text="Results: 1974 passed (89%), 196 skipped (9%), 39 failed (2%)"/>
+      <outline text="Duration: 38.6s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2227 tests (2031 active, 196 marked skip) across 66 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -587,9 +587,11 @@ class ProtocolExecutor:
 # These sets are kept as fallback for files that haven't been updated yet.
 SEQUENTIAL_TEST_FILES = {
     'tcp_verbs_network.yaml',
-    'webserver_verbs.yaml',
     'dialog_verbs.yaml',
     'file_dialog_verbs.yaml',
+    # Note: webserver_verbs.yaml was listed here but never existed.
+    # webserver_hello_world.yaml and webserver_http_roundtrip_tests.yaml
+    # now use the sequential: true YAML flag instead.
 }
 
 NON_PROTOCOL_TEST_FILES = {
@@ -612,7 +614,7 @@ def load_file_metadata(yaml_path: str) -> dict:
       protocol_mode: bool   - Use NDJSON protocol executor (default: true)
     """
     try:
-        with open(yaml_path) as f:
+        with open(yaml_path, encoding='utf-8') as f:
             data = yaml.safe_load(f)
         if not isinstance(data, dict):
             return {}
@@ -621,7 +623,9 @@ def load_file_metadata(yaml_path: str) -> dict:
             'needs_guest_dbs': data.get('needs_guest_dbs', False),
             'protocol_mode': data.get('protocol_mode', True),
         }
-    except Exception:
+    except yaml.YAMLError as e:
+        print(f"Warning: failed to parse YAML metadata from {yaml_path}: {e}",
+              file=sys.stderr)
         return {}
 
 

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -582,18 +582,47 @@ class ProtocolExecutor:
         return self._proc is not None and self._proc.poll() is None
 
 
-# Test files that must run sequentially (port conflicts or shared resources)
+# Deprecated: Hardcoded per-file behavior sets.
+# Prefer YAML-level metadata flags (sequential, needs_guest_dbs, protocol_mode).
+# These sets are kept as fallback for files that haven't been updated yet.
 SEQUENTIAL_TEST_FILES = {
     'tcp_verbs_network.yaml',
     'webserver_verbs.yaml',
-    'dialog_verbs.yaml',        # REPL stdin piping is fragile under parallel workers
-    'file_dialog_verbs.yaml',   # REPL stdin piping is fragile under parallel workers
+    'dialog_verbs.yaml',
+    'file_dialog_verbs.yaml',
 }
 
-# Test files that should NOT use protocol mode (they hang or need special process behavior)
 NON_PROTOCOL_TEST_FILES = {
-    'window_verbs.yaml',      # window verbs may block waiting for UI interaction
+    'window_verbs.yaml',
 }
+
+# Legacy set — replaced by needs_guest_dbs YAML flag.
+NEEDS_GUEST_DBS = {
+    'guest_db_externals.yaml',
+    'efptable_stability.yaml',
+}
+
+
+def load_file_metadata(yaml_path: str) -> dict:
+    """Read file-level metadata from a YAML test file.
+
+    Supported keys (all optional):
+      sequential: bool      - Run in main process, not parallel worker (default: false)
+      needs_guest_dbs: bool - Copy sibling .root files + Guest Databases/ to worker (default: false)
+      protocol_mode: bool   - Use NDJSON protocol executor (default: true)
+    """
+    try:
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {
+            'sequential': data.get('sequential', False),
+            'needs_guest_dbs': data.get('needs_guest_dbs', False),
+            'protocol_mode': data.get('protocol_mode', True),
+        }
+    except Exception:
+        return {}
 
 
 def _is_protocol_compatible(test: 'TestCase') -> bool:
@@ -651,6 +680,9 @@ def _run_file_worker(args: tuple) -> dict:
     """
     yaml_path, cli_path, system_root, test_root_dir, protocol_batch, verbose, worker_id = args
 
+    # Load file-level metadata (sequential, needs_guest_dbs, protocol_mode)
+    meta = load_file_metadata(yaml_path)
+
     # Set up per-worker temp dir
     worker_tmp = os.path.join(test_root_dir, 'tmp', 'integration', f'worker_{worker_id}')
     os.makedirs(worker_tmp, exist_ok=True)
@@ -665,11 +697,9 @@ def _run_file_worker(args: tuple) -> dict:
         worker_system_root = worker_db_path
 
         # Copy sibling .root files and Guest Databases/ for tests that
-        # open guest databases. Files that use fileMenu.open() or reference
-        # paths relative to Frontier.getFilePath() need these alongside the
-        # copied system root.
-        NEEDS_GUEST_DBS = {'guest_db_externals.yaml', 'efptable_stability.yaml'}
-        if os.path.basename(yaml_path) in NEEDS_GUEST_DBS:
+        # open guest databases. Controlled by needs_guest_dbs YAML flag
+        # (with hardcoded NEEDS_GUEST_DBS set as deprecated fallback).
+        if meta.get('needs_guest_dbs', False) or os.path.basename(yaml_path) in NEEDS_GUEST_DBS:
             src_dir = os.path.dirname(system_root)
             # Copy sibling .root files (StartupTasks.root, test.root, etc.)
             for sibling in os.listdir(src_dir):
@@ -690,7 +720,8 @@ def _run_file_worker(args: tuple) -> dict:
     try:
         file_name = Path(yaml_path).name
         executor = None
-        if protocol_batch and file_name not in NON_PROTOCOL_TEST_FILES:
+        use_protocol = meta.get('protocol_mode', True) and file_name not in NON_PROTOCOL_TEST_FILES
+        if protocol_batch and use_protocol:
             executor = ProtocolExecutor(cli_path, worker_system_root)
             try:
                 executor.start()
@@ -1508,7 +1539,8 @@ def main():
     parallel_files = []
     for f in valid_files:
         basename = Path(f).name
-        if basename in SEQUENTIAL_TEST_FILES:
+        meta = load_file_metadata(f)
+        if meta.get('sequential', False) or basename in SEQUENTIAL_TEST_FILES:
             sequential_files.append(f)
         else:
             parallel_files.append(f)

--- a/tests/integration/test_cases/dialog_verbs.yaml
+++ b/tests/integration/test_cases/dialog_verbs.yaml
@@ -1,3 +1,5 @@
+sequential: true  # REPL stdin piping is fragile under parallel workers
+
 # Dialog Verb Integration Tests
 #
 # Tests for dialog verbs in both interactive (PTY) and batch modes.

--- a/tests/integration/test_cases/efptable_stability.yaml
+++ b/tests/integration/test_cases/efptable_stability.yaml
@@ -1,3 +1,5 @@
+needs_guest_dbs: true  # Opens StartupTasks.root, test.root via fileMenu.open
+
 # Integration tests for efptable stability across database operations
 #
 # CONTEXT: Issue #292 — efptable refactored from extern global to module-private

--- a/tests/integration/test_cases/file_dialog_verbs.yaml
+++ b/tests/integration/test_cases/file_dialog_verbs.yaml
@@ -1,3 +1,5 @@
+sequential: true  # REPL stdin piping is fragile under parallel workers
+
 # File Dialog Verb Integration Tests
 #
 # Phase 1: File dialog verbs reject in non-interactive mode (batch)

--- a/tests/integration/test_cases/guest_db_externals.yaml
+++ b/tests/integration/test_cases/guest_db_externals.yaml
@@ -1,3 +1,5 @@
+needs_guest_dbs: true  # Opens mainResponder.root, StartupTasks.root via fileMenu.open
+
 # Integration tests for guest database external loading
 #
 # These tests verify that non-table external types (scripts, outlines, WP text)

--- a/tests/integration/test_cases/tcp_verbs_network.yaml
+++ b/tests/integration/test_cases/tcp_verbs_network.yaml
@@ -1,3 +1,5 @@
+sequential: true  # Port conflicts between parallel workers
+
 # Integration tests for TCP Phase 1A - Client Networking Verbs
 # All tests are self-contained using localhost (tcp.listenStream + tcp.openStream/openAddrStream)
 # No external network dependencies.

--- a/tests/integration/test_cases/webserver_hello_world.yaml
+++ b/tests/integration/test_cases/webserver_hello_world.yaml
@@ -1,3 +1,5 @@
+sequential: true  # Binds to TCP port — conflicts between parallel workers
+
 # Integration tests for Webserver Hello World
 # Tests the complete webserver stack end-to-end using the built-in helloWorld responder
 #

--- a/tests/integration/test_cases/webserver_http_roundtrip_tests.yaml
+++ b/tests/integration/test_cases/webserver_http_roundtrip_tests.yaml
@@ -1,3 +1,5 @@
+sequential: true  # Binds to TCP port — conflicts between parallel workers
+
 # Integration tests for Webserver HTTP Round-Trip (Gap #9)
 #
 # Tests the HTTP request -> server dispatch -> responder -> HTTP response path.

--- a/tests/integration/test_cases/window_verbs.yaml
+++ b/tests/integration/test_cases/window_verbs.yaml
@@ -1,3 +1,5 @@
+protocol_mode: false  # Window verbs may block waiting for UI interaction
+
 # Integration tests for window.isOpen() in headless mode
 #
 # window.isOpen(x) checks if a database "window" is open. In headless mode,


### PR DESCRIPTION
## Summary

- Adds file-level YAML metadata flags (`sequential`, `needs_guest_dbs`, `protocol_mode`) to control how the parallel test runner executes each test file
- Replaces three hardcoded Python sets (`SEQUENTIAL_TEST_FILES`, `NEEDS_GUEST_DBS`, `NON_PROTOCOL_TEST_FILES`) with data-driven YAML flags
- Documents the flags in TESTING_GUIDE.md, AI_SHARED_GUIDELINES.md, and CLAUDE.md

**Bonus**: Moving flaky tests to sequential execution reduced pre-existing failures from 58 to 39 (19 fewer failures).

## Design

```yaml
# File-level metadata (all optional)
sequential: true        # run in main process, not parallel worker
needs_guest_dbs: true   # copy sibling .root files + Guest Databases/
protocol_mode: false    # skip NDJSON protocol, spawn per-process

tests:
  - name: "my test"
    script: "..."
```

## Files Updated

| File | Flag Added |
|------|-----------|
| `tcp_verbs_network.yaml` | `sequential: true` |
| `dialog_verbs.yaml` | `sequential: true` |
| `file_dialog_verbs.yaml` | `sequential: true` |
| `webserver_hello_world.yaml` | `sequential: true` |
| `webserver_http_roundtrip_tests.yaml` | `sequential: true` |
| `guest_db_externals.yaml` | `needs_guest_dbs: true` |
| `efptable_stability.yaml` | `needs_guest_dbs: true` |
| `window_verbs.yaml` | `protocol_mode: false` |

## Test plan

- [x] Build: `make -C frontier-cli` — clean
- [x] Integration tests: 2209 total, 1974 passed, 39 failed (down from 58)
- [x] efptable_stability.yaml: 9/9 pass (uses needs_guest_dbs flag)
- [x] guest_db_externals.yaml: 11/11 pass (uses needs_guest_dbs flag)
- [x] Doc validation hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)