### PR TITLE
fix(palette): distinguish overflow vs forbidden-byte in palette_arg_escape (#595)

### DIFF
--- a/frontier-cli/palette_arg_inject.c
+++ b/frontier-cli/palette_arg_inject.c
@@ -14,43 +14,52 @@
 #include <stdlib.h>
 #include <string.h>
 
-bool palette_arg_escape(const char *arg, char *out, size_t out_cap) {
-	if (out == NULL || out_cap == 0)
-		return false;
+palette_arg_escape_result_t palette_arg_escape(const char *arg,
+                                               char *out, size_t out_cap) {
+	if (out == NULL)
+		return PALETTE_ARG_ESCAPE_OVERFLOW;
+	if (out_cap == 0) {
+		/* No room even for a NUL terminator — strictly an overflow case.
+		 * Don't dereference out; the contract says out_cap is the buffer
+		 * size, and 0 means "no buffer to write to". */
+		return PALETTE_ARG_ESCAPE_OVERFLOW;
+	}
 	out[0] = '\0';
 	if (arg == NULL) {
 		/* NULL arg is treated as empty — escape produces an empty string,
 		 * which the caller may detect and skip injection for. */
-		return true;
+		return PALETTE_ARG_ESCAPE_OK;
 	}
 	size_t outpos = 0;
 	for (const char *p = arg; *p != '\0'; ++p) {
 		unsigned char c = (unsigned char)*p;
 		/* Reject control bytes and DEL. Newline / CR / tab fall in here
-		 * deliberately — see header comment. */
+		 * deliberately — see header comment. Forbidden-byte check runs
+		 * before the bounds check so the more actionable diagnostic
+		 * wins when both would fail (issue #595). */
 		if (c < 0x20 || c == 0x7F) {
 			out[0] = '\0';
-			return false;
+			return PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE;
 		}
 		/* Each '"' or '\\' produces two output bytes plus we need 1 for
 		 * trailing NUL. Bound check before each write. */
 		if (c == '"' || c == '\\') {
 			if (outpos + 2 >= out_cap) {
 				out[0] = '\0';
-				return false;
+				return PALETTE_ARG_ESCAPE_OVERFLOW;
 			}
 			out[outpos++] = '\\';
 			out[outpos++] = (char)c;
 		} else {
 			if (outpos + 1 >= out_cap) {
 				out[0] = '\0';
-				return false;
+				return PALETTE_ARG_ESCAPE_OVERFLOW;
 			}
 			out[outpos++] = (char)c;
 		}
 	}
 	out[outpos] = '\0';
-	return true;
+	return PALETTE_ARG_ESCAPE_OK;
 }
 
 /*

--- a/frontier-cli/palette_arg_inject.h
+++ b/frontier-cli/palette_arg_inject.h
@@ -71,6 +71,21 @@ extern "C" {
 #endif
 
 /*
+ * palette_arg_escape result codes — distinguish the two failure modes
+ * so callers can surface accurate, actionable diagnostics. Issue #595:
+ * lumping forbidden-byte and overflow under a single bool meant a user
+ * who typed too many quote characters saw "argument contains a forbidden
+ * character" — misleading because they typed nothing forbidden, just
+ * too much. Splitting the result lets the REPL say "argument too long"
+ * vs "argument contains a forbidden character" appropriately.
+ */
+typedef enum {
+	PALETTE_ARG_ESCAPE_OK = 0,
+	PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE,
+	PALETTE_ARG_ESCAPE_OVERFLOW,
+} palette_arg_escape_result_t;
+
+/*
  * palette_arg_escape — escape a typed argument for safe insertion inside
  * a UserTalk double-quoted string literal.
  *
@@ -93,13 +108,21 @@ extern "C" {
  *     bytes are legitimate inside string literals.
  *
  * Returns:
- *   true  — out is NUL-terminated and contains the escaped form.
- *   false — input contained a forbidden control byte, OR escaped form
- *           did not fit in out_cap. On failure out[0] is set to '\\0'
- *           (caller-side defensive cleanup) but the caller MUST still
- *           treat the operation as failed.
+ *   PALETTE_ARG_ESCAPE_OK              — out is NUL-terminated and
+ *                                        contains the escaped form.
+ *   PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE  — input contained a control byte
+ *                                        or DEL.
+ *   PALETTE_ARG_ESCAPE_OVERFLOW        — escaped form did not fit in
+ *                                        out_cap (or out_cap == 0).
+ *
+ * On any failure, out[0] is set to '\\0' (defensive cleanup) but the
+ * caller MUST treat the operation as failed. Forbidden-byte detection
+ * is left-to-right, so it takes precedence over overflow when both
+ * conditions apply (the diagnostic is more actionable: remove the bad
+ * byte vs. type less).
  */
-bool palette_arg_escape(const char *arg, char *out, size_t out_cap);
+palette_arg_escape_result_t palette_arg_escape(const char *arg,
+                                               char *out, size_t out_cap);
 
 /*
  * palette_arg_inject_into_script — produce a new UserTalk source string

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -2512,13 +2512,25 @@ static boolean dispatch_slash_command(const char *line, boolean *running) {
 			 * as "<handler> (\"typed-arg\")" and dispatch via the
 			 * menubar handler. */
 			char escaped[PALETTE_ARG_MAX * 2 + 4];
-			if (!palette_arg_escape(args_start, escaped, sizeof(escaped))) {
-				/* Forbidden control byte / overflow: refuse to dispatch
-				 * with this arg and surface a clear diagnostic. The user
-				 * can re-type without the offending byte. */
-				fputs("Error: argument contains a forbidden character "
-				      "(control bytes, newlines, and tabs are not allowed)\n",
-				      stdout);
+			palette_arg_escape_result_t esc_r =
+				palette_arg_escape(args_start, escaped, sizeof(escaped));
+			if (esc_r != PALETTE_ARG_ESCAPE_OK) {
+				/* Issue #595: distinguish the two failure modes so the
+				 * user sees an actionable diagnostic. Forbidden-byte
+				 * means the input contained a control char or DEL;
+				 * overflow means the argument was too long. */
+				switch (esc_r) {
+					case PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE:
+						fputs("Error: argument contains a forbidden character "
+						      "(control bytes, newlines, and tabs are not allowed)\n",
+						      stdout);
+						break;
+					case PALETTE_ARG_ESCAPE_OVERFLOW:
+						fputs("Error: argument is too long\n", stdout);
+						break;
+					case PALETTE_ARG_ESCAPE_OK:
+						break;       /* unreachable */
+				}
 				fflush(stdout);
 				return true;
 			}
@@ -3542,7 +3554,9 @@ int repl_main(cli_options_t *options, ws_server_t *ws_server) {
 						bool synth_used = false;
 						if (arg_present) {
 							char escaped[PALETTE_ARG_MAX * 2 + 4];
-							if (palette_arg_escape(palette_arg, escaped, sizeof(escaped))) {
+							palette_arg_escape_result_t esc_r =
+								palette_arg_escape(palette_arg, escaped, sizeof(escaped));
+							if (esc_r == PALETTE_ARG_ESCAPE_OK) {
 								size_t script_len = 0;
 								char *script_cstr = script_handle_to_cstr(script, &script_len);
 								if (script_cstr != NULL) {
@@ -3559,11 +3573,21 @@ int repl_main(cli_options_t *options, ws_server_t *ws_server) {
 									free(script_cstr);
 								}
 							} else {
-								/* Forbidden control byte / overflow.
-								 * Surface a diagnostic and skip the
-								 * dispatch — the user can re-open the
-								 * palette and re-type. */
-								printf("(palette argument contains a forbidden character)\n");
+								/* Issue #595: distinguish the two
+								 * failure modes so the user sees an
+								 * actionable diagnostic. Skip dispatch
+								 * either way — the user can re-open
+								 * the palette and re-type. */
+								switch (esc_r) {
+									case PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE:
+										printf("(palette argument contains a forbidden character)\n");
+										break;
+									case PALETTE_ARG_ESCAPE_OVERFLOW:
+										printf("(palette argument is too long)\n");
+										break;
+									case PALETTE_ARG_ESCAPE_OK:
+										break;       /* unreachable */
+								}
 								fflush(stdout);
 								synth_used = true;       /* skip the no-arg fallback */
 								ok = true;               /* not a script failure per se */

--- a/tests/palette_arg_inject_tests.c
+++ b/tests/palette_arg_inject_tests.c
@@ -44,36 +44,36 @@
 
 static void test_escape_empty_input_yields_empty_output(void) {
 	char buf[8] = "junk";
-	bool ok = palette_arg_escape("", buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape("", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_null_input_yields_empty_output(void) {
 	char buf[8] = "junk";
-	bool ok = palette_arg_escape(NULL, buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape(NULL, buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_plain_ascii_passes_through_unchanged(void) {
 	char buf[64];
-	bool ok = palette_arg_escape("hello world", buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape("hello world", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(strcmp(buf, "hello world") == 0);
 }
 
 static void test_escape_double_quote_is_backslashed(void) {
 	char buf[64];
-	bool ok = palette_arg_escape("a\"b", buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape("a\"b", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(strcmp(buf, "a\\\"b") == 0);
 }
 
 static void test_escape_backslash_is_backslashed(void) {
 	char buf[64];
-	bool ok = palette_arg_escape("a\\b", buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape("a\\b", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(strcmp(buf, "a\\\\b") == 0);
 }
 
@@ -83,44 +83,44 @@ static void test_escape_quote_break_attempt_is_neutralized(void) {
 	 * whole sequence stays inside the literal — no UserTalk syntax
 	 * carries through. */
 	char buf[128];
-	bool ok = palette_arg_escape("\"); attack ()", buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape("\"); attack ()", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(strcmp(buf, "\\\"); attack ()") == 0);
 }
 
 static void test_escape_rejects_newline(void) {
 	char buf[64] = "junk";
-	bool ok = palette_arg_escape("a\nb", buf, sizeof(buf));
-	assert(!ok);
+	palette_arg_escape_result_t r = palette_arg_escape("a\nb", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_rejects_carriage_return(void) {
 	char buf[64] = "junk";
-	bool ok = palette_arg_escape("a\rb", buf, sizeof(buf));
-	assert(!ok);
+	palette_arg_escape_result_t r = palette_arg_escape("a\rb", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_rejects_tab(void) {
 	char buf[64] = "junk";
-	bool ok = palette_arg_escape("a\tb", buf, sizeof(buf));
-	assert(!ok);
+	palette_arg_escape_result_t r = palette_arg_escape("a\tb", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_rejects_low_control(void) {
 	char buf[64] = "junk";
-	bool ok = palette_arg_escape("a\x01""b", buf, sizeof(buf));
-	assert(!ok);
+	palette_arg_escape_result_t r = palette_arg_escape("a\x01""b", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_rejects_del(void) {
 	char buf[64] = "junk";
 	const char input[] = { 'a', 0x7F, 'b', '\0' };
-	bool ok = palette_arg_escape(input, buf, sizeof(buf));
-	assert(!ok);
+	palette_arg_escape_result_t r = palette_arg_escape(input, buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE);
 	assert(buf[0] == '\0');
 }
 
@@ -128,31 +128,62 @@ static void test_escape_passes_high_bytes(void) {
 	/* UTF-8 continuation bytes are legitimate inside string literals. */
 	char buf[64];
 	const char input[] = { 'a', (char)0xC3, (char)0xA9, 'b', '\0' };  /* "aéb" */
-	bool ok = palette_arg_escape(input, buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape(input, buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(strcmp(buf, input) == 0);
 }
 
-static void test_escape_buffer_overflow_returns_false(void) {
+static void test_escape_buffer_overflow_returns_overflow(void) {
 	char buf[4];
 	memset(buf, 'X', sizeof(buf));
-	/* "hello" is 5 chars + NUL — won't fit in 4. */
-	bool ok = palette_arg_escape("hello", buf, sizeof(buf));
-	assert(!ok);
+	/* "hello" is 5 chars + NUL — won't fit in 4. No forbidden bytes
+	 * present, so the failure mode is overflow, not forbidden-byte. */
+	palette_arg_escape_result_t r = palette_arg_escape("hello", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OVERFLOW);
 	assert(buf[0] == '\0');
 }
 
 static void test_escape_buffer_exact_fit_succeeds(void) {
 	char buf[4];      /* "ab" + NUL = 3 — fits in cap=4. */
-	bool ok = palette_arg_escape("ab", buf, sizeof(buf));
-	assert(ok);
+	palette_arg_escape_result_t r = palette_arg_escape("ab", buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OK);
 	assert(strcmp(buf, "ab") == 0);
 }
 
-static void test_escape_zero_capacity_returns_false(void) {
+static void test_escape_zero_capacity_returns_overflow(void) {
 	char buf[1] = { 'X' };
-	bool ok = palette_arg_escape("", buf, 0);
-	assert(!ok);
+	palette_arg_escape_result_t r = palette_arg_escape("", buf, 0);
+	/* Zero capacity is a buffer-too-small condition, not a forbidden
+	 * byte — the input is empty and contains nothing forbidden. */
+	assert(r == PALETTE_ARG_ESCAPE_OVERFLOW);
+}
+
+static void test_escape_quote_overflow_returns_overflow(void) {
+	/* Issue #595: a buffer of 300 quote characters needs ~600 bytes
+	 * escaped (each '"' becomes '\\' '"'). With a 516-byte buffer (the
+	 * production size), this overflows — but the input has NO forbidden
+	 * bytes. The failure mode must be OVERFLOW, not FORBIDDEN_BYTE.
+	 * Surfacing the wrong diagnostic here was the original bug. */
+	char input[301];
+	memset(input, '"', 300);
+	input[300] = '\0';
+	char buf[516];
+	palette_arg_escape_result_t r = palette_arg_escape(input, buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_OVERFLOW);
+	assert(buf[0] == '\0');
+}
+
+static void test_escape_forbidden_takes_precedence_over_overflow(void) {
+	/* Sanity: when input contains BOTH a forbidden byte AND would also
+	 * overflow, the forbidden-byte rejection happens first (we scan
+	 * left-to-right and refuse on the first forbidden byte before
+	 * we'd ever exceed capacity). The diagnostic surfaced is the more
+	 * actionable one — "remove the bad byte" vs "type less". */
+	char input[10] = { '\n', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '\0' };
+	char buf[2];     /* tiny buffer that would overflow on any input */
+	palette_arg_escape_result_t r = palette_arg_escape(input, buf, sizeof(buf));
+	assert(r == PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE);
+	assert(buf[0] == '\0');
 }
 
 /* ---------- palette_arg_inject_into_script ---------- */
@@ -312,9 +343,11 @@ int main(void) {
 	TR_RUN(test_escape_rejects_low_control);
 	TR_RUN(test_escape_rejects_del);
 	TR_RUN(test_escape_passes_high_bytes);
-	TR_RUN(test_escape_buffer_overflow_returns_false);
+	TR_RUN(test_escape_buffer_overflow_returns_overflow);
 	TR_RUN(test_escape_buffer_exact_fit_succeeds);
-	TR_RUN(test_escape_zero_capacity_returns_false);
+	TR_RUN(test_escape_zero_capacity_returns_overflow);
+	TR_RUN(test_escape_quote_overflow_returns_overflow);
+	TR_RUN(test_escape_forbidden_takes_precedence_over_overflow);
 
 	TR_RUN(test_inject_simple_call_substitutes_empty_parens);
 	TR_RUN(test_inject_handler_path_substitutes_empty_parens);


### PR DESCRIPTION
## Summary

Closes #595. Replace `palette_arg_escape`'s bool return with a result enum so the diagnostic can distinguish the two failure modes (forbidden byte vs output buffer overflow).

Before: typing 500+ quote characters into `/list` produced "argument contains a forbidden character" — misleading because the user typed nothing forbidden, just too much. Both forbidden-byte and overflow paths returned `false` and printed the same message.

## What lands

**`frontier-cli/palette_arg_inject.h`** — new enum:

```c
typedef enum {
    PALETTE_ARG_ESCAPE_OK = 0,
    PALETTE_ARG_ESCAPE_FORBIDDEN_BYTE,
    PALETTE_ARG_ESCAPE_OVERFLOW,
} palette_arg_escape_result_t;
```

**`frontier-cli/palette_arg_inject.c`** — `palette_arg_escape` returns the enum.

**`frontier-cli/repl.c`** — both call sites switch on the result:
- Slash-with-args path (~L2515): "argument is too long" vs "argument contains a forbidden character"
- Palette modal path (~L3545): "(palette argument is too long)" vs "(palette argument contains a forbidden character)"

**`tests/palette_arg_inject_tests.c`** — 30/30 tests pass after assertion update. Plus 2 new tests:
- `test_escape_quote_overflow_returns_overflow` — 300 quote chars in 516-byte buffer (the production scenario) — directly reproduces the original-issue case.
- `test_escape_forbidden_takes_precedence_over_overflow` — input has both a forbidden byte AND would overflow; asserts the forbidden-byte rejection wins (more actionable diagnostic).

Existing test names updated for clarity (`...returns_false` → `...returns_overflow`).

## TDD red/green

- **RED**: 20+ "use of undeclared identifier `palette_arg_escape_result_t`/`PALETTE_ARG_ESCAPE_OK`" compile errors after updating assertions but before implementing the enum. Failure for the right reason.
- **GREEN**: 30/30 palette_arg_inject tests pass; 471/471 full unit suite; 2289/2289 integration unchanged.

## Contract decision

Zero-capacity buffer (`out_cap == 0`) classified as `OVERFLOW` rather than a separate "invalid arg" code — semantically a zero-cap buffer is the limit case of "buffer too small" and the user-facing diagnostic ("too long") remains accurate.

## Test plan

- [x] `./tools/run_headless_tests.sh` — **471/471 pass** (was 469; +2 new tests)
- [x] `cd tests && make test-integration` — **2289 / 0 fail / 201 skip** (unchanged)
- [x] `make -C frontier-cli` clean

## Closes

#595

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
