### PR TITLE
chore: Standardize C code on tabs for indentation (rule + guardrails)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig (https://editorconfig.org) — Frontier repo
+#
+# Tabs are MANDATORY for C sources. Frontier's outline editor translates
+# between plaintext and outlines using tab-based indentation; spaces-indented
+# C code is actively hostile to that workflow. The pre-commit hook enforces
+# this for staged files; this file ensures editors do the right thing on save.
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 4
+
+[*.{py,sh,bash}]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,10 @@ trim_trailing_whitespace = true
 indent_style = tab
 # For tab indentation, indent_size is a display-width hint only (it becomes
 # tab_width); the actual indentation character is always a hard tab.
+# tab_width is set explicitly so editors (notably VS Code) that interpret
+# indent_size as a soft-tab-stop still treat Tab keypresses as hard tabs.
 indent_size = 4
+tab_width = 4
 
 [*.{py,sh,bash}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,4 +33,5 @@ indent_size = 2
 trim_trailing_whitespace = false
 
 [Makefile]
+# Makefiles require hard tabs in recipe lines; inherits charset/eol/newline from [*].
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,8 @@ trim_trailing_whitespace = true
 
 [*.{c,h}]
 indent_style = tab
+# For tab indentation, indent_size is a display-width hint only (it becomes
+# tab_width); the actual indentation character is always a hard tab.
 indent_size = 4
 
 [*.{py,sh,bash}]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,6 @@ This document is a concise contributor guide for Frontier’s C/C toolchain and 
 
 ## Coding Style & Naming Conventions
 
-<!-- 2026-04-19 Codex: Flipped indentation rule from spaces to tabs (project-wide). Reason: Frontier's outline editor translates between plaintext and outlines using tab-based indentation — spaces-indented C is hostile to that workflow. Enforced via .editorconfig and pre-commit hook. -->
-
 - **Language**: C — tests use `-std=c99`, CLI uses `-std=c17`.
 - **Indentation**: **Tabs** for all C code. No spaces for indentation in `*.c`/`*.h`.
   - **Why**: Frontier's outline editor translates between plaintext and outlines using tab-based indentation. Spaces-indented C code breaks that workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,22 @@ This document is a concise contributor guide for Frontier’s C/C toolchain and 
 - Static analysis: Not configured; optional local runs via `scan-build` or `clang-tidy` are encouraged.
 
 ## Coding Style & Naming Conventions
-- Language: C (tests `-std=c99`), CLI `-std=c17`.
-- Indentation: 4 spaces, no tabs; 100‑column soft limit.
-- Braces: K&R style (same line), consistent include order: system, project, local.
-- Filenames: C sources `snake_case.c/h`; tests use `test_*.c` or `*_tests.c`.
-- Warnings: Keep `-Wall -Wextra` clean; prefer small, focused functions.
+
+<!-- 2026-04-19 Codex: Flipped indentation rule from spaces to tabs (project-wide). Reason: Frontier's outline editor translates between plaintext and outlines using tab-based indentation — spaces-indented C is hostile to that workflow. Enforced via .editorconfig and pre-commit hook. -->
+
+- **Language**: C — tests use `-std=c99`, CLI uses `-std=c17`.
+- **Indentation**: **Tabs** for all C code. No spaces for indentation in `*.c`/`*.h`.
+  - **Why**: Frontier's outline editor translates between plaintext and outlines using tab-based indentation. Spaces-indented C code breaks that workflow.
+  - Enforced by `.editorconfig` (editor-on-save) and the pre-commit hook (rejects staged C files with leading-space indentation).
+  - A mass retab of pre-existing spaces-indented files happens in a separate PR; until then, the hook only checks staged files.
+- **Column width**: 100-column soft limit.
+- **Braces**: K&R style — opening brace on the same line.
+- **Include order**: system headers first, then project headers, then local.
+- **Filenames**:
+  - New C sources: `snake_case.c/h`.
+  - Legacy CamelCase/dot-compound filenames (e.g., `CallMachOFrameWork.c`, `FSCopyObject.c`, `memory.track.c`) are retained as-is to preserve history.
+  - Tests: `test_*.c` or `*_tests.c`.
+- **Warnings**: Keep `-Wall -Wextra` clean; prefer small, focused functions.
 
 ## Testing Guidelines
 - Add unit/integration tests under `tests/components/` or `tests/examples/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ Use those rules as mandatory baseline guidance.
   - **Why**: Frontier's outline editor translates between plaintext and outlines using tab-based indentation. Spaces-indented C source is hostile to that workflow, so tabs are mandatory project-wide.
   - Enforced by `.editorconfig` (editors auto-use tabs on save) and the pre-commit hook (rejects staged C files whose added lines use leading-space indentation).
   - A mass retab of pre-existing spaces-indented files is tracked as a separate PR; until then, the hook only checks staged files, so unrelated commits aren't blocked.
-  - Bypass (rare, e.g., vendored code imports): `git commit --no-verify`.
+  - **Agents: do NOT use `--no-verify` to bypass this hook.** Per the global Git Safety Protocol, hook skipping requires explicit user authorization. If the hook fires unexpectedly (e.g., comment/string continuation-line alignment), stop and surface the failure to the user rather than bypassing.
 - **Column width**: 100-column soft limit.
 - **Braces**: K&R style — opening brace on the same line.
 - **Include order**: system headers first, then project headers, then local.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,25 @@ Use those rules as mandatory baseline guidance.
 
 ---
 
+## C Coding Style & Naming Conventions
+
+- **Language**: C — tests use `-std=c99`, CLI uses `-std=c17`.
+- **Indentation**: **Tabs** for all C code. No spaces for indentation in `*.c`/`*.h`.
+  - **Why**: Frontier's outline editor translates between plaintext and outlines using tab-based indentation. Spaces-indented C source is hostile to that workflow, so tabs are mandatory project-wide.
+  - Enforced by `.editorconfig` (editors auto-use tabs on save) and the pre-commit hook (rejects staged C files whose added lines use leading-space indentation).
+  - A mass retab of pre-existing spaces-indented files is tracked as a separate PR; until then, the hook only checks staged files, so unrelated commits aren't blocked.
+  - Bypass (rare, e.g., vendored code imports): `git commit --no-verify`.
+- **Column width**: 100-column soft limit.
+- **Braces**: K&R style — opening brace on the same line.
+- **Include order**: system headers first, then project headers, then local.
+- **Filenames**:
+  - New C sources: `snake_case.c/h`.
+  - Legacy CamelCase/dot-compound filenames (e.g., `CallMachOFrameWork.c`, `FSCopyObject.c`, `memory.track.c`) are retained as-is to preserve history.
+  - Tests: `test_*.c` or `*_tests.c`.
+- **Warnings**: Keep `-Wall -Wextra` clean; prefer small, focused functions.
+
+---
+
 ## Critical Testing Constraints
 
 Cross-agent test requirements (including integration test expectations for verb changes) now live in `docs/AI_SHARED_GUIDELINES.md`.

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -51,6 +51,7 @@ These rules apply when working with high autonomy (e.g., iterating on PR feedbac
 
 ### File organization
 - **Production code in production locations.** Headers used by `frontier-cli/` code belong in `frontier-cli/`, not `tests/`. Think about the dependency direction before creating files.
+- **C indentation uses tabs** (project-wide). Enforced via `.editorconfig` and the pre-commit hook. See the "C Coding Style & Naming Conventions" section in `AGENTS.md` / `CLAUDE.md` for the full rule and rationale (outline editor tab-translation compatibility).
 
 ## Required Test and Validation Policy
 

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -17,7 +17,7 @@
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
-HOOK_VERSION=2
+HOOK_VERSION=3
 
 set -e
 
@@ -189,14 +189,29 @@ if [ -n "$C_FILES_CHANGED" ]; then
             /^\+\+\+/ { next }
             /^\+/ {
                 # Flag if the added line starts with a space-indent, BUT skip
-                # legitimate comment / docstring continuation lines whose
-                # indentation aligns the "*" of a block comment:
+                # legitimate block-comment continuation lines:
                 #     /* first
-                #      * continuation   <-- ends in " *", valid C style
+                #      * continuation   <-- valid C style
                 #      */
-                # We skip any added line whose leading whitespace is followed
-                # by "*" or "/" (catches "* comment", "*/", "/* foo").
-                if (substr($0, 2, 1) == " " && $0 !~ /^\+[ \t]*[*\/]/) {
+                #
+                # We must NOT exclude space-indented pointer code like:
+                #     *ptr = value;
+                #     **argv;
+                # so the exclusion matches only lines where the leading run
+                # of whitespace is followed by one of:
+                #   - "/*"   (start of block comment)
+                #   - "*/"   (end of block comment)
+                #   - "* "   (comment continuation with text)
+                #   - "**"   (but "**/"-style close falls under "*/" above;
+                #             bare "**something" as a pointer deref in C is
+                #             rare enough at indent column that flagging it
+                #             is preferable to a broad exclusion — we leave
+                #             "**" un-excluded so pointer code gets caught)
+                is_comment_cont = ($0 ~ /^\+[ \t]*\/\*/ || \
+                                   $0 ~ /^\+[ \t]*\*\// || \
+                                   $0 ~ /^\+[ \t]*\* /  || \
+                                   $0 ~ /^\+[ \t]*\*$/)
+                if (substr($0, 2, 1) == " " && !is_comment_cont) {
                     print lineno ": " $0
                 }
                 lineno++

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -17,7 +17,7 @@
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
-HOOK_VERSION=3
+HOOK_VERSION=4
 
 set -e
 
@@ -174,11 +174,11 @@ if [ -n "$C_FILES_CHANGED" ]; then
         [ -n "$f" ] || continue
         # Skip deleted files (diff-filter already excludes D, but be safe)
         [ -f "$f" ] || continue
-        # Note on the awk regex below: `\t` inside a character class is
-        # recognized by gawk and BSD awk (macOS default) but is not
-        # strictly POSIX. The repo targets macOS and Linux, both of
-        # which ship awks that support this, so it is safe in practice.
+        # The regex uses [[:blank:]] (POSIX) which matches tab and space on
+        # any awk implementation, avoiding portability concerns with \t
+        # inside a character class (gawk/BSD-only).
         VIOLATIONS=$(git diff --cached -U0 -- "$f" | awk '
+            BEGIN { lineno = 0 }
             /^@@/ {
                 # Extract the starting line number after "+"
                 if (match($0, /\+[0-9]+/)) {
@@ -198,27 +198,26 @@ if [ -n "$C_FILES_CHANGED" ]; then
                 #     *ptr = value;
                 #     **argv;
                 # so the exclusion matches only lines where the leading run
-                # of whitespace is followed by one of:
-                #   - "/*"   (start of block comment)
-                #   - "*/"   (end of block comment)
-                #   - "* "   (comment continuation with text)
-                #   - "**"   (but "**/"-style close falls under "*/" above;
-                #             bare "**something" as a pointer deref in C is
-                #             rare enough at indent column that flagging it
-                #             is preferable to a broad exclusion — we leave
-                #             "**" un-excluded so pointer code gets caught)
-                is_comment_cont = ($0 ~ /^\+[ \t]*\/\*/ || \
-                                   $0 ~ /^\+[ \t]*\*\// || \
-                                   $0 ~ /^\+[ \t]*\* /  || \
-                                   $0 ~ /^\+[ \t]*\*$/)
+                # of blanks is followed by one of:
+                #   - "/*"     (start of block comment)
+                #   - "*/"     (end of block comment)
+                #   - "* text" (comment continuation with content)
+                #   - bare "*" (blank continuation line)
+                is_comment_cont = ($0 ~ /^\+[[:blank:]]*\/\*/ || \
+                                   $0 ~ /^\+[[:blank:]]*\*\// || \
+                                   $0 ~ /^\+[[:blank:]]*\* /  || \
+                                   $0 ~ /^\+[[:blank:]]*\*$/)
                 if (substr($0, 2, 1) == " " && !is_comment_cont) {
                     print lineno ": " $0
                 }
                 lineno++
                 next
             }
-            # Context lines (with -U0 there should be none) and deletions:
+            # Context lines (with -U0 there should be none):
             /^ / { lineno++ }
+            # Deletion lines (/^-/) are intentionally unhandled: they do not
+            # exist in the new file and therefore do not advance the new-file
+            # line counter.
         ' || true)
         if [ -n "$VIOLATIONS" ]; then
             INDENT_VIOLATIONS="${INDENT_VIOLATIONS}${f}:\n${VIOLATIONS}\n"

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -3,10 +3,17 @@
 #
 # Checks:
 #   1. Block commits to develop in the main worktree (use feature branches)
-#   2. Auto-regenerate OPML export when integration tests change
-#   3. Validate documentation references when docs change
+#   2. Reject staged *.c/*.h files with leading-space indentation
+#   3. Auto-regenerate OPML export when integration tests change
+#   4. Validate documentation references when docs change
 #
 # Install: Run tools/install_git_hooks.sh
+#
+# HOOK_VERSION — bump when adding or materially changing a guard.
+# install_git_hooks.sh uses this value to detect stale installations and
+# reinstall automatically. Keep the assignment on its own line so the
+# installer can parse it with a simple grep.
+HOOK_VERSION=2
 
 set -e
 
@@ -171,7 +178,15 @@ if [ -n "$C_FILES_CHANGED" ]; then
             }
             /^\+\+\+/ { next }
             /^\+/ {
-                if (substr($0, 2, 1) == " ") {
+                # Flag if the added line starts with a space-indent, BUT skip
+                # legitimate comment / docstring continuation lines whose
+                # indentation aligns the "*" of a block comment:
+                #     /* first
+                #      * continuation   <-- ends in " *", valid C style
+                #      */
+                # We skip any added line whose leading whitespace is followed
+                # by "*" or "/" (catches "* comment", "*/", "/* foo").
+                if (substr($0, 2, 1) == " " && $0 !~ /^\+[ \t]*[*\/]/) {
                     print lineno ": " $0
                 }
                 lineno++
@@ -197,14 +212,14 @@ if [ -n "$C_FILES_CHANGED" ]; then
         echo "" >&2
         echo "Fix: Re-indent the file with tabs (one tab per indentation level)." >&2
         echo "" >&2
-        echo "Note: continuation-line alignment inside comment blocks and" >&2
-        echo "multi-line string literals can also trip this check (the second" >&2
-        echo "and later lines start with spaces for visual alignment). For" >&2
-        echo "those rare cases, 'git commit --no-verify' is the correct" >&2
-        echo "escape hatch — or reformat to start such continuation lines at" >&2
-        echo "column 0 so they are not caught." >&2
+        echo "Rare case: If this is a multi-line string literal whose" >&2
+        echo "continuation lines are space-aligned for visual readability," >&2
+        echo "reformat to start continuation lines at column 0 (or tab-indent" >&2
+        echo "them). Block comment continuation lines starting with '*' or" >&2
+        echo "'/' are already excluded from this check." >&2
         echo "" >&2
-        echo "To bypass (rare, e.g., importing vendored code): git commit --no-verify" >&2
+        echo "Agents: do not use --no-verify to bypass this hook. Surface the" >&2
+        echo "failure to the user and ask how to proceed." >&2
         exit 1
     fi
 fi

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -134,6 +134,52 @@ if [ -n "$DOC_FILES_CHANGED" ]; then
 fi
 
 # ──────────────────────────────────────────────────────────────
+# C indentation: Reject staged *.c/*.h with leading-space indent
+#
+# Frontier's outline editor translates between plaintext and outlines using
+# tab-based indentation. Spaces-indented C code breaks that workflow, so
+# ALL C code must use tabs for indentation.
+#
+# This check only inspects STAGED files, so existing spaces-indented files
+# won't block unrelated commits until they're touched.
+# ──────────────────────────────────────────────────────────────
+
+C_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|h)$' || true)
+
+if [ -n "$C_FILES_CHANGED" ]; then
+    # Examine only the added/changed lines in the staged diff. A leading-space
+    # indent in an added line means this commit would introduce (or keep)
+    # space-based indentation in a C source file.
+    INDENT_VIOLATIONS=""
+    for f in $C_FILES_CHANGED; do
+        # Skip deleted files (diff-filter already excludes D, but be safe)
+        [ -f "$f" ] || continue
+        # `git diff --cached -U0` shows added lines prefixed with '+' (not '+++').
+        # A violation is an added line whose first character is a space.
+        VIOLATIONS=$(git diff --cached -U0 -- "$f" | grep -nE '^\+ ' | grep -vE '^\+\+\+' || true)
+        if [ -n "$VIOLATIONS" ]; then
+            INDENT_VIOLATIONS="${INDENT_VIOLATIONS}${f}:\n${VIOLATIONS}\n"
+        fi
+    done
+
+    if [ -n "$INDENT_VIOLATIONS" ]; then
+        echo -e "${RED}ERROR: Staged C files use spaces for indentation. Frontier requires tabs.${NC}" >&2
+        echo "" >&2
+        echo "Rationale: Frontier's outline editor translates between plaintext and" >&2
+        echo "outlines using tab-based indentation. Spaces-indented C code breaks" >&2
+        echo "that workflow." >&2
+        echo "" >&2
+        echo "Offending files and added lines:" >&2
+        echo -e "$INDENT_VIOLATIONS" | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "Fix: Re-indent the file with tabs (one tab per indentation level)." >&2
+        echo "" >&2
+        echo "To bypass (rare, e.g., importing vendored code): git commit --no-verify" >&2
+        exit 1
+    fi
+fi
+
+# ──────────────────────────────────────────────────────────────
 # Verb registration: Check for broken \p prefixes and wrong lengths
 # ──────────────────────────────────────────────────────────────
 

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -17,7 +17,7 @@
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
-HOOK_VERSION=5
+HOOK_VERSION=6
 
 set -e
 
@@ -155,7 +155,7 @@ fi
 # won't block unrelated commits until they're touched.
 # ──────────────────────────────────────────────────────────────
 
-C_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|h)$' || true)
+C_FILES_CHANGED=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(c|h)$' || true)
 
 if [ -n "$C_FILES_CHANGED" ]; then
     # Examine only the added/changed lines in the staged diff. A leading-space
@@ -193,8 +193,10 @@ if [ -n "$C_FILES_CHANGED" ]; then
             }
             /^\+\+\+/ { next }
             /^\+/ {
-                # Flag if the added line starts with a space-indent, BUT skip
-                # legitimate block-comment continuation lines:
+                # Flag if the added line has ANY space in its leading
+                # whitespace run (pure-space indent, OR mixed tab+space
+                # like "\t    foo"), BUT skip legitimate block-comment
+                # continuation lines:
                 #     /* first
                 #      * continuation   <-- valid C style
                 #      */
@@ -212,7 +214,19 @@ if [ -n "$C_FILES_CHANGED" ]; then
                                    $0 ~ /^\+[[:blank:]]*\*\// || \
                                    $0 ~ /^\+[[:blank:]]*\* /  || \
                                    $0 ~ /^\+[[:blank:]]*\*$/)
-                if (substr($0, 2, 1) == " " && !is_comment_cont) {
+                # Extract the leading blank run (after the "+" diff marker)
+                # and check whether it contains any space character. This
+                # catches pure-space indent AND mixed indentation like
+                # a tab followed by spaces, or spaces followed by a tab —
+                # both of which break the outline editor tab translation.
+                has_space_in_indent = 0
+                if (match($0, /^\+[[:blank:]]*/)) {
+                    indent = substr($0, 2, RLENGTH - 1)
+                    if (index(indent, " ") > 0) {
+                        has_space_in_indent = 1
+                    }
+                }
+                if (has_space_in_indent && !is_comment_cont) {
                     print lineno ": " $0
                 }
                 lineno++

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -9,7 +9,11 @@
 #
 # Install: Run tools/install_git_hooks.sh
 #
-# HOOK_VERSION — bump when adding or materially changing a guard.
+# HOOK_VERSION — bump for any change that would cause existing installations
+# to behave differently from the source of truth. Concretely: new checks,
+# changed exit codes, changed error-message format, changed detection regex.
+# Pure comment/whitespace edits do not require a bump.
+#
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
@@ -165,9 +169,15 @@ if [ -n "$C_FILES_CHANGED" ]; then
     # context (' ') line, and emit file:lineno when an added line starts with
     # a space.
     INDENT_VIOLATIONS=""
-    for f in $C_FILES_CHANGED; do
+    # Read filenames line-by-line so paths with spaces are handled safely.
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
         # Skip deleted files (diff-filter already excludes D, but be safe)
         [ -f "$f" ] || continue
+        # Note on the awk regex below: `\t` inside a character class is
+        # recognized by gawk and BSD awk (macOS default) but is not
+        # strictly POSIX. The repo targets macOS and Linux, both of
+        # which ship awks that support this, so it is safe in practice.
         VIOLATIONS=$(git diff --cached -U0 -- "$f" | awk '
             /^@@/ {
                 # Extract the starting line number after "+"
@@ -198,7 +208,7 @@ if [ -n "$C_FILES_CHANGED" ]; then
         if [ -n "$VIOLATIONS" ]; then
             INDENT_VIOLATIONS="${INDENT_VIOLATIONS}${f}:\n${VIOLATIONS}\n"
         fi
-    done
+    done <<< "$C_FILES_CHANGED"
 
     if [ -n "$INDENT_VIOLATIONS" ]; then
         echo -e "${RED}ERROR: Staged C files use spaces for indentation. Frontier requires tabs.${NC}" >&2

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -17,7 +17,7 @@
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
-HOOK_VERSION=4
+HOOK_VERSION=5
 
 set -e
 
@@ -169,6 +169,7 @@ if [ -n "$C_FILES_CHANGED" ]; then
     # context (' ') line, and emit file:lineno when an added line starts with
     # a space.
     INDENT_VIOLATIONS=""
+    NL=$'\n'
     # Read filenames line-by-line so paths with spaces are handled safely.
     while IFS= read -r f; do
         [ -n "$f" ] || continue
@@ -177,6 +178,10 @@ if [ -n "$C_FILES_CHANGED" ]; then
         # The regex uses [[:blank:]] (POSIX) which matches tab and space on
         # any awk implementation, avoiding portability concerns with \t
         # inside a character class (gawk/BSD-only).
+        #
+        # With -U0, no context lines are emitted, and deletion lines
+        # (/^-/) do not exist in the new file — so only @@ headers and
+        # added lines (/^+/) need handling.
         VIOLATIONS=$(git diff --cached -U0 -- "$f" | awk '
             BEGIN { lineno = 0 }
             /^@@/ {
@@ -211,16 +216,10 @@ if [ -n "$C_FILES_CHANGED" ]; then
                     print lineno ": " $0
                 }
                 lineno++
-                next
             }
-            # Context lines (with -U0 there should be none):
-            /^ / { lineno++ }
-            # Deletion lines (/^-/) are intentionally unhandled: they do not
-            # exist in the new file and therefore do not advance the new-file
-            # line counter.
-        ' || true)
+        ')
         if [ -n "$VIOLATIONS" ]; then
-            INDENT_VIOLATIONS="${INDENT_VIOLATIONS}${f}:\n${VIOLATIONS}\n"
+            INDENT_VIOLATIONS="${INDENT_VIOLATIONS}${f}:${NL}${VIOLATIONS}${NL}"
         fi
     done <<< "$C_FILES_CHANGED"
 
@@ -236,11 +235,14 @@ if [ -n "$C_FILES_CHANGED" ]; then
         echo "" >&2
         echo "Fix: Re-indent the file with tabs (one tab per indentation level)." >&2
         echo "" >&2
-        echo "Rare case: If this is a multi-line string literal whose" >&2
-        echo "continuation lines are space-aligned for visual readability," >&2
-        echo "reformat to start continuation lines at column 0 (or tab-indent" >&2
-        echo "them). Block comment continuation lines starting with '*' or" >&2
-        echo "'/' are already excluded from this check." >&2
+        echo "Rare cases:" >&2
+        echo "  - Multi-line string literal whose continuation lines are" >&2
+        echo "    space-aligned for visual readability: reformat to start" >&2
+        echo "    continuation lines at column 0 (or tab-indent them)." >&2
+        echo "  - Multi-line macro with backslash continuation: use tab" >&2
+        echo "    indentation on continuation lines, not spaces." >&2
+        echo "  - Block comment continuation lines starting with '*' or" >&2
+        echo "    '/' are already excluded from this check." >&2
         echo "" >&2
         echo "Agents: do not use --no-verify to bypass this hook. Surface the" >&2
         echo "failure to the user and ask how to proceed." >&2

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -17,6 +17,20 @@
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
+#
+# Version history:
+#   v1: initial — OPML export + develop-branch guard + doc validation.
+#   v2: added HOOK_VERSION marker (prior unversioned hooks detected via
+#       legacy string match).
+#   v3: added C-indent check; line numbers reconstructed from @@ hunks.
+#   v4: C-indent regex tightened so `*ptr = x` is no longer falsely
+#       excluded by the block-comment carve-out.
+#   v5: POSIX [[:blank:]]; defensive lineno=0 init; error message
+#       reworded to disallow --no-verify and mention multi-line macros.
+#   v6: detect mixed tab+space indent (`\t    foo`); --diff-filter=ACMR
+#       so renamed-and-modified files are also checked.
+#   v7: error message lists alignment-space function-call continuation
+#       as a known false-positive with recommended fix.
 HOOK_VERSION=7
 
 set -e

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -17,7 +17,7 @@
 # install_git_hooks.sh uses this value to detect stale installations and
 # reinstall automatically. Keep the assignment on its own line so the
 # installer can parse it with a simple grep.
-HOOK_VERSION=6
+HOOK_VERSION=7
 
 set -e
 
@@ -250,6 +250,11 @@ if [ -n "$C_FILES_CHANGED" ]; then
         echo "Fix: Re-indent the file with tabs (one tab per indentation level)." >&2
         echo "" >&2
         echo "Rare cases:" >&2
+        echo "  - Multi-line function call with arguments column-aligned" >&2
+        echo "    under the open paren (tab + spaces): use tab-only" >&2
+        echo "    indent on continuation lines, e.g." >&2
+        echo "        foo(arg1," >&2
+        echo "            arg2);  // tab-indent, do not space-align" >&2
         echo "  - Multi-line string literal whose continuation lines are" >&2
         echo "    space-aligned for visual readability: reformat to start" >&2
         echo "    continuation lines at column 0 (or tab-indent them)." >&2

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -150,13 +150,36 @@ if [ -n "$C_FILES_CHANGED" ]; then
     # Examine only the added/changed lines in the staged diff. A leading-space
     # indent in an added line means this commit would introduce (or keep)
     # space-based indentation in a C source file.
+    #
+    # Line numbers are reconstructed from the @@ hunk headers so they map to
+    # the SOURCE file, not the diff output. Hunk header format is:
+    #     @@ -old,len +new,len @@
+    # We track the "+new" line counter, incrementing it on each added ('+') or
+    # context (' ') line, and emit file:lineno when an added line starts with
+    # a space.
     INDENT_VIOLATIONS=""
     for f in $C_FILES_CHANGED; do
         # Skip deleted files (diff-filter already excludes D, but be safe)
         [ -f "$f" ] || continue
-        # `git diff --cached -U0` shows added lines prefixed with '+' (not '+++').
-        # A violation is an added line whose first character is a space.
-        VIOLATIONS=$(git diff --cached -U0 -- "$f" | grep -nE '^\+ ' | grep -vE '^\+\+\+' || true)
+        VIOLATIONS=$(git diff --cached -U0 -- "$f" | awk '
+            /^@@/ {
+                # Extract the starting line number after "+"
+                if (match($0, /\+[0-9]+/)) {
+                    lineno = substr($0, RSTART + 1, RLENGTH - 1) + 0
+                }
+                next
+            }
+            /^\+\+\+/ { next }
+            /^\+/ {
+                if (substr($0, 2, 1) == " ") {
+                    print lineno ": " $0
+                }
+                lineno++
+                next
+            }
+            # Context lines (with -U0 there should be none) and deletions:
+            /^ / { lineno++ }
+        ' || true)
         if [ -n "$VIOLATIONS" ]; then
             INDENT_VIOLATIONS="${INDENT_VIOLATIONS}${f}:\n${VIOLATIONS}\n"
         fi
@@ -169,10 +192,17 @@ if [ -n "$C_FILES_CHANGED" ]; then
         echo "outlines using tab-based indentation. Spaces-indented C code breaks" >&2
         echo "that workflow." >&2
         echo "" >&2
-        echo "Offending files and added lines:" >&2
+        echo "Offending files and source line numbers:" >&2
         echo -e "$INDENT_VIOLATIONS" | sed 's/^/  /' >&2
         echo "" >&2
         echo "Fix: Re-indent the file with tabs (one tab per indentation level)." >&2
+        echo "" >&2
+        echo "Note: continuation-line alignment inside comment blocks and" >&2
+        echo "multi-line string literals can also trip this check (the second" >&2
+        echo "and later lines start with spaces for visual alignment). For" >&2
+        echo "those rare cases, 'git commit --no-verify' is the correct" >&2
+        echo "escape hatch — or reformat to start such continuation lines at" >&2
+        echo "column 0 so they are not caught." >&2
         echo "" >&2
         echo "To bypass (rare, e.g., importing vendored code): git commit --no-verify" >&2
         exit 1

--- a/tools/hooks/pre-commit-integration-tests
+++ b/tools/hooks/pre-commit-integration-tests
@@ -31,7 +31,9 @@
 #       so renamed-and-modified files are also checked.
 #   v7: error message lists alignment-space function-call continuation
 #       as a known false-positive with recommended fix.
-HOOK_VERSION=7
+#   v8: violation output strips the diff "+" prefix (cosmetic; line
+#       numbers unchanged).
+HOOK_VERSION=8
 
 set -e
 
@@ -241,7 +243,9 @@ if [ -n "$C_FILES_CHANGED" ]; then
                     }
                 }
                 if (has_space_in_indent && !is_comment_cont) {
-                    print lineno ": " $0
+                    # Strip the leading "+" diff marker so the printed line
+                    # looks like source, not diff output.
+                    print lineno ": " substr($0, 2)
                 }
                 lineno++
             }

--- a/tools/install_git_hooks.sh
+++ b/tools/install_git_hooks.sh
@@ -23,15 +23,23 @@ PRE_COMMIT_SRC="$TOOLS_HOOKS_DIR/pre-commit-integration-tests"
 PRE_COMMIT_DST="$HOOKS_DIR/pre-commit"
 
 if [ -f "$PRE_COMMIT_DST" ]; then
-    # Existing pre-commit hook - check if it's ours
-    # Marker string lives in the latest hook so older installations get upgraded.
-    if grep -q "C indentation: Reject staged" "$PRE_COMMIT_DST" 2>/dev/null; then
-        echo -e "${YELLOW}Pre-commit hook already installed (up to date)${NC}"
-    elif grep -q -E "pre-commit-integration-tests|Block commits to develop" "$PRE_COMMIT_DST" 2>/dev/null; then
-        # Older version without latest guards — upgrade it
+    # Existing pre-commit hook - check if it's ours.
+    # Version detection: compare HOOK_VERSION in source vs installed copy.
+    # Older hooks without HOOK_VERSION are detected via legacy markers.
+    SRC_VERSION=$(grep -E '^HOOK_VERSION=' "$PRE_COMMIT_SRC" 2>/dev/null | head -1 | cut -d= -f2)
+    DST_VERSION=$(grep -E '^HOOK_VERSION=' "$PRE_COMMIT_DST" 2>/dev/null | head -1 | cut -d= -f2)
+
+    if [ -n "$SRC_VERSION" ] && [ "$SRC_VERSION" = "$DST_VERSION" ]; then
+        echo -e "${YELLOW}Pre-commit hook already installed (HOOK_VERSION=$DST_VERSION, up to date)${NC}"
+    elif [ -n "$DST_VERSION" ] || grep -q -E "pre-commit-integration-tests|Block commits to develop" "$PRE_COMMIT_DST" 2>/dev/null; then
+        # Either a versioned hook at a different version, or an older unversioned hook — upgrade.
         cp "$PRE_COMMIT_SRC" "$PRE_COMMIT_DST"
         chmod +x "$PRE_COMMIT_DST"
-        echo -e "${GREEN}✓ Upgraded pre-commit hook (added C tab-indent guard)${NC}"
+        if [ -n "$DST_VERSION" ]; then
+            echo -e "${GREEN}✓ Upgraded pre-commit hook (HOOK_VERSION $DST_VERSION → $SRC_VERSION)${NC}"
+        else
+            echo -e "${GREEN}✓ Upgraded pre-commit hook (unversioned → HOOK_VERSION=$SRC_VERSION)${NC}"
+        fi
     else
         echo -e "${YELLOW}Warning: Existing pre-commit hook found${NC}"
         echo "You have an existing pre-commit hook. To use both hooks:"

--- a/tools/install_git_hooks.sh
+++ b/tools/install_git_hooks.sh
@@ -24,13 +24,14 @@ PRE_COMMIT_DST="$HOOKS_DIR/pre-commit"
 
 if [ -f "$PRE_COMMIT_DST" ]; then
     # Existing pre-commit hook - check if it's ours
-    if grep -q "Block commits to develop" "$PRE_COMMIT_DST" 2>/dev/null; then
+    # Marker string lives in the latest hook so older installations get upgraded.
+    if grep -q "C indentation: Reject staged" "$PRE_COMMIT_DST" 2>/dev/null; then
         echo -e "${YELLOW}Pre-commit hook already installed (up to date)${NC}"
-    elif grep -q "pre-commit-integration-tests" "$PRE_COMMIT_DST" 2>/dev/null; then
-        # Older version without develop guard — upgrade it
+    elif grep -q -E "pre-commit-integration-tests|Block commits to develop" "$PRE_COMMIT_DST" 2>/dev/null; then
+        # Older version without latest guards — upgrade it
         cp "$PRE_COMMIT_SRC" "$PRE_COMMIT_DST"
         chmod +x "$PRE_COMMIT_DST"
-        echo -e "${GREEN}✓ Upgraded pre-commit hook (added develop branch guard)${NC}"
+        echo -e "${GREEN}✓ Upgraded pre-commit hook (added C tab-indent guard)${NC}"
     else
         echo -e "${YELLOW}Warning: Existing pre-commit hook found${NC}"
         echo "You have an existing pre-commit hook. To use both hooks:"
@@ -53,6 +54,9 @@ echo "What this does:"
 echo "  • Blocks commits to 'develop' in the main worktree"
 echo "    - Use feature branches in worktrees instead"
 echo "    - Bypass with: git commit --no-verify"
+echo "  • Rejects staged *.c/*.h files with leading-space indentation"
+echo "    - Frontier requires tabs for C code (outline editor compatibility)"
+echo "    - Only checks staged files; pre-existing files are not affected"
 echo "  • When you commit changes to tests/integration/test_cases/*.yaml"
 echo "    - The hook automatically regenerates reports/integration_tests.opml"
 echo "    - The updated OPML is added to your commit"

--- a/tools/install_git_hooks.sh
+++ b/tools/install_git_hooks.sh
@@ -29,7 +29,16 @@ if [ -f "$PRE_COMMIT_DST" ]; then
     SRC_VERSION=$(grep -E '^HOOK_VERSION=' "$PRE_COMMIT_SRC" 2>/dev/null | head -1 | cut -d= -f2)
     DST_VERSION=$(grep -E '^HOOK_VERSION=' "$PRE_COMMIT_DST" 2>/dev/null | head -1 | cut -d= -f2)
 
-    if [ -n "$SRC_VERSION" ] && [ "$SRC_VERSION" = "$DST_VERSION" ]; then
+    # Defensive guard: a source file missing HOOK_VERSION= would produce
+    # misleading "upgraded to version ''" messages and defeat the detection.
+    if [ -z "$SRC_VERSION" ]; then
+        echo -e "${RED}ERROR: HOOK_VERSION= marker missing in $PRE_COMMIT_SRC${NC}" >&2
+        echo "The hook source file is corrupted or pre-dates versioning." >&2
+        echo "Cannot auto-upgrade safely. Restore the source file and retry." >&2
+        exit 1
+    fi
+
+    if [ "$SRC_VERSION" = "$DST_VERSION" ]; then
         echo -e "${YELLOW}Pre-commit hook already installed (HOOK_VERSION=$DST_VERSION, up to date)${NC}"
     elif [ -n "$DST_VERSION" ] || grep -q -E "pre-commit-integration-tests|Block commits to develop" "$PRE_COMMIT_DST" 2>/dev/null; then
         # Either a versioned hook at a different version, or an older unversioned hook — upgrade.


### PR DESCRIPTION
## Summary

- Standardize all Frontier C code on **tabs** for indentation (project-wide), flipping the prior AGENTS.md rule of "4 spaces, no tabs."
- **Rationale:** Frontier's outline editor translates between plaintext and outlines using tab-based indentation. Spaces-indented C source is hostile to that workflow, so tabs are mandatory.
- Add guardrails that make the rule enforceable without a CI linter:
  - `.editorconfig` — editors pick up `indent_style = tab` for `*.c`/`*.h` automatically on save.
  - Pre-commit hook — rejects staged `*.c`/`*.h` files whose added lines use leading-space indentation, with clear file:line error output. Only checks **staged** files, so pre-existing spaces-indented files don't block unrelated commits until they're touched.
- Update AGENTS.md and CLAUDE.md "C Coding Style" sections: require tabs everywhere, capture the outline-editor rationale inline.

## Out of scope (PR 2 of 2)

Retabbing pre-existing spaces-indented files (~17 new-era files in `Common/source/` plus any stragglers in `frontier-cli/`, `portable/`, `tests/`) is handled in a **separate** mechanical-whitespace PR so that:

- Reviewers can verify with `git diff -w` showing an empty diff.
- This PR stays small and focused on the rule + enforcement.
- If the retab misses anything, this hook will catch it on the first touch.

## Files touched

- `.editorconfig` (new) — 34 lines
- `AGENTS.md` — Coding Style section rewritten
- `CLAUDE.md` — New "C Coding Style & Naming Conventions" section added between UserTalk Critical Facts and Critical Testing Constraints
- `tools/hooks/pre-commit-integration-tests` — new "C indentation" guard block
- `tools/install_git_hooks.sh` — detect older hook versions, upgrade on install; updated "What this does" banner

## Test plan

- [x] **Unit:** `./tools/run_headless_tests.sh` — 302/302 pass
- [x] **Integration:** `cd tests && make test-integration` — 1971 pass, 234 skipped, 19 pre-existing failures (filemenu.save, guest db lifecycle, REPL /list; unrelated to this PR, which touches no C code)
- [x] **Hook validation** in an isolated scratch repo:
  - Spaces-indented `*.c` → **rejected** with file:line output ✓
  - Tabs-indented `*.c` → **accepted** ✓
  - Spaces-indented `*.h` → **rejected** ✓

## Follow-ups

- PR 2 (next): pure-whitespace retab of existing spaces-indented C/H files.
- Consider later: CI-side enforcement (GitHub Actions job that re-runs the hook's indentation check) once CI is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
