### PR TITLE
feat(cli): pane compositor + SGR 1006 mouse parser (slash-menu PR 4)

### DIFF
--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -89,7 +89,8 @@ CLI_SOURCES = \
     repl_commands.c \
     repl_eval.c \
     repl_output.c \
-    repl_variables.c
+    repl_variables.c \
+    pane.c
 
 # cJSON (vendored JSON parser)
 CJSON_SOURCES = $(THIRDPARTYDIR)/cJSON/cJSON.c

--- a/frontier-cli/pane.c
+++ b/frontier-cli/pane.c
@@ -1,0 +1,415 @@
+/*
+ * pane.c - REPL pane compositor + SGR 1006 mouse parser.
+ *
+ * See pane.h for the public-API contract and §1.3a of plan
+ * humming-painting-hejlsberg.md for the design rationale.
+ *
+ * Compositor data model
+ * ---------------------
+ * - Single linked list of registered panes, head = bottom z, tail = top z.
+ * - One screen-sized framebuffer (current frame) and one previous-frame
+ *   buffer for diff rendering. Both reallocated by compositor_on_resize().
+ * - compositor_render() walks the list head→tail, copying each pane's
+ *   cell buffer into the framebuffer at (pane.x, pane.y) with rect
+ *   clipping. Then it diffs current vs. previous, emitting CUP + cell
+ *   bytes only where cells changed, and finally swaps the buffers.
+ *
+ * SGR encoding
+ * ------------
+ * Output uses a minimal SGR emitter. PR 5 (TODO) will replace this with
+ * terminal_set_attr() once that helper lands in PR 3 — kept inline here so
+ * PR 4 has no source-level dependency on PR 3.
+ *
+ * Test hooks
+ * ----------
+ * compositor_test_fb_at / _size / _reset are exposed (not in pane.h) for
+ * unit tests in tests/pane_compositor_tests.c. They inspect the
+ * framebuffer state without depending on the SGR byte stream.
+ */
+
+#include "pane.h"
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ---------- internal compositor state ---------- */
+
+static pane_t *g_pane_list_head = NULL;  /* bottom z */
+static pane_t *g_pane_list_tail = NULL;  /* top z */
+
+static cell_t *g_fb_curr = NULL;
+static cell_t *g_fb_prev = NULL;
+static int g_fb_rows = 0;
+static int g_fb_cols = 0;
+
+/* ---------- helpers ---------- */
+
+static cell_t *alloc_cells(int n) {
+	cell_t *p = (cell_t *)calloc((size_t)n, sizeof(cell_t));
+	return p;
+}
+
+static void list_remove(pane_t *p) {
+	if (!p) return;
+	pane_t *prev = NULL;
+	for (pane_t *cur = g_pane_list_head; cur != NULL; cur = cur->next) {
+		if (cur == p) {
+			if (prev) prev->next = cur->next;
+			else g_pane_list_head = cur->next;
+			if (g_pane_list_tail == cur) g_pane_list_tail = prev;
+			cur->next = NULL;
+			return;
+		}
+		prev = cur;
+	}
+}
+
+static void list_append(pane_t *p) {
+	if (!p) return;
+	p->next = NULL;
+	if (!g_pane_list_head) {
+		g_pane_list_head = p;
+		g_pane_list_tail = p;
+		return;
+	}
+	g_pane_list_tail->next = p;
+	g_pane_list_tail = p;
+}
+
+static bool list_contains(pane_t *p) {
+	for (pane_t *cur = g_pane_list_head; cur != NULL; cur = cur->next) {
+		if (cur == p) return true;
+	}
+	return false;
+}
+
+/* ---------- pane lifecycle ---------- */
+
+void pane_init(pane_t *p, int x, int y, int w, int h) {
+	if (!p) return;
+	memset(p, 0, sizeof(*p));
+	p->x = x;
+	p->y = y;
+	p->w = (w > 0) ? w : 0;
+	p->h = (h > 0) ? h : 0;
+	p->z = 0;
+	if (p->w > 0 && p->h > 0) {
+		p->buf = alloc_cells(p->w * p->h);
+	}
+}
+
+void pane_destroy(pane_t *p) {
+	if (!p) return;
+	free(p->buf);
+	p->buf = NULL;
+	p->w = 0;
+	p->h = 0;
+	p->next = NULL;
+	p->parent = NULL;
+}
+
+void pane_set_title(pane_t *p, const char *title) {
+	if (!p) return;
+	if (!title) {
+		p->title[0] = '\0';
+		return;
+	}
+	size_t n = sizeof(p->title) - 1;
+	strncpy(p->title, title, n);
+	p->title[n] = '\0';
+}
+
+/* ---------- pane content writes ---------- */
+
+void pane_putc(pane_t *p, int x, int y, uint32_t ch, uint8_t attr) {
+	if (!p || !p->buf) return;
+	if (x < 0 || x >= p->w) return;
+	if (y < 0 || y >= p->h) return;
+	cell_t *c = &p->buf[y * p->w + x];
+	c->ch = ch;
+	c->attr = attr;
+}
+
+void pane_puts(pane_t *p, int x, int y, const char *s, uint8_t attr) {
+	if (!p || !p->buf || !s) return;
+	if (y < 0 || y >= p->h) return;
+	int col = x;
+	while (*s != '\0' && col < p->w) {
+		if (col >= 0) {
+			pane_putc(p, col, y, (uint32_t)(unsigned char)*s, attr);
+		}
+		++s;
+		++col;
+	}
+}
+
+void pane_clear(pane_t *p) {
+	if (!p || !p->buf) return;
+	memset(p->buf, 0, (size_t)(p->w * p->h) * sizeof(cell_t));
+}
+
+/* ---------- pane geometry ---------- */
+
+void pane_move(pane_t *p, int x, int y) {
+	if (!p) return;
+	p->x = x;
+	p->y = y;
+}
+
+void pane_resize(pane_t *p, int w, int h) {
+	if (!p) return;
+	int new_w = (w > 0) ? w : 0;
+	int new_h = (h > 0) ? h : 0;
+	free(p->buf);
+	p->buf = NULL;
+	p->w = new_w;
+	p->h = new_h;
+	if (new_w > 0 && new_h > 0) {
+		p->buf = alloc_cells(new_w * new_h);
+	}
+}
+
+void pane_raise(pane_t *p) {
+	if (!p) return;
+	if (!list_contains(p)) return;
+	if (g_pane_list_tail == p) return;  /* already on top */
+	list_remove(p);
+	list_append(p);
+}
+
+/* ---------- compositor ---------- */
+
+void compositor_register(pane_t *p) {
+	if (!p) return;
+	if (list_contains(p)) return;  /* idempotent */
+	list_append(p);
+}
+
+void compositor_unregister(pane_t *p) {
+	if (!p) return;
+	if (!list_contains(p)) return;  /* idempotent */
+	list_remove(p);
+}
+
+void compositor_on_resize(int rows, int cols) {
+	if (rows <= 0 || cols <= 0) {
+		free(g_fb_curr);
+		free(g_fb_prev);
+		g_fb_curr = g_fb_prev = NULL;
+		g_fb_rows = g_fb_cols = 0;
+		return;
+	}
+	free(g_fb_curr);
+	free(g_fb_prev);
+	g_fb_rows = rows;
+	g_fb_cols = cols;
+	g_fb_curr = alloc_cells(rows * cols);
+	g_fb_prev = alloc_cells(rows * cols);
+	/* Mark prev as a sentinel "definitely different" frame so the next
+	 * render emits everything. We use ch=0 in prev and a fresh zeroed
+	 * curr; the diff will skip identical zero cells, which is the
+	 * desired behaviour: a freshly resized terminal needn't repaint
+	 * unwritten cells until something draws there. */
+}
+
+pane_t *compositor_pane_at(int x, int y) {
+	/* Walk front-to-back: highest z (tail) wins. The list is singly
+	 * linked, so do a linear sweep recording the latest match. */
+	pane_t *hit = NULL;
+	for (pane_t *cur = g_pane_list_head; cur != NULL; cur = cur->next) {
+		if (x >= cur->x && x < cur->x + cur->w &&
+		    y >= cur->y && y < cur->y + cur->h) {
+			hit = cur;  /* later list entries override earlier ones */
+		}
+	}
+	return hit;
+}
+
+/* Copy one pane's buffer into the framebuffer at (pane.x, pane.y),
+ * clipping against framebuffer bounds. Only non-zero source cells
+ * overwrite destination cells — zero source cells are treated as
+ * transparent so a smaller top pane doesn't erase background panes
+ * outside its own filled area. (For the documented unit tests, panes
+ * are filled densely so this distinction is invisible. The transparency
+ * rule is what makes "two overlapping panes" composition predictable.) */
+static void blit_pane(const pane_t *p) {
+	if (!p || !p->buf) return;
+	for (int row = 0; row < p->h; ++row) {
+		int dy = p->y + row;
+		if (dy < 0 || dy >= g_fb_rows) continue;
+		for (int col = 0; col < p->w; ++col) {
+			int dx = p->x + col;
+			if (dx < 0 || dx >= g_fb_cols) continue;
+			const cell_t *src = &p->buf[row * p->w + col];
+			if (src->ch == 0) continue;  /* transparent */
+			g_fb_curr[dy * g_fb_cols + dx] = *src;
+		}
+	}
+}
+
+/* Minimal SGR emitter — TODO(PR 5): replace with terminal_set_attr().
+ * For now we just emit fg/bg as 8-color SGR codes when non-zero, and
+ * the bold/inverted/underline bits if attr has them set. */
+static void emit_attr(FILE *fp, uint8_t fg, uint8_t bg, uint8_t attr) {
+	/* SGR 0 reset, then accumulate. Keep deterministic order. */
+	fputs("\x1b[0", fp);
+	if (attr & 0x01) fputs(";1", fp);    /* bold */
+	if (attr & 0x02) fputs(";2", fp);    /* dim */
+	if (attr & 0x04) fputs(";4", fp);    /* underline */
+	if (attr & 0x08) fputs(";7", fp);    /* inverted */
+	if (fg != 0) {
+		fprintf(fp, ";3%u", (unsigned)(fg & 0x07));
+	}
+	if (bg != 0) {
+		fprintf(fp, ";4%u", (unsigned)(bg & 0x07));
+	}
+	fputc('m', fp);
+}
+
+void compositor_render(void) {
+	if (g_fb_rows <= 0 || g_fb_cols <= 0 || !g_fb_curr || !g_fb_prev) return;
+
+	/* Step 1: clear current framebuffer (fresh frame). */
+	memset(g_fb_curr, 0, (size_t)(g_fb_rows * g_fb_cols) * sizeof(cell_t));
+
+	/* Step 2: composite all panes back-to-front. */
+	for (pane_t *cur = g_pane_list_head; cur != NULL; cur = cur->next) {
+		blit_pane(cur);
+	}
+
+	/* Step 3: diff vs. previous frame and emit changes. */
+	for (int y = 0; y < g_fb_rows; ++y) {
+		for (int x = 0; x < g_fb_cols; ++x) {
+			int idx = y * g_fb_cols + x;
+			cell_t c = g_fb_curr[idx];
+			cell_t p = g_fb_prev[idx];
+			if (c.ch == p.ch && c.fg == p.fg && c.bg == p.bg && c.attr == p.attr) {
+				continue;
+			}
+			/* CUP: rows/cols are 1-based in ANSI. */
+			fprintf(stdout, "\x1b[%d;%dH", y + 1, x + 1);
+			emit_attr(stdout, c.fg, c.bg, c.attr);
+			if (c.ch == 0) {
+				fputc(' ', stdout);
+			} else if (c.ch < 0x80) {
+				fputc((int)c.ch, stdout);
+			} else {
+				/* Minimal UTF-8 encoder for the BMP/SMP range. */
+				uint32_t ch = c.ch;
+				if (ch < 0x800) {
+					fputc((int)(0xC0 | (ch >> 6)), stdout);
+					fputc((int)(0x80 | (ch & 0x3F)), stdout);
+				} else if (ch < 0x10000) {
+					fputc((int)(0xE0 | (ch >> 12)), stdout);
+					fputc((int)(0x80 | ((ch >> 6) & 0x3F)), stdout);
+					fputc((int)(0x80 | (ch & 0x3F)), stdout);
+				} else {
+					fputc((int)(0xF0 | (ch >> 18)), stdout);
+					fputc((int)(0x80 | ((ch >> 12) & 0x3F)), stdout);
+					fputc((int)(0x80 | ((ch >> 6) & 0x3F)), stdout);
+					fputc((int)(0x80 | (ch & 0x3F)), stdout);
+				}
+			}
+		}
+	}
+	fflush(stdout);
+
+	/* Step 4: promote current → previous for next diff. */
+	memcpy(g_fb_prev, g_fb_curr, (size_t)(g_fb_rows * g_fb_cols) * sizeof(cell_t));
+}
+
+/* ---------- test-only inspection hooks (not in pane.h) ---------- */
+
+const cell_t *compositor_test_fb_at(int x, int y) {
+	if (!g_fb_curr) return NULL;
+	if (x < 0 || x >= g_fb_cols || y < 0 || y >= g_fb_rows) return NULL;
+	return &g_fb_curr[y * g_fb_cols + x];
+}
+
+void compositor_test_fb_size(int *rows, int *cols) {
+	if (rows) *rows = g_fb_rows;
+	if (cols) *cols = g_fb_cols;
+}
+
+void compositor_test_reset(void) {
+	g_pane_list_head = NULL;
+	g_pane_list_tail = NULL;
+	free(g_fb_curr);
+	free(g_fb_prev);
+	g_fb_curr = NULL;
+	g_fb_prev = NULL;
+	g_fb_rows = 0;
+	g_fb_cols = 0;
+}
+
+/* ---------- SGR 1006 mouse parser ----------
+ *
+ * Format: ESC [ < Cb ; Cx ; Cy ('M' | 'm')
+ * Cb: button index (low 2 bits) | wheel bit 6 | modifier bits.
+ * For PR 4 we only care about: 0=left, 1=middle, 2=right, 64=wheel up,
+ * 65=wheel down. Other values (modifier-encoded buttons, motion events)
+ * map to MOUSE_LEFT for now — PR 5 may extend this.
+ */
+
+/* Parse a non-negative decimal integer starting at *pos within [seq, end).
+ * On success: writes the value to *out, advances *pos, returns true.
+ * Empty sequence (no digits) is rejected. */
+static bool parse_uint(const char *seq, size_t end, size_t *pos, int *out) {
+	if (*pos >= end) return false;
+	if (!isdigit((unsigned char)seq[*pos])) return false;
+	int v = 0;
+	while (*pos < end && isdigit((unsigned char)seq[*pos])) {
+		int d = seq[*pos] - '0';
+		if (v > (INT32_MAX - d) / 10) return false;  /* overflow */
+		v = v * 10 + d;
+		++(*pos);
+	}
+	*out = v;
+	return true;
+}
+
+bool mouse_parse(const char *seq, size_t len, mouse_event_t *out) {
+	if (!seq || !out) return false;
+	if (len < 6) return false;  /* minimum: ESC [ < d ; d ; d M */
+	if (seq[0] != 0x1b) return false;
+	if (seq[1] != '[') return false;
+	if (seq[2] != '<') return false;
+
+	size_t pos = 3;
+	int cb = 0, cx = 0, cy = 0;
+	if (!parse_uint(seq, len, &pos, &cb)) return false;
+	if (pos >= len || seq[pos] != ';') return false;
+	++pos;
+	if (!parse_uint(seq, len, &pos, &cx)) return false;
+	if (pos >= len || seq[pos] != ';') return false;
+	++pos;
+	if (!parse_uint(seq, len, &pos, &cy)) return false;
+	if (pos >= len) return false;
+	char term = seq[pos];
+	if (term != 'M' && term != 'm') return false;
+
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.x = cx;
+	ev.y = cy;
+	ev.press = (term == 'M');
+
+	if (cb == 64) {
+		ev.btn = MOUSE_WHEEL_UP;
+	} else if (cb == 65) {
+		ev.btn = MOUSE_WHEEL_DOWN;
+	} else {
+		switch (cb & 0x03) {
+		case 0: ev.btn = MOUSE_LEFT; break;
+		case 1: ev.btn = MOUSE_MIDDLE; break;
+		case 2: ev.btn = MOUSE_RIGHT; break;
+		default: ev.btn = MOUSE_LEFT; break;  /* "release of any" → left */
+		}
+	}
+
+	*out = ev;
+	return true;
+}

--- a/frontier-cli/pane.c
+++ b/frontier-cli/pane.c
@@ -35,7 +35,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* ---------- internal compositor state ---------- */
+/* ---------- internal compositor state ----------
+ *
+ * These globals are intentionally unlocked. The compositor is a
+ * single-threaded surface (REPL main thread only); background producers
+ * must marshal through a main-thread queue before touching panes. See
+ * pane.h "Threading" for the full contract.
+ */
 
 static pane_t *g_pane_list_head = NULL;  /* bottom z */
 static pane_t *g_pane_list_tail = NULL;  /* top z */
@@ -45,11 +51,22 @@ static cell_t *g_fb_prev = NULL;
 static int g_fb_rows = 0;
 static int g_fb_cols = 0;
 
-/* ---------- helpers ---------- */
+/* ---------- helpers ----------
+ *
+ * The list helpers below are O(n) in the number of registered panes.
+ * That's intentional: the slash-menu surface is expected to host on the
+ * order of 5-10 panes (REPL output, prompt, palette, hint footer, plus
+ * any transient overlays). If the pane count grows, revisit with a
+ * doubly-linked list + tail pointer maintained on remove.
+ */
 
-static cell_t *alloc_cells(int n) {
-	cell_t *p = (cell_t *)calloc((size_t)n, sizeof(cell_t));
-	return p;
+/* Allocate a zero-initialised cell array of `count` cells.
+ * Promotes to size_t before any multiplication so the math is safe even
+ * for theoretical large counts; calloc itself also guards against
+ * size_t overflow. Returns NULL on OOM (callers degrade to a no-op). */
+static cell_t *alloc_cells(size_t count) {
+	if (count == 0) return NULL;
+	return (cell_t *)calloc(count, sizeof(cell_t));
 }
 
 static void list_remove(pane_t *p) {
@@ -97,7 +114,7 @@ void pane_init(pane_t *p, int x, int y, int w, int h) {
 	p->h = (h > 0) ? h : 0;
 	p->z = 0;
 	if (p->w > 0 && p->h > 0) {
-		p->buf = alloc_cells(p->w * p->h);
+		p->buf = alloc_cells((size_t)p->w * (size_t)p->h);
 	}
 }
 
@@ -168,7 +185,7 @@ void pane_resize(pane_t *p, int w, int h) {
 	p->w = new_w;
 	p->h = new_h;
 	if (new_w > 0 && new_h > 0) {
-		p->buf = alloc_cells(new_w * new_h);
+		p->buf = alloc_cells((size_t)new_w * (size_t)new_h);
 	}
 }
 
@@ -206,8 +223,8 @@ void compositor_on_resize(int rows, int cols) {
 	free(g_fb_prev);
 	g_fb_rows = rows;
 	g_fb_cols = cols;
-	g_fb_curr = alloc_cells(rows * cols);
-	g_fb_prev = alloc_cells(rows * cols);
+	g_fb_curr = alloc_cells((size_t)rows * (size_t)cols);
+	g_fb_prev = alloc_cells((size_t)rows * (size_t)cols);
 	/* Mark prev as a sentinel "definitely different" frame so the next
 	 * render emits everything. We use ch=0 in prev and a fresh zeroed
 	 * curr; the diff will skip identical zero cells, which is the

--- a/frontier-cli/pane.h
+++ b/frontier-cli/pane.h
@@ -1,0 +1,98 @@
+/*
+ * pane.h - REPL pane compositor + SGR 1006 mouse parser.
+ *
+ * Pane substrate for the slash-menu REPL palette (plan §1.3a). Each pane
+ * owns a w*h cell_t buffer; the compositor renders all registered panes
+ * back-to-front into a screen-sized framebuffer, then diffs against the
+ * previous frame and emits ANSI cursor-positioning + cell content for
+ * changed cells only. Z-order is implicit: list order = z-order
+ * (head = bottom, tail = top). pane_raise() moves a pane to the tail.
+ *
+ * Scope is intentionally narrow: no tabs, splits, layouts, themes,
+ * animations, or wide-character handling. PR 5 owns event routing — the
+ * compositor only provides hit-testing via compositor_pane_at().
+ *
+ * Mouse parser handles xterm SGR 1006 (ESC[<Cb;Cx;Cy(M|m)). Buffer-bounded
+ * — the caller's slice may not be NUL-terminated.
+ */
+
+#ifndef FRONTIER_PANE_H
+#define FRONTIER_PANE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* A single screen cell. ch is a Unicode codepoint (UTF-8 encoded on
+ * output). attr is a small bitmap for bold/dim/inverted/underline; the
+ * exact encoding is internal to pane.c (PR 5 will consolidate this with
+ * terminal_set_attr()). */
+typedef struct cell {
+	uint32_t ch;
+	uint8_t fg;
+	uint8_t bg;
+	uint8_t attr;
+} cell_t;
+
+/* Forward declaration for the callback typedefs below. */
+struct pane;
+
+typedef void (*pane_mouse_cb)(struct pane *p, int btn, int x, int y, bool press);
+typedef void (*pane_key_cb)(struct pane *p, int key);
+
+typedef struct pane {
+	int x, y, w, h;             /* position (screen cells) and size */
+	int z;                      /* informational; ordering is by list position */
+	char title[64];
+	bool has_border;
+	bool focused;
+	cell_t *buf;                /* w*h cell buffer (owned) */
+	struct pane *parent;
+	struct pane *next;          /* intrusive z-sorted list (head=bottom) */
+	void *userdata;
+	pane_mouse_cb on_mouse;
+	pane_key_cb on_key;
+} pane_t;
+
+/* Pane lifecycle. */
+void pane_init(pane_t *p, int x, int y, int w, int h);
+void pane_destroy(pane_t *p);
+void pane_set_title(pane_t *p, const char *title);
+
+/* Content writes. Out-of-bounds (x,y) is silently clipped — never crashes. */
+void pane_putc(pane_t *p, int x, int y, uint32_t ch, uint8_t attr);
+void pane_puts(pane_t *p, int x, int y, const char *s, uint8_t attr);
+void pane_clear(pane_t *p);
+
+/* Geometry. resize allocates a new zeroed buffer; the prior buffer is freed. */
+void pane_move(pane_t *p, int x, int y);
+void pane_resize(pane_t *p, int w, int h);
+
+/* Z-order: detach from list (if registered) and append at tail (top). */
+void pane_raise(pane_t *p);
+
+/* Compositor. */
+void compositor_register(pane_t *p);
+void compositor_unregister(pane_t *p);
+void compositor_render(void);
+void compositor_on_resize(int rows, int cols);
+pane_t *compositor_pane_at(int x, int y);
+
+/* SGR 1006 mouse-event protocol parser. */
+typedef enum {
+	MOUSE_LEFT,
+	MOUSE_MIDDLE,
+	MOUSE_RIGHT,
+	MOUSE_WHEEL_UP,
+	MOUSE_WHEEL_DOWN
+} mouse_btn_t;
+
+typedef struct {
+	mouse_btn_t btn;
+	int x, y;       /* 1-based terminal coordinates */
+	bool press;     /* true if final byte is 'M', false if 'm' */
+} mouse_event_t;
+
+bool mouse_parse(const char *seq, size_t len, mouse_event_t *out);
+
+#endif /* FRONTIER_PANE_H */

--- a/frontier-cli/pane.h
+++ b/frontier-cli/pane.h
@@ -14,6 +14,15 @@
  *
  * Mouse parser handles xterm SGR 1006 (ESC[<Cb;Cx;Cy(M|m)). Buffer-bounded
  * — the caller's slice may not be NUL-terminated.
+ *
+ * Threading
+ * ---------
+ * The compositor uses module-level globals (pane list, framebuffer) with
+ * NO internal locking. ALL compositor_* and pane_* functions MUST be
+ * called from the same thread (the REPL main thread). Background
+ * producers (e.g. async stdout, agent-browser callbacks) MUST marshal
+ * their writes onto the main thread before touching panes — see PR 5's
+ * repl_async_output() rerouting for the queue mechanism.
  */
 
 #ifndef FRONTIER_PANE_H

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -220,7 +220,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -391,6 +391,13 @@ cli_runtime_tests: cli_runtime_tests.c $(CLI_BIN)
 
 $(CLI_BIN):
 	$(MAKE) -C ../frontier-cli frontier-cli
+
+# Pane compositor + SGR 1006 mouse parser tests (pure CLI-side, no runtime)
+pane_compositor_tests: pane_compositor_tests.c ../frontier-cli/pane.c ../frontier-cli/pane.h
+	$(CC) $(CFLAGS) -I../frontier-cli pane_compositor_tests.c ../frontier-cli/pane.c -o $@ $(LINK_LIBS)
+
+mouse_parser_tests: mouse_parser_tests.c ../frontier-cli/pane.c ../frontier-cli/pane.h
+	$(CC) $(CFLAGS) -I../frontier-cli mouse_parser_tests.c ../frontier-cli/pane.c -o $@ $(LINK_LIBS)
 
 # Test framework object
 framework/test_framework.o: framework/test_framework.c framework/test_framework.h

--- a/tests/mouse_parser_tests.c
+++ b/tests/mouse_parser_tests.c
@@ -1,0 +1,142 @@
+/*
+ * mouse_parser_tests.c - Unit tests for SGR 1006 mouse-event parser.
+ *
+ * Verifies mouse_parse() against the xterm SGR 1006 protocol:
+ *   ESC [ < Cb ; Cx ; Cy ('M' = press, 'm' = release)
+ * Cb low 2 bits = button (0=left, 1=middle, 2=right, 3=release-of-any),
+ * bit 6 (value 64) = wheel events (64=up, 65=down). Cx/Cy are 1-based
+ * terminal coordinates.
+ *
+ * Tests cover the full button matrix plus malformed-input rejection. The
+ * parser MUST be safe against truncated / non-null-terminated buffers —
+ * the slice provided to mouse_parse() may not be NUL-bounded.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "pane.h"
+#include "test_report.h"
+
+static bool parse_str(const char *s, mouse_event_t *out) {
+	return mouse_parse(s, strlen(s), out);
+}
+
+static void test_valid_press_left(void) {
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	bool ok = parse_str("\x1b[<0;10;5M", &ev);
+	assert(ok);
+	assert(ev.btn == MOUSE_LEFT);
+	assert(ev.x == 10);
+	assert(ev.y == 5);
+	assert(ev.press == true);
+}
+
+static void test_valid_release_left(void) {
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	bool ok = parse_str("\x1b[<0;10;5m", &ev);
+	assert(ok);
+	assert(ev.btn == MOUSE_LEFT);
+	assert(ev.x == 10);
+	assert(ev.y == 5);
+	assert(ev.press == false);
+}
+
+static void test_wheel_up(void) {
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	bool ok = parse_str("\x1b[<64;10;5M", &ev);
+	assert(ok);
+	assert(ev.btn == MOUSE_WHEEL_UP);
+	assert(ev.x == 10);
+	assert(ev.y == 5);
+	assert(ev.press == true);
+}
+
+static void test_wheel_down(void) {
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	bool ok = parse_str("\x1b[<65;10;5M", &ev);
+	assert(ok);
+	assert(ev.btn == MOUSE_WHEEL_DOWN);
+}
+
+static void test_middle_and_right(void) {
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	bool ok = parse_str("\x1b[<1;3;4M", &ev);
+	assert(ok);
+	assert(ev.btn == MOUSE_MIDDLE);
+	assert(ev.x == 3);
+	assert(ev.y == 4);
+	assert(ev.press == true);
+
+	memset(&ev, 0, sizeof(ev));
+	ok = parse_str("\x1b[<2;7;8m", &ev);
+	assert(ok);
+	assert(ev.btn == MOUSE_RIGHT);
+	assert(ev.x == 7);
+	assert(ev.y == 8);
+	assert(ev.press == false);
+}
+
+static void test_large_coordinates(void) {
+	mouse_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	bool ok = parse_str("\x1b[<0;200;120M", &ev);
+	assert(ok);
+	assert(ev.x == 200);
+	assert(ev.y == 120);
+}
+
+static void test_malformed_inputs_rejected(void) {
+	mouse_event_t ev;
+	/* Missing terminator. */
+	assert(!parse_str("\x1b[<0;10;5", &ev));
+	/* Missing '<'. */
+	assert(!parse_str("\x1b[0;10;5M", &ev));
+	/* Missing leading ESC. */
+	assert(!parse_str("[<0;10;5M", &ev));
+	/* Missing semicolon. */
+	assert(!parse_str("\x1b[<010;5M", &ev));
+	/* Non-digit content. */
+	assert(!parse_str("\x1b[<0;1a;5M", &ev));
+	/* Too short. */
+	assert(!mouse_parse("\x1b[<", 3, &ev));
+	/* NULL inputs. */
+	assert(!mouse_parse(NULL, 5, &ev));
+	assert(!mouse_parse("\x1b[<0;1;1M", 9, NULL));
+	/* Empty. */
+	assert(!mouse_parse("", 0, &ev));
+}
+
+static void test_buffer_bounded_no_overrun(void) {
+	mouse_event_t ev;
+	/* len shorter than the apparent string — parser must respect len,
+	 * not run off into unspecified memory after a missing terminator. */
+	const char *seq = "\x1b[<0;10;5";  /* 9 bytes, no terminator */
+	assert(!mouse_parse(seq, 9, &ev));
+
+	/* Fully terminated within len. */
+	const char *seq2 = "\x1b[<0;10;5M";
+	assert(mouse_parse(seq2, 10, &ev));
+	assert(ev.btn == MOUSE_LEFT);
+}
+
+int main(void) {
+	TR_INIT("mouse_parser_tests");
+	TR_RUN(test_valid_press_left);
+	TR_RUN(test_valid_release_left);
+	TR_RUN(test_wheel_up);
+	TR_RUN(test_wheel_down);
+	TR_RUN(test_middle_and_right);
+	TR_RUN(test_large_coordinates);
+	TR_RUN(test_malformed_inputs_rejected);
+	TR_RUN(test_buffer_bounded_no_overrun);
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}

--- a/tests/pane_compositor_tests.c
+++ b/tests/pane_compositor_tests.c
@@ -1,0 +1,300 @@
+/*
+ * pane_compositor_tests.c - Unit tests for the REPL pane compositor.
+ *
+ * Verifies the public API surface of pane.{c,h} (see plan
+ * humming-painting-hejlsberg.md §1.3a):
+ *   - pane lifecycle (init/destroy/clear/move/resize)
+ *   - pane content writes (putc/puts) with buffer-bound clipping
+ *   - compositor registry (register/unregister, idempotency)
+ *   - back-to-front composition into the framebuffer
+ *   - z-order (raise) and front-to-back hit testing
+ *   - framebuffer reallocation on resize
+ *
+ * Tests are behavioural — they exercise the framebuffer state via the
+ * test-only inspection hooks compositor_test_fb_at() / _size(), not by
+ * scraping the SGR byte stream (whose exact form is an implementation
+ * detail of pane.c that PR 5 will swap out).
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pane.h"
+#include "test_report.h"
+
+/* Test-only framebuffer inspection — exposed by pane.c for unit tests. */
+extern const cell_t *compositor_test_fb_at(int x, int y);
+extern void compositor_test_fb_size(int *rows, int *cols);
+extern void compositor_test_reset(void);
+
+static void test_pane_init_creates_buffer(void) {
+	pane_t p;
+	pane_init(&p, 5, 7, 20, 10);
+	assert(p.x == 5);
+	assert(p.y == 7);
+	assert(p.w == 20);
+	assert(p.h == 10);
+	assert(p.buf != NULL);
+	/* Newly initialised buffer is zeroed. */
+	for (int i = 0; i < 20 * 10; ++i) {
+		assert(p.buf[i].ch == 0);
+		assert(p.buf[i].fg == 0);
+		assert(p.buf[i].bg == 0);
+		assert(p.buf[i].attr == 0);
+	}
+	pane_destroy(&p);
+}
+
+static void test_pane_putc_and_puts(void) {
+	pane_t p;
+	pane_init(&p, 0, 0, 10, 4);
+	pane_putc(&p, 3, 1, 'X', 7);
+	assert(p.buf[1 * 10 + 3].ch == (uint32_t)'X');
+	assert(p.buf[1 * 10 + 3].attr == 7);
+
+	pane_puts(&p, 0, 2, "hi", 3);
+	assert(p.buf[2 * 10 + 0].ch == (uint32_t)'h');
+	assert(p.buf[2 * 10 + 1].ch == (uint32_t)'i');
+	assert(p.buf[2 * 10 + 0].attr == 3);
+
+	/* Out-of-bounds writes are silently clipped, not crashes. */
+	pane_putc(&p, -1, 0, 'A', 0);
+	pane_putc(&p, 10, 0, 'A', 0);
+	pane_putc(&p, 0, 4, 'A', 0);
+	pane_puts(&p, 8, 3, "abcdef", 0);
+	assert(p.buf[3 * 10 + 8].ch == (uint32_t)'a');
+	assert(p.buf[3 * 10 + 9].ch == (uint32_t)'b');
+	/* The 'c' onward fell off the right edge — no crash, no corruption. */
+
+	pane_destroy(&p);
+}
+
+static void test_pane_clear_zeros_buffer(void) {
+	pane_t p;
+	pane_init(&p, 0, 0, 4, 3);
+	pane_puts(&p, 0, 0, "ABCD", 5);
+	pane_puts(&p, 0, 1, "EFGH", 5);
+	pane_clear(&p);
+	for (int i = 0; i < 4 * 3; ++i) {
+		assert(p.buf[i].ch == 0);
+		assert(p.buf[i].attr == 0);
+	}
+	pane_destroy(&p);
+}
+
+static void test_compositor_register_unregister(void) {
+	compositor_test_reset();
+	compositor_on_resize(10, 20);
+
+	pane_t p1, p2;
+	pane_init(&p1, 0, 0, 4, 4);
+	pane_init(&p2, 5, 5, 4, 4);
+
+	compositor_register(&p1);
+	compositor_register(&p2);
+
+	pane_t *hit = compositor_pane_at(1, 1);
+	assert(hit == &p1);
+	hit = compositor_pane_at(6, 6);
+	assert(hit == &p2);
+
+	compositor_unregister(&p1);
+	hit = compositor_pane_at(1, 1);
+	assert(hit == NULL);
+	hit = compositor_pane_at(6, 6);
+	assert(hit == &p2);
+
+	/* Unregister of an already-removed pane is a no-op. */
+	compositor_unregister(&p1);
+
+	compositor_unregister(&p2);
+	pane_destroy(&p1);
+	pane_destroy(&p2);
+}
+
+static void test_compositor_render_single_pane(void) {
+	compositor_test_reset();
+	compositor_on_resize(5, 10);
+
+	pane_t p;
+	pane_init(&p, 2, 1, 3, 2);
+	pane_puts(&p, 0, 0, "abc", 1);
+	pane_puts(&p, 0, 1, "def", 1);
+	compositor_register(&p);
+
+	compositor_render();
+
+	const cell_t *c = compositor_test_fb_at(2, 1);
+	assert(c->ch == (uint32_t)'a');
+	c = compositor_test_fb_at(3, 1);
+	assert(c->ch == (uint32_t)'b');
+	c = compositor_test_fb_at(4, 1);
+	assert(c->ch == (uint32_t)'c');
+	c = compositor_test_fb_at(2, 2);
+	assert(c->ch == (uint32_t)'d');
+
+	/* Cells outside the pane rect remain zeroed by composition. */
+	c = compositor_test_fb_at(0, 0);
+	assert(c->ch == 0);
+	c = compositor_test_fb_at(5, 1);
+	assert(c->ch == 0);
+
+	compositor_unregister(&p);
+	pane_destroy(&p);
+}
+
+static void test_compositor_render_overlapping(void) {
+	compositor_test_reset();
+	compositor_on_resize(5, 10);
+
+	pane_t bottom, top;
+	pane_init(&bottom, 0, 0, 5, 3);
+	pane_init(&top, 2, 1, 3, 2);
+	pane_puts(&bottom, 0, 0, "BBBBB", 1);
+	pane_puts(&bottom, 0, 1, "BBBBB", 1);
+	pane_puts(&bottom, 0, 2, "BBBBB", 1);
+	pane_puts(&top, 0, 0, "TTT", 2);
+	pane_puts(&top, 0, 1, "TTT", 2);
+
+	compositor_register(&bottom);
+	compositor_register(&top);
+	compositor_render();
+
+	/* In overlapping cells, top wins. */
+	const cell_t *c = compositor_test_fb_at(2, 1);
+	assert(c->ch == (uint32_t)'T');
+	assert(c->attr == 2);
+
+	/* Cells covered only by bottom remain bottom. */
+	c = compositor_test_fb_at(0, 0);
+	assert(c->ch == (uint32_t)'B');
+	c = compositor_test_fb_at(0, 2);
+	assert(c->ch == (uint32_t)'B');
+
+	compositor_unregister(&top);
+	compositor_unregister(&bottom);
+	pane_destroy(&top);
+	pane_destroy(&bottom);
+}
+
+static void test_pane_raise_reorders(void) {
+	compositor_test_reset();
+	compositor_on_resize(5, 10);
+
+	pane_t a, b;
+	pane_init(&a, 0, 0, 5, 3);
+	pane_init(&b, 0, 0, 5, 3);
+	pane_puts(&a, 0, 0, "AAAAA", 1);
+	pane_puts(&b, 0, 0, "BBBBB", 2);
+
+	compositor_register(&a);
+	compositor_register(&b);
+	/* b registered last → b is on top. */
+	pane_t *hit = compositor_pane_at(0, 0);
+	assert(hit == &b);
+
+	pane_raise(&a);
+	hit = compositor_pane_at(0, 0);
+	assert(hit == &a);
+
+	compositor_render();
+	const cell_t *c = compositor_test_fb_at(0, 0);
+	assert(c->ch == (uint32_t)'A');
+
+	compositor_unregister(&a);
+	compositor_unregister(&b);
+	pane_destroy(&a);
+	pane_destroy(&b);
+}
+
+static void test_compositor_pane_at_highest_z(void) {
+	compositor_test_reset();
+	compositor_on_resize(5, 10);
+
+	pane_t a, b, c;
+	pane_init(&a, 0, 0, 8, 3);
+	pane_init(&b, 1, 0, 6, 3);
+	pane_init(&c, 2, 0, 4, 3);
+	compositor_register(&a);
+	compositor_register(&b);
+	compositor_register(&c);
+
+	/* (0,0) only inside a. */
+	assert(compositor_pane_at(0, 0) == &a);
+	/* (1,0) inside a and b → b (registered later, on top). */
+	assert(compositor_pane_at(1, 0) == &b);
+	/* (3,0) inside a, b, c → c. */
+	assert(compositor_pane_at(3, 0) == &c);
+	/* Outside everything. */
+	assert(compositor_pane_at(9, 9) == NULL);
+
+	compositor_unregister(&a);
+	compositor_unregister(&b);
+	compositor_unregister(&c);
+	pane_destroy(&a);
+	pane_destroy(&b);
+	pane_destroy(&c);
+}
+
+static void test_compositor_on_resize_reallocates(void) {
+	compositor_test_reset();
+	compositor_on_resize(10, 20);
+	int rows = 0, cols = 0;
+	compositor_test_fb_size(&rows, &cols);
+	assert(rows == 10);
+	assert(cols == 20);
+
+	compositor_on_resize(30, 80);
+	compositor_test_fb_size(&rows, &cols);
+	assert(rows == 30);
+	assert(cols == 80);
+
+	/* After resize the framebuffer is freshly cleared. */
+	const cell_t *cell = compositor_test_fb_at(0, 0);
+	assert(cell->ch == 0);
+	cell = compositor_test_fb_at(79, 29);
+	assert(cell->ch == 0);
+}
+
+static void test_pane_move_and_resize(void) {
+	compositor_test_reset();
+	compositor_on_resize(10, 20);
+
+	pane_t p;
+	pane_init(&p, 0, 0, 4, 2);
+	compositor_register(&p);
+	pane_move(&p, 5, 5);
+	assert(p.x == 5);
+	assert(p.y == 5);
+
+	pane_resize(&p, 6, 3);
+	assert(p.w == 6);
+	assert(p.h == 3);
+	assert(p.buf != NULL);
+	/* Resize zeros the new buffer. */
+	for (int i = 0; i < 6 * 3; ++i) {
+		assert(p.buf[i].ch == 0);
+	}
+
+	compositor_unregister(&p);
+	pane_destroy(&p);
+}
+
+int main(void) {
+	TR_INIT("pane_compositor_tests");
+	TR_RUN(test_pane_init_creates_buffer);
+	TR_RUN(test_pane_putc_and_puts);
+	TR_RUN(test_pane_clear_zeros_buffer);
+	TR_RUN(test_compositor_register_unregister);
+	TR_RUN(test_compositor_render_single_pane);
+	TR_RUN(test_compositor_render_overlapping);
+	TR_RUN(test_pane_raise_reorders);
+	TR_RUN(test_compositor_pane_at_highest_z);
+	TR_RUN(test_compositor_on_resize_reallocates);
+	TR_RUN(test_pane_move_and_resize);
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}


### PR DESCRIPTION
## Summary

PR 4 of the REPL slash-menu palette series. Introduces the UI substrate that PR 5 will glue into the palette state machine. **Independent of PR 3** at the source level — does not touch terminal_control.{c,h}.

- New `frontier-cli/pane.{c,h}`: pane lifecycle, back-to-front diff renderer over a screen-sized framebuffer, intrusive z-ordered linked list, front-to-back hit testing.
- SGR 1006 mouse parser: buffer-bounded (no NUL-terminator requirement), strict malformed-input rejection.
- Inline minimal SGR emitter; TODO marker for PR 5 to consolidate via `terminal_set_attr()` once PR 3 lands.

Scope locked per plan §1.3a — no tabs, splits, layouts, themes, animations, or wide-char handling.

## Tests (TDD — written first)

- `tests/pane_compositor_tests.c` — 10 tests: init/buffer, putc/puts with out-of-bounds clipping, clear, register/unregister idempotency, single-pane render, two-pane overlap (top wins), pane_raise reorders, highest-z hit testing, framebuffer reallocation, move/resize.
- `tests/mouse_parser_tests.c` — 8 tests: left press/release, wheel up/down, middle/right buttons, large coordinates, malformed inputs (missing terminator/ESC/'<'/semicolon, non-digit, NULL inputs, empty), explicit buffer-bounded no-overrun check.

Behavioural — exercises framebuffer state via test-only inspection hooks rather than scraping the SGR byte stream (which is an implementation detail PR 5 will swap out).

## Test plan

- [x] `./tools/run_headless_tests.sh` — 335/335 pass (was 317, +18)
- [x] `cd tests && make test-integration` — 2029 passed, 0 failed (no regressions)
- [x] `make -C frontier-cli` — clean build, no new pane.c warnings under `-Wall -Wextra`

## Out of scope (deferred)

- Background-output integration (`repl_async_output()` rerouting) — PR 5 owns
- Mouse-over-ssh SGR 1006 capability probe — PR 5 risk-register item
- Wide-char / fullwidth handling — defer to PR 8 if ever needed
- Theming / animation — out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)