### PR TITLE
Phase B: mainResponder.respond smoke test

### DIFF
--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:21:13 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:28:55 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 06:20 UTC"/>
+      <outline text="Run: 2026-04-20 at 06:28 UTC"/>
       <outline text="Results: 1991 passed (89%), 234 skipped (11%), 0 failed (0%)"/>
-      <outline text="Duration: 35.7s (8 workers, batch mode)"/>
+      <outline text="Duration: 33.8s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:28:55 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:35:21 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 06:28 UTC"/>
+      <outline text="Run: 2026-04-20 at 06:34 UTC"/>
       <outline text="Results: 1991 passed (89%), 234 skipped (11%), 0 failed (0%)"/>
-      <outline text="Duration: 33.8s (8 workers, batch mode)"/>
+      <outline text="Duration: 35.5s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:14:32 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:21:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 06:14 UTC"/>
-      <outline text="Results: 1989 passed (89%), 234 skipped (11%), 2 failed (0%)"/>
-      <outline text="Duration: 61.5s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-04-20 at 06:20 UTC"/>
+      <outline text="Results: 1991 passed (89%), 234 skipped (11%), 0 failed (0%)"/>
+      <outline text="Duration: 35.7s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:41:28 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:49:14 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 06:41 UTC"/>
+      <outline text="Run: 2026-04-20 at 06:46 UTC"/>
       <outline text="Results: 1991 passed (89%), 234 skipped (11%), 0 failed (0%)"/>
-      <outline text="Duration: 34.5s (8 workers, batch mode)"/>
+      <outline text="Duration: 37.0s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:35:21 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:41:28 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 06:34 UTC"/>
+      <outline text="Run: 2026-04-20 at 06:41 UTC"/>
       <outline text="Results: 1991 passed (89%), 234 skipped (11%), 0 failed (0%)"/>
-      <outline text="Duration: 35.5s (8 workers, batch mode)"/>
+      <outline text="Duration: 34.5s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -2,13 +2,13 @@
 <opml version="2.0">
   <head>
     <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:07:05 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:14:32 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 06:05 UTC"/>
-      <outline text="Results: 1972 passed (89%), 234 skipped (11%), 19 failed (1%)"/>
-      <outline text="Duration: 30.7s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-04-20 at 06:14 UTC"/>
+      <outline text="Results: 1989 passed (89%), 234 skipped (11%), 2 failed (0%)"/>
+      <outline text="Duration: 61.5s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 2242 tests: 2008 pass (89%) 234 skip (10%)</title>
-    <dateCreated>Sat, 18 Apr 2026 23:06:17 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2243 tests: 2009 pass (89%) 234 skip (10%)</title>
+    <dateCreated>Mon, 20 Apr 2026 06:07:05 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-18 at 23:06 UTC"/>
-      <outline text="Results: 1971 passed (89%), 234 skipped (11%), 19 failed (1%)"/>
-      <outline text="Duration: 30.5s (8 workers, batch mode)"/>
-      <outline text="YAML-defined: 2242 tests (2008 active, 234 marked skip) across 68 categories"/>
+      <outline text="Run: 2026-04-20 at 06:05 UTC"/>
+      <outline text="Results: 1972 passed (89%), 234 skipped (11%), 19 failed (1%)"/>
+      <outline text="Duration: 30.7s (8 workers, batch mode)"/>
+      <outline text="YAML-defined: 2243 tests (2009 active, 234 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>
     <outline text="Builtins Priority (builtins_priority) - 24 tests: 24 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/builtins_priority.opml"/>
@@ -35,6 +35,7 @@
     <outline text="Html Image Tests (html_image_tests) - 19 tests: 1 pass (5%) 18 skip (94%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_image_tests.opml"/>
     <outline text="Html Text Processing Phase2 Tests (html_text_processing_phase2_tests) - 30 tests: 24 pass (80%) 6 skip (20%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/html_text_processing_phase2_tests.opml"/>
     <outline text="Lang Verbs (lang_verbs) - 156 tests: 141 pass (90%) 15 skip (9%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/lang_verbs.opml"/>
+    <outline text="Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/mainresponder_smoke.opml"/>
     <outline text="Menu Data Verbs (menu_data_verbs) - 49 tests: 29 pass (59%) 20 skip (40%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/menu_data_verbs.opml"/>
     <outline text="Menu Value Copy (menu_value_copy) - 5 tests: 4 pass (80%) 1 skip (20%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/menu_value_copy.opml"/>
     <outline text="Migration Externals (migration_externals) - 19 tests: 16 pass (84%) 3 skip (15%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/migration_externals.opml"/>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:35:20 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:41:28 GMT</dateCreated>
   </head>
   <body>
     <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
@@ -12,7 +12,6 @@
         <outline text="notes: Smoke test — passed on first run (2026-04-19), confirming that&#10;mainResponder.respond() executes end-to-end in the headless runtime&#10;with no missing verbs or globals.  Assertions verify responseBody is&#10;a string and non-empty; body content is not checked because it&#10;depends on config.mainResponder.domains.default pointing to a www&#10;folder, which is environment-specific.&#10;&#10;Cleanup uses conditional delete based on pre-test defined() snapshot&#10;so the test is idempotent across repeated runs and does not leak&#10;sysroot state into subsequent tests.&#10;"/>
       </outline>
       <outline text="Script">
-        <outline text="local(succeeded = false)"/>
         <outline text="local(guestpath)"/>
         <outline text="// Locate mainResponder.root relative to the Frontier binary"/>
         <outline text="guestpath = file.folderFromPath(Frontier.getFilePath()) + &quot;Guest Databases/apps/mainResponder.root&quot;"/>
@@ -62,7 +61,6 @@
           <outline text="if string.length(system.temp.mrSmoke.req.responseBody) == 0">
             <outline text="scriptError(&quot;mainResponder.respond returned an empty responseBody&quot;)"/>
           </outline>
-          <outline text="succeeded = true"/>
         </outline>
         <outline text="else">
           <outline text="local(err = tryError)"/>
@@ -73,11 +71,12 @@
           <outline text="// add a snapshot variable above, both cleanup blocks must gain a"/>
           <outline text="// matching conditional delete."/>
           <outline text="//"/>
-          <outline text="// Yield briefly to let the background thread spawned by init()"/>
+          <outline text="// Yield briefly (6 ticks ≈ 100 ms, 60 ticks/sec) to let the"/>
+          <outline text="// background thread spawned by init()"/>
           <outline text="// (mainResponder.subscriptions.updateAllChangesTables) drain before"/>
           <outline text="// we delete the paths it may touch.  This reduces — but does not"/>
-          <outline text="// eliminate — the race window.  Sequential test ordering keeps the"/>
-          <outline text="// remainder of the risk bounded."/>
+          <outline text="// eliminate — the race window.  A heavily loaded CI host may need"/>
+          <outline text="// more, but sequential test ordering bounds the residual risk."/>
           <outline text="try { thread.sleepTicks(6) }"/>
           <outline text="try { fileMenu.close(guestpath) }"/>
           <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
@@ -97,8 +96,8 @@
         <outline text="// pre-test snapshot above.  KEEP IN SYNC with exception-path cleanup"/>
         <outline text="// in the else branch above."/>
         <outline text="//"/>
-        <outline text="// Yield briefly to let init()'s background thread drain (see note in"/>
-        <outline text="// the else branch)."/>
+        <outline text="// Yield briefly (6 ticks ≈ 100 ms) to let init()'s background thread"/>
+        <outline text="// drain before deletes — see the longer note in the else branch."/>
         <outline text="try { thread.sleepTicks(6) }"/>
         <outline text="try { fileMenu.close(guestpath) }"/>
         <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
@@ -109,7 +108,9 @@
         <outline text="if not preAfterInstallPart { try { delete(@user.rootUpdates.callbacks.afterInstallPart) } }"/>
         <outline text="if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } }"/>
         <outline text="try { delete(@system.temp.mrSmoke) }"/>
-        <outline text="return succeeded"/>
+        <outline text="// Reached only on the success path — the else branch above always"/>
+        <outline text="// calls scriptError() which does not return."/>
+        <outline text="return true"/>
       </outline>
     </outline>
   </body>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:14:32 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:21:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
@@ -33,9 +33,18 @@
         <outline text="try">
           <outline text="fileMenu.open(guestpath, true)"/>
           <outline text="mainResponder.init()"/>
+          <outline text="// mainResponder.respond() writes responseBody back into the param"/>
+          <outline text="// table rather than returning a separate response object.  Pass the"/>
+          <outline text="// address so the callee can mutate our table in place."/>
           <outline text="mainResponder.respond(@system.temp.mrSmoke.req)"/>
           <outline text="if typeof(system.temp.mrSmoke.req.responseBody) != 'TEXT'">
             <outline text="scriptError(&quot;mainResponder.respond returned no responseBody (or non-string)&quot;)"/>
+          </outline>
+          <outline text="// Even in a headless environment without a real www folder, respond()"/>
+          <outline text="// should produce a non-empty body (error page, 404, etc.).  An empty"/>
+          <outline text="// string would indicate it bailed out silently."/>
+          <outline text="if string.length(system.temp.mrSmoke.req.responseBody) == 0">
+            <outline text="scriptError(&quot;mainResponder.respond returned an empty responseBody&quot;)"/>
           </outline>
           <outline text="succeeded = true"/>
         </outline>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<opml version="2.0">
+  <head>
+    <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
+    <dateCreated>Mon, 20 Apr 2026 06:07:05 GMT</dateCreated>
+  </head>
+  <body>
+    <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
+      <outline text="Metadata">
+        <outline text="timeout: 30"/>
+        <outline text="expected_result: true"/>
+        <outline text="notes: Smoke test — passed on first run (2026-04-19), confirming that&#10;mainResponder.respond() executes end-to-end in the headless runtime&#10;with no missing verbs or globals.  Assertions verify responseBody is&#10;a string; body content is not checked because it depends on&#10;config.mainResponder.domains.default pointing to a www folder, which&#10;is environment-specific.&#10;"/>
+      </outline>
+      <outline text="Script">
+        <outline text="local(succeeded = false)"/>
+        <outline text="local(guestpath)"/>
+        <outline text="// Locate mainResponder.root relative to the Frontier binary"/>
+        <outline text="guestpath = file.folderFromPath(Frontier.getFilePath()) + &quot;Guest Databases/apps/mainResponder.root&quot;"/>
+        <outline text="// Skip if guest DB not available"/>
+        <outline text="if not file.exists(guestpath)">
+          <outline text="return &quot;skip&quot;"/>
+        </outline>
+        <outline text="// Prepare the param table BEFORE try — so else branch can clean it up"/>
+        <outline text="new(tableType, @system.temp.mrSmoke)"/>
+        <outline text="new(tableType, @system.temp.mrSmoke.req)"/>
+        <outline text="system.temp.mrSmoke.req.method = &quot;GET&quot;"/>
+        <outline text="system.temp.mrSmoke.req.path = &quot;/&quot;"/>
+        <outline text="system.temp.mrSmoke.req.host = &quot;localhost&quot;"/>
+        <outline text="system.temp.mrSmoke.req.firstLine = &quot;GET / HTTP/1.0&quot;"/>
+        <outline text="system.temp.mrSmoke.req.client = &quot;127.0.0.1&quot;"/>
+        <outline text="new(tableType, @system.temp.mrSmoke.req.requestHeaders)"/>
+        <outline text="system.temp.mrSmoke.req.requestHeaders.[&quot;User-Agent&quot;] = &quot;Testing in Debugger&quot;"/>
+        <outline text="try">
+          <outline text="fileMenu.open(guestpath, true)"/>
+          <outline text="mainResponder.init()"/>
+          <outline text="mainResponder.respond(@system.temp.mrSmoke.req)"/>
+          <outline text="if typeof(system.temp.mrSmoke.req.responseBody) != 'TEXT'">
+            <outline text="scriptError(&quot;mainResponder.respond returned no responseBody (or non-string)&quot;)"/>
+          </outline>
+          <outline text="succeeded = true"/>
+        </outline>
+        <outline text="else">
+          <outline text="local(err = tryError)"/>
+          <outline text="try { delete(@config.mainResponder) }"/>
+          <outline text="try { delete(@system.temp.mrSmoke) }"/>
+          <outline text="scriptError(&quot;mainResponder.respond smoke failed: &quot; + err)"/>
+        </outline>
+        <outline text="try { delete(@config.mainResponder) }"/>
+        <outline text="try { delete(@system.temp.mrSmoke) }"/>
+        <outline text="return succeeded"/>
+      </outline>
+    </outline>
+  </body>
+</opml>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:41:28 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:49:13 GMT</dateCreated>
   </head>
   <body>
     <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
@@ -71,13 +71,13 @@
           <outline text="// add a snapshot variable above, both cleanup blocks must gain a"/>
           <outline text="// matching conditional delete."/>
           <outline text="//"/>
-          <outline text="// Yield briefly (6 ticks ≈ 100 ms, 60 ticks/sec) to let the"/>
-          <outline text="// background thread spawned by init()"/>
+          <outline text="// Yield (12 ticks ≈ 200 ms, 60 ticks/sec) to let the background"/>
+          <outline text="// thread spawned by init()"/>
           <outline text="// (mainResponder.subscriptions.updateAllChangesTables) drain before"/>
           <outline text="// we delete the paths it may touch.  This reduces — but does not"/>
-          <outline text="// eliminate — the race window.  A heavily loaded CI host may need"/>
-          <outline text="// more, but sequential test ordering bounds the residual risk."/>
-          <outline text="try { thread.sleepTicks(6) }"/>
+          <outline text="// eliminate — the race window.  Sequential test ordering bounds"/>
+          <outline text="// the residual risk."/>
+          <outline text="try { thread.sleepTicks(12) }"/>
           <outline text="try { fileMenu.close(guestpath) }"/>
           <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
           <outline text="if not preIsRadio { try { delete(@system.environment.isRadio) } }"/>
@@ -96,9 +96,9 @@
         <outline text="// pre-test snapshot above.  KEEP IN SYNC with exception-path cleanup"/>
         <outline text="// in the else branch above."/>
         <outline text="//"/>
-        <outline text="// Yield briefly (6 ticks ≈ 100 ms) to let init()'s background thread"/>
+        <outline text="// Yield (12 ticks ≈ 200 ms) to let init()'s background thread"/>
         <outline text="// drain before deletes — see the longer note in the else branch."/>
-        <outline text="try { thread.sleepTicks(6) }"/>
+        <outline text="try { thread.sleepTicks(12) }"/>
         <outline text="try { fileMenu.close(guestpath) }"/>
         <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
         <outline text="if not preIsRadio { try { delete(@system.environment.isRadio) } }"/>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:28:55 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:35:20 GMT</dateCreated>
   </head>
   <body>
     <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
@@ -24,10 +24,17 @@
         <outline text="// may create.  We'll only delete paths that didn't already exist, so"/>
         <outline text="// the test leaves the sysroot exactly as it found it and is idempotent"/>
         <outline text="// across repeated runs in the shared protocol-mode process."/>
+        <outline text="//"/>
+        <outline text="// Snapshots are checked against BOTH the leaf and every intermediate"/>
+        <outline text="// table so that if init() created a brand-new branch (e.g. the whole"/>
+        <outline text="// user.rootUpdates.callbacks.afterInstallPart subtree) we can delete"/>
+        <outline text="// the branch at its root rather than leaving empty parent tables."/>
         <outline text="local(preConfigMainResponder = defined(@config.mainResponder))"/>
         <outline text="local(preIsRadio = defined(@system.environment.isRadio))"/>
+        <outline text="local(preInetdConfig = defined(@user.inetd.config))"/>
         <outline text="local(preHttp2 = defined(@user.inetd.config.http2))"/>
         <outline text="local(preRootUpdatesCallbacks = defined(@user.rootUpdates.callbacks))"/>
+        <outline text="local(preAfterInstallPart = defined(@user.rootUpdates.callbacks.afterInstallPart))"/>
         <outline text="local(preAfterInstall = defined(@user.rootUpdates.callbacks.afterInstallPart.mainResponder))"/>
         <outline text="// Prepare the param table BEFORE try — so else branch can clean it up"/>
         <outline text="new(tableType, @system.temp.mrSmoke)"/>
@@ -62,11 +69,23 @@
           <outline text="// Cleanup runs here on exception; success-path cleanup is after the"/>
           <outline text="// try/else block.  The duplication is intentional — scriptError()"/>
           <outline text="// below does not return, so we cannot consolidate into a finally."/>
+          <outline text="// KEEP IN SYNC with success-path cleanup after the try/else.  If you"/>
+          <outline text="// add a snapshot variable above, both cleanup blocks must gain a"/>
+          <outline text="// matching conditional delete."/>
+          <outline text="//"/>
+          <outline text="// Yield briefly to let the background thread spawned by init()"/>
+          <outline text="// (mainResponder.subscriptions.updateAllChangesTables) drain before"/>
+          <outline text="// we delete the paths it may touch.  This reduces — but does not"/>
+          <outline text="// eliminate — the race window.  Sequential test ordering keeps the"/>
+          <outline text="// remainder of the risk bounded."/>
+          <outline text="try { thread.sleepTicks(6) }"/>
           <outline text="try { fileMenu.close(guestpath) }"/>
           <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
           <outline text="if not preIsRadio { try { delete(@system.environment.isRadio) } }"/>
           <outline text="if not preHttp2 { try { delete(@user.inetd.config.http2) } }"/>
+          <outline text="if not preInetdConfig { try { delete(@user.inetd.config) } }"/>
           <outline text="if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } }"/>
+          <outline text="if not preAfterInstallPart { try { delete(@user.rootUpdates.callbacks.afterInstallPart) } }"/>
           <outline text="if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } }"/>
           <outline text="try { delete(@system.temp.mrSmoke) }"/>
           <outline text="scriptError(&quot;mainResponder.respond smoke failed: &quot; + err)"/>
@@ -75,12 +94,19 @@
         <outline text="// mode runner shares one CLI process across tests and only resets REPL"/>
         <outline text="// variables via script/clearContext, which does not close open DBs."/>
         <outline text="// Conditional deletes restore only what we created, based on the"/>
-        <outline text="// pre-test snapshot above."/>
+        <outline text="// pre-test snapshot above.  KEEP IN SYNC with exception-path cleanup"/>
+        <outline text="// in the else branch above."/>
+        <outline text="//"/>
+        <outline text="// Yield briefly to let init()'s background thread drain (see note in"/>
+        <outline text="// the else branch)."/>
+        <outline text="try { thread.sleepTicks(6) }"/>
         <outline text="try { fileMenu.close(guestpath) }"/>
         <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
         <outline text="if not preIsRadio { try { delete(@system.environment.isRadio) } }"/>
         <outline text="if not preHttp2 { try { delete(@user.inetd.config.http2) } }"/>
+        <outline text="if not preInetdConfig { try { delete(@user.inetd.config) } }"/>
         <outline text="if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } }"/>
+        <outline text="if not preAfterInstallPart { try { delete(@user.rootUpdates.callbacks.afterInstallPart) } }"/>
         <outline text="if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } }"/>
         <outline text="try { delete(@system.temp.mrSmoke) }"/>
         <outline text="return succeeded"/>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -2,14 +2,14 @@
 <opml version="2.0">
   <head>
     <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:21:13 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:28:55 GMT</dateCreated>
   </head>
   <body>
     <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
       <outline text="Metadata">
         <outline text="timeout: 30"/>
         <outline text="expected_result: true"/>
-        <outline text="notes: Smoke test — passed on first run (2026-04-19), confirming that&#10;mainResponder.respond() executes end-to-end in the headless runtime&#10;with no missing verbs or globals.  Assertions verify responseBody is&#10;a string; body content is not checked because it depends on&#10;config.mainResponder.domains.default pointing to a www folder, which&#10;is environment-specific.&#10;"/>
+        <outline text="notes: Smoke test — passed on first run (2026-04-19), confirming that&#10;mainResponder.respond() executes end-to-end in the headless runtime&#10;with no missing verbs or globals.  Assertions verify responseBody is&#10;a string and non-empty; body content is not checked because it&#10;depends on config.mainResponder.domains.default pointing to a www&#10;folder, which is environment-specific.&#10;&#10;Cleanup uses conditional delete based on pre-test defined() snapshot&#10;so the test is idempotent across repeated runs and does not leak&#10;sysroot state into subsequent tests.&#10;"/>
       </outline>
       <outline text="Script">
         <outline text="local(succeeded = false)"/>
@@ -20,6 +20,15 @@
         <outline text="if not file.exists(guestpath)">
           <outline text="return &quot;skip&quot;"/>
         </outline>
+        <outline text="// Snapshot pre-test state for sysroot paths that mainResponder.init()"/>
+        <outline text="// may create.  We'll only delete paths that didn't already exist, so"/>
+        <outline text="// the test leaves the sysroot exactly as it found it and is idempotent"/>
+        <outline text="// across repeated runs in the shared protocol-mode process."/>
+        <outline text="local(preConfigMainResponder = defined(@config.mainResponder))"/>
+        <outline text="local(preIsRadio = defined(@system.environment.isRadio))"/>
+        <outline text="local(preHttp2 = defined(@user.inetd.config.http2))"/>
+        <outline text="local(preRootUpdatesCallbacks = defined(@user.rootUpdates.callbacks))"/>
+        <outline text="local(preAfterInstall = defined(@user.rootUpdates.callbacks.afterInstallPart.mainResponder))"/>
         <outline text="// Prepare the param table BEFORE try — so else branch can clean it up"/>
         <outline text="new(tableType, @system.temp.mrSmoke)"/>
         <outline text="new(tableType, @system.temp.mrSmoke.req)"/>
@@ -54,15 +63,25 @@
           <outline text="// try/else block.  The duplication is intentional — scriptError()"/>
           <outline text="// below does not return, so we cannot consolidate into a finally."/>
           <outline text="try { fileMenu.close(guestpath) }"/>
-          <outline text="try { delete(@config.mainResponder) }"/>
+          <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
+          <outline text="if not preIsRadio { try { delete(@system.environment.isRadio) } }"/>
+          <outline text="if not preHttp2 { try { delete(@user.inetd.config.http2) } }"/>
+          <outline text="if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } }"/>
+          <outline text="if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } }"/>
           <outline text="try { delete(@system.temp.mrSmoke) }"/>
           <outline text="scriptError(&quot;mainResponder.respond smoke failed: &quot; + err)"/>
         </outline>
         <outline text="// Success-path cleanup.  Close the guest DB explicitly — the protocol-"/>
         <outline text="// mode runner shares one CLI process across tests and only resets REPL"/>
         <outline text="// variables via script/clearContext, which does not close open DBs."/>
+        <outline text="// Conditional deletes restore only what we created, based on the"/>
+        <outline text="// pre-test snapshot above."/>
         <outline text="try { fileMenu.close(guestpath) }"/>
-        <outline text="try { delete(@config.mainResponder) }"/>
+        <outline text="if not preConfigMainResponder { try { delete(@config.mainResponder) } }"/>
+        <outline text="if not preIsRadio { try { delete(@system.environment.isRadio) } }"/>
+        <outline text="if not preHttp2 { try { delete(@user.inetd.config.http2) } }"/>
+        <outline text="if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } }"/>
+        <outline text="if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } }"/>
         <outline text="try { delete(@system.temp.mrSmoke) }"/>
         <outline text="return succeeded"/>
       </outline>

--- a/reports/integration_tests/mainresponder_smoke.opml
+++ b/reports/integration_tests/mainresponder_smoke.opml
@@ -2,7 +2,7 @@
 <opml version="2.0">
   <head>
     <title>Mainresponder Smoke (mainresponder_smoke) - 1 tests: 1 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 06:07:05 GMT</dateCreated>
+    <dateCreated>Mon, 20 Apr 2026 06:14:32 GMT</dateCreated>
   </head>
   <body>
     <outline text="mainresponder_respond_smoke - Smoke test: does mainResponder.respond() run and return a response table?">
@@ -41,10 +41,18 @@
         </outline>
         <outline text="else">
           <outline text="local(err = tryError)"/>
+          <outline text="// Cleanup runs here on exception; success-path cleanup is after the"/>
+          <outline text="// try/else block.  The duplication is intentional — scriptError()"/>
+          <outline text="// below does not return, so we cannot consolidate into a finally."/>
+          <outline text="try { fileMenu.close(guestpath) }"/>
           <outline text="try { delete(@config.mainResponder) }"/>
           <outline text="try { delete(@system.temp.mrSmoke) }"/>
           <outline text="scriptError(&quot;mainResponder.respond smoke failed: &quot; + err)"/>
         </outline>
+        <outline text="// Success-path cleanup.  Close the guest DB explicitly — the protocol-"/>
+        <outline text="// mode runner shares one CLI process across tests and only resets REPL"/>
+        <outline text="// variables via script/clearContext, which does not close open DBs."/>
+        <outline text="try { fileMenu.close(guestpath) }"/>
         <outline text="try { delete(@config.mainResponder) }"/>
         <outline text="try { delete(@system.temp.mrSmoke) }"/>
         <outline text="return succeeded"/>

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -1,0 +1,88 @@
+sequential: true
+needs_guest_dbs: true
+protocol_mode: true
+
+# Phase B discovery test for the mainResponder.respond() verb.
+#
+# Purpose:
+#   Verify that mainResponder.respond() runs end-to-end in the headless
+#   runtime against a freshly-initialized param table.  This was designed as
+#   a discovery probe expected to fail on first run — but it PASSED on first
+#   run, confirming that the legacy UserTalk dispatcher (~1000 lines) works
+#   headlessly without any verb stubs or workarounds.  Keep the test in the
+#   suite as a regression guard for Phases C–F.
+#
+# Known false-positive drift warning:
+#   The integration test runner's MD5-based sysroot drift check flags this
+#   file as mutating the system root.  Investigation (2026-04-19) confirmed
+#   the test cleanup is logically complete — no paths leak after delete.
+#   The MD5 drift is caused by save-path non-determinism in the ODB file
+#   format (timestamps / block allocation order), and reproduces for a pure
+#   no-op CLI invocation.  Tracked for runner fix in a follow-up PR; not a
+#   bug in this test.
+#
+# Reference:
+#   - planning/MANILA_MAINRESPONDER_E2E.md (Phase B)
+#   - usertalk_scripts/mainResponder.root/mainResponder/respond.ut
+#   - usertalk_scripts/mainResponder.root/mainResponder/init.ut
+#   - tests/integration/test_cases/guest_db_externals.yaml (guest DB pattern)
+#   - tests/integration/test_cases/webserver_inetd_e2e.yaml (structural template)
+
+tests:
+  - name: "mainresponder_respond_smoke"
+    description: "Smoke test: does mainResponder.respond() run and return a response table?"
+    timeout: 30
+    script: |
+      local(succeeded = false);
+      local(guestpath);
+
+      // Locate mainResponder.root relative to the Frontier binary
+      guestpath = file.folderFromPath(Frontier.getFilePath()) + "Guest Databases/apps/mainResponder.root";
+
+      // Skip if guest DB not available
+      if not file.exists(guestpath) {
+        return "skip"
+      };
+
+      // Prepare the param table BEFORE try — so else branch can clean it up
+      new(tableType, @system.temp.mrSmoke);
+      new(tableType, @system.temp.mrSmoke.req);
+      system.temp.mrSmoke.req.method = "GET";
+      system.temp.mrSmoke.req.path = "/";
+      system.temp.mrSmoke.req.host = "localhost";
+      system.temp.mrSmoke.req.firstLine = "GET / HTTP/1.0";
+      system.temp.mrSmoke.req.client = "127.0.0.1";
+      new(tableType, @system.temp.mrSmoke.req.requestHeaders);
+      system.temp.mrSmoke.req.requestHeaders.["User-Agent"] = "Testing in Debugger";
+
+      try {
+        fileMenu.open(guestpath, true);
+        mainResponder.init();
+        mainResponder.respond(@system.temp.mrSmoke.req);
+
+        if typeof(system.temp.mrSmoke.req.responseBody) != 'TEXT' {
+          scriptError("mainResponder.respond returned no responseBody (or non-string)")
+        };
+
+        succeeded = true
+      }
+      else {
+        local(err = tryError);
+        try { delete(@config.mainResponder) };
+        try { delete(@system.temp.mrSmoke) };
+        scriptError("mainResponder.respond smoke failed: " + err)
+      };
+
+      try { delete(@config.mainResponder) };
+      try { delete(@system.temp.mrSmoke) };
+
+      return succeeded
+    expected_success: true
+    expected_result: "true"
+    notes: |
+      Smoke test — passed on first run (2026-04-19), confirming that
+      mainResponder.respond() executes end-to-end in the headless runtime
+      with no missing verbs or globals.  Assertions verify responseBody is
+      a string; body content is not checked because it depends on
+      config.mainResponder.domains.default pointing to a www folder, which
+      is environment-specific.

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -23,9 +23,12 @@ protocol_mode: true
 #
 #   NOTE: init() also spawns a background thread via thread.callScript()
 #   to run mainResponder.subscriptions.updateAllChangesTables.  That
-#   thread is unbounded and cannot be cleanly joined from the test; it
-#   exits on its own once no DB updates are pending.  Documented as a
-#   known limitation of legacy UserTalk for this smoke test.
+#   thread is unbounded and cannot be cleanly joined from the test.  The
+#   cleanup block yields via thread.sleepTicks(6) (~100 ms) before any
+#   delete, which lets the thread drain in practice — the thread exits
+#   almost immediately in the headless environment because there are no
+#   pending DB updates to process.  Sequential test ordering bounds the
+#   residual risk.
 #
 # Known false-positive drift warning:
 #   Even with full conditional cleanup, the runner's MD5-based sysroot
@@ -61,10 +64,17 @@ tests:
       // may create.  We'll only delete paths that didn't already exist, so
       // the test leaves the sysroot exactly as it found it and is idempotent
       // across repeated runs in the shared protocol-mode process.
+      //
+      // Snapshots are checked against BOTH the leaf and every intermediate
+      // table so that if init() created a brand-new branch (e.g. the whole
+      // user.rootUpdates.callbacks.afterInstallPart subtree) we can delete
+      // the branch at its root rather than leaving empty parent tables.
       local(preConfigMainResponder = defined(@config.mainResponder));
       local(preIsRadio = defined(@system.environment.isRadio));
+      local(preInetdConfig = defined(@user.inetd.config));
       local(preHttp2 = defined(@user.inetd.config.http2));
       local(preRootUpdatesCallbacks = defined(@user.rootUpdates.callbacks));
+      local(preAfterInstallPart = defined(@user.rootUpdates.callbacks.afterInstallPart));
       local(preAfterInstall = defined(@user.rootUpdates.callbacks.afterInstallPart.mainResponder));
 
       // Prepare the param table BEFORE try — so else branch can clean it up
@@ -105,11 +115,23 @@ tests:
         // Cleanup runs here on exception; success-path cleanup is after the
         // try/else block.  The duplication is intentional — scriptError()
         // below does not return, so we cannot consolidate into a finally.
+        // KEEP IN SYNC with success-path cleanup after the try/else.  If you
+        // add a snapshot variable above, both cleanup blocks must gain a
+        // matching conditional delete.
+        //
+        // Yield briefly to let the background thread spawned by init()
+        // (mainResponder.subscriptions.updateAllChangesTables) drain before
+        // we delete the paths it may touch.  This reduces — but does not
+        // eliminate — the race window.  Sequential test ordering keeps the
+        // remainder of the risk bounded.
+        try { thread.sleepTicks(6) };
         try { fileMenu.close(guestpath) };
         if not preConfigMainResponder { try { delete(@config.mainResponder) } };
         if not preIsRadio { try { delete(@system.environment.isRadio) } };
         if not preHttp2 { try { delete(@user.inetd.config.http2) } };
+        if not preInetdConfig { try { delete(@user.inetd.config) } };
         if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } };
+        if not preAfterInstallPart { try { delete(@user.rootUpdates.callbacks.afterInstallPart) } };
         if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } };
         try { delete(@system.temp.mrSmoke) };
         scriptError("mainResponder.respond smoke failed: " + err)
@@ -119,12 +141,19 @@ tests:
       // mode runner shares one CLI process across tests and only resets REPL
       // variables via script/clearContext, which does not close open DBs.
       // Conditional deletes restore only what we created, based on the
-      // pre-test snapshot above.
+      // pre-test snapshot above.  KEEP IN SYNC with exception-path cleanup
+      // in the else branch above.
+      //
+      // Yield briefly to let init()'s background thread drain (see note in
+      // the else branch).
+      try { thread.sleepTicks(6) };
       try { fileMenu.close(guestpath) };
       if not preConfigMainResponder { try { delete(@config.mainResponder) } };
       if not preIsRadio { try { delete(@system.environment.isRadio) } };
       if not preHttp2 { try { delete(@user.inetd.config.http2) } };
+      if not preInetdConfig { try { delete(@user.inetd.config) } };
       if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } };
+      if not preAfterInstallPart { try { delete(@user.rootUpdates.callbacks.afterInstallPart) } };
       if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } };
       try { delete(@system.temp.mrSmoke) };
 

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -68,11 +68,19 @@ tests:
       }
       else {
         local(err = tryError);
+        // Cleanup runs here on exception; success-path cleanup is after the
+        // try/else block.  The duplication is intentional — scriptError()
+        // below does not return, so we cannot consolidate into a finally.
+        try { fileMenu.close(guestpath) };
         try { delete(@config.mainResponder) };
         try { delete(@system.temp.mrSmoke) };
         scriptError("mainResponder.respond smoke failed: " + err)
       };
 
+      // Success-path cleanup.  Close the guest DB explicitly — the protocol-
+      // mode runner shares one CLI process across tests and only resets REPL
+      // variables via script/clearContext, which does not close open DBs.
+      try { fileMenu.close(guestpath) };
       try { delete(@config.mainResponder) };
       try { delete(@system.temp.mrSmoke) };
 

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -49,7 +49,6 @@ tests:
     description: "Smoke test: does mainResponder.respond() run and return a response table?"
     timeout: 30
     script: |
-      local(succeeded = false);
       local(guestpath);
 
       // Locate mainResponder.root relative to the Frontier binary
@@ -106,9 +105,7 @@ tests:
         // string would indicate it bailed out silently.
         if string.length(system.temp.mrSmoke.req.responseBody) == 0 {
           scriptError("mainResponder.respond returned an empty responseBody")
-        };
-
-        succeeded = true
+        }
       }
       else {
         local(err = tryError);
@@ -119,11 +116,12 @@ tests:
         // add a snapshot variable above, both cleanup blocks must gain a
         // matching conditional delete.
         //
-        // Yield briefly to let the background thread spawned by init()
+        // Yield briefly (6 ticks ≈ 100 ms, 60 ticks/sec) to let the
+        // background thread spawned by init()
         // (mainResponder.subscriptions.updateAllChangesTables) drain before
         // we delete the paths it may touch.  This reduces — but does not
-        // eliminate — the race window.  Sequential test ordering keeps the
-        // remainder of the risk bounded.
+        // eliminate — the race window.  A heavily loaded CI host may need
+        // more, but sequential test ordering bounds the residual risk.
         try { thread.sleepTicks(6) };
         try { fileMenu.close(guestpath) };
         if not preConfigMainResponder { try { delete(@config.mainResponder) } };
@@ -144,8 +142,8 @@ tests:
       // pre-test snapshot above.  KEEP IN SYNC with exception-path cleanup
       // in the else branch above.
       //
-      // Yield briefly to let init()'s background thread drain (see note in
-      // the else branch).
+      // Yield briefly (6 ticks ≈ 100 ms) to let init()'s background thread
+      // drain before deletes — see the longer note in the else branch.
       try { thread.sleepTicks(6) };
       try { fileMenu.close(guestpath) };
       if not preConfigMainResponder { try { delete(@config.mainResponder) } };
@@ -157,8 +155,9 @@ tests:
       if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } };
       try { delete(@system.temp.mrSmoke) };
 
-      return succeeded
-    expected_success: true
+      // Reached only on the success path — the else branch above always
+      // calls scriptError() which does not return.
+      return true
     expected_result: "true"
     notes: |
       Smoke test — passed on first run (2026-04-19), confirming that

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -24,7 +24,7 @@ protocol_mode: true
 #   NOTE: init() also spawns a background thread via thread.callScript()
 #   to run mainResponder.subscriptions.updateAllChangesTables.  That
 #   thread is unbounded and cannot be cleanly joined from the test.  The
-#   cleanup block yields via thread.sleepTicks(6) (~100 ms) before any
+#   cleanup block yields via thread.sleepTicks(12) (~200 ms) before any
 #   delete, which lets the thread drain in practice — the thread exits
 #   almost immediately in the headless environment because there are no
 #   pending DB updates to process.  Sequential test ordering bounds the
@@ -116,13 +116,13 @@ tests:
         // add a snapshot variable above, both cleanup blocks must gain a
         // matching conditional delete.
         //
-        // Yield briefly (6 ticks ≈ 100 ms, 60 ticks/sec) to let the
-        // background thread spawned by init()
+        // Yield (12 ticks ≈ 200 ms, 60 ticks/sec) to let the background
+        // thread spawned by init()
         // (mainResponder.subscriptions.updateAllChangesTables) drain before
         // we delete the paths it may touch.  This reduces — but does not
-        // eliminate — the race window.  A heavily loaded CI host may need
-        // more, but sequential test ordering bounds the residual risk.
-        try { thread.sleepTicks(6) };
+        // eliminate — the race window.  Sequential test ordering bounds
+        // the residual risk.
+        try { thread.sleepTicks(12) };
         try { fileMenu.close(guestpath) };
         if not preConfigMainResponder { try { delete(@config.mainResponder) } };
         if not preIsRadio { try { delete(@system.environment.isRadio) } };
@@ -142,9 +142,9 @@ tests:
       // pre-test snapshot above.  KEEP IN SYNC with exception-path cleanup
       // in the else branch above.
       //
-      // Yield briefly (6 ticks ≈ 100 ms) to let init()'s background thread
+      // Yield (12 ticks ≈ 200 ms) to let init()'s background thread
       // drain before deletes — see the longer note in the else branch.
-      try { thread.sleepTicks(6) };
+      try { thread.sleepTicks(12) };
       try { fileMenu.close(guestpath) };
       if not preConfigMainResponder { try { delete(@config.mainResponder) } };
       if not preIsRadio { try { delete(@system.environment.isRadio) } };

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -12,14 +12,27 @@ protocol_mode: true
 #   headlessly without any verb stubs or workarounds.  Keep the test in the
 #   suite as a regression guard for Phases C–F.
 #
+# Sysroot cleanup strategy:
+#   mainResponder.init() writes several system-root tables beyond
+#   config.mainResponder — notably system.environment.isRadio,
+#   user.inetd.config.http2 (port 5336 listener), and
+#   user.rootUpdates.callbacks.  The cleanup below snapshots defined() for
+#   each of these *before* init() and conditionally deletes only the
+#   paths that didn't already exist, so repeated runs are idempotent and
+#   the sysroot is restored to its pre-test state.
+#
+#   NOTE: init() also spawns a background thread via thread.callScript()
+#   to run mainResponder.subscriptions.updateAllChangesTables.  That
+#   thread is unbounded and cannot be cleanly joined from the test; it
+#   exits on its own once no DB updates are pending.  Documented as a
+#   known limitation of legacy UserTalk for this smoke test.
+#
 # Known false-positive drift warning:
-#   The integration test runner's MD5-based sysroot drift check flags this
-#   file as mutating the system root.  Investigation (2026-04-19) confirmed
-#   the test cleanup is logically complete — no paths leak after delete.
-#   The MD5 drift is caused by save-path non-determinism in the ODB file
-#   format (timestamps / block allocation order), and reproduces for a pure
-#   no-op CLI invocation.  Tracked for runner fix in a follow-up PR; not a
-#   bug in this test.
+#   Even with full conditional cleanup, the runner's MD5-based sysroot
+#   drift check will flag the file as mutated, because the ODB save path
+#   is non-deterministic at the byte level (timestamps / block allocation
+#   order).  This reproduces for a pure no-op CLI invocation.  Tracked in
+#   #545 for runner-side fix.
 #
 # Reference:
 #   - planning/MANILA_MAINRESPONDER_E2E.md (Phase B)
@@ -43,6 +56,16 @@ tests:
       if not file.exists(guestpath) {
         return "skip"
       };
+
+      // Snapshot pre-test state for sysroot paths that mainResponder.init()
+      // may create.  We'll only delete paths that didn't already exist, so
+      // the test leaves the sysroot exactly as it found it and is idempotent
+      // across repeated runs in the shared protocol-mode process.
+      local(preConfigMainResponder = defined(@config.mainResponder));
+      local(preIsRadio = defined(@system.environment.isRadio));
+      local(preHttp2 = defined(@user.inetd.config.http2));
+      local(preRootUpdatesCallbacks = defined(@user.rootUpdates.callbacks));
+      local(preAfterInstall = defined(@user.rootUpdates.callbacks.afterInstallPart.mainResponder));
 
       // Prepare the param table BEFORE try — so else branch can clean it up
       new(tableType, @system.temp.mrSmoke);
@@ -83,7 +106,11 @@ tests:
         // try/else block.  The duplication is intentional — scriptError()
         // below does not return, so we cannot consolidate into a finally.
         try { fileMenu.close(guestpath) };
-        try { delete(@config.mainResponder) };
+        if not preConfigMainResponder { try { delete(@config.mainResponder) } };
+        if not preIsRadio { try { delete(@system.environment.isRadio) } };
+        if not preHttp2 { try { delete(@user.inetd.config.http2) } };
+        if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } };
+        if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } };
         try { delete(@system.temp.mrSmoke) };
         scriptError("mainResponder.respond smoke failed: " + err)
       };
@@ -91,8 +118,14 @@ tests:
       // Success-path cleanup.  Close the guest DB explicitly — the protocol-
       // mode runner shares one CLI process across tests and only resets REPL
       // variables via script/clearContext, which does not close open DBs.
+      // Conditional deletes restore only what we created, based on the
+      // pre-test snapshot above.
       try { fileMenu.close(guestpath) };
-      try { delete(@config.mainResponder) };
+      if not preConfigMainResponder { try { delete(@config.mainResponder) } };
+      if not preIsRadio { try { delete(@system.environment.isRadio) } };
+      if not preHttp2 { try { delete(@user.inetd.config.http2) } };
+      if not preAfterInstall { try { delete(@user.rootUpdates.callbacks.afterInstallPart.mainResponder) } };
+      if not preRootUpdatesCallbacks { try { delete(@user.rootUpdates.callbacks) } };
       try { delete(@system.temp.mrSmoke) };
 
       return succeeded
@@ -102,6 +135,10 @@ tests:
       Smoke test — passed on first run (2026-04-19), confirming that
       mainResponder.respond() executes end-to-end in the headless runtime
       with no missing verbs or globals.  Assertions verify responseBody is
-      a string; body content is not checked because it depends on
-      config.mainResponder.domains.default pointing to a www folder, which
-      is environment-specific.
+      a string and non-empty; body content is not checked because it
+      depends on config.mainResponder.domains.default pointing to a www
+      folder, which is environment-specific.
+
+      Cleanup uses conditional delete based on pre-test defined() snapshot
+      so the test is idempotent across repeated runs and does not leak
+      sysroot state into subsequent tests.

--- a/tests/integration/test_cases/mainresponder_smoke.yaml
+++ b/tests/integration/test_cases/mainresponder_smoke.yaml
@@ -58,10 +58,21 @@ tests:
       try {
         fileMenu.open(guestpath, true);
         mainResponder.init();
+
+        // mainResponder.respond() writes responseBody back into the param
+        // table rather than returning a separate response object.  Pass the
+        // address so the callee can mutate our table in place.
         mainResponder.respond(@system.temp.mrSmoke.req);
 
         if typeof(system.temp.mrSmoke.req.responseBody) != 'TEXT' {
           scriptError("mainResponder.respond returned no responseBody (or non-string)")
+        };
+
+        // Even in a headless environment without a real www folder, respond()
+        // should produce a non-empty body (error page, 404, etc.).  An empty
+        // string would indicate it bailed out silently.
+        if string.length(system.temp.mrSmoke.req.responseBody) == 0 {
+          scriptError("mainResponder.respond returned an empty responseBody")
         };
 
         succeeded = true


### PR DESCRIPTION
## Summary

- Adds `tests/integration/test_cases/mainresponder_smoke.yaml` — a discovery probe verifying `mainResponder.respond()` runs end-to-end in the headless runtime
- Designed as a discovery test expected to fail on first run; **passed on first run**, confirming the legacy ~1000-line UserTalk dispatcher works headlessly without verb stubs
- Significant de-risking signal for Phase C (inetd + mainResponder integration) and Phase D (Manila install) of the Manila/mainResponder plan
- As a side effect, fixing the initial PR #543 review finding (add `fileMenu.close()` to cleanup) **resolved 17 cascading test failures** across persistence_save / dual_db / filemenu_verbs / cross-db categories — the protocol-mode runner shares one `frontier-cli` process across tests and does not close guest DBs between them

## Test design

Opens `mainResponder.root` as a guest DB, builds a minimal `GET / HTTP/1.0` param table in `system.temp`, calls `mainResponder.init()` then `mainResponder.respond()`, asserts `responseBody` is a string and non-empty, and restores sysroot state on both the happy and exception paths using a snapshot-and-restore pattern (conditional deletes based on `defined()` checks captured before `init()`).

`User-Agent = "Testing in Debugger"` is set so `respond.ut` skips its debug-log and `scratchpad.paramtable` writes. Uses `try/else` with `scriptError(tryError)` for informative CI output on failure.

## Cleanup strategy

`mainResponder.init()` writes several sysroot paths beyond `config.mainResponder`:

- `system.environment.isRadio`
- `user.inetd.config` / `user.inetd.config.http2`
- `user.rootUpdates.callbacks` / `.afterInstallPart` / `.afterInstallPart.mainResponder`

The test snapshots `defined()` for each path (including intermediate parent tables) before calling `init()`, then conditionally deletes only paths that didn't previously exist. This makes the test idempotent across repeated runs in the shared protocol-mode process.

`init()` also spawns a background thread via `thread.callScript()` for `mainResponder.subscriptions.updateAllChangesTables`. The cleanup yields via `thread.sleepTicks(12)` (~200 ms) before deleting paths the thread may touch — in the headless environment the thread exits almost immediately because there are no pending DB updates.

## Known false positive

The runner's MD5-based sysroot drift check warns this test mutates the system root. Investigation confirmed the drift is caused by ODB save-path non-determinism (timestamps + block-allocation order) and reproduces for a pure no-op CLI invocation. **Tracked in jsavin/Frontier#545 for runner-side fix** — this is not a bug in the test.

## Test plan

- [x] New test passes in isolation (1/1)
- [x] Full integration suite: **2225 total / 1991 pass / 0 fail / 234 skip**
- [x] Unit tests: 302/302 pass
- [x] OPML manifest regenerated and committed

Note: Baseline at PR open showed 19 fail; adding `fileMenu.close()` in round 1 (per reviewer) resolved 17 of those as a side effect. The remaining 2 were known-flaky baseline tests that surface intermittently and were green on the current run.

## Files changed

- `tests/integration/test_cases/mainresponder_smoke.yaml` (new)
- `reports/integration_tests.opml` (regenerated)
- `reports/integration_tests/mainresponder_smoke.opml` (new, per-category OPML)

## Follow-up issues

- jsavin/Frontier#545 — MD5 drift check false positive (runner-side fix)
- jsavin/Frontier#546 — OPML pluralization nit ("1 tests" → "1 test")

## Plan context

Phase B of the Manila/mainResponder E2E plan. Follows Phase A (PR #541, merged) which established the inetd E2E test foundation. Next up: Phase C wires inetd → mainResponder together.

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto

