### PR TITLE
test: clean up 33 inert skip_reason="" lines in menu_*.yaml

### DIFF
--- a/tests/integration/test_cases/menu_data_verbs.yaml
+++ b/tests/integration/test_cases/menu_data_verbs.yaml
@@ -28,8 +28,6 @@ tests:
 
   - name: "menu.addMenuCommand - create new menu and add item"
     description: "Add a command to a new menubar, creating the menu if it doesn't exist"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       local(ok = menu.addMenuCommand(@system.temp.testMenu, "File", "New", "dialog.alert(\"New!\")"));
@@ -40,8 +38,6 @@ tests:
 
   - name: "menu.addMenuCommand - add multiple items to same menu"
     description: "Add multiple commands to the same menu"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "Edit", "Cut", "edit.cut()");
@@ -54,8 +50,6 @@ tests:
 
   - name: "menu.addMenuCommand - replace existing item script"
     description: "Adding an item that already exists should replace its script"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -72,8 +66,6 @@ tests:
 
   - name: "menu.addMenuCommand - create multiple menus"
     description: "Add items to different menus in the same menubar"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -92,8 +84,6 @@ tests:
 
   - name: "menu.deleteMenuCommand - delete existing item"
     description: "Delete a command that exists in the menu"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "File", "ToDelete", "script()");
@@ -105,8 +95,6 @@ tests:
 
   - name: "menu.deleteMenuCommand - delete nonexistent item (no-op in headless)"
     description: "deleteMenuCommand is a no-op in headless mode, returns true regardless"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -120,8 +108,6 @@ tests:
 
   - name: "menu.deleteMenuCommand - delete from nonexistent menu (no-op in headless)"
     description: "deleteMenuCommand is a no-op in headless mode, returns true regardless"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -135,8 +121,6 @@ tests:
 
   - name: "menu.deleteMenuCommand - verify item is actually removed"
     description: "After deletion, adding same item again should work"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -189,8 +173,6 @@ tests:
 
   - name: "menu.setScript - change script on menu item"
     description: "Set a new script on a menu item using address"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -250,8 +232,6 @@ tests:
 
   - name: "menu.setCommandKey - set keyboard shortcut"
     description: "Set a command key (keyboard shortcut) on a menu item"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -346,8 +326,6 @@ tests:
 
   - name: "menu.addMenuCommand - empty menu name creates unnamed menu"
     description: "Using empty string for menu name should still work"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -361,8 +339,6 @@ tests:
 
   - name: "menu.addMenuCommand - empty item name"
     description: "Using empty string for item name"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -376,8 +352,6 @@ tests:
 
   - name: "menu.addMenuCommand - special characters in item name"
     description: "Item names with special characters should work"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -391,8 +365,6 @@ tests:
 
   - name: "menu.addMenuCommand - separator item"
     description: "Using dash for item name may create separator"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -406,8 +378,6 @@ tests:
 
   - name: "menu.addMenuCommand - multiline script"
     description: "Script parameter can contain multiple lines"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -427,8 +397,6 @@ tests:
 
   - name: "menu.buildMenuBar - no-op in headless mode"
     description: "buildMenuBar is a no-op in headless mode, returns true"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "File", "New", "test()");
@@ -443,8 +411,6 @@ tests:
 
   - name: "menu.install - no-op in headless mode"
     description: "menu.install is a no-op in headless mode, returns true"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "Custom", "Test", "test()");
@@ -479,8 +445,6 @@ tests:
 
   - name: "menu verbs - build complete menu structure"
     description: "Create a realistic menu structure with multiple menus and items"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -510,8 +474,6 @@ tests:
 
   - name: "menu verbs - modify existing menu"
     description: "Add items, delete some, modify others"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -565,8 +527,6 @@ tests:
 
   - name: "menu.addSubMenu - add as new top-level menu with empty menuName"
     description: "Using empty string for menuName adds submenu as new top-level menu"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.parentMenu);
 
@@ -585,8 +545,6 @@ tests:
 
   - name: "menu.addSubMenu - creates menu if menuName doesn't exist"
     description: "If menuName doesn't exist, it should be created"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.parentMenu);
       # parentMenu is empty - no "Custom" menu exists yet
@@ -605,8 +563,6 @@ tests:
 
   - name: "menu.addSubMenu - no-op ignores invalid address in headless"
     description: "addSubMenu is a no-op in headless mode, returns true regardless of params"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.parentMenu);
 
@@ -619,8 +575,6 @@ tests:
 
   - name: "menu.deleteSubMenu - delete existing submenu"
     description: "Delete a menu from the menubar by name"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -639,8 +593,6 @@ tests:
 
   - name: "menu.deleteSubMenu - delete nonexistent menu (no-op in headless)"
     description: "deleteSubMenu is a no-op in headless mode, returns true regardless"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "File", "New", "fileNew()");
@@ -655,8 +607,6 @@ tests:
 
   - name: "menu.deleteSubMenu - can delete single item too"
     description: "deleteSubMenu can delete a single item, not just a submenu"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "File", "SingleItem", "doIt()");
@@ -1019,8 +969,6 @@ tests:
 
   - name: "menu.buildMenuBar - returns true without error in headless"
     description: "buildMenuBar is a no-op returning true in headless without throwing error"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "File", "New", "test()");
@@ -1036,8 +984,6 @@ tests:
 
   - name: "menu.install - returns true without error in headless"
     description: "install is a no-op returning true in headless without throwing error"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "Custom", "Test", "test()");
@@ -1053,8 +999,6 @@ tests:
 
   - name: "menu.isInstalled - returns false without error"
     description: "isInstalled should return false in headless without throwing error"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
 
@@ -1069,8 +1013,6 @@ tests:
 
   - name: "menu.remove - returns true without error in headless"
     description: "remove is a no-op returning true in headless without throwing error"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.testMenu);
       menu.addMenuCommand(@system.temp.testMenu, "File", "Test", "test()");

--- a/tests/integration/test_cases/menu_value_copy.yaml
+++ b/tests/integration/test_cases/menu_value_copy.yaml
@@ -19,8 +19,6 @@ tests:
 
   - name: "mbar copy - copy menubar value to new location"
     description: "Create a menubar at system.temp.src, copy to system.temp.dst, verify typeof is mbar"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.src);
       system.temp.dst = system.temp.src;
@@ -37,8 +35,6 @@ tests:
 
   - name: "mbar copy - defined() works after copy"
     description: "Create menubar, copy it, verify defined() returns true on the copy"
-    skip: false
-    skip_reason: ""
     script: |
       new(menubarType, @system.temp.src);
       system.temp.dst = system.temp.src;
@@ -80,8 +76,6 @@ tests:
 
   - name: "mbar read - typeof userland.virginBookmarkMenu is mbar"
     description: "Verify we can access userland.virginBookmarkMenu and its type is mbar"
-    skip: false
-    skip_reason: ""
     script: |
       return typeof(userland.virginBookmarkMenu) == 'mbar'
     expected_success: true
@@ -93,8 +87,6 @@ tests:
 
   - name: "mbar copy - copy userland.virginBookmarkMenu to workspace"
     description: "Copy userland.virginBookmarkMenu to workspace location - this is the exact operation that was failing"
-    skip: false
-    skip_reason: ""
     script: |
       system.temp.testCopy = userland.virginBookmarkMenu;
       local (result = typeof(system.temp.testCopy) == 'mbar');


### PR DESCRIPTION
## Summary

Cleans up 33 inert `skip_reason: ""` lines across two integration test files. **Surprising finding**: every one of these 33 entries had `skip: false` set alongside the empty `skip_reason` — meaning the runner was already executing them. The empty skip_reason was leftover metadata from earlier triage scaffolding, not a real skip directive.

These tests have been passing all along. No tests needed to be unskipped, no skip_reasons needed to be filled in, no tests were obsolete.

## Action

Removed both the `skip: false` and `skip_reason: ""` lines from all 33 entries, bringing them in line with the canonical style used by the other ~100 test files (which simply omit `skip:` on tests that should run).

- `tests/integration/test_cases/menu_data_verbs.yaml`: 29 entries cleaned
- `tests/integration/test_cases/menu_value_copy.yaml`: 4 entries cleaned

Total: 66 line deletions, 0 line additions. No test logic, names, descriptions, or commands changed.

## Audit categorization

| Category | Count |
|----------|-------|
| (a) Passing-now → unskipped | 33 |
| (b) Still failing → reason filled in | 0 |
| (c) Obsolete → deleted | 0 |

The "passing-now" count is technically misleading — these were already passing because they were never actually being skipped. The empty `skip_reason` was inert metadata.

## Why the original triage flagged them

During the skip-burn-down audit (#566), `grep "skip_reason: \"\""` was used as a coarse filter to find tests that needed proper skip reasons written. It conflated two cases:

1. **`skip: true` with empty reason** — real undocumented skips needing investigation (zero of these existed)
2. **`skip: false` with empty reason** — inert template metadata (all 33 fell here)

This PR is the resolution: case 2 just needs cleanup.

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` → **302/302 pass, 0 fail**
- [x] Integration tests: `./tools/run_integration_tests.sh` → **2222 / 2011 / 211 / 0** (identical to post-#569 baseline — all deltas zero, as expected for cosmetic cleanup)
- [x] Both YAML files round-trip through `yaml.safe_load`
- [x] Zero remaining `skip_reason: ""` matches across `tests/integration/test_cases/`

## /gate

PASS — bar-raiser confirmed the diff is exactly 66 lines of `skip: false` / `skip_reason: ""` pair removals with no other content touched.

## Context

Final of three burn-down PRs from skip-triage audit (#566):

- #568 — investigate the 10 false regressions (✅ merged)
- #569 — delete 21 dead REPL tests (✅ merged)
- This PR — clean up 33 inert empty-reason metadata lines

After all three merge, integration suite goes from 2243 / 2001 / 232 / 10 (broken baseline before audit) → 2222 / 2011 / 211 / 0 (clean, accurate baseline). 232 → 211 skipped (-21 dead REPL tests removed); the remaining 211 are all *real* skips with proper documented reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
