### PR TITLE
fix: op.insert normalizes LF/CRLF to CR before outline split

### DIFF
--- a/Common/headers/opinternal.h
+++ b/Common/headers/opinternal.h
@@ -259,6 +259,8 @@ extern void opdisposeoutline (hdloutlinerecord, boolean);
 
 extern boolean optexttooutline (hdloutlinerecord, Handle, hdlheadrecord *);
 
+extern boolean opnormalizelineendings_cr (Handle htext); /*CRLF and bare LF -> CR; caller must own htext*/
+
 extern boolean opemptysummit (hdlheadrecord);
 
 extern boolean opemptyoutlinerecord (hdloutlinerecord);

--- a/Common/source/opstructure.c
+++ b/Common/source/opstructure.c
@@ -2604,12 +2604,89 @@ boolean opcut (void) {
 
 
 
-boolean isoutlinetext (Handle htext) {
-	
+boolean opnormalizelineendings_cr (Handle htext) {
+
 	/*
-	return true if the text represents a multiple headline 
+	Normalize line endings in htext IN PLACE to CR-only:
+	  CRLF (\r\n)  -> CR (\r)
+	  bare LF (\n) -> CR (\r)
+	  bare CR (\r) unchanged
+
+	op.insert uses CR as the canonical outline node separator, so input
+	with modern (LF-only) or Windows (CRLF) endings must be converged to
+	CR before isoutlinetext() decides whether to split.
+
+	Callers MUST pass a handle they own (copy the input first if it was
+	borrowed — see opinserthandle_ctx).
+
+	Returns false only if the final sethandlesize() fails; the in-place
+	byte rewrite itself cannot fail.
+
+	This is the outline-side analogue of wpnormalizelineendings (wpengine.c),
+	which normalizes to CRLF for the WP/paige engine.
+	*/
+
+	long srclen = gethandlesize (htext);
+	long src, dst = 0;
+	byte chlast = 0; /*previous SOURCE byte — NOT previous output byte*/
+	byte *p;
+
+	if (srclen == 0)
+		return (true);
+
+	p = (byte *) *htext;
+
+	for (src = 0; src < srclen; ++src) {
+
+		byte ch = p [src];
+
+		if (ch == chlinefeed) {
+
+			/*
+			LF after CR in the SOURCE (CRLF pair): drop the LF — the
+			CR has already been written at dst-1.
+
+			Bare LF (including LF after a previously-normalized LF
+			such as "\n\n"): rewrite as CR.
+
+			IMPORTANT: track the previous SOURCE byte via chlast, not
+			the previous OUTPUT byte via p[dst-1]. After we rewrite a
+			bare LF to CR, p[dst-1] will equal chreturn, and using
+			that to gate the "is this a CRLF tail?" check would
+			incorrectly drop subsequent bare LFs (e.g. blank lines
+			represented as consecutive LFs in Unix source files).
+
+			This mirrors wpnormalizelineendings in wpengine.c, which
+			uses the same chlast-on-source pattern.
+			*/
+
+			if (chlast == chreturn) {
+				chlast = ch;
+				continue; /*drop LF; preserve source-level chlast*/
+				}
+
+			p [dst++] = chreturn;
+			chlast = ch;
+			continue;
+			}
+
+		p [dst++] = ch;
+		chlast = ch;
+		}
+
+	if (dst < srclen)
+		return (sethandlesize (htext, dst));
+
+	return (true);
+	} /*opnormalizelineendings_cr*/
+
+
+boolean isoutlinetext (Handle htext) {
+
+	/*
+	return true if the text represents a multiple headline
 	outline, false if it is just flat text
-	
+
 	2.1b9 dmb: broke out this snippet so it can be shared
 
 	6.0a1 dmb: fat headlines can be > lenbigstring

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -1770,6 +1770,7 @@ boolean opinserthandle_ctx (op_context_t *ctx, Handle htext, tydirection dir) {
 	register boolean fl;
 	hdlheadrecord hnode;
 	boolean floutline;
+	Handle hnorm; /*owned local copy of htext with normalized line endings*/
 
 	hbarcursor = (**ho).hbarcursor; /*copy into register*/
 
@@ -1785,11 +1786,30 @@ boolean opinserthandle_ctx (op_context_t *ctx, Handle htext, tydirection dir) {
 		dir = down;
 		}
 
+	/*
+	Normalize line endings on an owned local copy BEFORE isoutlinetext
+	decides the path. Input htext is borrowed — never mutate it.
+	CRLF and bare LF both converge to CR so the outline splitter works
+	correctly for .ut files read with file.readWholeFile (modern LF-only
+	endings). See opnormalizelineendings_cr in opstructure.c.
+	*/
+	if (!copyhandle (htext, &hnorm))
+		return (false);
+
+	if (!opnormalizelineendings_cr (hnorm)) {
+		disposehandle (hnorm);
+		return (false);
+		}
+
+	htext = hnorm; /*shadow the parameter; caller's handle untouched*/
+
 	floutline = isoutlinetext (htext);
 
 	if (floutline)
-		if (!optexttooutline (ho, htext, &hnode))
+		if (!optexttooutline (ho, htext, &hnode)) {
+			disposehandle (hnorm);
 			return (false);
+			}
 
 	if (dir == right) { /*maybe we need to expand?*/
 
@@ -1803,10 +1823,19 @@ boolean opinserthandle_ctx (op_context_t *ctx, Handle htext, tydirection dir) {
 
 		if (!fl)
 			opdisposestructure (hnode, false);
+
+		disposehandle (hnorm); /*optexttooutline copied data out; free normalized buffer*/
 		}
 	else {
 
+		/*
+		Flat-text path: opinsertheadline consumes its handle. Copy the
+		normalized buffer and hand the copy to opinsertheadline; dispose
+		our normalized intermediate either way.
+		*/
 		fl = copyhandle (htext, &htext);
+
+		disposehandle (hnorm); /*free normalized intermediate*/
 
 		if (fl)
 			fl = opinsertheadline (htext, dir, false);

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2238 tests: 2004 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Sat, 18 Apr 2026 08:53:00 GMT</dateCreated>
+    <dateCreated>Sat, 18 Apr 2026 09:03:07 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-18 at 08:52 UTC"/>
-      <outline text="Results: 11 passed (100%), 0 skipped (0%), 0 failed (0%)"/>
-      <outline text="Duration: 0.1s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-04-18 at 09:03 UTC"/>
+      <outline text="Results: 1967 passed (89%), 234 skipped (11%), 19 failed (1%)"/>
+      <outline text="Duration: 31.5s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2238 tests (2004 active, 234 marked skip) across 67 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 2227 tests: 1993 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Thu, 16 Apr 2026 07:48:18 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2237 tests: 2003 pass (89%) 234 skip (10%)</title>
+    <dateCreated>Sat, 18 Apr 2026 08:28:15 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-16 at 07:44 UTC"/>
-      <outline text="Results: 1975 passed (89%), 234 skipped (11%), 0 failed (0%)"/>
-      <outline text="Duration: 34.8s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 2227 tests (1993 active, 234 marked skip) across 66 categories"/>
+      <outline text="Run: 2026-04-18 at 08:25 UTC"/>
+      <outline text="Results: 1966 passed (89%), 234 skipped (11%), 19 failed (1%)"/>
+      <outline text="Duration: 32.2s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 2237 tests (2003 active, 234 marked skip) across 67 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
@@ -39,6 +39,7 @@
     <outline text="Menu Value Copy (menu_value_copy) - 5 tests: 4 pass (80%) 1 skip (20%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/menu_value_copy.opml"/>
     <outline text="Migration Externals (migration_externals) - 19 tests: 16 pass (84%) 3 skip (15%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/migration_externals.opml"/>
     <outline text="Nested Parentof (nested_parentof) - 18 tests: 13 pass (72%) 5 skip (27%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/nested_parentof.opml"/>
+    <outline text="Op Insert Line Endings (op_insert_line_endings) - 10 tests: 10 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_insert_line_endings.opml"/>
     <outline text="Op Outlinetoxml Headless (op_outlinetoxml_headless) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_outlinetoxml_headless.opml"/>
     <outline text="Op Verbs (op_verbs) - 266 tests: 254 pass (95%) 12 skip (4%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_verbs.opml"/>
     <outline text="Opattributes Verbs (opattributes_verbs) - 7 tests: 0 pass (0%) 7 skip (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/opattributes_verbs.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 2237 tests: 2003 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Sat, 18 Apr 2026 08:28:15 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2238 tests: 2004 pass (89%) 234 skip (10%)</title>
+    <dateCreated>Sat, 18 Apr 2026 08:53:00 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-18 at 08:25 UTC"/>
-      <outline text="Results: 1966 passed (89%), 234 skipped (11%), 19 failed (1%)"/>
-      <outline text="Duration: 32.2s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 2237 tests (2003 active, 234 marked skip) across 67 categories"/>
+      <outline text="Run: 2026-04-18 at 08:52 UTC"/>
+      <outline text="Results: 11 passed (100%), 0 skipped (0%), 0 failed (0%)"/>
+      <outline text="Duration: 0.1s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 2238 tests (2004 active, 234 marked skip) across 67 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
@@ -39,7 +39,7 @@
     <outline text="Menu Value Copy (menu_value_copy) - 5 tests: 4 pass (80%) 1 skip (20%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/menu_value_copy.opml"/>
     <outline text="Migration Externals (migration_externals) - 19 tests: 16 pass (84%) 3 skip (15%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/migration_externals.opml"/>
     <outline text="Nested Parentof (nested_parentof) - 18 tests: 13 pass (72%) 5 skip (27%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/nested_parentof.opml"/>
-    <outline text="Op Insert Line Endings (op_insert_line_endings) - 10 tests: 10 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_insert_line_endings.opml"/>
+    <outline text="Op Insert Line Endings (op_insert_line_endings) - 11 tests: 11 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_insert_line_endings.opml"/>
     <outline text="Op Outlinetoxml Headless (op_outlinetoxml_headless) - 15 tests: 15 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_outlinetoxml_headless.opml"/>
     <outline text="Op Verbs (op_verbs) - 266 tests: 254 pass (95%) 12 skip (4%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/op_verbs.opml"/>
     <outline text="Opattributes Verbs (opattributes_verbs) - 7 tests: 0 pass (0%) 7 skip (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/opattributes_verbs.opml"/>

--- a/reports/integration_tests/op_insert_line_endings.opml
+++ b/reports/integration_tests/op_insert_line_endings.opml
@@ -1,0 +1,196 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Op Insert Line Endings (op_insert_line_endings) - 10 tests: 10 pass (100%)</title>
+    <dateCreated>Sat, 18 Apr 2026 08:28:15 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="op.insert line endings - CR splits into multiple nodes (baseline) - CR is the canonical node separator and must produce a multi-node outline">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.cr_baseline)"/>
+        <outline text="target.set (@system.temp.cr_baseline)"/>
+        <outline text="op.insert (&quot;line1\rline2\rline3&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n2 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n3 = op.getLineText ())"/>
+        <outline text="return (summits == 3) and (n1 == &quot;line1&quot;) and (n2 == &quot;line2&quot;) and (n3 == &quot;line3&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - LF-only splits into multiple nodes - LF-only input (Unix line endings) must be normalized to CR and split into separate nodes, not collapsed into a single flat node with literal LF bytes">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.lf_only)"/>
+        <outline text="target.set (@system.temp.lf_only)"/>
+        <outline text="op.insert (&quot;line1\nline2\nline3&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n2 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n3 = op.getLineText ())"/>
+        <outline text="return (summits == 3) and (n1 == &quot;line1&quot;) and (n2 == &quot;line2&quot;) and (n3 == &quot;line3&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - CRLF splits into multiple nodes - CRLF input (Windows line endings) must be normalized to CR and split into separate nodes; the LF after CR must not appear as a literal byte">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.crlf)"/>
+        <outline text="target.set (@system.temp.crlf)"/>
+        <outline text="op.insert (&quot;line1\r\nline2\r\nline3&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n2 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n3 = op.getLineText ())"/>
+        <outline text="return (summits == 3) and (n1 == &quot;line1&quot;) and (n2 == &quot;line2&quot;) and (n3 == &quot;line3&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - mixed CR/LF/CRLF splits cleanly - Text with a mix of CR, LF, and CRLF separators must all be normalized to single-CR boundaries">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.mixed)"/>
+        <outline text="target.set (@system.temp.mixed)"/>
+        <outline text="op.insert (&quot;a\rb\nc\r\nd&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n2 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n3 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n4 = op.getLineText ())"/>
+        <outline text="return (summits == 4) and (n1 == &quot;a&quot;) and (n2 == &quot;b&quot;) and (n3 == &quot;c&quot;) and (n4 == &quot;d&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - single line with no separator is one node - Flat text with no line-ending characters must still insert as a single node (behavior unchanged by the fix)">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.flat)"/>
+        <outline text="target.set (@system.temp.flat)"/>
+        <outline text="op.insert (&quot;just one line&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="return (summits == 1) and (n1 == &quot;just one line&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - LF-only produces clean nodes with no embedded LF bytes - After LF-only insert, the resulting node text must NOT contain literal LF bytes - the whole point of the fix. sizeOf of first node must be exactly 5 (length of 'hello').">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.noleak)"/>
+        <outline text="target.set (@system.temp.noleak)"/>
+        <outline text="op.insert (&quot;hello\nworld&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="return (sizeOf (n1) == 5) and (n1 == &quot;hello&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - trailing LF does not create empty node - Input ending with LF must not produce a trailing empty node (the final line terminator is consumed, not turned into an empty line)">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.trailing)"/>
+        <outline text="target.set (@system.temp.trailing)"/>
+        <outline text="op.insert (&quot;line1\nline2\n&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="return (summits == 2)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - consecutive LFs preserve blank nodes - Two consecutive bare LFs (Unix blank line) must produce an empty node between them, not collapse into a single separator">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.blanklf)"/>
+        <outline text="target.set (@system.temp.blanklf)"/>
+        <outline text="op.insert (&quot;a\n\nb&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n2 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n3 = op.getLineText ())"/>
+        <outline text="return (summits == 3) and (n1 == &quot;a&quot;) and (n2 == &quot;&quot;) and (n3 == &quot;b&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - CRLF followed by bare LF preserves blank - a\r\n\nb must produce 3 nodes — CRLF ends first line, bare LF starts an empty second line, b begins the third">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.crlflf)"/>
+        <outline text="target.set (@system.temp.crlflf)"/>
+        <outline text="op.insert (&quot;a\r\n\nb&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n2 = op.getLineText ())"/>
+        <outline text="op.go (down, 1)"/>
+        <outline text="local (n3 = op.getLineText ())"/>
+        <outline text="return (summits == 3) and (n1 == &quot;a&quot;) and (n2 == &quot;&quot;) and (n3 == &quot;b&quot;)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - simulated .ut-file install via raw op.insert - Simulates the scenario that originally surfaced the bug: read a source file containing LF-only newlines and pass it straight to op.insert. Tab-indented lines become child nodes (standard outliner behavior). Pre-fix this produced a single flat node with literal \n bytes.">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.utsim)"/>
+        <outline text="target.set (@system.temp.utsim)"/>
+        <outline text="local (src = &quot;on greet () {\n\treturn (\&quot;hi\&quot;)}&quot;)"/>
+        <outline text="op.insert (src, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="local (n1 = op.getLineText ())"/>
+        <outline text="op.expand (infinity)"/>
+        <outline text="op.go (right, 1)"/>
+        <outline text="local (child1 = op.getLineText ())"/>
+        <outline text="return (summits == 1) and (n1 == &quot;on greet () {&quot;) and (child1 == &quot;return (\&quot;hi\&quot;)}&quot;)"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/op_insert_line_endings.opml
+++ b/reports/integration_tests/op_insert_line_endings.opml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Op Insert Line Endings (op_insert_line_endings) - 10 tests: 10 pass (100%)</title>
-    <dateCreated>Sat, 18 Apr 2026 08:28:15 GMT</dateCreated>
+    <title>Op Insert Line Endings (op_insert_line_endings) - 11 tests: 11 pass (100%)</title>
+    <dateCreated>Sat, 18 Apr 2026 08:52:59 GMT</dateCreated>
   </head>
   <body>
     <outline text="op.insert line endings - CR splits into multiple nodes (baseline) - CR is the canonical node separator and must produce a multi-node outline">
@@ -126,6 +126,20 @@
         <outline text="lang.new (outlineType, @system.temp.trailing)"/>
         <outline text="target.set (@system.temp.trailing)"/>
         <outline text="op.insert (&quot;line1\nline2\n&quot;, down)"/>
+        <outline text="op.firstSummit ()"/>
+        <outline text="op.deleteLine ()"/>
+        <outline text="local (summits = op.countSummits ())"/>
+        <outline text="return (summits == 2)"/>
+      </outline>
+    </outline>
+    <outline text="op.insert line endings - trailing CRLF does not create empty node - Input ending with CRLF must behave the same as trailing LF and trailing CR — no spurious empty trailing node">
+      <outline text="Metadata">
+        <outline text="expected_result: true"/>
+      </outline>
+      <outline text="Script">
+        <outline text="lang.new (outlineType, @system.temp.trailingcrlf)"/>
+        <outline text="target.set (@system.temp.trailingcrlf)"/>
+        <outline text="op.insert (&quot;line1\r\nline2\r\n&quot;, down)"/>
         <outline text="op.firstSummit ()"/>
         <outline text="op.deleteLine ()"/>
         <outline text="local (summits = op.countSummits ())"/>

--- a/tests/integration/test_cases/op_insert_line_endings.yaml
+++ b/tests/integration/test_cases/op_insert_line_endings.yaml
@@ -166,6 +166,24 @@ tests:
     expected_result: "true"
 
   # ========================================================================
+  # Trailing CRLF - symmetric to trailing LF. CRLF normalizes to CR, then
+  # the trailing CR behaves like any other trailing separator.
+  # ========================================================================
+
+  - name: "op.insert line endings - trailing CRLF does not create empty node"
+    description: "Input ending with CRLF must behave the same as trailing LF and trailing CR — no spurious empty trailing node"
+    script: |
+      lang.new (outlineType, @system.temp.trailingcrlf);
+      target.set (@system.temp.trailingcrlf);
+      op.insert ("line1\r\nline2\r\n", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      return (summits == 2)
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
   # Consecutive LFs - blank lines must be preserved as empty nodes.
   # Guards against a subtle CRLF-detection bug: if the algorithm checks
   # the OUTPUT buffer (p[dst-1]) rather than tracking the previous SOURCE

--- a/tests/integration/test_cases/op_insert_line_endings.yaml
+++ b/tests/integration/test_cases/op_insert_line_endings.yaml
@@ -1,0 +1,241 @@
+# Integration tests for op.insert line-ending normalization
+#
+# BUG: op.insert did not normalize LF (Unix) or CRLF (Windows) line endings
+# to CR (the canonical outline node separator). Text read from modern-editor-
+# written files (LF-only) or Windows-written files (CRLF) was inserted as a
+# single flat node with literal \n bytes instead of being split into multiple
+# nodes. This broke UserTalk verbs that read .ut source files and installed
+# them via op.insert (e.g., script.newScriptObject from file.readWholeFile).
+#
+# FIX: opinserthandle_ctx now normalizes CRLF -> CR and bare LF -> CR on a
+# local copy of the input handle BEFORE isoutlinetext() is checked. Callers'
+# handles are never modified.
+#
+# UserTalk note: there is no char() builtin; we use the \r and \n escape
+# sequences directly in string literals (both work inside double-quoted
+# strings). \r == CR == ASCII 13, \n == LF == ASCII 10.
+
+tests:
+  # ========================================================================
+  # Baseline: CR-only (the canonical format - must still work unchanged)
+  # ========================================================================
+
+  - name: "op.insert line endings - CR splits into multiple nodes (baseline)"
+    description: "CR is the canonical node separator and must produce a multi-node outline"
+    script: |
+      lang.new (outlineType, @system.temp.cr_baseline);
+      target.set (@system.temp.cr_baseline);
+      op.insert ("line1\rline2\rline3", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.go (down, 1);
+      local (n2 = op.getLineText ());
+      op.go (down, 1);
+      local (n3 = op.getLineText ());
+      return (summits == 3) and (n1 == "line1") and (n2 == "line2") and (n3 == "line3")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # LF-only (Unix / modern editors) - the primary bug case
+  # ========================================================================
+
+  - name: "op.insert line endings - LF-only splits into multiple nodes"
+    description: "LF-only input (Unix line endings) must be normalized to CR and split into separate nodes, not collapsed into a single flat node with literal LF bytes"
+    script: |
+      lang.new (outlineType, @system.temp.lf_only);
+      target.set (@system.temp.lf_only);
+      op.insert ("line1\nline2\nline3", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.go (down, 1);
+      local (n2 = op.getLineText ());
+      op.go (down, 1);
+      local (n3 = op.getLineText ());
+      return (summits == 3) and (n1 == "line1") and (n2 == "line2") and (n3 == "line3")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # CRLF (Windows) - the secondary bug case
+  # ========================================================================
+
+  - name: "op.insert line endings - CRLF splits into multiple nodes"
+    description: "CRLF input (Windows line endings) must be normalized to CR and split into separate nodes; the LF after CR must not appear as a literal byte"
+    script: |
+      lang.new (outlineType, @system.temp.crlf);
+      target.set (@system.temp.crlf);
+      op.insert ("line1\r\nline2\r\nline3", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.go (down, 1);
+      local (n2 = op.getLineText ());
+      op.go (down, 1);
+      local (n3 = op.getLineText ());
+      return (summits == 3) and (n1 == "line1") and (n2 == "line2") and (n3 == "line3")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Mixed line endings - pathological but must not corrupt
+  # Test body uses CR, then LF, then CRLF between four fields.
+  # ========================================================================
+
+  - name: "op.insert line endings - mixed CR/LF/CRLF splits cleanly"
+    description: "Text with a mix of CR, LF, and CRLF separators must all be normalized to single-CR boundaries"
+    script: |
+      lang.new (outlineType, @system.temp.mixed);
+      target.set (@system.temp.mixed);
+      op.insert ("a\rb\nc\r\nd", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.go (down, 1);
+      local (n2 = op.getLineText ());
+      op.go (down, 1);
+      local (n3 = op.getLineText ());
+      op.go (down, 1);
+      local (n4 = op.getLineText ());
+      return (summits == 4) and (n1 == "a") and (n2 == "b") and (n3 == "c") and (n4 == "d")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # No line endings - single insert must still be single node (unchanged)
+  # ========================================================================
+
+  - name: "op.insert line endings - single line with no separator is one node"
+    description: "Flat text with no line-ending characters must still insert as a single node (behavior unchanged by the fix)"
+    script: |
+      lang.new (outlineType, @system.temp.flat);
+      target.set (@system.temp.flat);
+      op.insert ("just one line", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      return (summits == 1) and (n1 == "just one line")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Node bytes - verify no LF bytes leak into node text
+  # ========================================================================
+
+  - name: "op.insert line endings - LF-only produces clean nodes with no embedded LF bytes"
+    description: "After LF-only insert, the resulting node text must NOT contain literal LF bytes - the whole point of the fix. sizeOf of first node must be exactly 5 (length of 'hello')."
+    script: |
+      lang.new (outlineType, @system.temp.noleak);
+      target.set (@system.temp.noleak);
+      op.insert ("hello\nworld", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      return (sizeOf (n1) == 5) and (n1 == "hello")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Trailing LF - must not produce a spurious empty trailing node
+  # ========================================================================
+
+  - name: "op.insert line endings - trailing LF does not create empty node"
+    description: "Input ending with LF must not produce a trailing empty node (the final line terminator is consumed, not turned into an empty line)"
+    script: |
+      lang.new (outlineType, @system.temp.trailing);
+      target.set (@system.temp.trailing);
+      op.insert ("line1\nline2\n", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      return (summits == 2)
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Consecutive LFs - blank lines must be preserved as empty nodes.
+  # Guards against a subtle CRLF-detection bug: if the algorithm checks
+  # the OUTPUT buffer (p[dst-1]) rather than tracking the previous SOURCE
+  # byte, the second LF in "a\n\nb" gets incorrectly dropped because
+  # dst-1 holds a freshly-written CR from the first LF's rewrite.
+  # ========================================================================
+
+  - name: "op.insert line endings - consecutive LFs preserve blank nodes"
+    description: "Two consecutive bare LFs (Unix blank line) must produce an empty node between them, not collapse into a single separator"
+    script: |
+      lang.new (outlineType, @system.temp.blanklf);
+      target.set (@system.temp.blanklf);
+      op.insert ("a\n\nb", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.go (down, 1);
+      local (n2 = op.getLineText ());
+      op.go (down, 1);
+      local (n3 = op.getLineText ());
+      return (summits == 3) and (n1 == "a") and (n2 == "") and (n3 == "b")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # CRLF followed by bare LF - another guard against the same bug class.
+  # The CRLF tail must be dropped but the subsequent bare LF must still
+  # produce a blank node — not get dropped because p[dst-1] is still CR.
+  # ========================================================================
+
+  - name: "op.insert line endings - CRLF followed by bare LF preserves blank"
+    description: "a\\r\\n\\nb must produce 3 nodes — CRLF ends first line, bare LF starts an empty second line, b begins the third"
+    script: |
+      lang.new (outlineType, @system.temp.crlflf);
+      target.set (@system.temp.crlflf);
+      op.insert ("a\r\n\nb", down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.go (down, 1);
+      local (n2 = op.getLineText ());
+      op.go (down, 1);
+      local (n3 = op.getLineText ());
+      return (summits == 3) and (n1 == "a") and (n2 == "") and (n3 == "b")
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Real-world scenario: simulate reading a .ut file with LF endings
+  # ========================================================================
+
+  - name: "op.insert line endings - simulated .ut-file install via raw op.insert"
+    description: "Simulates the scenario that originally surfaced the bug: read a source file containing LF-only newlines and pass it straight to op.insert. Tab-indented lines become child nodes (standard outliner behavior). Pre-fix this produced a single flat node with literal \\n bytes."
+    script: |
+      lang.new (outlineType, @system.temp.utsim);
+      target.set (@system.temp.utsim);
+      local (src = "on greet () {\n\treturn (\"hi\")}");
+      op.insert (src, down);
+      op.firstSummit ();
+      op.deleteLine ();
+      local (summits = op.countSummits ());
+      op.firstSummit ();
+      local (n1 = op.getLineText ());
+      op.expand (infinity);
+      op.go (right, 1);
+      local (child1 = op.getLineText ());
+      return (summits == 1) and (n1 == "on greet () {") and (child1 == "return (\"hi\")}")
+    expected_success: true
+    expected_result: "true"


### PR DESCRIPTION
## Summary

- Fixes `op.insert` LF/CRLF line-ending normalization — text from modern-editor `.ut` files was being inserted as a single flat node with literal `\n` bytes instead of splitting into outline nodes.
- Adds 11 integration tests covering CR baseline, LF-only, CRLF, mixed, flat, no-leak, trailing LF, trailing CRLF, consecutive LFs (blank-line guard), CRLF-then-LF (same bug class guard), and simulated `.ut`-file install.
- Zero regressions: 302/302 unit tests pass; integration suite has same 19 pre-existing failures as `origin/develop` (baseline verified via stash-and-rebuild).

## Why

Reading a Unix-format source file with `file.readWholeFile` and passing the result directly to `op.insert` stored the entire file as a single node with embedded `\n` bytes. This was the root cause of the mangled `script.newScriptObject` and other mangled scripts observed in `Virgin.root`. A .ut file is "outline text" in the outliner's sense — the fix makes the outline splitter see that.

## What changed

- **`Common/source/opverbs.c`** — `opinserthandle_ctx` now copies the borrowed input handle to an owned `hnorm`, normalizes line endings in place, then runs `isoutlinetext` against the normalized copy. The caller's handle is never mutated. `hnorm` is disposed on all exit paths.
- **`Common/source/opstructure.c`** — new helper `opnormalizelineendings_cr` that rewrites `CRLF → CR` and bare `LF → CR` in place. Follows the `chlast`-on-source pattern from `wpnormalizelineendings` in `wpengine.c` (which normalizes the other direction, to CRLF, for the WP engine).
- **`Common/headers/opinternal.h`** — forward declaration for the new helper (internal-use-only; callers must own the handle).
- **`tests/integration/test_cases/op_insert_line_endings.yaml`** — 11 new tests.

## Review notes

Self-reviewed with two parallel agents (`code-review-bar-raiser` + `system-architect`) before push. Bar raiser caught a P0 bug in my first cut — I was checking `p[dst-1]` (output buffer) to detect CRLF pairs, which caused consecutive LFs and `\r\n\n` sequences to silently lose data. Fixed by switching to a `chlast`-on-source variable matching the existing `wpnormalizelineendings` precedent. Two new tests guard that class of regression.

Also moved the forward declaration from `op.h` (public) to `opinternal.h` (internal) per bar raiser P1 — the function's safety contract requires callers to own the handle, and the public header would invite misuse.

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 302/302 pass
- [x] Integration tests: `cd tests && make test-integration` — 2219 total (was 2209), 1966 pass (was 1956), 234 skipped, **same 19 failures** as origin/develop baseline (verified by stash-and-rebuild)
- [x] Line-endings test file isolated: 10/10 pass
- [x] Manually probed with `--protocol` against both CR, LF, CRLF, `\n\n`, and `\r\n\n` inputs
- [ ] Reviewer: verify handle disposal on all exit paths in `opinserthandle_ctx`
- [ ] Reviewer: verify the `chlast`-on-source pattern is correct for all three input conventions

## Follow-up (separate PR)

After this lands: repair `Virgin.root` mangled scripts (`newScriptObject`, `startupScript`, and audit others) that were corrupted by the pre-fix behavior. Then resume PR #541 (Phase A inetd E2E) which depends on working `script.newScriptObject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

