### PR TITLE
fix(usertalk): restore script.newScriptObject round-trip for inline source

### DIFF
--- a/Common/headers/langinternal.h
+++ b/Common/headers/langinternal.h
@@ -494,7 +494,7 @@ extern boolean langisidentifier (bigstring);
 
 extern boolean langdeparsestring (bigstring, byte);
 
-extern boolean langstriptextsyntax (Handle);
+extern boolean langstripstructuremarkers (Handle, Handle *);
 
 extern boolean langaddapplescriptsyntax (Handle);
 

--- a/Common/source/langscan.c
+++ b/Common/source/langscan.c
@@ -1253,14 +1253,11 @@ boolean langstripstructuremarkers (Handle hin, Handle *hout) {
 		/*detect whole-line comment — « or // as first non-whitespace byte*/
 		if (linestart + indent < lineend) {
 			byte ch1 = buf [linestart + indent];
-			if (ch1 == chcomment) {
+			if (ch1 == chcomment
+			    || (ch1 == '/'
+			        && (linestart + indent + 1) < lineend
+			        && buf [linestart + indent + 1] == '/'))
 				fliscomment = true;
-				}
-			else if (ch1 == '/'
-			         && (linestart + indent + 1) < lineend
-			         && buf [linestart + indent + 1] == '/') {
-				fliscomment = true;
-				}
 			}
 
 		commentstart = lineend; /*default: no trailing comment, content runs to EOL*/
@@ -1268,33 +1265,40 @@ boolean langstripstructuremarkers (Handle hin, Handle *hout) {
 		if (!fliscomment) {
 
 			/*scan forward from the indent boundary to find the start of any
-			trailing comment (« or //) that's outside a string literal*/
+			trailing comment (« or //) outside a string literal. UserTalk
+			strings use ASCII " (chdoublequote, 0x22) OR the Mac smart-quote
+			pair chopencurlyquote (0xD2) / chclosecurlyquote (0xD3); the
+			scanner accepts both forms (langscan.c parsepopstringconst), so
+			we track both here. Without that, a string like "a // b" with
+			"" delimiters works, but "a // b" with «...» smart quotes would
+			get its // misread as a comment start and the rest of the line
+			truncated. flqcurly distinguishes the closing delimiter to use.*/
 			long i = linestart + indent;
+			boolean flqcurly = false;
 			while (i < lineend) {
 				byte ch = buf [i];
 				if (flinstring) {
-					/*inside a double-quoted string. \" is an escape, "" closes.
-					UserTalk uses \ as a string escape (see langdeparsestring),
-					so skip the next byte after a backslash.*/
+					/*\ escapes the next byte (e.g. \" inside ASCII strings).
+					Same convention applies inside curly-quote strings; the
+					scanner doesn't distinguish.*/
 					if (ch == '\\' && i + 1 < lineend) {
 						i += 2;
 						continue;
 						}
-					if (ch == '"')
+					if ((!flqcurly && ch == '"')
+					    || (flqcurly && ch == (byte) chclosecurlyquote))
 						flinstring = false;
 					++i;
 					continue;
 					}
-				if (ch == '"') {
+				if (ch == '"' || ch == chopencurlyquote) {
 					flinstring = true;
+					flqcurly = (ch == chopencurlyquote);
 					++i;
 					continue;
 					}
-				if (ch == chcomment) {
-					commentstart = i;
-					break;
-					}
-				if (ch == '/' && i + 1 < lineend && buf [i + 1] == '/') {
+				if (ch == chcomment
+				    || (ch == '/' && i + 1 < lineend && buf [i + 1] == '/')) {
 					commentstart = i;
 					break;
 					}
@@ -1340,8 +1344,15 @@ boolean langstripstructuremarkers (Handle hin, Handle *hout) {
 			}
 		}
 
-	if (writeix != size)
-		sethandlesize (hcopy, writeix);
+	if (writeix != size) {
+		if (!sethandlesize (hcopy, writeix)) {
+			/*shrink should never fail in practice, but if it does we'd
+			be returning a handle whose declared size points past valid
+			data. Dispose and fail rather than hand back a stale tail.*/
+			disposehandle (hcopy);
+			return (false);
+			}
+		}
 
 	*hout = hcopy;
 

--- a/Common/source/langscan.c
+++ b/Common/source/langscan.c
@@ -1157,102 +1157,196 @@ tokentype parsegettoken (hdltreenode *nodetoken) {
 	} /*parsegettoken*/
 
 
-boolean langstriptextsyntax (Handle htext) {
-	
-	/*
-	strip out braces and semicolons from the source text, so it 
-	can be pasted into a script outline
-	*/
-	
-	boolean fldone = false;
-	hdltreenode hnode;
-	tokentype token, token2 = 0;
-	long ixstart;
-	long ix1 = 0, ix2 = 0;
-	unsigned long line2 =  0;
-	short ctendbraces = 0;
-	
-	parsesetscanstring (htext, true);
-	
-	disablelangerror ();
-	
-	while (!fldone) {
-		
-		ixstart = ixparsestring;
-		
-		token = langscanner (&hnode);
-		
-		langdisposetree (hnode); /*we don't need it*/
-		
-		if (ix2 > 0) { /*something waiting to be stripped*/
-			
-			if ((token2 == '}') && (ctendbraces > 0))
-				--ctendbraces;
-			
-			else {
-				
-				if ((token2 == '}') || (ctscanlines > line2)) { /*we got a return, go ahead & strip it*/
-					
-					short len;
-					
-					if (token2 == '}') /* 2005-01-15 creedon - fix suggested by JES w/caveats < http://sourceforge.net/tracker/index.php?func=detail&aid=1093595&group_id=120666&atid=687798 > */
-						ix1 = ix2 - 1;
+boolean langstripstructuremarkers (Handle hin, Handle *hout) {
 
-					len = ix2 - ix1;
-					
-					pullfromhandle (htext, ix1, len, nil); /*get rid of the token source*/
-					
-					lenparsestring -= len; /*make adjustments*/
-					
-					ixparsestring -= len; /*ditto*/
-					
-					ixstart -= len;
-					
-					ctendbraces = 0; /*reset*/
-					}
-				else {
-					
-					if (token2 == '{')
-						++ctendbraces;
-					}
-				}
-			
-			ix2 = 0; /*reset*/
+	/*
+	Produce a fresh copy of UserTalk source text with structural { } ; markers
+	stripped from line ends. The outline-builder splits the result by CR into
+	nodes; the outline-export pass (oplangtextvisit) re-emits { } ; based on
+	outline level transitions on read-back. If those markers survive into a
+	node's text AND the export side also emits them, the result is doubled
+	markers ({{, ;;, }}) and the script no longer compiles. So storage
+	convention is: node text contains content only — no trailing structural
+	markers.
+
+	Input contract:
+	  - hin: borrowed handle, untouched.
+	  - The caller has normalized line endings to CR. This function does NOT
+	    re-normalize; if your caller didn't, fix the caller (every path that
+	    reaches scripttexttooutlineroutine goes through opnormalizelineendings_cr
+	    first, so this should be a non-issue in practice).
+	  - Indentation may be tabs OR spaces; we only look at "is this line a
+	    comment" (skip-strip) — we do not infer or use indent levels. The
+	    outline-builder (opgetlinetext) handles indent inference separately.
+
+	Output contract:
+	  - On success: *hout owns a freshly-allocated handle. Caller disposes.
+	  - On failure: *hout = nil, returns false.
+
+	Per-line algorithm:
+	  1. Skip leading whitespace to find the line's first semantic byte.
+	  2. If the whole line is a comment (starts with « or //) — leave it
+	     untouched. Comments may legitimately contain { } ; as text.
+	  3. Otherwise find the start of any trailing comment by scanning forward
+	     while tracking string-literal state. The portion of the line up to
+	     that point (or end-of-line) is the "content".
+	  4. From the end of content, strip a contiguous trailing run of
+	     { } ; space tab. This catches both end-of-line markers
+	     (`local (i);`) and end-of-content-followed-by-comment forms
+	     (`on foo () { //note` — strips the ` { ` before `//note`, leaving
+	     `on foo () //note`).
+	  5. Preserve any trailing comment verbatim.
+
+	Replaces langstriptextsyntax, which used a scanner-token-based heuristic
+	("a brace separated from its next token by a CR is structural"). That
+	worked for the historical script-export format but mis-classified inline
+	braces in modern source — `on foo (x) { //comment\r\tlocal (i = 1);` had
+	its `{` stripped because the scanner skipped over the comment and CR
+	before seeing the next token, even though the brace was load-bearing.
+	*/
+
+	long size;
+	long readix = 0;
+	long writeix = 0;
+	ptrbyte buf;
+	Handle hcopy = nil;
+
+	*hout = nil;
+
+	if (!copyhandle (hin, &hcopy))
+		return (false);
+
+	size = gethandlesize (hcopy);
+
+	if (size <= 0) {
+		*hout = hcopy;
+		return (true);
+		}
+
+	buf = (ptrbyte) (*hcopy);
+
+	while (readix < size) {
+
+		long linestart = readix;
+		long lineend;
+		long indent = 0;
+		long commentstart; /*offset where any trailing comment begins; == content-end*/
+		long stripfrom;
+		boolean fliscomment = false;
+		boolean flinstring = false;
+
+		/*find end-of-line — CR or end-of-buffer*/
+		while (readix < size && buf [readix] != chreturn)
+			++readix;
+
+		lineend = readix;
+
+		/*skip leading whitespace to find the line's first semantic byte*/
+		while (linestart + indent < lineend) {
+			byte ch = buf [linestart + indent];
+			if (ch == chtab || ch == chspace)
+				++indent;
+			else
+				break;
 			}
-		
-		switch (token) {
-			
-			case errortoken:
-			case eoltoken:
-				fldone = true;
-				
-				break;
-			
-			case '{':
-			case '}':
-			case ';':
-				token2 = token;
-				
-				ix1 = ixstart;
-				
-				ix2 = ixparsestring;
-				
-				line2 = ctscanlines;
-				
-				break;
-			
-			default:
-				break;
+
+		/*detect whole-line comment — « or // as first non-whitespace byte*/
+		if (linestart + indent < lineend) {
+			byte ch1 = buf [linestart + indent];
+			if (ch1 == chcomment) {
+				fliscomment = true;
+				}
+			else if (ch1 == '/'
+			         && (linestart + indent + 1) < lineend
+			         && buf [linestart + indent + 1] == '/') {
+				fliscomment = true;
+				}
+			}
+
+		commentstart = lineend; /*default: no trailing comment, content runs to EOL*/
+
+		if (!fliscomment) {
+
+			/*scan forward from the indent boundary to find the start of any
+			trailing comment (« or //) that's outside a string literal*/
+			long i = linestart + indent;
+			while (i < lineend) {
+				byte ch = buf [i];
+				if (flinstring) {
+					/*inside a double-quoted string. \" is an escape, "" closes.
+					UserTalk uses \ as a string escape (see langdeparsestring),
+					so skip the next byte after a backslash.*/
+					if (ch == '\\' && i + 1 < lineend) {
+						i += 2;
+						continue;
+						}
+					if (ch == '"')
+						flinstring = false;
+					++i;
+					continue;
+					}
+				if (ch == '"') {
+					flinstring = true;
+					++i;
+					continue;
+					}
+				if (ch == chcomment) {
+					commentstart = i;
+					break;
+					}
+				if (ch == '/' && i + 1 < lineend && buf [i + 1] == '/') {
+					commentstart = i;
+					break;
+					}
+				++i;
+				}
+			}
+
+		/*strip trailing run of {, }, ;, space, tab from the content portion
+		(linestart+indent .. commentstart). Leave the comment span untouched.*/
+		stripfrom = commentstart;
+
+		if (!fliscomment) {
+
+			while (stripfrom > linestart + indent) {
+				byte ch = buf [stripfrom - 1];
+				if (ch == '{' || ch == '}' || ch == ';' || ch == chspace || ch == chtab)
+					--stripfrom;
+				else
+					break;
+				}
+			}
+
+		/*copy kept content [linestart .. stripfrom) into the write cursor*/
+		{
+			long ct = stripfrom - linestart;
+			if (writeix != linestart && ct > 0)
+				moveleft (buf + linestart, buf + writeix, ct);
+			writeix += ct;
+			}
+
+		/*copy any trailing comment [commentstart .. lineend)*/
+		if (commentstart < lineend) {
+			long ct = lineend - commentstart;
+			if (writeix != commentstart && ct > 0)
+				moveleft (buf + commentstart, buf + writeix, ct);
+			writeix += ct;
+			}
+
+		/*copy the CR delimiter (if present), then advance past it*/
+		if (readix < size && buf [readix] == chreturn) {
+			buf [writeix++] = chreturn;
+			++readix;
 			}
 		}
-	
-	if (ix2 > 0) /*something waiting to be stripped*/
-		pullfromhandle (htext, ix1, ix2 - ix1, nil);
-	
-	enablelangerror ();
-	
+
+	if (writeix != size)
+		sethandlesize (hcopy, writeix);
+
+	*hout = hcopy;
+
 	return (true);
-	} /*langstriptextsyntax*/
+	} /*langstripstructuremarkers*/
 
 
 boolean langaddapplescriptsyntax (Handle hscript) {

--- a/frontier-cli/stubs/headless_mac_compat.c
+++ b/frontier-cli/stubs/headless_mac_compat.c
@@ -394,7 +394,103 @@ void rollbeachball (void) { }
 /* secondstodatetime and secondstodayofweek now in Common/source/timedate.c with portable implementations */
 void setfserrorparam ( const ptrfilespec fs ) { (void)fs; }
 boolean setoserrorparam (bigstring bs) { (void)bs; return false; }
-void scriptsetcallbacks (hdloutlinerecord ho) { (void)ho; }
+/*
+Headless equivalent of scripts.c's scriptsetcallbacks. The kernel's scripts.c
+isn't compiled in headless (OSA/AppleEvent dependencies), so we install the
+text-to-outline callback ourselves with a headless-only implementation. The
+other Mac-UI callbacks (cmdclick, doubleclick, scrap) have no headless trigger
+and remain unset.
+
+The texttooutline callback is where structural { } ; markers get stripped on
+script import — without this, op.insert deposits raw text into the outline,
+and oplangtextvisit later re-emits structural markers on top of the surviving
+literals, producing duplicates like {{, ;;, }} that don't compile.
+*/
+
+extern boolean langstripstructuremarkers (Handle, Handle *);
+
+static boolean headless_scriptcommentvisit (hdlheadrecord hnode, void *refcon) {
+	(void) refcon;
+
+	/*
+	Mark a node as a comment line if its text begins with the legacy chcomment
+	glyph (0xC7, historically «) OR a modern // marker. bigstring is Pascal-
+	style: bs[0] is the length byte, bs[1] is the first content byte. Strip
+	the marker so the outline stores only the comment body, matching legacy
+	behavior for «.
+	*/
+
+	register hdlheadrecord h = hnode;
+	bigstring bs;
+	short markerlen = 0;
+
+	getheadstring (h, bs);
+
+	if (!isemptystring (bs)) {
+		if (bs [1] == chcomment)
+			markerlen = 1;
+		else if (stringlength (bs) >= 2 && bs [1] == '/' && bs [2] == '/')
+			markerlen = 2;
+		}
+
+	if (markerlen > 0) {
+
+		pullfromhandle ((**h).headstring, 0, markerlen, nil);
+
+		if (!opnestedincomment (h))
+			(**h).flcomment = true;
+		}
+
+	return (true);
+	}
+
+static boolean headless_scripttexttooutline (hdloutlinerecord houtline, Handle hscrap, hdlheadrecord *hnode) {
+
+	/*
+	Build a script outline from inline UserTalk source text.
+
+	Storage convention: node text contains content only; outline export
+	(oplangtextvisit) re-derives { } ; structural markers from outline level
+	transitions. If trailing structural markers survive in node text, the
+	export side adds them on top — producing {{, ;;, }} on read-back.
+
+	langstripstructuremarkers makes a clean copy with trailing structural
+	markers stripped (skipping comment lines, where those bytes may appear
+	as human-readable content). The caller's handle is not mutated.
+
+	scriptcommentvisit then walks the resulting outline and marks comment
+	nodes (« or // prefix) with flcomment so the outline UI / export treats
+	them as comments.
+	*/
+
+	boolean flusertalk = (**houtline).outlinesignature == typeLAND;
+	Handle hstripped = nil;
+	Handle htouse = hscrap;
+	boolean fl;
+
+	if (flusertalk) {
+		if (!langstripstructuremarkers (hscrap, &hstripped))
+			return (false);
+		htouse = hstripped;
+		}
+
+	fl = optextscraptooutline (houtline, htouse, hnode);
+
+	if (hstripped != nil)
+		disposehandle (hstripped);
+
+	if (!fl)
+		return (false);
+
+	if (flusertalk)
+		opsiblingvisiter (*hnode, false, &headless_scriptcommentvisit, nil);
+
+	return (true);
+	}
+
+void scriptsetcallbacks (hdloutlinerecord ho) {
+	(**ho).texttooutlinecallback = (optexttooutlinecallback) &headless_scripttexttooutline;
+	}
 boolean shellfindcallbacks (short id, short *ix) { (void)id; if (ix) *ix=0; return false; }
 boolean browsergetrefcon (hdlheadrecord hnode, tybrowserinfo *info) { (void)hnode; if (info) memset(info,0,sizeof(*info)); return false; }
 boolean memoryerror (void) { return false; }

--- a/frontier-cli/stubs/headless_mac_compat.c
+++ b/frontier-cli/stubs/headless_mac_compat.c
@@ -463,10 +463,19 @@ static boolean headless_scripttexttooutline (hdloutlinerecord houtline, Handle h
 	them as comments.
 	*/
 
-	boolean flusertalk = (**houtline).outlinesignature == typeLAND;
+	boolean flusertalk;
 	Handle hstripped = nil;
-	Handle htouse = hscrap;
+	Handle htouse;
 	boolean fl;
+
+	/*Callers (optexttooutline → outline texttooutlinecallback) should always
+	pass a real scrap, but the callback contract is broader than the single
+	op.insert path in this PR's tests — be defensive.*/
+	if (houtline == nil || hscrap == nil)
+		return (false);
+
+	flusertalk = (**houtline).outlinesignature == typeLAND;
+	htouse = hscrap;
 
 	if (flusertalk) {
 		if (!langstripstructuremarkers (hscrap, &hstripped))

--- a/tests/integration/test_cases/script_install_roundtrip.yaml
+++ b/tests/integration/test_cases/script_install_roundtrip.yaml
@@ -86,3 +86,15 @@ tests:
       return (back == expectCR)
     expected_success: true
     expected_result: "true"
+
+  - name: "round-trip: // and ; inside string literal are not treated as structure"
+    description: "A string literal containing the bytes // (comment marker) or { } ; (structural markers) must round-trip unchanged. The strip pass must track string-literal state so it does not mis-classify these bytes."
+    script: |
+      local (src = "on f () {\r\tlocal (s = \"a // b ; c { d } e\");\r\treturn (s)}");
+      new (tabletype, @system.temp.rt);
+      script.newScriptObject (src, @system.temp.rt.f);
+      local (result = system.temp.rt.f ());
+      delete (@system.temp.rt);
+      return (result == "a // b ; c { d } e")
+    expected_success: true
+    expected_result: "true"

--- a/tests/integration/test_cases/script_install_roundtrip.yaml
+++ b/tests/integration/test_cases/script_install_roundtrip.yaml
@@ -1,0 +1,88 @@
+# Integration tests for script.newScriptObject round-trip fidelity
+#
+# BUG: script.newScriptObject ran inserted text through langstriptextsyntax,
+# which strips { } ; tokens it identifies as redundant outline-export markers.
+# That heuristic was designed for an export format where outline parent/child
+# encoded nesting; modern .ut files use { and ; as load-bearing syntax with
+# conventional line-break placement. Result: real braces got stripped and the
+# re-emit pass injected garbage { / }; / ;; into the body, producing scripts
+# that no longer compile.
+#
+# Additional: scriptcommentvisit only recognized « (0xC7) as a comment line
+# marker. Modern .ut files use //. Comment lines on import were not marked
+# flcomment, so they parsed as code on outline render (compile may still
+# succeed because the scanner separately recognizes // at line start).
+#
+# FIX:
+#   1. Remove the langstriptextsyntax call from scripttexttooutlineroutine.
+#      The strip path served pre-headless clipboard-paste cleanup; that path
+#      doesn't fire in headless builds, and on the script-import path it
+#      actively corrupts modern source.
+#   2. Extend scriptcommentvisit to recognize a leading "//" sequence as a
+#      comment marker, equivalent to chcomment (0xC7).
+#
+# These tests are end-to-end behavioral checks: install via script.newScriptObject,
+# read back via string(adrScript), assert the body is byte-equal to what was
+# installed (or that the installed script still works).
+
+tests:
+  - name: "round-trip: // comments preserved as comments"
+    description: "Install a script with // comments; read-back should be byte-equal"
+    script: |
+      local (src = "on f () { //a comment\r\tlocal (i = 42);\r\treturn (i)}");
+      new (tabletype, @system.temp.rt);
+      script.newScriptObject (src, @system.temp.rt.foo);
+      local (back = string (system.temp.rt.foo));
+      delete (@system.temp.rt);
+      return (back == src)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "round-trip: « comments preserved (legacy form)"
+    description: "Install with « comments (the historical ODB form); read-back byte-equal"
+    script: |
+      local (src = "on f () { «a comment\r\tlocal (i = 42);\r\treturn (i)}");
+      new (tabletype, @system.temp.rt);
+      script.newScriptObject (src, @system.temp.rt.foo);
+      local (back = string (system.temp.rt.foo));
+      delete (@system.temp.rt);
+      return (back == src)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "round-trip: script compiles after install"
+    description: "After installing via script.newScriptObject, calling the script must work"
+    script: |
+      local (src = "on f (x) { //double it\r\treturn (x * 2)}");
+      new (tabletype, @system.temp.rt);
+      script.newScriptObject (src, @system.temp.rt.f);
+      local (result = system.temp.rt.f (21));
+      delete (@system.temp.rt);
+      return (result == 42)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "round-trip: nested braces survive"
+    description: "if/while/for blocks with proper brace structure must not be corrupted"
+    script: |
+      local (src = "on f () {\r\tlocal (i);\r\tfor i = 1 to 3 {\r\t\tif i == 2 {\r\t\t\treturn (i)}};\r\treturn (0)}");
+      new (tabletype, @system.temp.rt);
+      script.newScriptObject (src, @system.temp.rt.f);
+      local (result = system.temp.rt.f ());
+      delete (@system.temp.rt);
+      return (result == 2)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "round-trip: LF line endings normalize"
+    description: "Source with LF line endings round-trips cleanly with no duplicated structural markers. The body is expected to be the LF input with CR substituted for LF; comment-marker form (// vs «) on the export side is implementation detail — both should be accepted."
+    script: |
+      local (srcLF = "on f () {\n\tlocal (i = 1);\n\treturn (i)}");
+      local (expectCR = "on f () {\r\tlocal (i = 1);\r\treturn (i)}");
+      new (tabletype, @system.temp.rt);
+      script.newScriptObject (srcLF, @system.temp.rt.foo);
+      local (back = string (system.temp.rt.foo));
+      delete (@system.temp.rt);
+      return (back == expectCR)
+    expected_success: true
+    expected_result: "true"


### PR DESCRIPTION
## Summary

- Fixes `script.newScriptObject` round-trip for inline UserTalk source. Modern source files (e.g. `.ut` exports) and any installer that uses `op.insert` against a script outline were producing outlines with trailing `{`/`}`/`;` literals in node text; the export pass `oplangtextvisit` then re-emitted structural markers from outline level transitions on top of those literals, producing `{{` / `;;` / `}}` duplicates that did not compile.
- Replaces the legacy `langstriptextsyntax` (scanner-token-based heuristic, broke on modern brace placement) with a new line-based `langstripstructuremarkers` that strips trailing structural runs while preserving comment spans and string-literal contents.
- Un-stubs `scriptsetcallbacks` in the headless build so the script-outline `texttooutlinecallback` is actually installed; the kernel `scripts.c` is not compiled in headless and the previous no-op stub meant no strip pass ran at all.
- Extends the outline's comment visitor to recognize a leading `//` marker (in addition to legacy `«`) so modern comment lines get `flcomment` set for outline rendering.

## Root cause

Storage convention: script outline nodes store text content only. The export pass re-derives `{` (level deepening), `}` (level rising), and `;` (sibling separator) from level transitions. In the original Mac build, `scripttexttooutlineroutine` stripped trailing markers via `langstriptextsyntax` before depositing nodes — keeping the convention. In the headless build, `scriptsetcallbacks` was stubbed to a no-op, so that callback never fired and the strip never happened. Even when `scriptsetcallbacks` was wired up, the legacy `langstriptextsyntax`'s "brace separated from next token by a CR is structural" heuristic mis-classified inline braces in modern source where `{` sits at end of header line above an indented body. Both problems are fixed.

## Files

- `Common/source/langscan.c` — replaces `langstriptextsyntax` with `langstripstructuremarkers`.
- `Common/headers/langinternal.h` — updates extern declaration.
- `frontier-cli/stubs/headless_mac_compat.c` — un-stubs `scriptsetcallbacks`; installs `headless_scripttexttooutline` callback; adds `headless_scriptcommentvisit` recognizing both `«` and `//`.
- `tests/integration/test_cases/script_install_roundtrip.yaml` — 5 new behavioral tests.

## Test plan

- [x] `./tools/run_headless_tests.sh` — 484 / 484 unit tests passing.
- [x] `cd tests && make test-integration` — 2294 total, 0 failed, 188 skipped (matches develop baseline).
- [x] 5 new round-trip tests covering: `//` comments preserved, legacy `«` comments preserved, installed scripts execute, nested braces survive, LF endings normalize cleanly to CR.
- [x] Manual probe: `script.newScriptObject(file.readWholeFile(<.ut>), @addr)` followed by `string(addr)` returns byte-equivalent input for representative production scripts.

## Known follow-up (NOT this PR)

- `databases/Virgin.root` still ships with a corrupted `system.startup.startupScript` body (line 3 compile error at REPL boot). The fix in this PR cleans up the import path so `.ut` reinstall works, but reinstalling the script body surfaces issue #586 (parser quirk: top-level `//` comment followed by code). The reinstall depends on #586 landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
