### PR TITLE
test(html): burndown 5 of 7 html sanitization tests (#620 partial)

### DIFF
--- a/tests/integration/test_cases/html_core_tests.yaml
+++ b/tests/integration/test_cases/html_core_tests.yaml
@@ -347,8 +347,6 @@ tests:
     expected_result: "{safe}"
 
   - name: "html.neutermacros - mixed safe and unsafe"
-    skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
     description: "Escape only unsafe macros, leave safe ones"
     script: |
       local(safemacros);
@@ -356,7 +354,7 @@ tests:
       safemacros.safe = true;
       local(original = "{safe} {unsafe}");
       local(result = html.neutermacros(original, @safemacros));
-      local(hasSafe = string.patternMatch("{safe}*", result));
+      local(hasSafe = (result contains "{safe}"));
       local(isLonger = sizeOf(result) > sizeOf(original));
       return hasSafe and isLonger
     expected_success: true
@@ -403,13 +401,11 @@ tests:
     expected_result: "plain text"
 
   - name: "html.neutermacros - macro with params (unsafe)"
-    skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
     description: "Macros with parameters should be checked"
     script: |
       local(safemacros);
       lang.new(tableType, @safemacros);
-      safemacros.clock = true;  # Allow clock without params
+      safemacros.clock = true;
       local(original = "{clock.now()}");
       local(result = html.neutermacros(original, @safemacros));
       return sizeOf(result) > sizeOf(original)
@@ -456,8 +452,6 @@ tests:
     # Should return with <b> tags intact
 
   - name: "html.neutertags - mixed safe and unsafe"
-    skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
     description: "Escape only unsafe tags, leave safe ones"
     script: |
       local(safetags);
@@ -465,7 +459,7 @@ tests:
       safetags.b = true;
       local(original = "<b>bold</b> <script>alert('xss')</script>");
       local(result = html.neutertags(original, @safetags));
-      local(hasB = string.patternMatch("*<b>*", result));
+      local(hasB = (result contains "<b>"));
       local(isLonger = sizeOf(result) > sizeOf(original));
       return hasB and isLonger
     expected_success: true
@@ -536,9 +530,7 @@ tests:
     expected_result: "true"
 
   - name: "html.neutertags - tag balancing"
-    skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
-    description: "Multiple unclosed safe tags should all be closed"
+    description: "Multiple unclosed safe tags should all be closed. countFields takes a single-character delimiter in UserTalk, so we test by string equality against the expected balanced output instead."
     script: |
       local(safetags);
       lang.new(tableType, @safetags);
@@ -546,7 +538,7 @@ tests:
       safetags.i.flLegal = true;
       safetags.i.flClose = true;
       local(result = html.neutertags("<i>one <i>two", @safetags));
-      return string.countFields(result, "</i>") == 2
+      return result == "<i>one <i>two</i></i>"
     expected_success: true
     expected_result: "true"
 
@@ -555,8 +547,6 @@ tests:
   # =============================================================================
 
   - name: "html - complete sanitization workflow"
-    skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
     description: "SECURITY: Full sanitization of untrusted user input"
     script: |
       local(safetags, safemacros);
@@ -567,7 +557,7 @@ tests:
       local(untrustedInput = "<b>Hello</b> <script>alert('xss')</script> {file.delete()}");
       local(step1 = html.neutertags(untrustedInput, @safetags));
       local(step2 = html.neutermacros(step1, @safemacros));
-      local(hasB = string.patternMatch("*<b>*", step2));
+      local(hasB = (step2 contains "<b>"));
       local(isLonger = sizeOf(step2) > sizeOf(untrustedInput));
       return hasB and isLonger
     expected_success: true

--- a/tests/integration/test_cases/html_text_processing_phase2_tests.yaml
+++ b/tests/integration/test_cases/html_text_processing_phase2_tests.yaml
@@ -129,7 +129,7 @@ tests:
 
   - name: "searchengine.stripmarkup - script tags"
     skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
+    skip_reason: "Design question: searchengine.stripmarkup currently strips <script>/<style> tag delimiters but keeps tag-internal content (e.g. `alert('xss')` survives stripping `<script>...</script>`). Test expects search-indexer semantics where script/style contents are dropped. Awaiting product decision on whether to change kernel semantics — tracked under #620."
     description: "Remove script tags and their content"
     script: |
       local(html = "<p>Text</p><script>alert('xss')</script><p>More</p>");
@@ -295,7 +295,7 @@ tests:
 
   - name: "searchengine - extract text from complex HTML"
     skip: true
-    skip_reason: "Pre-existing failure surfaced by #618 fix (eval-trap was masking compile/runtime errors as success: true). Tracked in umbrella issue #620 for per-category triage."
+    skip_reason: "Same design question as 'searchengine.stripmarkup - script tags': test expects script-content stripping but current kernel implementation only strips tag delimiters. Awaiting product decision tracked under #620."
     description: "Strip markup from real-world HTML document"
     script: |
       local(complexHtml = "<!DOCTYPE html>\r<html>\r<head>\r<meta charset='utf-8'>\r<title>Blog Post</title>\r<style>body{margin:0;}</style>\r</head>\r<body>\r<header><h1>My Blog</h1></header>\r<article>\r<h2>Post Title</h2>\r<p>First paragraph with <a href='#'>link</a>.</p>\r<p>Second paragraph with <img src='test.jpg' alt='image'/>.</p>\r</article>\r<footer>Copyright 2026</footer>\r<script>console.log('test');</script>\r</body>\r</html>");


### PR DESCRIPTION
## Summary

Burndown of 5 html-sanitization tests skipped under umbrella issue #620 (test failures surfaced when the #618 eval-trap fix stopped masking compile/runtime errors). All 5 were test-fixture authoring bugs, not kernel bugs.

| Test | Fix |
|---|---|
| `html.neutertags - mixed safe and unsafe` | `string.patternMatch("*<b>*", str)` → `(str contains "<b>")` |
| `html.neutermacros - mixed safe and unsafe` | same wildcard patternMatch fix |
| `html - complete sanitization workflow` | same wildcard patternMatch fix |
| `html.neutermacros - macro with params (unsafe)` | removed inline `# comment` (UserTalk doesn't allow `#` comments; was eval-trap-masked on develop) |
| `html.neutertags - tag balancing` | `string.countFields(result, "</i>") == 2` (countFields needs single-char delim) → `result == "<i>one <i>two</i></i>"` direct equality |

## Two re-skipped with sharper reason (not autonomous-decidable)

- `searchengine.stripmarkup - script tags`
- `searchengine - extract text from complex HTML`

Current `searchengine.stripmarkup` strips `<script>` / `<style>` tag *delimiters* but keeps tag-internal content — so `alert('xss')` survives stripping `<script>...</script>`. The tests expect search-indexer semantics (strip script/style **content** too). Both interpretations are defensible. Skipped with a specific reason linking to #620 for product decision.

## Test plan

- [x] `./tools/run_headless_tests.sh` — 489 / 489 unit pass
- [x] `cd tests && make test-integration` — 2018 pass / 291 skipped / 0 failed (was 2013 / 296 / 0 — net +5 passing, no regressions)

## Refs

- #620 burndown umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)
