### PR TITLE
feat(cli): terminal_control palette substrate + SIGWINCH + mouse mode (PR 3 of slash-menu)

### DIFF
--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -43,6 +43,7 @@
 
 #include "linenoise.h"
 
+#include "terminal_control.h"
 #include "repl.h"
 #include "repl_eval.h"
 #include "repl_variables.h"
@@ -1404,25 +1405,78 @@ volatile sig_atomic_t g_repl_interrupt_requested = 0;
 // Global script running flag for interrupt handling
 static volatile sig_atomic_t g_script_running = 0;
 
+/* SIGWINCH (window-size change) flag.
+ *
+ * Set by sigwinch_handler() and consumed by repl_sigwinch_consumed().  The
+ * flag exists so that the upcoming slash-menu palette renderer (PR 5) and
+ * other render-tick consumers can react to terminal resize without each
+ * needing to install their own sigaction.
+ *
+ * Coexists with file_browser.c's local SIGWINCH handler — file_browser saves
+ * and restores the previous sigaction around its modal session, so this
+ * REPL-level handler is the long-lived one. */
+static volatile sig_atomic_t g_sigwinch = 0;
+
 // Global linenoise state for terminal cleanup and async output
 static struct linenoiseState *g_active_linenoisestate = NULL;
 
 // Forward declaration for completion callback
 static void linenoise_completion_callback(const char *buf, linenoiseCompletions *lc);
 
-/* Signal handler for SIGINT (Ctrl-C) - must be async-signal-safe */
+/*
+ * Async-signal-safe mouse-tracking disable.
+ *
+ * terminal_disable_mouse() uses fputs/fflush, which are NOT async-signal-safe
+ * (POSIX.1-2017 §2.4.3).  When a signal handler needs to leave mouse mode
+ * before _exit(), it must talk to the kernel directly via write(2), which is
+ * on the AS-safe list.
+ *
+ * The byte sequence matches terminal_disable_mouse() exactly: 16 bytes
+ * "ESC [ ? 1 0 0 0 l ESC [ ? 1 0 0 6 l".  Kept in sync by the matching
+ * unit tests.
+ */
+static void async_signal_safe_disable_mouse(void) {
+	static const char DISABLE_SEQ[] = "\x1b[?1000l\x1b[?1006l";
+	/* Best effort — if write() fails (closed fd, EINTR), there is nothing
+	 * sensible a signal handler can do about it.  Ignore the result
+	 * deliberately to avoid a noisy compile warning. */
+	ssize_t r = write(STDERR_FILENO, DISABLE_SEQ, sizeof(DISABLE_SEQ) - 1);
+	(void)r;
+}
+
+/* Signal handler for SIGINT (Ctrl-C) - must be async-signal-safe.
+ *
+ * The interrupt flag is consumed in user context by handle_interrupt(); the
+ * one new responsibility here is to leave the terminal in a sane mouse mode
+ * if the palette had enabled tracking.  Calling write(2) directly keeps this
+ * AS-safe even though terminal_disable_mouse() itself is not. */
 static void sigint_handler(int sig) {
 	(void)sig;
+	async_signal_safe_disable_mouse();
 	g_repl_interrupt_requested = 1;
 }
 
 /* Signal handler for SIGTERM - exit immediately
  * NOTE: We don't call linenoiseEditStop() here because it's not async-signal-safe.
  * Terminal mode is automatically restored by the OS when the process exits.
+ * Mouse tracking, however, is NOT restored by the OS — it's a remote terminal
+ * mode set by escape sequence.  We emit the disable sequence inline here
+ * (write(2) is async-signal-safe) before _exit so the user does not get left
+ * with a terminal that streams mouse coordinates as garbage characters.
  * Using _exit() to avoid calling atexit handlers from signal context (unsafe). */
 static void sigterm_handler(int sig) {
 	(void)sig;
+	async_signal_safe_disable_mouse();
 	_exit(0);
+}
+
+/* SIGWINCH handler — terminal window resized.
+ *
+ * Only the flag set; consumers poll repl_sigwinch_consumed() in user context.
+ * Coexists with file_browser.c's bounded-scope handler. */
+static void sigwinch_handler(int sig) {
+	(void)sig;
+	g_sigwinch = 1;
 }
 
 /* Terminal cleanup for atexit() */
@@ -1433,7 +1487,7 @@ static void cleanup_terminal(void) {
 	}
 }
 
-/* Install signal handlers for Ctrl-C and SIGTERM */
+/* Install signal handlers for Ctrl-C, SIGTERM, and SIGWINCH */
 static void install_signal_handlers(void) {
 	struct sigaction sa;
 
@@ -1449,8 +1503,25 @@ static void install_signal_handlers(void) {
 	sigemptyset(&sa.sa_mask);
 	sigaction(SIGTERM, &sa, NULL);
 
+	// SIGWINCH handler (terminal resize) — used by the future slash-menu
+	// palette renderer (PR 5).  SA_RESTART so blocking syscalls (read on
+	// stdin, etc.) auto-resume after the signal is delivered.
+	sa.sa_handler = sigwinch_handler;
+	sa.sa_flags = SA_RESTART;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGWINCH, &sa, NULL);
+
 	// Register terminal cleanup for atexit
 	atexit(cleanup_terminal);
+}
+
+/* Public consumer for the SIGWINCH flag — see repl.h. */
+boolean repl_sigwinch_consumed(void) {
+	if (g_sigwinch) {
+		g_sigwinch = 0;
+		return true;
+	}
+	return false;
 }
 
 /* Guard to prevent re-entrant interrupt handling */

--- a/frontier-cli/repl.h
+++ b/frontier-cli/repl.h
@@ -111,4 +111,23 @@ boolean repl_resolve_path_ex(const char *path, typathlookupresult *result,
  */
 boolean repl_is_active(void);
 
+/*
+ * SIGWINCH (window-size change) consumer.
+ *
+ * install_signal_handlers() registers a SIGWINCH handler that sets a
+ * process-wide sig_atomic_t flag.  Callers that need to react to terminal
+ * resize (the upcoming slash-menu palette renderer in PR 5, etc.) poll this
+ * accessor each render tick: it returns true exactly once per SIGWINCH
+ * delivery and resets the flag.
+ *
+ * Coexists with file_browser.c's own SIGWINCH handling — file_browser saves
+ * the previous sigaction and restores it on exit, so its scope is bounded to
+ * the file-browser modal.  The REPL handler installed here is the
+ * long-lived handler that file_browser's restore returns to.
+ *
+ * Returns false (without side effect) if no SIGWINCH has occurred.  Returning
+ * true is destructive — only one consumer should poll this per frame.
+ */
+boolean repl_sigwinch_consumed(void);
+
 #endif // REPL_H

--- a/frontier-cli/terminal_control.c
+++ b/frontier-cli/terminal_control.c
@@ -361,6 +361,113 @@ key_input terminal_read_key(void) {
 	return result;
 }
 
+/* ---------------------------------------------------------------------------
+ * Slash-menu palette UI substrate (PR 3)
+ *
+ * Cursor positioning, SGR colour/attribute, Unicode box drawing, and xterm
+ * mouse tracking enable/disable.  See header for usage notes and rationale.
+ * ------------------------------------------------------------------------- */
+
+/* Move cursor to absolute (row, col) — 1-based.  CSI CUP. */
+void terminal_move_to(int row, int col) {
+	fprintf(stderr, "\x1b[%d;%dH", row, col);
+	fflush(stderr);
+}
+
+/* Set foreground/background colour and bold/inverse/underline flags.
+ * Always emits a leading SGR 0 reset so callers don't have to track state. */
+void terminal_set_attr(uint8_t fg, uint8_t bg, uint8_t flags) {
+	/* Build "ESC [ 0[;1][;7][;4][;3<fg>][;4<bg>] m" */
+	char buf[64];
+	int n = 0;
+	n += snprintf(buf + n, sizeof(buf) - n, "\x1b[0");
+	if (flags & TERM_ATTR_BOLD)      n += snprintf(buf + n, sizeof(buf) - n, ";1");
+	if (flags & TERM_ATTR_UNDERLINE) n += snprintf(buf + n, sizeof(buf) - n, ";4");
+	if (flags & TERM_ATTR_INVERSE)   n += snprintf(buf + n, sizeof(buf) - n, ";7");
+	if (fg >= 1 && fg <= 7)          n += snprintf(buf + n, sizeof(buf) - n, ";3%u", (unsigned)fg);
+	if (bg >= 1 && bg <= 7)          n += snprintf(buf + n, sizeof(buf) - n, ";4%u", (unsigned)bg);
+	n += snprintf(buf + n, sizeof(buf) - n, "m");
+	(void)n;
+	fputs(buf, stderr);
+	fflush(stderr);
+}
+
+/* Draw a rectangular border using Unicode box-drawing chars. */
+void terminal_emit_box(int x, int y, int w, int h, bool double_line) {
+	if (w < 2 || h < 2) {
+		/* Degenerate — nothing meaningful to draw. */
+		return;
+	}
+
+	/* UTF-8 sequences for the two glyph sets. */
+	const char *tl, *tr, *bl, *br, *hz, *vt;
+	if (double_line) {
+		tl = "\xe2\x95\x94";  /* ╔ U+2554 */
+		tr = "\xe2\x95\x97";  /* ╗ U+2557 */
+		bl = "\xe2\x95\x9a";  /* ╚ U+255A */
+		br = "\xe2\x95\x9d";  /* ╝ U+255D */
+		hz = "\xe2\x95\x90";  /* ═ U+2550 */
+		vt = "\xe2\x95\x91";  /* ║ U+2551 */
+	} else {
+		tl = "\xe2\x94\x8c";  /* ┌ U+250C */
+		tr = "\xe2\x94\x90";  /* ┐ U+2510 */
+		bl = "\xe2\x94\x94";  /* └ U+2514 */
+		br = "\xe2\x94\x98";  /* ┘ U+2518 */
+		hz = "\xe2\x94\x80";  /* ─ U+2500 */
+		vt = "\xe2\x94\x82";  /* │ U+2502 */
+	}
+
+	/* Top edge */
+	fprintf(stderr, "\x1b[%d;%dH", y, x);
+	fputs(tl, stderr);
+	for (int i = 0; i < w - 2; i++) fputs(hz, stderr);
+	fputs(tr, stderr);
+
+	/* Side edges */
+	for (int row = 1; row < h - 1; row++) {
+		fprintf(stderr, "\x1b[%d;%dH", y + row, x);
+		fputs(vt, stderr);
+		fprintf(stderr, "\x1b[%d;%dH", y + row, x + w - 1);
+		fputs(vt, stderr);
+	}
+
+	/* Bottom edge */
+	fprintf(stderr, "\x1b[%d;%dH", y + h - 1, x);
+	fputs(bl, stderr);
+	for (int i = 0; i < w - 2; i++) fputs(hz, stderr);
+	fputs(br, stderr);
+
+	fflush(stderr);
+}
+
+/* atexit-registered cleanup so a normal exit() always restores the terminal. */
+static void terminal_mouse_atexit_cleanup(void) {
+	/* Direct write to STDERR_FILENO using only async-signal-safe APIs is
+	 * unnecessary here (atexit runs from normal context), but using fputs
+	 * + fflush keeps it consistent with the rest of this file. */
+	terminal_disable_mouse();
+}
+
+/* Enable xterm SGR (1006) + button-event (1000) mouse tracking.
+ * Registers atexit cleanup on first call only (idempotent). */
+void terminal_enable_mouse(void) {
+	static bool atexit_registered = false;
+	if (!atexit_registered) {
+		atexit(terminal_mouse_atexit_cleanup);
+		atexit_registered = true;
+	}
+
+	fputs("\x1b[?1006h\x1b[?1000h", stderr);
+	fflush(stderr);
+}
+
+/* Disable mouse tracking.  Order matches xterm convention: turn off the
+ * encoding extension after the button-event tracking that referenced it. */
+void terminal_disable_mouse(void) {
+	fputs("\x1b[?1000l\x1b[?1006l", stderr);
+	fflush(stderr);
+}
+
 /* Sets a custom SIGINT handler; returns the previous handler. */
 terminal_sigint_handler terminal_set_sigint_handler(terminal_sigint_handler handler) {
 	terminal_sigint_handler old_handler = original_sigint_handler;

--- a/frontier-cli/terminal_control.h
+++ b/frontier-cli/terminal_control.h
@@ -15,6 +15,7 @@
 #define TERMINAL_CONTROL_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /* Terminal state structure */
 typedef struct terminal_state {
@@ -71,6 +72,68 @@ bool terminal_get_size(int *rows, int *cols);
 void terminal_clear_screen(void);
 void terminal_hide_cursor(void);
 void terminal_show_cursor(void);
+
+/*
+ * Slash-menu palette UI substrate (PR 3).
+ *
+ * These primitives back the future REPL slash-command palette renderer
+ * (terminal_emit_box, terminal_set_attr, terminal_move_to) and its mouse
+ * input mode (terminal_enable_mouse / terminal_disable_mouse).
+ *
+ * All emitters write to stderr and fflush, matching the existing convention
+ * in this header.
+ */
+
+/* Attribute flag bits for terminal_set_attr().  Combine with bitwise OR. */
+#define TERM_ATTR_BOLD      0x01u
+#define TERM_ATTR_INVERSE   0x02u
+#define TERM_ATTR_UNDERLINE 0x04u
+
+/*
+ * Move cursor to absolute position (1-based row, 1-based column) using the
+ * ANSI CUP sequence (ESC [ row ; col H).  Synonym of terminal_move_cursor()
+ * with the slash-menu palette naming convention.
+ */
+void terminal_move_to(int row, int col);
+
+/*
+ * Set foreground and background colour plus a bitmask of TERM_ATTR_* flags.
+ * fg / bg use the standard 8-colour palette indices (0..7); 0 in both with
+ * no flags emits a plain SGR reset.  Always begins with SGR 0 so callers do
+ * not have to track previous attribute state.
+ */
+void terminal_set_attr(uint8_t fg, uint8_t bg, uint8_t flags);
+
+/*
+ * Draw a rectangular border at column x, row y with width w and height h
+ * (both 1-based) using Unicode box-drawing characters.  When double_line is
+ * true, uses ╔═╗║╚╝ glyphs; otherwise ┌─┐│└┘.  No-ops if w<2 or h<2.
+ * Does not clear the box interior — caller paints contents separately.
+ */
+void terminal_emit_box(int x, int y, int w, int h, bool double_line);
+
+/*
+ * Enable xterm SGR-encoded mouse tracking (DEC private mode 1006) plus
+ * button-event tracking (mode 1000).  On the first call in a process, also
+ * registers an atexit() hook that calls terminal_disable_mouse() — this
+ * prevents the terminal from being left in mouse-tracking mode if the
+ * process exits via a normal exit() path (Ctrl-D, quit command, etc.).
+ *
+ * NOTE: atexit handlers do NOT run on _exit(), so signal handlers that
+ * terminate via _exit must call terminal_disable_mouse() directly.
+ *
+ * NOTE: SGR 1006 is xterm 277+ (2012) and is widely supported (iTerm2,
+ * Terminal.app, alacritty, kitty, gnome-terminal).  Older terminals or
+ * mouse-over-ssh without TERM forwarding may ignore it; capability probing
+ * is deferred to a later PR (P-low risk).
+ */
+void terminal_enable_mouse(void);
+
+/*
+ * Disable mouse tracking (modes 1000 and 1006).  Idempotent and safe to
+ * call even if terminal_enable_mouse() was never invoked.
+ */
+void terminal_disable_mouse(void);
 
 /* Display formatting */
 void terminal_start_inverted(void);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -220,7 +220,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -305,6 +305,12 @@ refcon_phase2_tests: refcon_cli_tests/phase2_serialization.c
 opattributes_stub_tests: opattributes_stub_tests.c $(LANG_RUNTIME_SOURCES) ../frontier-cli/stubs/headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -I../Common/headers -I../Common/SystemHeaders -I../portable \
 		opattributes_stub_tests.c $(LANG_RUNTIME_SOURCES) ../frontier-cli/stubs/headless_shell.c -o $@ $(LINK_LIBS)
+
+# terminal_control_tests - PR 3 slash-menu palette UI substrate.
+# Standalone (no Frontier runtime needed); links only terminal_control.c.
+terminal_control_tests: terminal_control_tests.c ../frontier-cli/terminal_control.c ../frontier-cli/terminal_control.h
+	$(CC) -std=c17 -Wall -Wextra -g -O0 -I../frontier-cli \
+		terminal_control_tests.c ../frontier-cli/terminal_control.c -o $@
 
 # Thread safety Layer 1 tests - standalone, no full runtime needed
 headless_thread_registry_tests: headless_thread_registry_tests.c ../Common/source/threadregistry.c ../Common/source/logging.c

--- a/tests/terminal_control_tests.c
+++ b/tests/terminal_control_tests.c
@@ -1,0 +1,393 @@
+/*	$Id$    */
+
+/*
+    SPDX-License-Identifier: MIT
+
+    Copyright (c) 2026 Frontier contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/*
+ * terminal_control_tests.c - Unit tests for slash-menu palette UI substrate
+ *
+ * Covers the new emitter functions added to terminal_control for the REPL
+ * slash-menu palette (PR 3 of the slash-menu series):
+ *   - terminal_move_to(row, col)         CSI CUP
+ *   - terminal_set_attr(fg, bg, flags)   SGR colour + bold/inverse/underline
+ *   - terminal_emit_box(x, y, w, h, dbl) Unicode box-drawing borders
+ *   - terminal_enable_mouse()            xterm SGR 1006 + 1000 enable
+ *   - terminal_disable_mouse()           xterm 1000 + SGR 1006 disable
+ *
+ * Strategy: redirect stderr to a temp file, invoke the function, fflush, then
+ * read back the bytes and compare against the expected escape sequence. This
+ * is a behavioural test of the wire-format output, which is what consumers
+ * (palette renderer, file_browser, etc.) actually see.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "terminal_control.h"
+#include "test_report.h"
+
+/* ---------- output capture ---------- */
+
+static FILE *g_saved_stderr = NULL;
+static int g_saved_stderr_fd = -1;
+static char g_capture_path[256];
+
+static void capture_begin(void) {
+	/* Build a unique temp path */
+	snprintf(g_capture_path, sizeof(g_capture_path),
+		"/tmp/term_ctrl_test_%d_%ld.bin", (int)getpid(), (long)random());
+
+	fflush(stderr);
+	g_saved_stderr_fd = dup(STDERR_FILENO);
+	if (g_saved_stderr_fd < 0) {
+		perror("dup stderr");
+		exit(1);
+	}
+
+	FILE *f = freopen(g_capture_path, "w+", stderr);
+	if (!f) {
+		perror("freopen stderr");
+		exit(1);
+	}
+	g_saved_stderr = f;
+}
+
+/* Returns a malloc'd buffer of captured bytes; *out_len receives length. */
+static char *capture_end(size_t *out_len) {
+	fflush(stderr);
+
+	/* Read back captured bytes */
+	FILE *r = fopen(g_capture_path, "rb");
+	if (!r) {
+		perror("fopen capture");
+		exit(1);
+	}
+	fseek(r, 0, SEEK_END);
+	long sz = ftell(r);
+	fseek(r, 0, SEEK_SET);
+
+	char *buf = malloc((size_t)sz + 1);
+	if (!buf) {
+		fclose(r);
+		exit(1);
+	}
+	size_t n = fread(buf, 1, (size_t)sz, r);
+	buf[n] = '\0';
+	fclose(r);
+
+	/* Restore stderr */
+	if (g_saved_stderr_fd >= 0) {
+		dup2(g_saved_stderr_fd, STDERR_FILENO);
+		close(g_saved_stderr_fd);
+		g_saved_stderr_fd = -1;
+		clearerr(stderr);
+	}
+	unlink(g_capture_path);
+
+	if (out_len) *out_len = n;
+	return buf;
+}
+
+/* ---------- assertion helpers ----------
+ *
+ * These are thin wrappers around assert() so that the test_report.h SIGABRT
+ * trampoline catches a failure and continues with the next TR_RUN().  We
+ * print a labelled PASS line (visible in the per-test output) and let
+ * assert() surface the FAIL with file/line. */
+
+static void expect_eq_str(const char *label, const char *actual, size_t actual_len,
+                          const char *expected) {
+	size_t exp_len = strlen(expected);
+	bool ok = (actual_len == exp_len && memcmp(actual, expected, exp_len) == 0);
+	if (!ok) {
+		fprintf(stdout, "  FAIL: %s\n    expected (%zu bytes): ", label, exp_len);
+		for (size_t i = 0; i < exp_len; i++) {
+			unsigned char c = (unsigned char)expected[i];
+			if (c >= 0x20 && c < 0x7f) printf("%c", c);
+			else printf("\\x%02x", c);
+		}
+		fprintf(stdout, "\n    actual   (%zu bytes): ", actual_len);
+		for (size_t i = 0; i < actual_len; i++) {
+			unsigned char c = (unsigned char)actual[i];
+			if (c >= 0x20 && c < 0x7f) printf("%c", c);
+			else printf("\\x%02x", c);
+		}
+		fprintf(stdout, "\n");
+		fflush(stdout);
+	} else {
+		printf("  PASS: %s\n", label);
+	}
+	assert(ok);
+}
+
+static void expect_contains(const char *label, const char *actual, size_t actual_len,
+                            const char *needle) {
+	size_t nlen = strlen(needle);
+	bool found = false;
+	if (actual_len >= nlen) {
+		for (size_t i = 0; i + nlen <= actual_len; i++) {
+			if (memcmp(actual + i, needle, nlen) == 0) { found = true; break; }
+		}
+	}
+	if (!found) {
+		fprintf(stdout, "  FAIL: %s — needle not found\n", label);
+		fflush(stdout);
+	} else {
+		printf("  PASS: %s\n", label);
+	}
+	assert(found);
+}
+
+static void expect_true(const char *label, bool cond) {
+	if (cond) printf("  PASS: %s\n", label);
+	else { fprintf(stdout, "  FAIL: %s\n", label); fflush(stdout); }
+	assert(cond);
+}
+
+/* ---------- tests ---------- */
+
+static void test_move_to_basic(void) {
+	printf("test_move_to_basic\n");
+	capture_begin();
+	terminal_move_to(5, 10);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_eq_str("move_to(5,10) emits CSI 5;10 H", buf, n, "\x1b[5;10H");
+	free(buf);
+}
+
+static void test_move_to_origin(void) {
+	printf("test_move_to_origin\n");
+	capture_begin();
+	terminal_move_to(1, 1);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_eq_str("move_to(1,1) emits CSI 1;1 H", buf, n, "\x1b[1;1H");
+	free(buf);
+}
+
+static void test_set_attr_default(void) {
+	printf("test_set_attr_default\n");
+	capture_begin();
+	/* fg=0, bg=0, no flags → should reset (SGR 0) */
+	terminal_set_attr(0, 0, 0);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_eq_str("set_attr(0,0,0) emits SGR 0 reset", buf, n, "\x1b[0m");
+	free(buf);
+}
+
+static void test_set_attr_fg_only(void) {
+	printf("test_set_attr_fg_only\n");
+	capture_begin();
+	/* fg=red(1), bg=0, no flags → SGR 0;31 (reset + fg red) */
+	terminal_set_attr(1, 0, 0);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("set_attr(1,0,0) contains 31 (fg red)", buf, n, "31");
+	expect_contains("set_attr(1,0,0) starts with ESC [", buf, n, "\x1b[");
+	expect_contains("set_attr(1,0,0) ends with m", buf, n, "m");
+	free(buf);
+}
+
+static void test_set_attr_bg(void) {
+	printf("test_set_attr_bg\n");
+	capture_begin();
+	/* fg=0, bg=blue(4) → contains 44 */
+	terminal_set_attr(0, 4, 0);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("set_attr bg=4 contains 44", buf, n, "44");
+	free(buf);
+}
+
+static void test_set_attr_bold(void) {
+	printf("test_set_attr_bold\n");
+	capture_begin();
+	terminal_set_attr(0, 0, TERM_ATTR_BOLD);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("set_attr bold contains ;1 or 1m", buf, n, "1");
+	free(buf);
+}
+
+static void test_set_attr_inverse(void) {
+	printf("test_set_attr_inverse\n");
+	capture_begin();
+	terminal_set_attr(0, 0, TERM_ATTR_INVERSE);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("set_attr inverse contains 7", buf, n, "7");
+	free(buf);
+}
+
+static void test_set_attr_underline(void) {
+	printf("test_set_attr_underline\n");
+	capture_begin();
+	terminal_set_attr(0, 0, TERM_ATTR_UNDERLINE);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("set_attr underline contains 4", buf, n, "4");
+	free(buf);
+}
+
+static void test_emit_box_single(void) {
+	printf("test_emit_box_single\n");
+	capture_begin();
+	/* 3x3 box at (1,1): corners + horizontals + verticals */
+	terminal_emit_box(1, 1, 3, 3, false);
+	size_t n;
+	char *buf = capture_end(&n);
+	/* Single-line UTF-8: ┌ E2 94 8C  ─ E2 94 80  ┐ E2 94 90
+	                      │ E2 94 82  └ E2 94 94  ┘ E2 94 98 */
+	expect_contains("emit_box single contains top-left ┌", buf, n, "\xe2\x94\x8c");
+	expect_contains("emit_box single contains top-right ┐", buf, n, "\xe2\x94\x90");
+	expect_contains("emit_box single contains bottom-left └", buf, n, "\xe2\x94\x94");
+	expect_contains("emit_box single contains bottom-right ┘", buf, n, "\xe2\x94\x98");
+	expect_contains("emit_box single contains horizontal ─", buf, n, "\xe2\x94\x80");
+	expect_contains("emit_box single contains vertical │", buf, n, "\xe2\x94\x82");
+	/* Should NOT contain double-line glyphs */
+	bool has_double = false;
+	for (size_t i = 0; i + 2 < n; i++) {
+		if ((unsigned char)buf[i] == 0xe2 && (unsigned char)buf[i+1] == 0x95 &&
+		    (unsigned char)buf[i+2] == 0x94) { has_double = true; break; }  /* ╔ */
+	}
+	expect_true("single-line box has no double-line chars", !has_double);
+	free(buf);
+}
+
+static void test_emit_box_double(void) {
+	printf("test_emit_box_double\n");
+	capture_begin();
+	terminal_emit_box(1, 1, 4, 3, true);
+	size_t n;
+	char *buf = capture_end(&n);
+	/* Double-line UTF-8: ╔ E2 95 94  ═ E2 95 90  ╗ E2 95 97
+	                      ║ E2 95 91  ╚ E2 95 9A  ╝ E2 95 9D */
+	expect_contains("emit_box double contains top-left ╔", buf, n, "\xe2\x95\x94");
+	expect_contains("emit_box double contains top-right ╗", buf, n, "\xe2\x95\x97");
+	expect_contains("emit_box double contains bottom-left ╚", buf, n, "\xe2\x95\x9a");
+	expect_contains("emit_box double contains bottom-right ╝", buf, n, "\xe2\x95\x9d");
+	expect_contains("emit_box double contains horizontal ═", buf, n, "\xe2\x95\x90");
+	expect_contains("emit_box double contains vertical ║", buf, n, "\xe2\x95\x91");
+	free(buf);
+}
+
+static void test_emit_box_positions_cursor(void) {
+	printf("test_emit_box_positions_cursor\n");
+	capture_begin();
+	/* Box at (col=10, row=5), 4x3 — must include CSI CUP for row 5,col 10 */
+	terminal_emit_box(10, 5, 4, 3, false);
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("emit_box positions at row 5", buf, n, "\x1b[5;10H");
+	free(buf);
+}
+
+static void test_emit_box_too_small(void) {
+	printf("test_emit_box_too_small\n");
+	capture_begin();
+	/* Degenerate box (w<2 or h<2) should not emit corners */
+	terminal_emit_box(1, 1, 1, 1, false);
+	size_t n;
+	char *buf = capture_end(&n);
+	/* Either zero output or no corner glyph — just ensure no crash and
+	 * no top-left corner appears */
+	bool has_corner = false;
+	for (size_t i = 0; i + 2 < n; i++) {
+		if ((unsigned char)buf[i] == 0xe2 && (unsigned char)buf[i+1] == 0x94 &&
+		    (unsigned char)buf[i+2] == 0x8c) { has_corner = true; break; }
+	}
+	expect_true("degenerate box emits no corner glyph", !has_corner);
+	free(buf);
+}
+
+static void test_enable_mouse_emits_sgr_and_button_event(void) {
+	printf("test_enable_mouse_emits_sgr_and_button_event\n");
+	capture_begin();
+	terminal_enable_mouse();
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("enable_mouse contains SGR 1006 enable",
+	                buf, n, "\x1b[?1006h");
+	expect_contains("enable_mouse contains button-event 1000 enable",
+	                buf, n, "\x1b[?1000h");
+	free(buf);
+}
+
+static void test_disable_mouse_emits_disable_sequences(void) {
+	printf("test_disable_mouse_emits_disable_sequences\n");
+	capture_begin();
+	terminal_disable_mouse();
+	size_t n;
+	char *buf = capture_end(&n);
+	expect_contains("disable_mouse contains 1000 disable",
+	                buf, n, "\x1b[?1000l");
+	expect_contains("disable_mouse contains 1006 disable",
+	                buf, n, "\x1b[?1006l");
+	free(buf);
+}
+
+static void test_enable_disable_round_trip(void) {
+	printf("test_enable_disable_round_trip\n");
+	capture_begin();
+	terminal_enable_mouse();
+	terminal_disable_mouse();
+	size_t n;
+	char *buf = capture_end(&n);
+	/* Should contain both enable and disable sequences */
+	expect_contains("round-trip enable 1006", buf, n, "\x1b[?1006h");
+	expect_contains("round-trip disable 1006", buf, n, "\x1b[?1006l");
+	free(buf);
+}
+
+int main(void) {
+	TR_INIT("terminal_control_tests");
+	srandom((unsigned)getpid());
+
+	TR_RUN(test_move_to_basic);
+	TR_RUN(test_move_to_origin);
+	TR_RUN(test_set_attr_default);
+	TR_RUN(test_set_attr_fg_only);
+	TR_RUN(test_set_attr_bg);
+	TR_RUN(test_set_attr_bold);
+	TR_RUN(test_set_attr_inverse);
+	TR_RUN(test_set_attr_underline);
+	TR_RUN(test_emit_box_single);
+	TR_RUN(test_emit_box_double);
+	TR_RUN(test_emit_box_positions_cursor);
+	TR_RUN(test_emit_box_too_small);
+	TR_RUN(test_enable_mouse_emits_sgr_and_button_event);
+	TR_RUN(test_disable_mouse_emits_disable_sequences);
+	TR_RUN(test_enable_disable_round_trip);
+
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}


### PR DESCRIPTION
## Summary

PR 3 of 5 in the REPL slash-menu palette series. Adds the UI substrate (terminal control extensions + SIGWINCH plumbing + mouse-mode lifecycle) the upcoming palette renderer will sit on top of. **Does not** touch `pane.c` (PR 4) or `palette.c` (PR 5).

### `terminal_control` extensions (`frontier-cli/terminal_control.{c,h}`)

- `terminal_move_to(row, col)` -- 1-based CSI CUP cursor positioning
- `terminal_set_attr(fg, bg, flags)` -- SGR with `TERM_ATTR_BOLD | TERM_ATTR_INVERSE | TERM_ATTR_UNDERLINE`
- `terminal_emit_box(x, y, w, h, double_line)` -- Unicode box drawing (`┌─┐│└┘` or `╔═╗║╚╝`)
- `terminal_enable_mouse()` -- xterm SGR 1006 + button-event 1000; registers `atexit(terminal_disable_mouse)` on first call (P-medium risk mitigation: never leak mouse mode on normal exit)
- `terminal_disable_mouse()` -- idempotent, safe to call from any context

### REPL signal-handler additions (`frontier-cli/repl.c`, `repl.h`)

- SIGWINCH handler -- sets `volatile sig_atomic_t g_sigwinch`; consumers poll via new `repl_sigwinch_consumed()` accessor (returns true once per delivery, resets flag)
- SIGINT and SIGTERM handlers now also call `async_signal_safe_disable_mouse()` -- a small inline `write(2)` of the same byte sequence as `terminal_disable_mouse()`, since `fputs/fflush` are not async-signal-safe per POSIX.1-2017 sec 2.4.3. Keeps the terminal sane even when SIGTERM forces `_exit()` and skips atexit
- Coexists with `file_browser.c`'s bounded-scope SIGWINCH handler (file_browser saves/restores previous sigaction)

### Tests (`tests/terminal_control_tests.c` -- new)

15 behavioural tests with 31 expects. Strategy: redirect stderr to a temp file, invoke each emitter, fflush, then compare bytes against expected escape sequences. Tests the wire format the renderer will actually produce -- not source inspection.

## Test plan

- [x] `./tools/run_headless_tests.sh` -- 332 / 332 pass (was 317; adds 15 new TR_RUN tests)
- [x] `cd tests && make test-integration` -- 2029 pass / 0 fail / 201 skip
- [x] CLI builds clean (`make -C frontier-cli`)
- [x] No regressions in existing `terminal_control` consumers (`file_browser.c`, `dialog_prompts.c`, `file_dialog.c`, `tab_completion.c`, `repl_output.c`)

## /gate verdict: PASS

Inline gate run (bar-raiser + security + concurrency tiers; swiftui excluded per project config). No P0 or P1 findings. Notable points:

- `terminal_set_attr` uses `snprintf` into a fixed 64-byte buffer -- bounded
- `async_signal_safe_disable_mouse` uses only `write(2)` on a literal -- AS-safe
- atexit ordering: mouse cleanup registers after `cleanup_terminal`, runs first (LIFO) -- correct order
- `g_sigwinch` is `volatile sig_atomic_t`; consumer's read-clear has a benign race window (next resize re-sets it)

## Out of scope (deferred)

- Mouse-over-ssh capability probe / SGR 1006 fallback (P-low risk)
- `pane.c` integration (PR 4)
- `palette.c` integration + SIGWINCH polling in event loop (PR 5)
