### PR TITLE
test: Run *_network.yaml integration tests by default

### DIFF
--- a/docs/TCP_ARCHITECTURE.md
+++ b/docs/TCP_ARCHITECTURE.md
@@ -252,12 +252,15 @@ TCP tests are organized into separate suites based on network dependencies:
 - Safe for CI/CD environments with restricted network access
 - Run automatically in all test execution contexts
 
-**Network Tests (Opt-In)**:
-- `tests/integration/test_cases/tcp_verbs_network.yaml` - 20 network-dependent tests (as of 2026-01-24)
-- Require external connectivity (connect to example.com:80)
-- Run manually via `FRONTIER_RUN_NETWORK_TESTS=1 make test-integration`
-- Validate actual TCP connectivity and protocol behavior
-- Not run by default to avoid test fragility
+**Self-Contained "Network" Tests**:
+- `tests/integration/test_cases/tcp_verbs_network.yaml` - 18 tests using
+  `tcp.listenStream` + localhost (ports 9100-9115)
+- The `_network.yaml` suffix is historical (these tests once hit
+  `example.com:80`). After the Phase 3 migration to localhost listeners,
+  the tests are deterministic and run by default.
+- One DNS-resolution test (`tcp.openNameStream` for an invalid hostname)
+  depends on the system resolver returning NXDOMAIN. Environments that
+  hijack NXDOMAIN responses will surface that as a real signal.
 
 **Server Operation Tests** (Phase 3):
 - `tests/integration/test_cases/tcp_server_verbs.yaml` - 37 tests for server operations
@@ -266,22 +269,16 @@ TCP tests are organized into separate suites based on network dependencies:
 
 ### Testing Progression (Phase 1 → Phase 3)
 
-**Phase 1A/1B (Complete)**: External dependency tests
-- Network tests connect to `example.com:80` for validation
-- Tests are opt-in and skipped by default
-- Enables manual verification of TCP implementation
-
-**Phase 2 (Planned)**: Buffered I/O with external dependencies
-- Continue pattern of separate network test suite
-- Add tests for `tcp.readStreamUntil`, `tcp.readStreamBytes`, etc.
-- Remain opt-in via `FRONTIER_RUN_NETWORK_TESTS=1`
+**Phase 1A/1B (Complete)**: Initial tests connected to `example.com:80`
+and were opt-in via `FRONTIER_RUN_NETWORK_TESTS=1` to avoid CI/CD
+fragility from DNS, timeouts, and firewall restrictions.
 
 **Phase 3 (Complete as of PR #330)**: Self-contained deterministic tests
 - `tcp.listenStream()` and `tcp.closeListen()` implemented
-- Tests can launch Frontier-based test server within integration test harness
-- Client tests can connect to localhost instead of external servers
-- Enables fully deterministic and CI/CD-friendly network tests
-- No external dependencies required for server operation testing
+- Tests now launch a Frontier-based test server within the test harness
+- Client tests connect to localhost instead of external servers
+- Fully deterministic and CI/CD-friendly
+- No external dependencies — `_network.yaml` files run by default
 
 **Example Phase 3 Self-Contained Test**:
 ```yaml
@@ -320,11 +317,8 @@ tests:
 ### Running Network Tests
 
 ```bash
-# Run all tests (local tests only, network tests skipped)
+# Run all tests, including tcp_verbs_network.yaml (uses localhost listeners)
 cd tests && make test-integration
-
-# Run with network tests enabled (manual verification)
-FRONTIER_RUN_NETWORK_TESTS=1 cd tests && make test-integration
 ```
 
 **See also**: `planning/phase4/networking/IMPLEMENTATION_PLAN.md` - Phase 2/3 testing roadmap

--- a/docs/TCP_ARCHITECTURE.md
+++ b/docs/TCP_ARCHITECTURE.md
@@ -258,9 +258,12 @@ TCP tests are organized into separate suites based on network dependencies:
 - The `_network.yaml` suffix is historical (these tests once hit
   `example.com:80`). After the Phase 3 migration to localhost listeners,
   the tests are deterministic and run by default.
+- Tests bind ports 9100-9115 — ensure no other process on the host is
+  using them.
 - One DNS-resolution test (`tcp.openNameStream` for an invalid hostname)
   depends on the system resolver returning NXDOMAIN. Environments that
-  hijack NXDOMAIN responses will surface that as a real signal.
+  hijack NXDOMAIN responses will surface that as a real signal. Set
+  `FRONTIER_SKIP_NETWORK_TESTS=1` to opt out of `*_network.yaml` files.
 
 **Server Operation Tests** (Phase 3):
 - `tests/integration/test_cases/tcp_server_verbs.yaml` - 37 tests for server operations

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -387,43 +387,32 @@ TESTDIR=$(./tools/get_test_temp_path.sh)
 
 ### Test Suite Organization
 
-TCP networking tests are split into two suites based on network dependencies:
+TCP networking tests are split across multiple files; all run by default:
 
-**Local Tests (Always Run)**:
+**Local TCP Tests**:
 - File: `tests/integration/test_cases/tcp_verbs.yaml`
-- 13 local-only tests (error handling, address encoding, parameter validation)
+- Local-only tests (error handling, address encoding, parameter validation)
 - No external network connectivity required
-- Run automatically in all test contexts
 
-**Network Tests (Opt-In)**:
+**Self-Contained "Network" Tests**:
 - File: `tests/integration/test_cases/tcp_verbs_network.yaml`
-- 9 network-dependent tests (connect to example.com:80)
-- Require external internet connectivity
-- Run manually via: `FRONTIER_RUN_NETWORK_TESTS=1 make test-integration`
-- Skipped by default to avoid test fragility
+- 18 tests using `tcp.listenStream` + localhost connections (ports 9100-9115)
+- The `_network.yaml` suffix is historical (these tests once hit external
+  servers). They are now self-contained and run by default.
+- One DNS-resolution test depends on the system resolver returning NXDOMAIN
+  for `this.hostname.does.not.exist.invalid`. Environments that hijack
+  NXDOMAIN responses (some corporate networks, captive portals) will
+  surface that test failure as a real signal.
 
-### Why Separate Network Tests?
+### Background: Why the `_network.yaml` Naming
 
-**Problem**: External network dependencies create test fragility
-- DNS resolution failures
-- Network timeouts and latency
-- Firewall restrictions in CI/CD
-- Tests fail for reasons unrelated to code changes
+Historically, `tcp_verbs_network.yaml` connected to external servers
+(e.g. `example.com:80`) and was opt-in via `FRONTIER_RUN_NETWORK_TESTS=1`
+to avoid CI/CD fragility from DNS, timeouts, and firewall restrictions.
 
-**Solution**: Split tests into local (always run) and network (opt-in)
-- CI/CD runs local tests only (fast, deterministic)
-- Developers run network tests manually for verification
-- Network test failures don't block PR merges
-
-### Phase 3 Self-Contained Tests (Now Available)
-
-As of PR #330 (2026-01-24), `tcp.listenStream()` is implemented, enabling **self-contained** network tests:
-- Launch Frontier-based test server within test harness
-- Tests connect to localhost instead of external servers
-- Fully deterministic with no external dependencies
-- Safe for air-gapped CI/CD environments
-
-**Status**: Infrastructure is complete. New tests can use localhost test servers for deterministic TCP testing.
+After `tcp.listenStream()` landed (PR #330, 2026-01-24), the tests were
+migrated to localhost listeners and are now deterministic. The opt-in gate
+was removed; the filename is preserved for git history continuity.
 
 **Example future self-contained test**:
 ```yaml

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -399,10 +399,13 @@ TCP networking tests are split across multiple files; all run by default:
 - 18 tests using `tcp.listenStream` + localhost connections (ports 9100-9115)
 - The `_network.yaml` suffix is historical (these tests once hit external
   servers). They are now self-contained and run by default.
+- Tests bind ports 9100-9115 — ensure nothing else on the host is using
+  them or tests will fail with bind errors.
 - One DNS-resolution test depends on the system resolver returning NXDOMAIN
   for `this.hostname.does.not.exist.invalid`. Environments that hijack
   NXDOMAIN responses (some corporate networks, captive portals) will
-  surface that test failure as a real signal.
+  surface that test failure as a real signal. To opt out of `*_network.yaml`
+  files entirely, set `FRONTIER_SKIP_NETWORK_TESTS=1`.
 
 ### Background: Why the `_network.yaml` Naming
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -414,7 +414,7 @@ After `tcp.listenStream()` landed (PR #330, 2026-01-24), the tests were
 migrated to localhost listeners and are now deterministic. The opt-in gate
 was removed; the filename is preserved for git history continuity.
 
-**Example future self-contained test**:
+**Example self-contained test**:
 ```yaml
 # Phase 3 pattern - test server runs within test harness
 tests:

--- a/docs/TEST_STATUS_SUMMARY.md
+++ b/docs/TEST_STATUS_SUMMARY.md
@@ -51,7 +51,7 @@ make: *** [headless_thread_registry_tests] Error 1
 | Total Tests Registered | ~1,495 |
 | Known Passing Tests | ~380-400 (estimated 25-27%) |
 | Known Failing Tests | ~400-450 (estimated 27-30%) |
-| Skipped Tests | Network tests (set FRONTIER_RUN_NETWORK_TESTS=1 to enable) |
+| Skipped Tests | YAML-level `skip:` directives only (no env-var gates) |
 
 ### Test Files & Results
 
@@ -239,8 +239,9 @@ These processors have no implementations yet:
 ### Critical Test Constraints
 
 **Network Tests:**
-- By default: Skipped (TCP network tests disabled)
-- To enable: `FRONTIER_RUN_NETWORK_TESTS=1 make test-integration`
+- TCP integration tests in `tcp_verbs_network.yaml` use localhost listeners
+  (ports 9100-9115) and run by default. The `_network.yaml` suffix is
+  historical — see `docs/TESTING_GUIDE.md` for context.
 
 ---
 

--- a/reports/integration_tests.opml
+++ b/reports/integration_tests.opml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <opml version="2.0">
   <head>
-    <title>Frontier Integration Tests - 2225 tests: 1993 pass (89%) 232 skip (10%)</title>
-    <dateCreated>Mon, 20 Apr 2026 08:11:15 GMT</dateCreated>
+    <title>Frontier Integration Tests - 2243 tests: 2011 pass (89%) 232 skip (10%)</title>
+    <dateCreated>Mon, 27 Apr 2026 04:12:42 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 08:10 UTC"/>
-      <outline text="Results: 1993 passed (90%), 232 skipped (10%), 0 failed (0%)"/>
-      <outline text="Duration: 37.4s (8 workers, batch mode)"/>
+      <outline text="Run: 2026-04-27 at 04:12 UTC"/>
+      <outline text="Results: 2011 passed (90%), 232 skipped (10%), 0 failed (0%)"/>
+      <outline text="Duration: 38.5s (8 workers, batch mode)"/>
       <outline text="YAML-defined: 2243 tests (2011 active, 232 marked skip) across 69 categories"/>
     </outline>
     <outline text="Bigstring Boundary Tests (bigstring_boundary_tests) - 28 tests: 28 pass (100%)" type="link" url="https://raw.githubusercontent.com/jsavin/Frontier/develop/reports/integration_tests/bigstring_boundary_tests.opml"/>

--- a/reports/unit_tests.opml
+++ b/reports/unit_tests.opml
@@ -2,11 +2,11 @@
 <opml version="2.0">
   <head>
     <title>Frontier Unit Tests - 302 tests: 302 pass (100%)</title>
-    <dateCreated>Mon, 20 Apr 2026 08:11:52 GMT</dateCreated>
+    <dateCreated>Mon, 27 Apr 2026 04:11:51 GMT</dateCreated>
   </head>
   <body>
     <outline text="Last Test Run">
-      <outline text="Run: 2026-04-20 at 08:11 UTC"/>
+      <outline text="Run: 2026-04-27 at 04:11 UTC"/>
       <outline text="Results: 302 passed (100%), 0 failed (0%)"/>
       <outline text="Executables: 30 (302 tests total)"/>
     </outline>

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -64,10 +64,15 @@ if [ $# -eq 0 ]; then
     # localhost listeners and are self-contained, so they now run by default.
     # (One DNS-resolution test in tcp_verbs_network.yaml depends on the
     # system resolver returning NXDOMAIN for an invalid hostname; environments
-    # that hijack NXDOMAIN responses will surface that as a real signal rather
-    # than flake.)
+    # that hijack NXDOMAIN responses can opt out via
+    # FRONTIER_SKIP_NETWORK_TESTS=1.)
     for f in "$TEST_CASES_DIR"/*.yaml; do
         if [ -f "$f" ]; then
+            if [[ "$f" == *"_network.yaml" ]] && [ "${FRONTIER_SKIP_NETWORK_TESTS:-0}" = "1" ]; then
+                echo -e "${YELLOW}Skipping network tests: $(basename "$f")${NC}"
+                echo "  (FRONTIER_SKIP_NETWORK_TESTS=1)"
+                continue
+            fi
             TEST_FILES+=("$f")
         fi
     done
@@ -106,9 +111,15 @@ else
                 echo "will be run, including *_network.yaml files (which now use localhost"
                 echo "listeners and are self-contained)."
                 echo
+                echo "Environment Variables:"
+                echo "  FRONTIER_SKIP_NETWORK_TESTS=1    Opt out of *_network.yaml files (e.g."
+                echo "                                   for environments that hijack NXDOMAIN"
+                echo "                                   DNS responses)"
+                echo
                 echo "Examples:"
                 echo "  $0                                    # Run all tests (batch + parallel)"
                 echo "  $0 --no-batch -j 1                   # Old behavior (per-process, sequential)"
+                echo "  FRONTIER_SKIP_NETWORK_TESTS=1 $0      # Skip *_network.yaml files"
                 echo "  $0 tests/integration/test_cases/string_verbs.yaml"
                 echo "  $0 --verbose tests/integration/test_cases/*.yaml"
                 exit 0

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -58,17 +58,16 @@ BATCH_FLAG="--batch"
 WORKERS_FLAG="-j 0"
 
 if [ $# -eq 0 ]; then
-    # No arguments - run all tests (except network tests unless opt-in)
+    # No arguments - run all tests. Files matching *_network.yaml were
+    # historically gated on FRONTIER_RUN_NETWORK_TESTS=1 because they hit
+    # external network resources. Those tests have since been migrated to
+    # localhost listeners and are self-contained, so they now run by default.
+    # (One DNS-resolution test in tcp_verbs_network.yaml depends on the
+    # system resolver returning NXDOMAIN for an invalid hostname; environments
+    # that hijack NXDOMAIN responses will surface that as a real signal rather
+    # than flake.)
     for f in "$TEST_CASES_DIR"/*.yaml; do
         if [ -f "$f" ]; then
-            # Skip network tests unless FRONTIER_RUN_NETWORK_TESTS=1
-            if [[ "$f" == *"_network.yaml" ]]; then
-                if [ "${FRONTIER_RUN_NETWORK_TESTS:-0}" != "1" ]; then
-                    echo -e "${YELLOW}Skipping network tests: $(basename "$f")${NC}"
-                    echo "  (Set FRONTIER_RUN_NETWORK_TESTS=1 to enable)"
-                    continue
-                fi
-            fi
             TEST_FILES+=("$f")
         fi
     done
@@ -103,16 +102,13 @@ else
                 echo "  -j N               Number of parallel workers (0=auto, 1=sequential)"
                 echo "  -h, --help         Show this help"
                 echo
-                echo "If no test files are specified, all tests in tests/integration/test_cases/ will be run."
-                echo "Network tests (*_network.yaml) are skipped by default unless FRONTIER_RUN_NETWORK_TESTS=1."
-                echo
-                echo "Environment Variables:"
-                echo "  FRONTIER_RUN_NETWORK_TESTS=1    Enable network-dependent tests (default: 0)"
+                echo "If no test files are specified, all tests in tests/integration/test_cases/"
+                echo "will be run, including *_network.yaml files (which now use localhost"
+                echo "listeners and are self-contained)."
                 echo
                 echo "Examples:"
-                echo "  $0                                    # Run all local tests (batch + parallel)"
+                echo "  $0                                    # Run all tests (batch + parallel)"
                 echo "  $0 --no-batch -j 1                   # Old behavior (per-process, sequential)"
-                echo "  FRONTIER_RUN_NETWORK_TESTS=1 $0      # Run all tests including network"
                 echo "  $0 tests/integration/test_cases/string_verbs.yaml"
                 echo "  $0 --verbose tests/integration/test_cases/*.yaml"
                 exit 0


### PR DESCRIPTION
## Summary

- Removes the `FRONTIER_RUN_NETWORK_TESTS=1` opt-in gate in `tools/run_integration_tests.sh`. The 18 tests in `tcp_verbs_network.yaml` now run by default.
- These tests were originally gated when they connected to `example.com:80`. After the Phase 3 migration to localhost listeners (PR #330) they are self-contained, deterministic, and add ~1s to the suite.
- Closes the 18-test gap between YAML-declared (2243) and run total (was 2225, now 2243), addressing PR #549 review feedback. The OPML title and body now align exactly.
- Updates `docs/TESTING_GUIDE.md`, `docs/TCP_ARCHITECTURE.md`, `docs/TEST_STATUS_SUMMARY.md` to reflect current reality (the `_network.yaml` suffix is now historical).

## Context

One DNS-resolution test (`tcp.openNameStream` for `this.hostname.does.not.exist.invalid`) depends on the system resolver returning NXDOMAIN. Environments that hijack NXDOMAIN responses (some corporate networks, captive portals) will surface that as a real environmental signal rather than flake. Per discussion, this is acceptable.

## Test plan

- [x] Unit tests: 302/302 pass
- [x] Integration tests: 2243 tests, 2011 pass, 232 skip, 0 fail (38.5s with network tests included)
- [x] OPML title and body now show consistent metrics (2243/2011/232/0)
- [x] `--help` text updated to remove obsolete env-var documentation
- [x] Verified that planning archives (`planning/archive/...`, `planning/phase4/networking/IMPLEMENTATION_PLAN.md`) are left as-is — they document historical decisions

## Related

- Follow-up to PR #549 (review feedback on OPML 18-test gap)
- Builds on PR #330 (Phase 3 localhost migration that made this gate obsolete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
