### PR TITLE
docs: add ADR-009 reader's note for /clear and /vars removal

### DIFF
--- a/planning/architectural_decision_records/ADR-009-repl-hash-table-stack-management.md
+++ b/planning/architectural_decision_records/ADR-009-repl-hash-table-stack-management.md
@@ -5,6 +5,27 @@
 **Author**: System Architect
 **Relates to**: Issue #135 (Collaborative ODB), ADR-005 (Thread-Safety), ADR-006 (Outline Context)
 
+---
+
+> **Reader's note (2026-04-28)**: The `/clear` and `/vars` REPL commands referenced
+> throughout the body of this ADR were **removed by design** when the QuickScript
+> model shipped in PR #304 (see "Implementation Update: QuickScript Model Decision"
+> near the bottom of this document). The 21 obsolete tests covering them were
+> deleted in PR #569 (2026-04-28).
+>
+> All discussion below of "3 failing tests", "97.8% pass rate", workspace
+> persistence workarounds, and the Phase 3B documentation plan describes the
+> *abandoned* approach — preserved as historical context for *why* the QuickScript
+> model was chosen over the workaround direction. The workaround code at
+> `repl_eval.c:259-267` and `repl_eval.c:142-170` no longer exists.
+>
+> The thread-local `hashtablestack` infrastructure (Phase 3A) IS still in place
+> and IS still load-bearing — it remains the foundation for the Phase 6+ explicit
+> hash-table context architecture (Option 5). The bootstrap-initialization
+> constraint that blocks the macro migration also still applies.
+
+---
+
 ## Executive Summary
 
 The REPL Interactive Mode implementation encounters a critical architectural limitation where `langrunhandletraperror()` calls `pushprocess(nil)` / `popprocess()`, which saves and restores the entire `hashtablestack` state. This causes REPL workspace modifications to be lost between evaluations, breaking the fundamental REPL contract that variables persist across sessions.
@@ -1377,6 +1398,7 @@ This approach follows the principle: "Solve real problems, not hypothetical ones
 
 ## Document History
 
+- **2026-04-28**: Added reader's note clarifying /clear and /vars are removed by design (post-#569 cleanup); body of ADR is historical context for the abandoned workaround direction
 - **2026-01-15**: Added QuickScript MVP scope clarification (PR #310 bot feedback response)
 - **2026-01-15**: Update with QuickScript model decision (PR #304 merged)
 - **2026-01-14**: Initial draft (Phase 3A thread-local migration + Phase 3B documentation)

--- a/planning/architectural_decision_records/ADR-009-repl-hash-table-stack-management.md
+++ b/planning/architectural_decision_records/ADR-009-repl-hash-table-stack-management.md
@@ -16,8 +16,10 @@
 > All discussion below of "3 failing tests", "97.8% pass rate", workspace
 > persistence workarounds, and the Phase 3B documentation plan describes the
 > *abandoned* approach — preserved as historical context for *why* the QuickScript
-> model was chosen over the workaround direction. The workaround code at
-> `repl_eval.c:259-267` and `repl_eval.c:142-170` no longer exists.
+> model was chosen over the workaround direction. The workaround code that
+> formerly lived in `repl_eval.c` (around lines 142–267 of the pre-#304 version)
+> no longer exists; the file is now 128 lines and contains no
+> workspace-forcing or manual hash-table-clearing code.
 >
 > The thread-local `hashtablestack` infrastructure (Phase 3A) IS still in place
 > and IS still load-bearing — it remains the foundation for the Phase 6+ explicit


### PR DESCRIPTION
## Summary

Adds a reader's note near the top of ADR-009 clarifying that the `/clear` and `/vars` REPL commands referenced throughout its body were removed by design when QuickScript shipped (PR #304), and the 21 obsolete tests covering them were deleted in PR #569.

## Why

The body of ADR-009 still reads as if `/clear` and `/vars` are active features with known-issue workarounds — "97.8% pass rate", "3 failing tests", and the Phase 3B documentation plan all describe the *abandoned* workaround approach. The QuickScript section near the bottom supersedes that direction but is easy to miss on a top-down read.

A future reader landing on the ADR (or being pointed at it from a code reference) would otherwise believe:
- there are 3 failing REPL tests (there aren't — they were deleted)
- the workaround code at `repl_eval.c:259-267` and `repl_eval.c:142-170` exists (it doesn't — `repl_eval.c` is now 128 lines)
- `/clear` and `/vars` are commands they should be testing (they're not — they're removed)

The new note makes the historical framing explicit at first read.

## Scope

- Single doc edit, 22 lines added (anchor note + history line)
- Deliberately does NOT rewrite the body — the historical narrative of *why* QuickScript was chosen over workarounds remains valuable
- The Phase 3A thread-local infrastructure section is explicitly called out as still load-bearing (foundation for Phase 6+ explicit context)

## Test plan

- [x] No code touched — no test gate required
- [x] Verified workaround code is gone: `repl_eval.c` is 128 lines, no matches for `FORCED workspace` / `CRITICAL WORKAROUND` / `Manually clear workspace`
- [x] Markdown renders cleanly (blockquote + horizontal rules)

## Context

Identified as a P2 follow-up during the bar-raiser review of #569 (REPL test deletion). User decision: skip the suggested CI lint, do the ADR clarification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
