### PR TITLE
fix(palette): correct snprintf clamp off-by-one in filter footer (#596)

### DIFF
--- a/frontier-cli/palette.c
+++ b/frontier-cli/palette.c
@@ -391,9 +391,12 @@ static void render_level(palette_state_t *st, int depth) {
 		if (n < 0) n = 0;
 		/* snprintf clamp: when the formatted output would exceed
 		 * sizeof(footer) it returns the would-have-been length, not
-		 * the truncated length actually written. Clamp here so the
-		 * subsequent loop doesn't read past the truncated NUL. */
-		if (n > (int)sizeof(footer)) n = (int)sizeof(footer);
+		 * the truncated length actually written. Clamp at sizeof-1
+		 * so the subsequent loop never reads the NUL byte snprintf
+		 * wrote at footer[sizeof(footer)-1]. Currently dead code
+		 * (PALETTE_FILTER_MAX=63 → max n=67 < sizeof(footer)=72),
+		 * but defends against future widening of PALETTE_FILTER_MAX. */
+		if (n >= (int)sizeof(footer)) n = (int)sizeof(footer) - 1;
 		if (n > p->w - 2) n = p->w - 2;
 		int fx = (p->w - n) / 2;
 		if (fx < 1) fx = 1;


### PR DESCRIPTION
## Summary

Closes #596. Trivial 1-character correctness fix.

The defensive clamp at `palette.c:396` used `n > sizeof(footer)` which would let the rendering loop read `footer[sizeof(footer)-1]` — the NUL byte snprintf writes when truncating. Change to `n >= sizeof(footer)` with clamp value `sizeof(footer) - 1`.

## Dead-code today, defends future widening

`PALETTE_FILTER_MAX = 63` plus 4-byte format prefix `"> %s_"` gives max `n = 67`, well under `sizeof(footer) = 72`. The bug is unreachable at current dimensions. If `PALETTE_FILTER_MAX` is ever widened past 67, the off-by-one becomes live and would render a stray NUL byte (or, post-PR #582 P1-2 control-byte filter, a `?` substitution) in the filter footer.

## What lands

`frontier-cli/palette.c` (3 lines changed in clamp + 3 added comment lines):
- `if (n > (int)sizeof(footer)) n = (int)sizeof(footer);` → `if (n >= (int)sizeof(footer)) n = (int)sizeof(footer) - 1;`
- Comment expanded to document dead-code status and future-widening rationale

## Test plan

- [x] `./tools/run_headless_tests.sh` — **469/469 pass** (unchanged)
- [x] `cd tests && make test-integration` — **2289 / 0 fail / 201 skip** (unchanged)
- [x] `make -C frontier-cli` clean

## Closes

#596

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
