### PR TITLE
fix(repl): two carryover bugs in repl_jump_script (#591)

### DIFF
--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -152,6 +152,21 @@ static boolean g_repl_active = false;
  */
 static volatile sig_atomic_t g_repl_exit_requested = 0;
 
+/*
+ * Set across user-script execution so the SIGINT handler (installed further
+ * down) knows it should request interruption rather than tearing the REPL
+ * down. Hoisted to the top of the file so callers earlier in the source
+ * (e.g. repl_jump_script) can wrap their langrun() calls.
+ *
+ * Writers: any function on the GIL that runs a user script. Reader: the
+ * SIGINT handler, which uses sig_atomic_t reads to stay async-signal-safe.
+ *
+ * NOTE: writers MUST clear this flag on every exit path (success and
+ * failure) — a stale "1" makes Ctrl-C requests interruption against a
+ * non-running script and confuses the next command's signal handling.
+ */
+static volatile sig_atomic_t g_script_running = 0;
+
 // Session command tracking for merge-before-save
 static char *session_commands[MAX_SESSION_COMMANDS];
 static size_t session_command_count = 0;
@@ -319,7 +334,16 @@ static boolean repl_jump_script(const char *script) {
 	if (flpushpop)
 		flpushpop = pushprocess(nil);
 
+	/* Mark script-running across the langrun call so the SIGINT handler
+	 * requests interruption of the user expression rather than tearing the
+	 * REPL down. Mirrors the wrap pattern used by process_line() (the
+	 * eval-line path) and dispatch_synthesized_script() / dispatch_leaf_via_menubar()
+	 * (the menubar-handler paths). The legacy `/jump expr()` path was missing
+	 * this wrap (issue #591); without it Ctrl-C during a long-running jump
+	 * expression would not interrupt cleanly. */
+	g_script_running = 1;
 	boolean fl = langrun(htext, &val);	/* langrun consumes htext */
+	g_script_running = 0;
 
 	if (flpushpop)
 		popprocess();
@@ -1513,8 +1537,9 @@ hdlhashtable repl_resolve_path(const char *path, char *resolved_path, size_t pat
 // Declared as non-static so lang.c can check it for script interruption
 volatile sig_atomic_t g_repl_interrupt_requested = 0;
 
-// Global script running flag for interrupt handling
-static volatile sig_atomic_t g_script_running = 0;
+/* g_script_running lives at the top of the file (near g_repl_exit_requested)
+ * so its readers and writers can be hoisted ahead of this point without
+ * forward-declaration churn. See the comment block on the declaration. */
 
 /* SIGWINCH (window-size change) flag.
  *
@@ -2549,7 +2574,7 @@ static boolean dispatch_slash_command(const char *line, boolean *running) {
 						fflush(stdout);
 						break;
 				}
-				if (strcasecmp(slot_name, "Exit") == 0) {
+				if (slot_key_eq(slot_name, "Exit")) {
 					replverbhost_exit();
 					*running = false;
 				}
@@ -2570,16 +2595,16 @@ static boolean dispatch_slash_command(const char *line, boolean *running) {
 					fflush(stdout);
 					break;
 			}
-			if (strcasecmp(slot_name, "Exit") == 0) {
+			if (slot_key_eq(slot_name, "Exit")) {
 				replverbhost_exit();
 				*running = false;
 			}
 			return true;
-		} else if (strcasecmp(slot_name, "List") == 0) {
+		} else if (slot_key_eq(slot_name, "List")) {
 			/* Path (b) legacy: List with arg. */
 			replverbhost_list(args_start);
 			return true;
-		} else if (strcasecmp(slot_name, "Jump") == 0) {
+		} else if (slot_key_eq(slot_name, "Jump")) {
 			/* Path (b) legacy: Jump with arg. */
 			if (!replverbhost_jump_path(args_start)) {
 				/* Match the legacy /jump error wording. The path
@@ -2622,7 +2647,7 @@ static boolean dispatch_slash_command(const char *line, boolean *running) {
 			break;
 	}
 
-	if (strcasecmp(slot_name, "Exit") == 0) {
+	if (slot_key_eq(slot_name, "Exit")) {
 		/* Belt-and-braces: also flag exit at this level. The menubar
 		 * handler's repl.exit() also sets g_repl_exit_requested via
 		 * replverbhost_exit, but a stale host adapter (NULL pointer

--- a/frontier-cli/repl_slash_resolver.c
+++ b/frontier-cli/repl_slash_resolver.c
@@ -130,6 +130,29 @@ static char fold_byte(char c) {
 
 
 /*
+ * Locale-independent ASCII case-insensitive equality. See the contract in
+ * repl_slash_resolver.h. Walks both strings byte-by-byte applying the same
+ * ASCII fold the resolver uses for label matching; this guarantees that the
+ * slot-key special-case sites in repl.c agree with the resolver regardless
+ * of process locale. NULL inputs are not-equal (defensive).
+ */
+boolean slot_key_eq(const char *a, const char *b) {
+	if (a == NULL || b == NULL)
+		return false;
+	for (;;) {
+		char ca = fold_byte(*a);
+		char cb = fold_byte(*b);
+		if (ca != cb)
+			return false;
+		if (ca == '\0')
+			return true; /* both reached terminator on the same step */
+		a++;
+		b++;
+	}
+}
+
+
+/*
  * Copy `src` into `dst` (size `dstsz`), case-folding ASCII and dropping
  * spaces. NUL-terminates dst. Returns the number of output bytes written
  * (excluding the trailing NUL). If dstsz is 0 returns 0 and writes nothing.

--- a/frontier-cli/repl_slash_resolver.h
+++ b/frontier-cli/repl_slash_resolver.h
@@ -109,6 +109,38 @@ extern boolean repl_resolve_slash_command(const char *token,
                                           char *out_name, size_t out_namesz);
 
 
+/*
+ * slot_key_eq - locale-independent ASCII case-insensitive equality for
+ * slot-key matching at the REPL dispatch sites.
+ *
+ * The resolver's label-folding (fold_byte) is hand-rolled, ASCII-only:
+ * 'A'..'Z' fold to 'a'..'z'; every other byte (including high-bit bytes
+ * 0x80..0xFF) is passed through unchanged. Call sites in repl.c that
+ * special-case the slot key returned by repl_resolve_slash_command (e.g.
+ * "Exit", "List", "Jump") historically used strcasecmp(3), which is
+ * locale-sensitive: under a non-C locale, classification of high-bit bytes
+ * can diverge between the resolver and the dispatcher. Slot keys today are
+ * pure ASCII so the divergence is dormant, but a future menubar entry with
+ * a non-ASCII slot key, or a setlocale() call elsewhere in the process,
+ * could turn that into a real bug.
+ *
+ * Contract:
+ *   - Returns true iff `a` and `b` are non-NULL and compare equal byte-for-
+ *     byte after applying the same ASCII-only case fold the resolver uses
+ *     ('A'..'Z' -> 'a'..'z'; everything else passes through).
+ *   - NULL inputs are treated as not-equal (defensive — the resolver always
+ *     populates the slot_name buffer with a NUL-terminated string, so NULL
+ *     should never reach call sites in practice).
+ *   - Symmetric: slot_key_eq(a, b) == slot_key_eq(b, a) for every input.
+ *   - Strings of differing length are unequal even when one is a prefix.
+ *
+ * No call to setlocale(), tolower(), strcasecmp(), or any other locale-
+ * sensitive C library routine. Safe to call from any thread; pure function
+ * over its inputs.
+ */
+extern boolean slot_key_eq(const char *a, const char *b);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/repl_slash_resolver_tests.c
+++ b/tests/repl_slash_resolver_tests.c
@@ -505,6 +505,133 @@ static void test_non_canonical_slot_key_rejected(void) {
 	fflush(stdout);
 }
 
+/* ---------- slot_key_eq tests ----------
+ *
+ * slot_key_eq is the locale-independent ASCII case-insensitive equality
+ * helper used by repl.c at the slot-key special-case sites ("Exit", "List",
+ * "Jump"). The legacy code there used strcasecmp, which is locale-sensitive
+ * — under a non-C locale, classification of high-bit bytes can diverge
+ * between strcasecmp and the resolver's hand-rolled fold_byte (ASCII-only).
+ * The helper guarantees the two paths agree byte-for-byte regardless of
+ * setlocale() state.
+ *
+ * These tests are pure-C and require no ODB state; they run before the
+ * menubar tests in main().
+ */
+
+static void test_slot_key_eq_basic_ascii(void) {
+	printf("[resolver] Test: slot_key_eq matches ASCII variants... ");
+	fflush(stdout);
+
+	/* All-lowercase, all-uppercase, and mixed-case all compare equal. */
+	assert(slot_key_eq("Exit", "Exit"));
+	assert(slot_key_eq("Exit", "exit"));
+	assert(slot_key_eq("Exit", "EXIT"));
+	assert(slot_key_eq("Exit", "eXiT"));
+	assert(slot_key_eq("List", "list"));
+	assert(slot_key_eq("Jump", "JUMP"));
+
+	/* Different strings (canonical slot keys) are not equal. */
+	assert(!slot_key_eq("Exit", "List"));
+	assert(!slot_key_eq("Exit", "Jump"));
+	assert(!slot_key_eq("List", "Jump"));
+
+	/* Different lengths are not equal even when one is a prefix. */
+	assert(!slot_key_eq("Exit", "Exi"));
+	assert(!slot_key_eq("Exi", "Exit"));
+	assert(!slot_key_eq("", "Exit"));
+	assert(!slot_key_eq("Exit", ""));
+
+	/* Two empty strings are equal. */
+	assert(slot_key_eq("", ""));
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+static void test_slot_key_eq_symmetric(void) {
+	printf("[resolver] Test: slot_key_eq is symmetric... ");
+	fflush(stdout);
+
+	/* Symmetry: f(a,b) == f(b,a) for every pair we care about. */
+	const char *pairs[][2] = {
+		{ "Exit", "exit" },
+		{ "EXIT", "ExIt" },
+		{ "Key codes", "key codes" },
+		{ "Help", "help" },
+		{ "List", "JUMP" },           /* unequal pair */
+		{ "Exi", "Exit" },            /* unequal length */
+		{ "abc\xC3\x84", "ABC\xC3\x84" }, /* high-bit byte: equal under
+		                                     byte-equality, regardless of
+		                                     locale-specific casing */
+		{ NULL, NULL }
+	};
+	for (int i = 0; pairs[i][0] != NULL; i++) {
+		boolean ab = slot_key_eq(pairs[i][0], pairs[i][1]);
+		boolean ba = slot_key_eq(pairs[i][1], pairs[i][0]);
+		assert(ab == ba);
+	}
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+static void test_slot_key_eq_high_bit_bytes_byte_equal(void) {
+	printf("[resolver] Test: slot_key_eq compares high-bit bytes byte-equal... ");
+	fflush(stdout);
+
+	/*
+	 * High-bit bytes (0x80-0xFF) must NOT be case-folded — the helper is
+	 * intentionally ASCII-only so that a process locale change via
+	 * setlocale() cannot reclassify them. Identical raw byte sequences are
+	 * equal; differing high-bit bytes are unequal even if some locale
+	 * would consider them a case pair.
+	 *
+	 * This is the carryover-1 invariant: the resolver's fold_byte is
+	 * ASCII-only, so the slot-key special-case sites in repl.c must
+	 * follow the same rule. Any locale-aware tolower at high bytes would
+	 * produce divergent classification between resolver and dispatcher.
+	 */
+
+	/* Two strings with the same high-bit byte: equal. */
+	assert(slot_key_eq("foo\xC3\xA9", "foo\xC3\xA9"));
+	assert(slot_key_eq("FOO\xC3\xA9", "foo\xC3\xA9"));  /* ASCII-fold
+	                                                       front, byte-equal
+	                                                       at the tail */
+
+	/* Two strings whose high-bit bytes differ: not equal. */
+	assert(!slot_key_eq("foo\xC3\x84", "foo\xC3\xA4"));
+	/* 0xC4 vs 0xE4 in ISO-8859-1 (Ä vs ä) — locale-aware tolower under
+	 * an ISO-8859-1 / UTF-8 locale might fold these together, but the
+	 * helper intentionally does not. */
+	assert(!slot_key_eq("foo\xC4", "foo\xE4"));
+
+	/* The ASCII fold range is strictly 'A'..'Z' / 'a'..'z'. Bytes outside
+	 * that range are passed through. Confirm ASCII non-letter bytes
+	 * (digits, punctuation) compare byte-equal without folding. */
+	assert(slot_key_eq("Exit-1", "EXIT-1"));
+	assert(!slot_key_eq("Exit-1", "Exit-2"));
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+static void test_slot_key_eq_null_safety(void) {
+	printf("[resolver] Test: slot_key_eq handles NULL safely... ");
+	fflush(stdout);
+
+	/* NULL inputs: defined as not-equal (defensive). The helper must not
+	 * crash on either-or-both NULL. The repl.c call sites pass slot_name
+	 * (a stack buffer that is always NUL-terminated by the resolver), but
+	 * a defensive contract is cheap and prevents future regressions. */
+	assert(!slot_key_eq(NULL, "Exit"));
+	assert(!slot_key_eq("Exit", NULL));
+	assert(!slot_key_eq(NULL, NULL));
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
 /* ---------- main ---------- */
 
 int main(void) {
@@ -522,6 +649,12 @@ int main(void) {
 	assert(langinitresources_headless());
 	assert(langinitverbs());
 	assert(wp_portable_init());
+
+	/* slot_key_eq helper tests (pure C, no ODB state). */
+	TR_RUN(test_slot_key_eq_basic_ascii);
+	TR_RUN(test_slot_key_eq_symmetric);
+	TR_RUN(test_slot_key_eq_high_bit_bytes_byte_equal);
+	TR_RUN(test_slot_key_eq_null_safety);
 
 	TR_RUN(test_exact_label_match);
 	TR_RUN(test_unique_prefix_match);


### PR DESCRIPTION
## Summary

Fix two paired carryovers in `repl_jump_script` flagged in PR #583 concurrency review and tracked in #591.

1. **Locale-independent slot-key match** — replace `strcasecmp` for menubar slot keys ("Exit", "List", "Jump") with new `slot_key_eq` helper (ASCII-only, locale-independent, NULL-safe). The resolver's `fold_byte` is hand-rolled ASCII; `strcasecmp` honors C locale. No practical risk today (slot keys are pure ASCII), but the divergence was a future-drift hazard.
2. **`g_script_running` set across `repl_jump_script` langrun** — wrap the `langrun` call with `g_script_running = 1; ...; g_script_running = 0;` to mirror the eval-path pattern. Makes Ctrl-C interrupt cleanly during `/jump expr()` calls.

## What lands

- `frontier-cli/repl_slash_resolver.{c,h}` — new `slot_key_eq` helper + 4 unit tests
- `frontier-cli/repl.c` — 5 `strcasecmp` to `slot_key_eq` call-site updates; `langrun` wrap in `repl_jump_script`; `g_script_running` static moved to top of file (cleaner forward-visibility)
- `tests/repl_slash_resolver_tests.c` — 4 new tests for `slot_key_eq` (basic ASCII, symmetric, high-bit byte equality, NULL safety)

## Scope notes

- Path-keyword matches at `repl.c:1103-1104` (`/jump root` / `/jump @root`) NOT converted — different invariant (user-typed paths, not menubar slot keys); separate scope decision if desired.
- g_script_running TDD treated as exception — structurally observable but not unit-testable without a `thread.new()` child or signal injection harness. Verified by code review against canonical pattern at `process_line` (repl.c:2680) and `dispatch_synthesized_script` (repl.c:2273). End-to-end SIGINT-during-/jump-expr verification would need subprocess signal injection — flagged as suitable follow-up.

## Test plan

- [x] `./tools/run_headless_tests.sh` — **468/468 pass** (was 464; +4 from `slot_key_eq` tests)
- [x] `cd tests && make test-integration` — **2287 / 0 fail / 201 skip** (unchanged)
- [x] `make -C frontier-cli` clean

## Closes

#591

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
