### PR TITLE
fix(cli): --protocol --system-root opens read-only by default (#588)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ The unit and integration commands above are also listed in the Quick Reference s
 
 **Edit `databases/Virgin.root`** for changes that should persist in builds. `Virgin.root` is the source of truth — `make dist` copies it to `dist/Frontier.root`. Edits to `databases/Frontier.root` are local only and overwritten.
 
-**Always use `--protocol` mode for ODB edits, never `-e`.** Protocol supports multi-step operations without shell escaping issues.
+**Always use `--protocol` mode for ODB edits, never `-e`.** Protocol supports multi-step operations without shell escaping issues. Pair with `--allow-mutate` when the edit must persist — `--protocol --system-root` defaults to **read-only** since #588, so `fileMenu.save()` will fail without it.
 
 **Always use `script.newScriptObject` / `op.newOutlineObject`** to install scripts — never raw `op.insert`. These verbs handle line ending normalization (LF/CRLF → CR).
 

--- a/docs/CLI_USAGE_GUIDE.md
+++ b/docs/CLI_USAGE_GUIDE.md
@@ -78,6 +78,8 @@ To run `frontier-cli` from any directory, either:
 | | `--non-interactive` | | Alias for `--batch` |
 | `-v` | `--verbose` | | Enable verbose output |
 | | `--debug` | | Enable debug mode |
+| | `--read-only` | | Open `--system-root` read-only; refuse all writes (default for `--protocol`) |
+| | `--allow-mutate` | | Opt `--protocol --system-root` back into read-write (e.g. for installs) |
 | `-h` | `--help` | | Show help message |
 | | `--version` | | Show version information |
 

--- a/docs/ODB_SCRIPT_EDITING.md
+++ b/docs/ODB_SCRIPT_EDITING.md
@@ -19,8 +19,18 @@ How to safely create, modify, and verify UserTalk scripts in the Frontier object
 
 ### Connecting
 
+For **read-only inspection** (no on-disk changes):
+
 ```bash
 frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
+```
+
+Since issue #588, `--protocol --system-root` defaults to **read-only**. `fileMenu.save()` will fail with "system root is read-only" until you opt into mutation.
+
+For **editing** (changes that persist to the .root file), add `--allow-mutate`:
+
+```bash
+frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
 ```
 
 Use `Virgin.root` for edits that should be part of the distribution. Use `databases/Frontier.root` for local testing only.
@@ -55,7 +65,7 @@ Read back and check it compiles:
 Guest databases (`databases/Guest Databases/apps/*.root`) ship with the dist build. To edit them, load the system root first (so system verbs like `script.newScriptObject` are available), then open the guest DB as a secondary database:
 
 ```bash
-frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
+frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
 ```
 
 ```json
@@ -188,7 +198,7 @@ Make your changes in the `.ut` file under `usertalk_scripts/`. This is the human
 ### 3. Install in Virgin.root via protocol
 
 ```bash
-frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
+frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
 ```
 
 ```json

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -337,8 +337,11 @@ dist: $(TARGET)
 # Use before shipping: make dist && make clean-root
 clean-root: dist
 	@echo "Running userland.cleanRoot on dist/Frontier.root..."
+	@# --allow-mutate opts back into read-write: the issue #588 default for
+	@# --protocol --system-root is read-only, but cleanRoot is an explicit
+	@# install path that needs to persist its mutations to the dist file.
 	@echo '{"op":"script/eval","id":1,"params":{"expression":"userland.cleanRoot()"}}' \
-		| $(DIST_DIR)/frontier-cli --protocol --system-root $(DIST_DIR)/Frontier.root 2>&1 \
+		| $(DIST_DIR)/frontier-cli --protocol --allow-mutate --system-root $(DIST_DIR)/Frontier.root 2>&1 \
 		| tee $(DIST_DIR)/cleanroot.log > /dev/null; \
 	if grep -q '"success":true' $(DIST_DIR)/cleanroot.log; then \
 		echo "cleanRoot completed successfully."; \

--- a/frontier-cli/README.md
+++ b/frontier-cli/README.md
@@ -111,6 +111,8 @@ The system root is opened read-only. The CLI will log descriptive warnings if th
 | `-h, --help` | Show help message | Available |
 | `--version` | Show build/version info | Available |
 | `--system-root PATH` | Load a system root database before running scripts | Available |
+| `--read-only` | Open `--system-root` read-only; refuse all writes (default for `--protocol`) | Available |
+| `--allow-mutate` | Opt `--protocol --system-root` back into read-write mode | Available |
 | `-d, --database FILE` | Select database for operations | Disabled (planned) |
 | `-q, --query QUERY` | Execute database query | Disabled (planned) |
 | `-m, --migrate` | Migrate database in place | Disabled (planned) |

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -209,6 +209,16 @@ boolean cli_validate_options(const cli_options_t* options) {
 		}
 	}
 
+	/* --read-only and --allow-mutate are mutually exclusive: a request to
+	 * both forbid and permit writes is contradictory and almost certainly a
+	 * scripting bug. Refusing here keeps the operator's intent explicit
+	 * rather than silently picking one. */
+	if (options->read_only && options->allow_mutate) {
+		log_error(LOG_COMP_GENERAL,
+			"Error: --read-only and --allow-mutate cannot be combined");
+		return false;
+	}
+
 	// Note: Conflict validation for positional .root argument is handled in cli_parse_arguments()
 	// when we detect a .root file and system_root is already set.
 
@@ -239,6 +249,13 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 	// Initialize options with defaults
 	cli_init_options(options);
 
+	/* Long-only option codes (no short alias). 256+ keeps them out of the
+	 * single-character optstring while remaining valid getopt return values. */
+	enum {
+		OPT_READ_ONLY = 256,
+		OPT_ALLOW_MUTATE,
+	};
+
 	// Define long options
 	static struct option long_options[] = {
 		{"execute", required_argument, 0, 'e'},
@@ -256,6 +273,8 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 		{"skip-startup", no_argument, 0, 'S'},
 		{"protocol", no_argument, 0, 'P'},
 		{"ws-port", optional_argument, 0, 'W'},
+		{"read-only", no_argument, 0, OPT_READ_ONLY},
+		{"allow-mutate", no_argument, 0, OPT_ALLOW_MUTATE},
 		{"help", no_argument, 0, 'h'},
 		{"version", no_argument, 0, 'V'},
 		{0, 0, 0, 0}
@@ -494,6 +513,8 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 			case 'D':  options->debug = true; break;
 			case 'S':  options->skip_startup = true; break;
 			case 'P':  options->protocol_mode = true; break;
+			case OPT_READ_ONLY:    options->read_only = true; break;
+			case OPT_ALLOW_MUTATE: options->allow_mutate = true; break;
 			case 'h':  options->show_help = true; break;
 			case 'V':  options->show_version = true; break;
 
@@ -668,6 +689,8 @@ void cli_print_options(const cli_options_t* options) {
 	printf("  Force Overwrite: %s\n", options->force_overwrite ? "yes" : "no");
 	printf("  Skip Startup: %s\n", options->skip_startup ? "yes" : "no");
 	printf("  Protocol Mode: %s\n", options->protocol_mode ? "yes" : "no");
+	printf("  Read-Only: %s\n", options->read_only ? "yes" : "no");
+	printf("  Allow Mutate: %s\n", options->allow_mutate ? "yes" : "no");
 	printf("  WebSocket Port: %d\n", options->ws_port);
 	printf("  Verbose: %s\n", options->verbose ? "yes" : "no");
 	printf("  Debug: %s\n", options->debug ? "yes" : "no");

--- a/frontier-cli/cli_parser.h
+++ b/frontier-cli/cli_parser.h
@@ -60,6 +60,8 @@ typedef struct {
 	boolean force_overwrite;	// Force overwrite existing output file (-f/--force)
 	boolean skip_startup;		// Skip startup scripts (--skip-startup)
 	boolean protocol_mode;		// NDJSON protocol mode (--protocol)
+	boolean read_only;			// Open system root read-only (--read-only); blocks all writes
+	boolean allow_mutate;		// Force read-write opt-in for --protocol --system-root (--allow-mutate)
 	int ws_port;				// WebSocket server port (--ws-port), 0 = disabled
 	boolean show_help;			// Show help flag
 	boolean show_version;		// Show version flag

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -115,6 +115,13 @@ static hdlfilenum g_system_root_fnum = 0;
 static hdldatabaserecord g_previous_database = nil;
 static char g_system_root_path[CLI_MAX_PATH_LENGTH + 1] = {0};
 
+/* Effective read-only state for the loaded system root.
+ *
+ * Computed once from g_cli_options at hydrate time so consumers (filemenu.save,
+ * shutdown save path) can consult a single boolean without re-deriving the
+ * policy each time. See cli_compute_effective_read_only() for the rules. */
+static boolean g_system_root_read_only = false;
+
 /*
  * Accessor functions for system root state.
  * Used by frontier.getFilePath() verb to access CLI state without exposing globals.
@@ -134,6 +141,37 @@ const char* cli_get_system_root_path(void) {
 
 boolean cli_should_skip_startup(void) {
 	return g_cli_options.skip_startup;
+}
+
+/*
+ * Decide whether to open the system root read-only based on parsed CLI flags.
+ *
+ * Policy (issue #588):
+ *   --read-only            -> always read-only (explicit operator request)
+ *   --allow-mutate         -> always read-write (explicit opt-in)
+ *   otherwise + --protocol -> read-only by default (protects canonical roots
+ *                             during inspection / scripted probes; matches the
+ *                             primary use case)
+ *   otherwise              -> read-write (preserve legacy -e / REPL behavior)
+ *
+ * Validation in cli_validate_options() rejects --read-only + --allow-mutate
+ * together, so the explicit branches never disagree.
+ */
+static boolean cli_compute_effective_read_only(const cli_options_t *opts) {
+	if (opts->read_only)
+		return true;
+	if (opts->allow_mutate)
+		return false;
+	if (opts->protocol_mode)
+		return true;
+	return false;
+}
+
+/* Returns the effective read-only state for the loaded system root.
+ * Used by filemenu.save (and the shutdown save path) to refuse writes
+ * that would mutate a database opened for inspection. */
+boolean cli_is_system_root_read_only(void) {
+	return g_system_root_read_only;
 }
 
 /* system.environment.args key names (camelCase from CLI flags). */
@@ -323,7 +361,7 @@ static boolean load_system_root_database(const char* path);
 static void unload_system_root_database(void);
 static void save_system_root_on_exit(void);
 static boolean ensure_named_subtable(hdlhashtable parent, const unsigned char *name, hdlhashtable *out, boolean mark_dont_save);
-static boolean hydrate_system_root_database(const char* path);
+static boolean hydrate_system_root_database(const char* path, boolean read_only);
 static boolean read_root_table_address(const char *path, dbaddress *adr_out, short *version_out);
 static void log_system_subtable_status(const char *phase,
 									   hdlhashtable system,
@@ -536,7 +574,13 @@ int main(int argc, char* argv[]) {
 	}
 
 	if (system_root_to_load != NULL) {
-		if (!hydrate_system_root_database(system_root_to_load)) {
+		/* Compute effective read-only state once and stash it in a global so
+		 * downstream consumers (filemenu.save, shutdown save path) see a
+		 * consistent answer regardless of which call edge they live on.
+		 * Set BEFORE hydrate so any logging during hydrate reflects the
+		 * decision; hydrate reads the parameter, not the global. */
+		g_system_root_read_only = cli_compute_effective_read_only(&g_cli_options);
+		if (!hydrate_system_root_database(system_root_to_load, g_system_root_read_only)) {
 			log_error(LOG_COMP_GENERAL, "Error: Failed to load system root: %s", system_root_to_load);
 			cleanup_frontier_runtime();
 			return 1;
@@ -801,6 +845,10 @@ static void print_usage(const char* program_name) {
 	printf("  --ws-port PORT		   Start WebSocket server on PORT (localhost only, no auth).\n");
 	printf("						   WARNING: Any local process or browser page (including file://)\n");
 	printf("						   can access the ODB while the server is running.\n");
+	printf("  --read-only			   Open --system-root read-only; refuse all writes (fileMenu.save\n");
+	printf("						   etc. fail with a read-only error). Default for --protocol mode.\n");
+	printf("  --allow-mutate		   Opt --protocol --system-root back into read-write mode (use\n");
+	printf("						   for install paths like cleanRoot or ODB script editing).\n");
 	printf("  -h, --help			   Show this help message\n");
 	printf("  --version				   Show version information\n");
 	printf("\n");
@@ -960,7 +1008,13 @@ static void cleanup_frontier_runtime(void) {
 	 * Killed debug threads leave pushed hash table scopes in the chain,
 	 * making hashpack traversal crash on stale pointers. This is a
 	 * fundamental limitation of killing scripts mid-execution. */
-	if (g_system_root_loaded && debug_is_safe_to_save()) {
+	/* Read-only opens (--read-only, or default for --protocol) deliberately
+	 * skip the on-exit save: the goal of #588 is that inspecting a canonical
+	 * .root file leaves it untouched on disk. The lower-layer flreadonly bit
+	 * already shorts dbflushheader, but skipping the save here is the
+	 * intent-level guarantee — the operator asked for read-only, so honor
+	 * it at every layer. */
+	if (g_system_root_loaded && debug_is_safe_to_save() && !g_system_root_read_only) {
 		save_system_root_on_exit();
 	}
 
@@ -1070,10 +1124,11 @@ static void log_system_subtable_status(const char *phase,
 }
 
 /* Loads and fully initializes the system root database, linking EFP tables and resolving paths. */
-static boolean hydrate_system_root_database(const char* path) {
+static boolean hydrate_system_root_database(const char* path, boolean read_only) {
 	/* Always start from a clean slate; useful to confirm entry. */
 #if defined(FRONTIER_HEADLESS)
-	log_trace(LOG_COMP_STARTUP, "hydrate_system_root_database enter path=%s", path ? path : "(nil)");
+	log_trace(LOG_COMP_STARTUP, "hydrate_system_root_database enter path=%s read_only=%s",
+	          path ? path : "(nil)", read_only ? "true" : "false");
 #endif
 	cleartablestructureglobals();
 
@@ -1097,9 +1152,13 @@ static boolean hydrate_system_root_database(const char* path) {
 	/* After ensure_database_v7, we always have a v7 database (either the original if already v7,
 	 * or the original path now containing the migrated v7 data, with v6 backed up to .v6.root).
 	 *
-	 * v7 databases are opened read-write by default to allow startup scripts and system table
-	 * updates. Use FRONTIER_OPEN_READONLY=1 environment variable to force read-only mode. */
-	boolean flreadonly_for_hydration = (getenv("FRONTIER_OPEN_READONLY") != NULL);
+	 * Read-only mode honors any of:
+	 *   - the explicit `read_only` parameter (driven by --read-only / default
+	 *     for --protocol, see cli_compute_effective_read_only)
+	 *   - FRONTIER_OPEN_READONLY=1 environment override (back-compat with
+	 *     pre-flag scripts; harmless when the flag is already set).
+	 * Either gate is sufficient — neither false-overrides the other. */
+	boolean flreadonly_for_hydration = read_only || (getenv("FRONTIER_OPEN_READONLY") != NULL);
 
 	/* Use the output path from ensure_database_v7 if it differs from input.
 	 * This handles both fresh migrations and cases where a v7 file already exists. */
@@ -1286,8 +1345,13 @@ static boolean hydrate_system_root_database(const char* path) {
 							   objectmodeltable);
 
 	/* Only save if we made changes (created optional tables). Skip for freshly-migrated databases.
-	 * Also skip if no optional tables were created - v7 databases are already complete. */
-	if ((!migrated && created_optional)) {
+	 * Also skip if no optional tables were created - v7 databases are already complete.
+	 * Skip when read-only: the optional-tables patch is in-memory only and
+	 * must not propagate to disk; tablesavesystemtable will trip the
+	 * dbflushheader read-only guard, which logs an error and aborts the
+	 * hydration. The patched tables remain valid in memory for this
+	 * process. See issue #588. */
+	if ((!migrated && created_optional && !read_only)) {
 		boolean repack_scope = false;
 		db_format_mode mode = {true, true};	 /* 64-bit, adapter_repack */
 		db_format_mode_push(&mode);
@@ -1304,11 +1368,18 @@ static boolean hydrate_system_root_database(const char* path) {
 			db_format_mode_pop();
 			repack_scope = false;
 		}
+	} else if (read_only && created_optional) {
+		cli_log_debug("Read-only: skipping in-memory optional-table save for %s", path);
 	} else {
 		cli_log_debug("Skipping save for freshly-migrated database: %s", path);
 	}
 
-	dbsetview(cancoonview, adr);
+	/* dbsetview writes the header to disk via dbflushheader. The lower
+	 * layer's flreadonly guard already short-circuits the actual write,
+	 * but skipping the call here avoids a misleading log line and keeps
+	 * the read-only intent explicit at every layer. */
+	if (!read_only)
+		dbsetview(cancoonview, adr);
 
 	/* Log which system root was loaded and whether it was auto-migrated */
 	if (migrated) {

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -114,6 +114,20 @@ static boolean filemenu_save_systemroot(void) {
 
     log_debug(LOG_COMP_DB, "filemenu_save_systemroot: saving system root database");
 
+    /* Refuse to save when the system root was opened read-only (--read-only
+     * or default for --protocol). The CLI symbol is dynamically resolved so
+     * test binaries that don't link main.o still compile; a missing
+     * definition there is fine because tests don't reach this verb on a
+     * read-only DB. See issue #588. */
+    extern boolean cli_is_system_root_read_only(void) __attribute__((weak));
+    if (cli_is_system_root_read_only && cli_is_system_root_read_only()) {
+        log_verb_error(LOG_COMP_DB,
+            "filemenu_save_systemroot: system root opened read-only; refusing save");
+        langerrormessage(PSTRING("\x43",
+            "Can't save: system root is read-only (use --allow-mutate to opt in)"));
+        return false;
+    }
+
     /* Check if we have a database open */
     if (databasedata == nil) {
         log_verb_error(LOG_COMP_DB, "filemenu_save_systemroot: no database open");

--- a/tests/integration/protocol_readonly_tests.sh
+++ b/tests/integration/protocol_readonly_tests.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# Integration tests for --protocol read-only behavior (issue #588).
+#
+# Verifies:
+#  1. Default: --protocol --system-root opens read-only; no-op script does
+#     not modify the .root file.
+#  2. --allow-mutate: opt-in to read-write mode; fileMenu.save() succeeds
+#     and modifies the file on disk.
+#  3. Default with mutation: fileMenu.save() returns success:false with
+#     a "read-only" error message — the file is not modified.
+#  4. --read-only and --allow-mutate together: rejected at argv parse.
+#  5. --read-only outside protocol mode: still honored (defense in depth).
+#
+# Each test stages a fresh copy of Virgin.root in tests/tmp/ to avoid
+# touching the canonical database under databases/.
+#
+# Note: this file is invoked from tools/run_integration_tests.sh. Tests are
+# tallied separately from the YAML runner.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+SOURCE_ROOT="$PROJECT_ROOT/databases/Virgin.root"
+TMP_DIR="$PROJECT_ROOT/tests/tmp/integration/protocol_readonly"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+if [ ! -x "$CLI" ]; then
+	echo -e "${RED}Error: frontier-cli not found at $CLI${NC}"
+	exit 1
+fi
+if [ ! -f "$SOURCE_ROOT" ]; then
+	echo -e "${RED}Error: source database not found at $SOURCE_ROOT${NC}"
+	exit 1
+fi
+
+mkdir -p "$TMP_DIR"
+
+_md5() {
+	# Cross-platform md5 of a file
+	if command -v md5 >/dev/null 2>&1; then
+		md5 -q "$1"
+	else
+		md5sum "$1" | cut -d' ' -f1
+	fi
+}
+
+# Stage a fresh copy of the source DB and return its absolute path
+_stage_db() {
+	local label="$1"
+	local dest="$TMP_DIR/$label.root"
+	cp "$SOURCE_ROOT" "$dest"
+	echo "$dest"
+}
+
+_record_test() {
+	local name="$1"
+	local result="$2"  # "pass" or "fail"
+	local detail="${3:-}"
+	TOTAL=$((TOTAL + 1))
+	if [ "$result" = "pass" ]; then
+		echo -e "  ${GREEN}PASS${NC}: $name"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $name"
+		if [ -n "$detail" ]; then
+			echo "    $detail"
+		fi
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+echo "=============================================="
+echo "Protocol Read-Only Tests (issue #588)"
+echo "=============================================="
+echo
+
+# -----------------------------------------------------------------------
+# Test 1: --protocol --system-root (no flags) — file unchanged after no-op.
+# This is the core regression: previously the CLI re-saved the file even
+# when no mutation was requested.
+# -----------------------------------------------------------------------
+{
+	db=$(_stage_db "test1_default_readonly")
+	before=$(_md5 "$db")
+	out=$(echo '{"id":1,"op":"script/eval","params":{"expression":"1+1"}}' \
+		| "$CLI" --protocol --skip-startup --system-root "$db" 2>&1)
+	after=$(_md5 "$db")
+	if [ "$before" = "$after" ]; then
+		_record_test "default --protocol leaves DB unchanged after no-op" pass
+	else
+		_record_test "default --protocol leaves DB unchanged after no-op" fail \
+			"md5 changed: $before -> $after"
+	fi
+}
+
+# -----------------------------------------------------------------------
+# Test 2: --allow-mutate + protocol with fileMenu.save() — file changes.
+# This confirms the install/build path (clean-root, ODB editing) still
+# works when explicitly opted in.
+# -----------------------------------------------------------------------
+{
+	db=$(_stage_db "test2_allow_mutate")
+	before=$(_md5 "$db")
+	# Touch a value, then save. The save should succeed and persist.
+	out=$(printf '%s\n%s\n' \
+		'{"id":1,"op":"script/eval","params":{"expression":"new(stringType,@workspace.testReadOnly588); workspace.testReadOnly588=\"changed\"; return true"}}' \
+		'{"id":2,"op":"script/eval","params":{"expression":"fileMenu.save()"}}' \
+		| "$CLI" --protocol --skip-startup --allow-mutate --system-root "$db" 2>&1)
+	after=$(_md5 "$db")
+	if [ "$before" != "$after" ] && echo "$out" | grep -q '"id":2.*"success":true'; then
+		_record_test "--allow-mutate permits fileMenu.save() to persist" pass
+	else
+		_record_test "--allow-mutate permits fileMenu.save() to persist" fail \
+			"md5 unchanged or save failed. before=$before after=$after out=$out"
+	fi
+}
+
+# -----------------------------------------------------------------------
+# Test 3: default --protocol with fileMenu.save() — error returned and
+# file unchanged. Failure is loud (success:false), not silent.
+# -----------------------------------------------------------------------
+{
+	db=$(_stage_db "test3_default_blocks_save")
+	before=$(_md5 "$db")
+	out=$(echo '{"id":1,"op":"script/eval","params":{"expression":"fileMenu.save()"}}' \
+		| "$CLI" --protocol --skip-startup --system-root "$db" 2>&1)
+	after=$(_md5 "$db")
+	# Save must report failure AND file must not have changed.
+	if [ "$before" = "$after" ] && echo "$out" | grep -q '"id":1' \
+		&& echo "$out" | grep -qi "read-only"; then
+		_record_test "default --protocol refuses fileMenu.save() with read-only error" pass
+	else
+		_record_test "default --protocol refuses fileMenu.save() with read-only error" fail \
+			"md5 changed=$([ \"$before\" != \"$after\" ] && echo yes || echo no), out=$out"
+	fi
+}
+
+# -----------------------------------------------------------------------
+# Test 4: --read-only and --allow-mutate together are rejected.
+# -----------------------------------------------------------------------
+{
+	db=$(_stage_db "test4_conflict")
+	# Use --batch to force exit on argv parse error rather than dropping
+	# into a REPL (some CLIs don't bail until an op arrives). The CLI
+	# should print an error and exit non-zero.
+	out=$("$CLI" --read-only --allow-mutate --skip-startup --system-root "$db" -e "1" 2>&1)
+	rc=$?
+	if [ "$rc" -ne 0 ] && echo "$out" | grep -qiE "read-only.*allow-mutate|allow-mutate.*read-only|cannot.*combined"; then
+		_record_test "--read-only + --allow-mutate is rejected" pass
+	else
+		_record_test "--read-only + --allow-mutate is rejected" fail \
+			"rc=$rc out=$out"
+	fi
+}
+
+# -----------------------------------------------------------------------
+# Test 5: --read-only honored outside --protocol (defense in depth).
+# Even with -e mode and an explicit fileMenu.save(), the file should not
+# change when --read-only is set.
+# -----------------------------------------------------------------------
+{
+	db=$(_stage_db "test5_read_only_outside_protocol")
+	before=$(_md5 "$db")
+	out=$("$CLI" --read-only --skip-startup --system-root "$db" \
+		-e "fileMenu.save()" 2>&1)
+	after=$(_md5 "$db")
+	if [ "$before" = "$after" ]; then
+		_record_test "--read-only honored in -e mode (file unchanged)" pass
+	else
+		_record_test "--read-only honored in -e mode (file unchanged)" fail \
+			"md5 changed: $before -> $after; out=$out"
+	fi
+}
+
+echo
+echo "=============================================="
+echo "Protocol Read-Only Tests: $PASS/$TOTAL passed"
+if [ $FAIL -eq 0 ]; then
+	echo -e "${GREEN}All tests passed${NC}"
+	rm -rf "$TMP_DIR"
+	exit 0
+else
+	echo -e "${RED}$FAIL tests failed${NC}"
+	echo "Test artifacts left in: $TMP_DIR"
+	exit 1
+fi

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -364,8 +364,17 @@ class ProtocolExecutor:
         self._next_id = 1
 
     def start(self):
-        """Spawn the frontier-cli --protocol subprocess."""
-        cmd = [self.cli_path, '--protocol', '--skip-startup']
+        """Spawn the frontier-cli --protocol subprocess.
+
+        --allow-mutate: opt back into read-write so tests can call
+        fileMenu.save(), workspace assignments, etc. Issue #588 made
+        --protocol --system-root default to read-only to protect canonical
+        roots during inspection. Integration tests run against staged
+        copies under tests/tmp/results/db/ — mutating those copies is
+        intentional, the staging layer (tools/run_integration_tests.sh)
+        treats them as disposable.
+        """
+        cmd = [self.cli_path, '--protocol', '--skip-startup', '--allow-mutate']
         if self.system_root:
             cmd.extend(['--system-root', self.system_root])
 

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -83,6 +83,9 @@ TEST_FILES=()
 VERBOSE=""
 BATCH_FLAG="--batch"
 WORKERS_FLAG="-j 0"
+# Track whether the user invoked us without args (run-everything mode) so
+# the post-YAML shell test pass can opt out for targeted runs.
+ORIG_ARG_COUNT=$#
 
 if [ $# -eq 0 ]; then
     # No arguments - run all tests. Files matching *_network.yaml were
@@ -253,6 +256,21 @@ done
 # Run the tests (using v7 source database directly)
 "$RUNNER" $VERBOSE $BATCH_FLAG $WORKERS_FLAG --cli "$CLI_PATH" --system-root "$SYSTEM_ROOT" "${TEST_FILES[@]}"
 EXIT_CODE=$?
+
+# Shell-based protocol read-only tests (issue #588). Independent from the
+# YAML runner because they exercise CLI argv parsing and on-disk md5
+# checks — neither is well-expressed in the YAML/protocol-ops harness.
+# Run only when the user did not pass explicit YAML test files (i.e.
+# default "all tests" mode), so targeted invocations stay focused.
+PROTOCOL_RO_TESTS="$PROJECT_ROOT/tests/integration/protocol_readonly_tests.sh"
+if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$PROTOCOL_RO_TESTS" ]; then
+    echo
+    "$PROTOCOL_RO_TESTS"
+    PROTOCOL_RO_RC=$?
+    if [ $PROTOCOL_RO_RC -ne 0 ]; then
+        EXIT_CODE=$PROTOCOL_RO_RC
+    fi
+fi
 
 # Verify integrity of every staged database after tests.
 #


### PR DESCRIPTION
## Summary

Closes #588. Make `frontier-cli --protocol --system-root <path>` open the target read-only by default. Add `--read-only` flag for explicit opt-in (also works in `-e` mode) and `--allow-mutate` flag to opt back into write mode for legitimate install workflows.

This bit twice during the slash-menu chain: Virgin.root grew from 99 MB to 117 MB during PR #581 development from supposedly-read-only probes, and again surfaced as a runner pollution vector in PR #584 work. The default of read-only protects canonical files; legitimate write workflows (cleanRoot, integration test staging, ODB editing) opt in via `--allow-mutate`.

## What lands

**New CLI flags** (`frontier-cli/cli_parser.{c,h}`)
- `--read-only` — explicit opt-in, works in both `--protocol` and `-e` modes
- `--allow-mutate` — opt back into write mode when paired with `--system-root` in protocol mode
- `--read-only` + `--allow-mutate` together is rejected at parse time (mutually exclusive)

**Default behavior change** (`frontier-cli/main.c`)
- `--protocol --system-root <path>` now defaults to read-only
- `-e <expr> --system-root <path>` unchanged (still RW; `-e` users typically know they want mutation; opt-in via `--read-only` if needed)

**Read-only enforcement**
- Threads read-only intent through `hydrate_system_root_database` to set `flreadonly` on the cancoon record (the existing `dbflushheader_core` guard then short-circuits writes)
- Skips `save_system_root_on_exit`, the optional-tables `tablesavesystemtable`, and post-hydration `dbsetview` so operators don't see misleading "save failed" log noise
- Mutation verbs (`fileMenu.save`, etc.) return a clear error when read-only

**Callers updated**
- `frontier-cli/Makefile` `clean-root` target adds `--allow-mutate`
- `tests/integration/runner.py` `ProtocolExecutor.start()` — staged DBs are designed to be mutated; integration test infrastructure adds `--allow-mutate`
- `docs/ODB_SCRIPT_EDITING.md` — 3 example invocations updated to show `--allow-mutate`
- `docs/CLI_USAGE_GUIDE.md`, `frontier-cli/README.md`, `CLAUDE.md` — documentation refreshed

**Tests** (`tests/integration/protocol_readonly_tests.sh`, new — wired into `make test-integration`)
- 5 behavioral shell tests:
  1. Default `--protocol` leaves DB unchanged after no-op (md5 stable)
  2. Default `--protocol` refuses `fileMenu.save()` with read-only error
  3. `--allow-mutate` permits `fileMenu.save()` to persist (md5 changes)
  4. `--read-only` + `--allow-mutate` together rejected at parse time
  5. `--read-only` honored in `-e` mode

## TDD red/green

- **RED**: 4/5 tests failed before implementation. Default leaves DB mutated (md5 changes); save not refused; flag combination not validated; `-e --read-only` not honored.
- **GREEN**: 5/5 pass after implementation. Smoke verified: `md5 databases/Virgin.root` unchanged after `--protocol --skip-startup --system-root databases/Virgin.root` with `1+1`.

## Architecture notes

- `dbflushheader_core` already had a `flreadonly` guard from prior v6→v7 migration work. The fix is mostly threading the read-only intent down to set the flag.
- `tests/headless_filemenu_verbs.c` is part of the CLI link set; unit-test binaries also link it. The CLI accessor `cli_is_system_root_read_only` is `__attribute__((weak))` so it dynamic-links from main.o in the CLI and is NULL in unit-test binaries (which never call it on a read-only DB anyway).

## Test plan

- [x] `./tools/run_headless_tests.sh` — **469/469 pass** (unchanged)
- [x] `cd tests && make test-integration` — **2289 / 0 fail / 201 skip** YAML + 5/5 new shell tests (wired into the integration target)
- [x] `make -C frontier-cli` clean
- [x] Smoke: `md5 databases/Virgin.root` stable after `--protocol --skip-startup --system-root` with no-op script

## Closes

#588

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
