### PR TITLE
docs: declare /auto Test Manifest in CLAUDE.md (#561)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Build/test/migration command reference: see `docs/QUICK_REFERENCE.md`. Key paths
 
 Test output dirs: `tests/tmp/{unit,integration,migration,results}/`. Scratch files: `/tmp` or `tests/tmp/` both work.
 
+The unit and integration commands above are also declared in the `## /auto Test Manifest` section below — keep both in sync.
+
 ### Documentation Index
 
 All docs live in `docs/`. Notable entry points:
@@ -137,7 +139,7 @@ See `~/.claude/skills/auto/SKILL.md` (a local Claude Code skill install — not 
 - **Integration**: `cd tests && make test-integration` (required)
 - **E2E / UI**: none (headless CLI project)
 - **Smoke / Browser**: none
-- **Lint**: none (no project lint command established yet)
+- **Lint**: none
 - **Base branch**: `develop`
 - **Merge strategy**: `--squash` (branch deletion is manual — see `/auto` skill Phase 6 for the exit-worktree-then-merge sequence; `--delete-branch` is incompatible with merging from inside a worktree)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,15 @@ After editing `.claude/gate.yaml`, validate with `/gate --validate` (or `python3
 
 ## /auto Test Manifest
 
-Test commands and contract used by the `/auto` skill. Status semantics: `required` = must run + must pass (blocks push and merge); `skippable` = run if infra available, else note skip in PR description; `manual-only` = do not run autonomously, list in PR for reviewer; `none` = layer does not exist in this project. See `~/.claude/skills/auto/SKILL.md` (a local Claude Code skill install — not in this repo) for the full table.
+Test commands and contract used by the `/auto` skill.
+
+Status semantics for the entries below:
+- `required` — must run and pass; blocks push and merge
+- `skippable` — run if infra is available; otherwise note skip in PR description
+- `manual-only` — do not run autonomously; list in PR for reviewer
+- `none` — this layer does not exist in this project
+
+See `~/.claude/skills/auto/SKILL.md` (a local Claude Code skill install — not in this repo) for the full table.
 
 - **Unit**: `./tools/run_headless_tests.sh` (required)
 - **Integration**: `cd tests && make test-integration` (required)
@@ -131,7 +139,7 @@ Test commands and contract used by the `/auto` skill. Status semantics: `require
 - **Smoke / Browser**: none
 - **Lint**: none (no project lint command established yet)
 - **Base branch**: `develop`
-- **Merge strategy**: `--squash` (cleanup is manual — see `/auto` skill Phase 6 for the exit-worktree-then-merge sequence; `--delete-branch` is incompatible with merging from inside a worktree)
+- **Merge strategy**: `--squash` (branch deletion is manual — see `/auto` skill Phase 6 for the exit-worktree-then-merge sequence; `--delete-branch` is incompatible with merging from inside a worktree)
 
 Both required test layers must pass before push and before merge. Frontier has no E2E/UI/Lint layers — those entries exist for cross-project portability of `/auto`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,22 @@ After editing `.claude/gate.yaml`, validate with `/gate --validate` (or `python3
 
 ---
 
+## /auto Test Manifest
+
+Test commands and contract used by the `/auto` skill. See `~/.claude/skills/auto/SKILL.md` for status semantics.
+
+- **Unit**: `./tools/run_headless_tests.sh` (required)
+- **Integration**: `cd tests && make test-integration` (required)
+- **E2E / UI**: none (headless CLI project)
+- **Smoke / Browser**: none
+- **Lint**: none (no project lint command established yet)
+- **Base branch**: `develop`
+- **Merge strategy**: `--squash` (cleanup is manual — see `/auto` skill Phase 6 for the exit-worktree-then-merge sequence; `--delete-branch` is incompatible with merging from inside a worktree)
+
+Both required test layers must pass before push and before merge. Frontier has no E2E/UI/Lint layers — those entries exist for cross-project portability of `/auto`.
+
+---
+
 ## ODB Script Editing Rules
 
 **Edit `databases/Virgin.root`** for changes that should persist in builds. `Virgin.root` is the source of truth — `make dist` copies it to `dist/Frontier.root`. Edits to `databases/Frontier.root` are local only and overwritten.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ Test commands and contract used by the `/auto` skill. See `~/.claude/skills/auto
 
 Both required test layers must pass before push and before merge. Frontier has no E2E/UI/Lint layers — those entries exist for cross-project portability of `/auto`.
 
+The unit and integration commands above are also listed in the Quick Reference section near the top of this file — keep both in sync.
+
 ---
 
 ## ODB Script Editing Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ After editing `.claude/gate.yaml`, validate with `/gate --validate` (or `python3
 
 ## /auto Test Manifest
 
-Test commands and contract used by the `/auto` skill. See `~/.claude/skills/auto/SKILL.md` for status semantics.
+Test commands and contract used by the `/auto` skill. Status semantics: `required` = must run + must pass (blocks push and merge); `skippable` = run if infra available, else note skip in PR description; `manual-only` = do not run autonomously, list in PR for reviewer; `none` = layer does not exist in this project. See `~/.claude/skills/auto/SKILL.md` (a local Claude Code skill install — not in this repo) for the full table.
 
 - **Unit**: `./tools/run_headless_tests.sh` (required)
 - **Integration**: `cd tests && make test-integration` (required)


### PR DESCRIPTION
## Summary

Declares the canonical Frontier `/auto` Test Manifest in `CLAUDE.md` so future `/auto` runs read the test contract from a known location instead of re-deriving it from prose each time.

This PR completes a four-issue batch addressing `/auto` skill quality issues surfaced during PR #557:

| Issue | What | Where it was fixed |
|-------|------|--------------------|
| #559 | Merge-safety regex matched `"blocking"` inside `"non-blocking"` | `~/.claude/skills/auto/SKILL.md` Phase 5 — replaced bare keywords with explicit phrases + negation guard |
| #560 | Phase 6 implied `gh pr merge --delete-branch` works from inside a worktree (it doesn't — git refuses to delete a checked-out branch) | `~/.claude/skills/auto/SKILL.md` Phase 6 — replaced with explicit ExitWorktree-then-merge sequence |
| #561 | Inferred test manifest worked but recommendation to declare one was never surfaced | **This PR** (Frontier side) + `~/.claude/skills/auto/SKILL.md` Phase 0/8 (skill side) |
| #562 | Post-merge PR self-reflection comment easy to skip — last item in Phase 8 reads as appendix to the in-session report | `~/.claude/skills/auto/SKILL.md` Phase 8 — reordered + added Closing Checklist |

The skill-side fixes were applied directly to `~/.claude/skills/auto/SKILL.md` (file lives outside any git repo — no PR possible). This PR is the only Frontier-repo-visible artifact of the batch.

## Test plan

- [x] Both required `/auto` Test Manifest layers run and pass on this branch:
  - **Unit**: `./tools/run_headless_tests.sh` → 302 tests, all pass
  - **Integration**: `cd tests && make test-integration` → 2243 tests, 2011 pass, 232 skip, 0 fail
- [x] Doc validation pre-commit hook passes (verified all referenced docs exist, gotchas present, size within target)
- [x] Diff is docs-only — no code changes, no behavior changes

## Manual Verification Needed

None — docs-only change.

Closes #561.
Refs #559, #560, #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
