### PR TITLE
fix(parser): bare-LF support in // comments and whitespace (#586) — DRAFT, do not merge

### DIFF
--- a/Common/source/langscan.c
+++ b/Common/source/langscan.c
@@ -667,53 +667,101 @@ static boolean parsepopstringconst (Handle *htext) {
 	
 
 static void parsepopcomment (void) {
-	
+
 	/*
 	consume characters up to and including the next chendcomment.
-	
+
 	comments cannot span more than one line, so endofline also causes
 	us to return.
+
+	2026-05-11 jes (Issue #586): terminate on chlinefeed (bare LF) as
+	well as chreturn. The 1997 RAB workaround in parsepopchar (langscan.c
+	lines ~336-342) peek-eats LFs *after* every returned char, which
+	means a bare LF immediately following a comment body char never
+	reaches us as `ch` here — the LF is silently consumed and the
+	comment runs on to swallow the next statement. Two layers of
+	detection are needed:
+
+	  1. Check parsefirstchar BEFORE each parsepopchar — catches LF as
+	     the next char to read (e.g., comment starts and is immediately
+	     followed by LF, or LF that survived parsepopchar's peek-eat).
+
+	  2. After parsepopchar, detect whether the peek-eat in parsepopchar
+	     just consumed a trailing LF — by observing a 2-char advance of
+	     ixparsestring when only 1 char was returned. If so, that LF
+	     was the line terminator and we should return.
+
+	parsepopchar itself is intentionally NOT modified — earlier attempts
+	(PR #609) to change its LF-eating produced 43 integration regressions
+	across cross-domain consumers that depended on it.
 	*/
-	
+
 	register byte ch;
-	
+	register long ixbefore;
+
 	while (true) {
-		
+
+		ch = parsefirstchar ();
+
+		if ((ch == chreturn) || (ch == chlinefeed)) {
+			parsepopchar (); /*consume the terminator before returning*/
+			return;
+			}
+
+		if (ch == chendscanstring)
+			return;
+
+		ixbefore = ixparsestring;
+
 		ch = parsepopchar ();
-		
-		if ((ch == chendcomment) || (ch == chreturn) || (ch == chendscanstring))
+
+		if (ch == chendcomment)
+			return;
+
+		/*
+		If parsepopchar advanced the index by 2, it peek-ate a trailing
+		LF after the char it returned. That LF is the comment terminator.
+		*/
+		if (ixparsestring - ixbefore == 2)
 			return;
 		} /*while*/
 	} /*parsepopcomment*/
 
 
 static boolean parsepopblanks (void) {
-	
+
 	/*
-	pop all the leading white space.  return false if the input stream is 
+	pop all the leading white space.  return false if the input stream is
 	empty, true otherwise.
 
 	5.0a12 dmb: handle // comments
+
+	2026-05-11 jes (Issue #586): treat chlinefeed (bare LF) as whitespace
+	on par with chreturn. The RAB-1997 LF-eat in parsepopchar swallows
+	most LFs before they reach the scanner, but bare LF at start of input
+	or LF in a "\n\n" blank-line pair still reaches us as a token char
+	and was previously reported as illegaltokenerror. Accepting LF here
+	is symmetrical to chreturn and does not affect parsepopchar.
 	*/
-	
+
 	register byte ch;
-	
+
 	while (true) {
-		
+
 		if (parsestringempty ())
 			return (false);
-		
+
 		ch = parsefirstchar ();
-		
+
 		if ((ch == chstartcomment) || (ch == '/' && parsenextchar () == '/')) {
-			
+
 			parsepopcomment (); /*pop everything up to and including endcomment char*/
 			}
-			
+
 		else {
-			if ((ch != ' ') && (ch != chtab) && (ch != chreturn))
+			if ((ch != ' ') && (ch != chtab) && (ch != chreturn) && (ch != chlinefeed))
 				return (true);
-			
+
 			parsepopchar (); /*consume a whitespace character*/
 			}
 		} /*while*/

--- a/tests/integration/test_cases/parser_line_endings.yaml
+++ b/tests/integration/test_cases/parser_line_endings.yaml
@@ -1,0 +1,143 @@
+# Integration tests for UserTalk parser line-ending handling (Issue #586)
+#
+# BACKGROUND
+# UserTalk source is canonically CR-terminated (the Frontier outline node
+# separator). When source enters the compiler from non-outline paths — most
+# notably the REPL's `with system.temp.FrontierREPL.variables { ... }` wrapper,
+# protocol-mode `script.eval` / `script.compile`, .ut files read directly via
+# file.readWholeFile + langcompiletext — the bytes are typically LF-terminated.
+#
+# The 1997 RAB workaround in parsepopchar (langscan.c) peek-eats a trailing LF
+# after every returned char, which silently absorbs most LFs and made plain
+# scripts work. But two related bugs remained:
+#
+#   Quirk 1: `// line comment` followed by `return v` returned boolean `true`
+#   instead of `v`, because parsepopcomment terminated only on CR — the
+#   peek-ate LF flowed through and the comment swallowed the next statement.
+#
+#   Quirk 2: any non-ASCII byte inside a // comment on an LF-terminated line
+#   (e.g. UTF-8 em-dash U+2014, bytes E2 80 94) caused silent compile failure.
+#   Same root cause as Quirk 1 — the comment did not terminate on the line
+#   end and ran into the rest of the script with unbalanced state.
+#
+#   Quirk 3: consecutive `local()` statements on LF-terminated lines or
+#   separated by an LF-only blank line produced an "illegal character" parse
+#   error. Root cause: parsepopblanks treated only CR (not LF) as whitespace,
+#   so a bare LF that survived parsepopchar's peek-eat surfaced as an
+#   unrecognized token.
+#
+# FIX (Common/source/langscan.c)
+#   - parsepopcomment now terminates on LF as well as CR, AND detects when
+#     parsepopchar's peek-eat just consumed the line-terminating LF (via a
+#     2-char index advance on a 1-char return).
+#   - parsepopblanks now treats chlinefeed as whitespace, same as chreturn.
+#   - parsepopchar's behavior is unchanged — earlier attempts to modify it
+#     (PR #609) introduced 43 integration-test regressions in cross-domain
+#     consumers (op.insert line-endings, db.compact, menu projection, REPL
+#     palette, fileMenu) that depended on the silent LF-eat.
+#
+# These integration tests are the cross-domain safety net the prior attempt
+# lacked. They exercise the parser fix through the same UserTalk paths the
+# bug surfaced from (protocol-mode script.eval, // comments, multi-statement
+# scripts with bare LF separators), independently of the C-level unit tests
+# in parser_tests.c.
+
+tests:
+  # ========================================================================
+  # Quirk 1: // comment followed by return — LF, CRLF, CR variants
+  # ========================================================================
+
+  - name: "parser line endings - LF comment + return preserves value"
+    description: "Issue #586 Quirk 1: `// comment` followed by `return v` on LF line endings must return v, not boolean true."
+    script: |
+      local (s = "local (x = 42);\n// comment\nreturn (x)\n");
+      local (result = lang.evaluate (s));
+      return (result == 42)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "parser line endings - CRLF comment + return preserves value"
+    description: "Issue #586 Quirk 1 (CRLF variant): `// comment` followed by `return v` on Windows line endings must return v."
+    script: |
+      local (s = "local (x = 42);\r\n// comment\r\nreturn (x)\r\n");
+      local (result = lang.evaluate (s));
+      return (result == 42)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "parser line endings - CR comment + return preserves value (baseline)"
+    description: "Canonical CR line endings must continue to work unchanged."
+    script: |
+      local (s = "local (x = 42);\r// comment\rreturn (x)\r");
+      local (result = lang.evaluate (s));
+      return (result == 42)
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Quirk 2: non-ASCII bytes inside // comments
+  # ========================================================================
+
+  - name: "parser line endings - non-ASCII byte in LF comment does not break compile"
+    description: "Issue #586 Quirk 2: any non-ASCII byte (high-bit set, including UTF-8 continuation bytes from chars like em-dash) inside a // comment on LF source must NOT cause silent compile failure."
+    script: |
+      // \xE2\x80\x94 is UTF-8 em-dash U+2014; the bytes 0xE2 0x80 0x94 used
+      // to make parsepopcomment lose its line bearings on LF-terminated source.
+      local (s = "local (x = 7);\n// a \xE2\x80\x94 b\nreturn (x)\n");
+      local (result = lang.evaluate (s));
+      return (result == 7)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "parser line endings - multiple non-ASCII bytes in comment"
+    description: "More than one non-ASCII byte in a single comment must be tolerated."
+    script: |
+      local (s = "local (x = 8);\n// \xC9 \xCA \xCB \xE2\x80\x94 end\nreturn (x)\n");
+      local (result = lang.evaluate (s));
+      return (result == 8)
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Quirk 3: consecutive local() with bare-LF separators / blank lines
+  # ========================================================================
+
+  - name: "parser line endings - adjacent local() on LF lines compiles"
+    description: "Issue #586 Quirk 3: two consecutive `local()` statements separated by a bare LF must compile and run."
+    script: |
+      local (s = "local (x = 1);\nlocal (y = 2);\nreturn (x + y)\n");
+      local (result = lang.evaluate (s));
+      return (result == 3)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "parser line endings - blank line between LF statements compiles"
+    description: "Issue #586 Quirk 3 (blank line variant): a bare LF as a blank line between statements must be treated as whitespace, not an illegal character."
+    script: |
+      local (s = "local (x = 4);\n\nlocal (y = 5);\nreturn (x + y)\n");
+      local (result = lang.evaluate (s));
+      return (result == 9)
+    expected_success: true
+    expected_result: "true"
+
+  # ========================================================================
+  # Compositional: // comments interleaved with statements
+  # ========================================================================
+
+  - name: "parser line endings - multiple // comments between statements (LF)"
+    description: "Several // comments interspersed with statements on LF source must not affect the result."
+    script: |
+      local (s = "// header\nlocal (x = 10);\n// mid\nlocal (y = 20);\n// trailing\nreturn (x + y)\n");
+      local (result = lang.evaluate (s));
+      return (result == 30)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "parser line endings - // comment as final line of script (LF)"
+    description: "A trailing // comment with no following statement must not corrupt the previous result."
+    script: |
+      local (s = "local (x = 99);\nreturn (x);\n// trailing\n");
+      local (result = lang.evaluate (s));
+      return (result == 99)
+    expected_success: true
+    expected_result: "true"

--- a/tests/parser_tests.c
+++ b/tests/parser_tests.c
@@ -34,6 +34,69 @@ static void eval_expect(const char *expr, const char *expected) {
     }
 }
 
+/*
+ * eval_handle_expect — evaluate a (possibly multi-line, > 255-byte) program
+ * passed as a raw C string. Allows arbitrary line endings (CR / LF / CRLF) in
+ * the source text — characterizes how the scanner handles each one.
+ *
+ * Compares the coerced string result against `expected` (NULL means "any").
+ */
+static void eval_handle_expect(const char *prog, const char *expected) {
+    Handle htext = NULL;
+    long len = (long) strlen(prog);
+    bigstring bsempty;
+    setstringlength(bsempty, 0);
+    if (!newtexthandle(bsempty, &htext)) {
+        printf("FAILED to allocate handle\n");
+        assert(0);
+        return;
+    }
+    /* Replace the empty handle's bytes with our raw C string (including any
+       embedded \n / \r). */
+    if (!sethandlesize(htext, len)) {
+        printf("FAILED to size handle\n");
+        assert(0);
+        return;
+    }
+    memcpy(*htext, prog, (size_t) len);
+
+    bigstring bsresult;
+    /* langrunhandle disposes the handle — match the contract used elsewhere. */
+    boolean ok = langrunhandle(htext, bsresult);
+    if (!ok) {
+        printf("FAILED to evaluate (compile or run error):\n----\n%.*s\n----\n",
+               (int) len, prog);
+        fflush(stdout);
+    }
+    assert(ok);
+    char c_result[512];
+    copyptocstring(bsresult, c_result);
+    if (expected != NULL) {
+        if (strcmp(c_result, expected) != 0) {
+            printf("FAILED: got %s, expected %s\n  program:\n----\n%.*s\n----\n",
+                   c_result, expected, (int) len, prog);
+            fflush(stdout);
+        }
+        assert(strcmp(c_result, expected) == 0);
+    }
+}
+
+/* Compile-only check: returns true if the program compiles, false otherwise.
+   Doesn't run the program. Useful for characterizing pure parser bugs. */
+static boolean compile_only(const char *prog) {
+    Handle htext = NULL;
+    long len = (long) strlen(prog);
+    bigstring bsempty;
+    setstringlength(bsempty, 0);
+    if (!newtexthandle(bsempty, &htext)) return false;
+    if (!sethandlesize(htext, len)) { disposehandle(htext); return false; }
+    memcpy(*htext, prog, (size_t) len);
+    hdltreenode hcode = NULL;
+    boolean ok = langcompiletext(htext, false, &hcode); /* disposes htext */
+    if (hcode != NULL) langdisposetree(hcode);
+    return ok;
+}
+
 static void test_boolean_unary_not(void) {
     eval_expect("! false", "true");
     eval_expect("! true", "false");
@@ -59,6 +122,125 @@ static void test_if_then_else_expr(void) {
     eval_expect("local(x = 0); if x == 1 then 2 else 3", "3");
 }
 
+/*
+ * Issue #586 Quirk 1: `// comment` followed by `return v` returns boolean true
+ * instead of v. Root cause: the // line-comment terminator scan only treats
+ * CR (chreturn, 0x0D) as end-of-line. With LF (0x0A) line endings, the
+ * comment consumes the rest of the input (including the `return` statement),
+ * leaving the script body effectively empty.
+ *
+ * These tests pin behavior across all three line-ending conventions.
+ */
+static void test_quirk1_line_comment_terminates_on_lf(void) {
+    /* LF line endings (Unix / modern editors) */
+    eval_handle_expect("local (x = 42);\n// some comment\nreturn (x)\n", "42");
+
+    /* CRLF line endings (Windows) */
+    eval_handle_expect("local (x = 42);\r\n// some comment\r\nreturn (x)\r\n", "42");
+
+    /* CR line endings (the original Mac / outline canonical form — already worked) */
+    eval_handle_expect("local (x = 42);\r// some comment\rreturn (x)\r", "42");
+
+    /* Comment with no following statement (just to confirm we don't eat too much) */
+    eval_handle_expect("local (x = 7);\nreturn (x);\n// trailing comment\n", "7");
+}
+
+/*
+ * Issue #586 Quirk 2: A UTF-8 em-dash (U+2014, bytes E2 80 94) inside a //
+ * comment causes silent compile failure on LF-terminated input. The same
+ * em-dash followed by a CR-terminated line works fine.
+ *
+ * This test confirms that any non-ASCII byte inside a // comment must NOT
+ * affect compilation, on any line-ending convention.
+ */
+static void test_quirk2_nonascii_in_line_comment(void) {
+    /* UTF-8 em-dash inside an LF-terminated // comment */
+    eval_handle_expect("local (x = 1);\n// hello \xE2\x80\x94 world\nreturn (x)\n",
+                       "1");
+
+    /* Other non-ASCII high bytes (would have collided with mac comment chars) */
+    eval_handle_expect("local (x = 2);\n// quote \xC9 here\nreturn (x)\n", "2");
+
+    /* Multiple non-ASCII chars in a comment */
+    eval_handle_expect("local (x = 3);\n// \xE2\x80\x94 a \xE2\x80\x94\nreturn (x)\n",
+                       "3");
+}
+
+/*
+ * Issue #586 Quirk 3: Two consecutive `local(x = expr);` statements where the
+ * second references a field of the first compile-fail without a blank line
+ * between them. Adding a blank line fixes it.
+ *
+ * We don't need a verb that returns a record — we can build the structure
+ * synthetically with a table reference. The bug is in the parser's handling of
+ * adjacent local() declarations on consecutive lines, not in any verb.
+ *
+ * Reduce to the minimal repro: a local that aliases a previously declared
+ * local, with the second referencing a member of the first via dot access.
+ */
+static void test_quirk3_consecutive_local_with_field_access(void) {
+    /* The original bug surfaces with two adjacent local() lines using LF
+       endings. Reproducing with a simple value substitute for the verb call:
+       once Quirk 1 is fixed, the second local() should still parse correctly. */
+    eval_handle_expect(
+        "local (x = 10);\n"
+        "local (y = x);\n"
+        "return (y)\n",
+        "10");
+
+    /* With a blank line between (the existing workaround). */
+    eval_handle_expect(
+        "local (x = 11);\n"
+        "\n"
+        "local (y = x);\n"
+        "return (y)\n",
+        "11");
+
+    /* CR-terminated form (canonical Frontier outline format) */
+    eval_handle_expect(
+        "local (x = 12);\r"
+        "local (y = x);\r"
+        "return (y)\r",
+        "12");
+}
+
+/*
+ * Issue #586 — compile-only smoke tests for common LF-source idioms that have
+ * historically caused silent compile failures.
+ */
+static void test_quirk_compile_smoke(void) {
+    /* Bare LF newlines should not break compilation of multi-statement
+       scripts that include // comments. */
+    assert(compile_only("local (x);\n// c\nx = 1;\nreturn (x)\n"));
+
+    /* CRLF likewise. */
+    assert(compile_only("local (x);\r\n// c\r\nx = 1;\r\nreturn (x)\r\n"));
+
+    /* CR canonical form likewise. */
+    assert(compile_only("local (x);\r// c\rx = 1;\rreturn (x)\r"));
+}
+
+/*
+ * Regression test for the canonical CR-only path. Production scripts stored
+ * in ODB use CR line endings and frequently look like the startupScript:
+ * leading tab-indented `// comments` followed by code. This must continue
+ * to work — earlier parser fixes (PR #609) broke this path and produced
+ * 43 integration regressions.
+ */
+static void test_cr_path_with_tab_indented_comments(void) {
+    /* Top-of-file comments, tab-indented like startupScript. */
+    eval_handle_expect("// header\r\t// indented comment\r\t\t// more indent\rreturn (42)\r",
+                       "42");
+
+    /* Tab + comment + code, common pattern in handler bodies. */
+    eval_handle_expect("\t// leading comment\r\treturn (5)\r",
+                       "5");
+
+    /* Comment line whose body is just tab+CR (blank-after-tab). */
+    eval_handle_expect("// header\r\t\rreturn (1)\r",
+                       "1");
+}
+
 int main(void) {
     TR_INIT("parser_tests");
 
@@ -76,6 +258,11 @@ int main(void) {
     TR_RUN(test_comparisons);
     TR_RUN(test_assign_and_local);
     TR_RUN(test_if_then_else_expr);
+    TR_RUN(test_quirk1_line_comment_terminates_on_lf);
+    TR_RUN(test_quirk2_nonascii_in_line_comment);
+    TR_RUN(test_quirk3_consecutive_local_with_field_access);
+    TR_RUN(test_quirk_compile_smoke);
+    TR_RUN(test_cr_path_with_tab_indented_comments);
 
     TR_SUMMARY();
     return TR_EXIT_CODE();


### PR DESCRIPTION
## Summary

Parser fix for the three UserTalk quirks in #586 (//+return, em-dash in comments, consecutive local() with bare-LF separators). Includes unit tests + integration characterization YAML.

**Opened as DRAFT — see KNOWN INTEGRATION REGRESSIONS below.**

## What the fix does

Two targeted changes to `Common/source/langscan.c`:

1. `parsepopcomment` now terminates on `chlinefeed` (bare LF) as well as `chreturn` (CR). Detection is two-layered to handle the 1997 RAB peek-eat in `parsepopchar` (which swallows LFs after each returned char): a `parsefirstchar` peek BEFORE `parsepopchar`, plus a `ixparsestring - ixbefore == 2` post-check to catch LFs the peek-eat just consumed.

2. `parsepopblanks` accepts `chlinefeed` as whitespace, symmetrical to `chreturn`.

`parsepopchar` is intentionally NOT modified. PR #609 tried that and produced 43 integration regressions across 5 cross-domain consumers that depended on the LF-eat behavior (#610 reverted it).

## Tests

- **Unit (parser_tests.c)**: +5 new C-level tests covering Quirks 1/2/3 plus a CR-canonical-form regression test (tab-indented comments like `startupScript`). Result: 9/9 pass. Suite total: 489/489 (was 484).
- **Integration (parser_line_endings.yaml)**: 9 new tests exercising the three quirks through `lang.evaluate` and the protocol-mode `with system.temp.FrontierREPL.variables` wrapper. All 9 pass with the fix; 3 fail on develop baseline (Quirks 1, 2, 3 blank-line variant) — the expected red state for characterization tests.

## KNOWN INTEGRATION REGRESSIONS — DO NOT MERGE

With this fix applied, the integration suite regresses **85 tests across 8 yaml files**. These are NOT parser bugs:

- Many integration test scripts use LF blank lines or LF inline `// comments`.
- On develop, the parser bug causes "Can't compile this script because [LF] is an illegal character".
- `repl_eval_with_variables_value` calls `langruntraperror`, which **traps the compile error and returns `success=true` with `value="true"`**.
- Tests assert `expected_success: true` and `expected_result: "true"`. These pass trivially regardless of what the script body actually does.

With the parser fix, scripts compile and execute for real. The underlying tested behavior surfaces. In many cases it does not return `true`, exposing latent semantic issues in:

- `db.open` auto-migration (db_verbs.yaml - 1 failed)
- `menu.describe` in headless mode (menu_list_describe.yaml - 3 failed)
- `menu.install` / `menu.isInstalled` / `menu.remove` headless (menu_data_verbs.yaml - 4 failed)
- migration externals deep access (migration_externals.yaml - 5 failed)
- `op.promote` / `op.demote` / `op.xmltooutline` workflow (op_verbs.yaml - 4 failed)
- TCP stream lifecycle (tcp_client_verbs / tcp_phase2_verbs / tcp_server_verbs - 41 failed)
- webserver HelloWorld, inetd E2E, mainresponder smoke

## Why this PR is still useful

The prior #609 attempt at this fix was reverted because it broke 43 integration tests across 5 domains. Per `docs/AUTO_CHAIN_LESSONS_2026-05-08.md` Section C, foundational-area changes need integration coverage in the same PR.

This PR provides exactly that coverage in the form of:

1. The fix itself, with two-layer detection that is surgically narrow (parsepopchar untouched).
2. Unit tests that pin both the bug-fix behavior AND the unaffected CR-canonical path.
3. Integration tests that exercise the three quirks through the same production paths the bug surfaced from.
4. Documented surfacing of the deeper test-correctness issue that #609 also encountered but did not diagnose.

## Recommended next steps (for reviewer)

1. **Decide on the eval-trap behavior**: should `repl_eval_with_variables_value` continue to mask compile errors as `success=true, value="true"` for REPL UX reasons? Or should protocol-mode `script/eval` surface compile failures distinctly?

2. **File a separate issue** for the test-correctness migration to assertions that exercise actual script behavior (not the trivially-true wrapper outcome).

3. **Migrate the 8 affected yaml files** to behavioral assertions before landing this parser fix.

4. **Then merge this PR** on a clean integration baseline. Or extract the parser fix into its own PR after the test files are fixed; the unit and integration characterization tests in this PR remain valid as a permanent regression net.

## Test plan

- [x] Unit: `./tools/run_headless_tests.sh` - 489/489 pass
- [x] Integration parser_line_endings.yaml - 9/9 pass with fix; 3 fail on baseline (expected red characterization)
- [ ] Integration full suite - known 85 regressions, see above
- [ ] Reviewer decision on path forward (this is the gate)

Refs #586. Prior attempts: #609 (reverted via #610). Lessons: `docs/AUTO_CHAIN_LESSONS_2026-05-08.md`.

Generated with [Claude Code](https://claude.com/claude-code) via /auto
