### PR TITLE
docs: drop stale Paige worktree-setup TODO (#376)

### DIFF
--- a/planning/_CURRENT_TODO_LIST.md
+++ b/planning/_CURRENT_TODO_LIST.md
@@ -358,7 +358,6 @@ Reference: `reports/coverage/verb-binding/2026-01-27-01.md`
 - **Issue #299** (P2): Implement proper process management verbs for headless mode
 
 ### Build & Infrastructure
-- **Issue #376**: Worktree setup requires manual copy of third_party/Paige/build-headless
 - **Issue #374**: Enable stricter compiler warning flags (-Wconversion, -Wsign-conversion, -Wcast-qual)
 
 ### User Experience


### PR DESCRIPTION
## Summary

Drops a single stale TODO line referencing **Issue #376** ("Worktree setup requires manual copy of `third_party/Paige/build-headless`"). The Paige dependency was removed in PR #565, so this issue describes a problem that no longer exists.

## Scope

- One-line deletion in `planning/_CURRENT_TODO_LIST.md`
- Issue #376 will be closed as obsolete with a pointer to PR #565

## Test plan

- [x] No code touched — no test gate required
- [x] No other references to `third_party/Paige` remain in active planning docs (`_STATUS_ARCHIVE.md` is by definition history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
