### PR TITLE
test: warn when CLI binary is older than first-party sources

### DIFF
--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -64,7 +64,7 @@ if [ -n "$STALE_SOURCES" ]; then
     echo -e "${YELLOW}Warning: source files newer than CLI binary ($CLI_PATH)${NC}"
     echo "  Sample (up to 5):"
     echo "$STALE_SOURCES" | sed 's/^/    /'
-    echo "  Tests may fail against stale code. Rebuild with: cd frontier-cli && make"
+    echo "  Tests may fail against stale code. Rebuild with: make -C \"$PROJECT_ROOT/frontier-cli\""
     echo ""
 fi
 

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -43,11 +43,15 @@ if [ ! -f "$CLI_PATH" ]; then
     exit 1
 fi
 
-# Warn if the binary is older than any first-party source file.
-# Stale binaries silently produce "regression" failures that don't reflect
-# the current code (e.g., recently merged fixes won't be present).
-# Search Common/source/, frontier-cli/, and tests/ (excluding tests/tmp/
-# which holds build output and would always look newer).
+# Warn if the binary is older than any first-party source file that
+# compiles into frontier-cli. Stale binaries silently produce "regression"
+# failures that don't reflect the current code (e.g., recently merged fixes
+# won't be present).
+#
+# Search Common/source/ and frontier-cli/ — the two trees that feed into
+# frontier-cli. tests/ is intentionally excluded: tests/*.c are unit-test
+# stubs that compile into the headless test binary, not frontier-cli, so
+# touching them shouldn't trigger a "rebuild CLI" warning.
 #
 # Use absolute paths via $PROJECT_ROOT so the check works regardless of the
 # caller's CWD — relative paths would silently match nothing when invoked
@@ -55,17 +59,15 @@ fi
 STALE_SOURCES=$(find \
     "$PROJECT_ROOT/Common/source" \
     "$PROJECT_ROOT/frontier-cli" \
-    "$PROJECT_ROOT/tests" \
     \( -name '*.c' -o -name '*.h' -o -name '*.m' \) \
     -newer "$CLI_PATH" \
-    -not -path "$PROJECT_ROOT/tests/tmp/*" \
     2>/dev/null | head -5)
 if [ -n "$STALE_SOURCES" ]; then
     echo -e "${YELLOW}Warning: source files newer than CLI binary ($CLI_PATH)${NC}"
     echo "  Sample (up to 5):"
     echo "$STALE_SOURCES" | sed 's/^/    /'
     echo "  Tests may fail against stale code. Rebuild with: make -C \"$PROJECT_ROOT/frontier-cli\""
-    echo ""
+    echo
 fi
 
 # Check for Python dependencies

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -43,6 +43,31 @@ if [ ! -f "$CLI_PATH" ]; then
     exit 1
 fi
 
+# Warn if the binary is older than any first-party source file.
+# Stale binaries silently produce "regression" failures that don't reflect
+# the current code (e.g., recently merged fixes won't be present).
+# Search Common/source/, frontier-cli/, and tests/ (excluding tests/tmp/
+# which holds build output and would always look newer).
+#
+# Use absolute paths via $PROJECT_ROOT so the check works regardless of the
+# caller's CWD — relative paths would silently match nothing when invoked
+# from outside the repo root, defeating the guard.
+STALE_SOURCES=$(find \
+    "$PROJECT_ROOT/Common/source" \
+    "$PROJECT_ROOT/frontier-cli" \
+    "$PROJECT_ROOT/tests" \
+    \( -name '*.c' -o -name '*.h' -o -name '*.m' \) \
+    -newer "$CLI_PATH" \
+    -not -path "$PROJECT_ROOT/tests/tmp/*" \
+    2>/dev/null | head -5)
+if [ -n "$STALE_SOURCES" ]; then
+    echo -e "${YELLOW}Warning: source files newer than CLI binary ($CLI_PATH)${NC}"
+    echo "  Sample (up to 5):"
+    echo "$STALE_SOURCES" | sed 's/^/    /'
+    echo "  Tests may fail against stale code. Rebuild with: cd frontier-cli && make"
+    echo ""
+fi
+
 # Check for Python dependencies
 if ! python3 -c "import yaml" 2>/dev/null; then
     echo -e "${YELLOW}Warning: PyYAML not installed${NC}"


### PR DESCRIPTION
## Summary

Adds a stale-binary check to `tools/run_integration_tests.sh` that warns when the CLI binary (`frontier-cli/frontier-cli`) is older than any first-party source under `Common/source/` or `frontier-cli/` (the two trees that compile into `frontier-cli`). Defensive only — non-fatal warning, run continues.

## Why

Investigated 10 apparent integration regressions on `develop` post-#567 (7× `op.insert` line-ending tests, 3× `fileMenu` headless no-ops). Root cause was a stale Apr 9 binary that predated #542 (`op.insert` line-ending fixes) and #565 (`fileMenu` headless no-ops). Rebuilding the CLI cleared every failure (full suite → 2243/2011/232/0).

This guard prevents the same false-regression investigation from recurring: if the binary lags any source file, the operator sees a sample of stale files and the rebuild command before the run starts.

## Implementation notes

- Uses absolute paths via `$PROJECT_ROOT` so the check works regardless of caller CWD (a relative-path version was caught by `/gate` bar-raiser review and fixed before push).
- `tests/` is intentionally excluded from the search — `tests/*.c` are unit-test stubs that compile into the headless test binary, not `frontier-cli`, so touching them shouldn't trigger a "rebuild CLI" warning. (Caught in round-2 review.)
- `head -5` caps the sample so the output stays readable.
- `2>/dev/null` suppresses missing-directory noise on partial checkouts.

## Test plan

- [x] Unit tests pass: `./tools/run_headless_tests.sh` → 302/302
- [x] Integration tests pass: `./tools/run_integration_tests.sh` → 2243 total, 2011 passed, 232 skipped, **0 failed**
- [x] Warning fires when source is touched: `touch Common/source/lang.c && ./tools/run_integration_tests.sh --help` → warning printed
- [x] Warning silent after rebuild / mtime reset
- [x] Works from non-root CWD: invoked from `/tmp` with absolute path → warning still fires
- [x] Warning silent on `tests/*.c` edits (correct: those don't affect `frontier-cli`)

## /gate

PASS — bar-raiser caught one P1 (relative paths) which was fixed before push; security clean; concurrency auto-skipped (no triggers); swiftui excluded (no Swift).

## Review-loop history

- **Round 1** (P2 nit): rebuild hint used relative path → fixed to `make -C "$PROJECT_ROOT/frontier-cli"`
- **Round 2** (substantive): `tests/*.c` shouldn't trigger CLI rebuild warning → dropped `tests/` from search; also bare `echo` for blank-line consistency
- **Round 3**: LGTM, only flagged outdated PR Summary text → updated above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
