### PR TITLE
docs(usertalk): primer + progressive-discovery deeper docs

### DIFF
--- a/.claude/agents/usertalk-engineer.md
+++ b/.claude/agents/usertalk-engineer.md
@@ -116,7 +116,8 @@ persistent (dbValue)         // Persistent globals (stored in ODB)
 
 1. **Repetition:**
    - `for i = 1 to N` - Counter-based loop
-   - `for element in list` - List iteration (0-based indexing)
+   - `for value in listOrRecord` - List/record iteration; visitor is the value. Order is positional/insertion-order.
+   - `for adrMember in @table` - Table iteration; visitor is the ADDRESS of each member. Dereference with `^` to get value; `nameOf (adrMember^)` for member name. **Pass the table's address (`@t`), not the value (`t`)** — `for x in tableValue` fails with "not supported for table values."
    - `while condition` - Conditional loop
    - `fileloop (f in path)` or `fileloop (f in path, depth)` - Recursive file iteration
    - `loop` with `break` - Infinite loop with exit condition (avoid in favor of for/while)
@@ -185,16 +186,18 @@ Frontier's verb architecture uses "glue scripts" to connect UserTalk code to ker
 - DocServer reference: 75+ verb categories at `docs/usertalk/docserver/` (source markup from docserver.userland.com CMS)
 
 **Data Types (28 total, focus on these):**
-- `stringType` - Text (full 255-char set), literal: `"Hello"`
+- `stringType` - Text, literal: `"Hello"`. Internally stored as Pascal-string (255-byte max) or `Handle` (arbitrary length) depending on context; see `docs/usertalk/strings_and_text.md` for the 255-byte truncation landmine.
 - `numberType` - Integer or float (dynamically typed), literal: `42` or `3.14`
 - `booleanType` - `true` or `false`
-- `addressType` - ODB reference, literal: `@table.object`
-- `arrayType` - 0-indexed heterogeneous list, literal: `{1, "two", true}`
-- `recordType` - Key-value associative, literal: `["key": "value", "age": 30]`
-- `tableType` - ODB table object, created: `new table`
-- `outlineType` - Hierarchical outline, created: `new outline`
-- `scriptType` - Executable code object, created: `new script`
-- `wptextType` - Rich text with formatting, created: `new wptext`
+- `addressType` - ODB reference, literal: `@table.object`. An address value is always defined; `defined (@x)` checks address validity (parent path exists), NOT target presence. Use `defined (adr^)` to check target.
+- `listType` (a.k.a. arrayType) - Positional, heterogeneous list. Literal: `{1, "two", true}` (curly braces, NOT square brackets). Iterate with `for x in listValue` (visitor is the value).
+- `recordType` - Insertion-ordered key/value structure. Literal: `{"key": "value", "age": 30}` (curly braces, NOT square brackets). Iterate with `for x in recordValue` (visitor is the value). **Records do NOT support dotted-name access** — `r.key` doesn't work. Use ordinal iteration. To add a member, use `+`: `r = r + {"newKey": "newValue"}`. `+` on a name collision is a silent no-op (a long-standing quirk; tables are the right choice for keyed-mutable storage). See `docs/usertalk/records_and_tables.md`.
+- `tableType` - Named-member container; the workhorse. Literal: created via `new (tableType, @address)`. Dotted-name access works (`t.name`); bracket form for dynamic/keyword-shadowing names (`t.[var]`, `t.["stringType"]`). Iterate with `for adrM in @tableAddress` (visitor is the ADDRESS of each member; dereference with `adrM^`). Member names must be unique. Headless: insertion order; legacy Mac: alpha-sorted (divergence).
+- `outlineType` - Hierarchical outline, created: `new (outlineType, @adr)`
+- `scriptType` - Executable code object, created: `new (scriptType, @adr)`
+- `wptextType` - Rich text with formatting, created: `new (wptextType, @adr)`
+
+**Square brackets are NOT a UserTalk literal syntax.** Both records and lists use curly braces; the parser distinguishes them by whether the elements have `"key":` prefix.
 
 **Operators (Support both symbols AND word equivalents):**
 - Arithmetic: `+` (add/concat), `-` (subtract), `*` (multiply), `/` (divide), `%` (modulo), `^` (power)
@@ -268,12 +271,14 @@ else {
 
 **CRITICAL UserTalk Parser Constraints:**
 
-1. **NO Inline Comments Inside Code Blocks**
-   - ❌ WRONG: `if true { // comment inside block`
-   - ❌ WRONG: `on handler() { // comment`
-   - ✅ CORRECT: Place all // comments OUTSIDE blocks (before `if`, `on`, `try`, etc.)
-   - **Why**: The UserTalk parser does not support inline // comments inside `{ }` blocks
-   - **Pattern**: Use compact formatting without comments inside blocks
+1. **`//` Comments Inside `{ }` Blocks — usually OK, with one caveat**
+   - ✅ CORRECT: `//` between statements inside a block compiles fine
+   - ✅ CORRECT: `//` on its own line inside a block
+   - ⚠️ UNSAFE: `//` on the same physical line directly BEFORE a closing `}` (interacts with brace tracking)
+   - ✅ CORRECT: `//` AFTER a closing `}` on the same line (since `}` ends the block first)
+   - **Why**: The parser tracks `//` to end-of-line; ambiguity is only at the `}` boundary
+   - **`/* */` is NOT a UserTalk comment** — never use it (either compile error or silent miscompile)
+   - **Pattern**: When in doubt, put comments on their own line inside blocks
 
 2. **Blank Lines Must Match Indentation Level**
    - ❌ WRONG: Blank line with zero indentation inside an indented block

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,10 @@ Cross-agent UserTalk invariants and integration-test parser constraints live in 
 - typeof() returns OSType codes (e.g. `'TEXT'`) not descriptive strings
 - Absolute paths required — UserTalk table paths must be fully qualified (e.g. `@workspace.foo`)
 
+### UserTalk language primer (load before .ut or yaml-script work)
+
+Before writing inline UserTalk in yaml integration tests, editing `.ut` files, or debugging UserTalk runtime behavior, load `docs/usertalk/CLAUDE_PRIMER.md` (~250 lines). It's the language tour with idioms and failure-mode decoder — what the docserver verb reference doesn't teach. Deeper docs in `docs/usertalk/` (records_and_tables, operators_and_idioms, strings_and_text, verb_invocation_patterns, testing_patterns, debugging_workflow) are linked from the primer and load on demand.
+
 ---
 
 ## C Coding Style

--- a/docs/AI_SHARED_GUIDELINES.md
+++ b/docs/AI_SHARED_GUIDELINES.md
@@ -80,6 +80,10 @@ Minimum expectations:
 
 ## UserTalk and Integration Test Constraints
 
+### Before writing UserTalk
+
+Load `docs/usertalk/CLAUDE_PRIMER.md` (~250 lines) before writing inline UserTalk in yaml integration tests, editing `.ut` files, or debugging UserTalk runtime behavior. Deeper docs in `docs/usertalk/` (records_and_tables, testing_patterns, debugging_workflow, etc.) are linked from the primer and load on demand. The primer covers idioms, the failure-mode decoder, the yaml-test `with`-wrapper trap (#624), and protocol UserTalk debugger usage — content the docserver verb reference doesn't cover.
+
 ### UserTalk runtime facts
 
 1. Strings use double quotes (`"text"`).
@@ -88,11 +92,13 @@ Minimum expectations:
 
 ### UserTalk integration YAML constraints
 
-- Do not place inline `//` comments inside UserTalk `{ ... }` blocks.
+- `//` comments inside `{ }` blocks are usually OK between statements; the failure mode is `//` directly before a closing `}` on the same physical line. See `docs/usertalk/CLAUDE_PRIMER.md` and `docs/usertalk/SYNTAX.md` for the current rules.
+- Never use `/* */` — not a UserTalk comment marker at all; silently miscompiles in some positions.
 - Keep indentation consistent inside blocks; avoid stray blank lines with mismatched indentation.
 - Isolate test state under `system.temp.*`, never by mutating `system.*` tables directly.
 - Cleanup of `system.temp` objects is unnecessary (the table is non-persistent and recreated fresh each run), but acceptable for clarity.
 - **NEVER use `new(tableType, @workspace)` or `new(tableType, @workspace.something)`** — this creates persistent tables in workspace that pollute the database across test runs and cause flaky tests. Always use `new(tableType, @system.temp.something)` instead.
+- **Multi-line `local`/`return` returns `true` instead of the value** in protocol mode (issue #624). Use same-line `;` to keep the statements together: `local (x = 5); return x`, OR set `repl_mode: true` on the test.
 
 ### Integration test parallel/sequential rules
 

--- a/docs/usertalk/CLAUDE_PRIMER.md
+++ b/docs/usertalk/CLAUDE_PRIMER.md
@@ -1,0 +1,216 @@
+# UserTalk Primer for Claude
+
+**Load this before touching `.ut` files, yaml integration tests, or UserTalk runtime debugging.** ~250 lines, eager-load cost is small. Deeper docs in this directory are linked from here and pulled in only when a task needs them.
+
+This primer's job: stop you from probing-and-experimenting for basic idioms during integration-test burndown. The verb-by-verb reference is in `docs/usertalk/docserver/`; the `usertalk-engineer` sub-agent has a comprehensive reference loaded as its system prompt. This file is the **language tour with idioms and gotchas** — what those don't teach.
+
+---
+
+## 1. Mental model — this is not Python or C
+
+| What you'd assume from Python/C | What's actually true in UserTalk |
+|---|---|
+| Strings literal: `'hello'` or `"hello"` | **Double quotes only.** `'X'` is a character constant; `'TEXT'` is a 4-byte OSType. `'hello'` is a syntax error. |
+| `string.contains(a, b)` is a method call | `contains` is an **infix operator**: `a contains b`. There is no `string.contains` verb. |
+| `a.b` is field access on any value | `a.b` reads a sub-table member from a `tableType`. Records (`recordType`) don't support dotted-name access — see records_and_tables.md. |
+| `defined (@x.y.z)` checks if the object exists | `defined ()` actually checks **address validity** — true if `@x.y.z` is well-formed (either points to a real object, OR points to a creatable location where the parent path exists). To check whether the object actually exists *right now*, use `defined (adr^)`. See section 2.2. (Tracked: #625.) |
+| `f(x, y)` always takes positional values | Many verbs take **addresses** (`@var`) so they can write back. `dialog.ask ("?", @result)` writes into `result`. |
+| `for x in collection` always yields values | Two forms: `for v in listOrRecordValue` yields **values** (works on records and lists). `for adrM in @table` yields **addresses** (works on tables; pass the address, not the value). Dereference with `adrM^`. |
+| `/* comment */` works | **Not a UserTalk comment.** It silently parses as a division-multiplication expression and can corrupt your script's return value. Use `//` or `«…»`. |
+| Verb calls: `f(x)` | UserLand style: **space before `(`**: `f (x)`. Both compile; only the spaced form is idiomatic. |
+| Closing brace on its own line | Idiomatically **inline at the end of the last statement**: `... ; return x}`. This matches outline ↔ text round-trip. |
+| Method-style verb evolution | UserTalk is dispatch-by-name through the ODB. The "verb" `string.upper` is a script at `system.verbs.builtins.string.upper` — a glue script that calls a C kernel implementation. |
+
+If something feels surprising, check this table before assuming. The rest of the primer expands each row.
+
+---
+
+## 2. The five idioms you'll write 90% of the time
+
+### 2.1 Substring check
+
+```
+if userInput contains "yes" {...}    // ✓ infix operator, no verb call
+```
+
+NOT `string.contains (userInput, "yes")` (no such verb), NOT `string.patternMatch ("*yes*", userInput)` (pattern matching is for wildcards, not substring).
+
+### 2.2 Existence check
+
+`defined ()` returns true if its argument is a **valid address** — either pointing to a real object, OR pointing to a creatable location (a path whose parent exists). It is NOT a simple "does this object exist" check.
+
+```
+defined (@workspace)                          // true — points to a real object
+defined (@workspace.notYetCreated)            // true — workspace exists; the address is creatable
+defined (@workspace.notYetCreated.deeper)     // false — invalid address (parent path doesn't resolve)
+defined (adrThing^)                           // true iff there's a real object at that address right now
+defined (path.to.thing)                       // resolves the path; runtime error if it doesn't exist (wrap in try)
+```
+
+The form you reach for depends on intent:
+
+| Question | Use |
+|---|---|
+| Is this address well-formed enough to write into? | `defined (@x.y.z)` |
+| Does the object actually exist right now? | `defined (adr^)` (dereference; doesn't error on missing) |
+| Does this name resolve in current scope? | `defined (name)` (no `@`) |
+
+### 2.3 Reading a script body
+
+`string ()` produces the text source of a script object. It takes the **value**, not the address:
+
+```
+local (s = string (string.length))            // ✓ value form: argument is the script object itself
+local (s = string (adrScript^))               // ✓ dereference an address to get the value
+local (s = string (@string.length))           // ✗ argument is an address VALUE; you get back "@string.length", NOT the script source
+```
+
+Common mistake: writing `string (@some.script.path)` thinking it dereferences. It doesn't — `string ()` stringifies whatever it's given, and an address stringifies to its dotted path.
+
+The same rule applies to `typeof ()`, `sizeOf ()`, etc.: they operate on the value, not the address. Always dereference with `^` when you have an address and want to operate on the target.
+
+### 2.4 Reading a table member
+
+```
+local (val = examples.colors.red)             // dotted name — works for tables
+local (val = examples.colors.[someVarName])   // bracket form for dynamic names
+local (val = examples.colors.["stringType"])  // bracket form when name shadows a keyword/global
+```
+
+**For records**, dotted-name access doesn't exist — use ordinal iteration. See records_and_tables.md.
+
+### 2.5 Iteration
+
+Two forms depending on what you're iterating:
+
+```
+// Tables — iterate over the ADDRESS of the table; visitor is the address of each member.
+for adrMember in @examples.colors {
+    log (nameOf (adrMember^) + " = " + adrMember^)}
+
+// Lists and records — iterate over the value; visitor is the value of each member.
+for n in {1, 2, 3} {
+    log (n)}                                              // n is 1, then 2, then 3
+
+local (rec = {"alpha": 1, "beta": 2});
+for v in rec {
+    log (v)}                                              // v is 1, then 2 (insertion order)
+```
+
+For tables: pass the address (`@examples.colors`), not the value (`examples.colors`). Passing the value gives `This operation is not supported for table values.`
+
+`nameOf (adrMember^)` gets the member name; `nameOf (adrMember)` gets the local variable's name (`"adrMember"`), which is rarely what you want.
+
+---
+
+## 3. Failure-mode decoder — when you see this error
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Can't compile this script because of a syntax error.` on `/* ... */` | `/* */` isn't a UserTalk comment | Use `//` or `«…»` |
+| Script `returns` a value but yaml test sees `true` (boolean) | Protocol-mode `with`-wrapper drops `local` scope across `\r` (#624) | Use `;` to keep `local`/`return` on one logical statement, or set `repl_mode: true` |
+| `Character constant isnt correctly specified. Must be of the form 'c'.` | Used `'foo'` for a string | Use `"foo"` |
+| `Can't find a sub-table named X` | Tried `r.X` on a value that's NOT a `tableType` (probably `recordType` or scalar) | `typeof (r)` to check; if it's a record, you must iterate ordinally |
+| `Can't call the script because the name X hasn't been defined.` | Verb doesn't exist, OR you forgot the system root, OR name collides with a global | Check verb name; confirm `--system-root` is loaded; try bracket form for the leaf |
+| `Cant evaluate the expression because the name X hasnt been defined.` | Referenced a name that doesn't resolve in current scope | `defined (X)` first; check spelling and scope |
+| `Cant coerce the string X to a character.` | Passed multi-char string to verb expecting `char` | Single-char `"X"`, or use `'X'` for a true char constant |
+| `Cant compile` on a path like `@x.y.stringType` | Leaf collides with a global constant/keyword | Use bracket form: `@x.y.["stringType"]` |
+| `This operation is not supported for table values.` | `for x in tableValue` (passed value, should be address) | `for adrM in @table` instead |
+| yaml test passes with `success: true` but `result_type: unknown` for an OSType | Test framework JSON-serializes OSType codes as strings | Use `"TEXT"` etc. in test expectations, not `stringType` |
+| `[lang-ERROR] langcallbacks.c:208:` (empty error line after success) | Harmless — known protocol bookkeeping noise | Ignore |
+| `expected_result: true` mismatch even though script returns `true` | yaml parsed `true` as a boolean, but test framework compares string | Quote it: `expected_result: "true"` |
+
+---
+
+## 4. Authoring UserTalk in yaml integration tests
+
+This is where most of your UserTalk writing happens during burndown. The constraints:
+
+### Quoting in yaml `expected_*` fields
+
+```yaml
+expected_success: true        # yaml boolean — comparison is to the protocol success field
+expected_result: "true"       # MUST be quoted string — compared against script's stringified return
+```
+
+`expected_result` is a **string comparison** against the script's return value as serialized by the protocol layer. If the yaml parses `true` as a boolean, the comparison silently fails — quote it.
+
+### The `with`-wrapper trap (tracked: #624)
+
+Protocol mode (default for yaml integration tests) wraps every `script:` block in `with system.temp.FrontierREPL.variables { ... }`. This causes:
+
+- **`local`s declared on one line don't survive past `\r` to a `return` on the next line.** The script silently returns `true` instead of the intended value. Filed as **#624 (P0)** — a real bug that can mask integration-test failures. **Fix**: same line + `;`, or set `repl_mode: true`.
+- Verbs taking `@addr` output parameters often fail inside the wrapper. **Fix**: `repl_mode: true`.
+- `thread.evaluate` doesn't work inside the wrapper. **Fix**: `repl_mode: true`.
+- Empty string returns may serialize as `null`.
+
+Full details: `testing_patterns.md`.
+
+### Comments in yaml `script:` blocks
+
+- `//` is OK between statements inside `script:` blocks (it consumes to end of line).
+- `«…»` works but YAML may mangle the bytes — avoid in yaml scripts; OK in `.ut` files.
+- `/* */` is **NEVER OK** — not a UserTalk comment at all.
+- `#` is a yaml comment but **NOT inside `script:` block content** — UserTalk doesn't have `#` comments.
+
+### `system.temp` only
+
+Integration tests must isolate state under `system.temp.*`. Never mutate `workspace.*` or any top-level system table directly. `system.temp` is cleared per process start, but cleanup with `delete (@system.temp.foo)` is still good practice for readability.
+
+Specifically forbidden: `new (tableType, @workspace)` — destroys the entire workspace table.
+
+### Handler scripts need end-to-end execution tests
+
+A handler that compiles cleanly can still fail at runtime if it calls a name that doesn't resolve (late binding). Tests must drive the handler through its production dispatch path (REPL, menu, slash command) and assert on observable side effects — not just `script.compile (s) == true`.
+
+---
+
+## 5. Tools for investigation
+
+### Protocol UserTalk debugger — the primary tool for "why?"
+
+The protocol exposes a real debugger (since #588 / protocol expansion): `debug/setBreakpoint`, `debug/run`, `debug/continue`, `debug/step`, `debug/getLocals`, `debug/getSource`, `debug/getStack`, `debug/setWatchpoint`, `debug/listThreads`, `debug/kill`. Suspension reasons: `entry`, `breakpoint`, `step`, `interrupted`, `watchpoint`. Conditional breakpoints supported.
+
+**Use the debugger first** for "why isn't this called?" / "what values flow through?" — matches the global "debugger-first for control flow" rule.
+
+Full walkthrough with burndown-relevant examples: `debugging_workflow.md`.
+
+### `script/eval` as a fast probe
+
+```bash
+./frontier-cli/frontier-cli --protocol --skip-startup --system-root databases/Frontier.root
+```
+
+Then NDJSON in, NDJSON out. One-shot expressions; great for "what does this verb return on this input?" Per-eval, the protocol wraps in the `with` block — same caveats as yaml tests.
+
+For ODB **edits**, add `--allow-mutate`. `--protocol --system-root` defaults to read-only since #588.
+
+### `string ()`, `typeof ()`, `nameOf ()` for inspection
+
+```
+typeof (x)                       // 'TEXT', 'tabl', 'reco', 'list', 'long', 'bool', etc.
+string (scriptObject)            // script source text
+nameOf (adrMember^)               // member name (NOT adrMember)
+```
+
+### `dialog.alert` doesn't work in headless
+
+Use `return` to surface values, or write to a temp object you can read back via protocol.
+
+---
+
+## 6. Deeper docs (load when topic comes up)
+
+- **records_and_tables.md** — when you hit "Can't find sub-table" or need to walk an unknown structure
+- **operators_and_idioms.md** — when an operator behaves unexpectedly (`contains`, `==`, `^`, `@`, word vs symbol forms)
+- **strings_and_text.md** — when truncation hits at 255 bytes, when escaping fights you, Pascal-string vs `Handle` distinction
+- **verb_invocation_patterns.md** — when a verb errors with "wrong number of parameters" — kernel verb vs `.ut` glue script vs headless overload
+- **testing_patterns.md** — yaml integration tests in depth: the `with`-wrapper trap, `repl_mode`, eval-trap history, behavioral vs source-inspection assertions
+- **debugging_workflow.md** — protocol debugger with worked examples
+- **values_and_types.md** — type taxonomy reference (stub)
+- **scripts_vs_handlers.md** — `on foo () {...}` vs top-level statements; how scripts get auto-loaded (stub)
+- **comments_and_whitespace.md** — `«…»` vs `//`, outline-vs-text storage of comments, `\r` as canonical line terminator (stub)
+
+The verb-by-verb reference (75+ categories) is at `docs/usertalk/docserver/`. The `usertalk-engineer` sub-agent has a comprehensive language reference loaded as its system prompt — delegate to it for deeper kernel-side work.
+
+Cross-cutting memory files (`feedback_usertalk_*` in your memory/) still apply — they're tight rules-each, not language tour.

--- a/docs/usertalk/SYNTAX.md
+++ b/docs/usertalk/SYNTAX.md
@@ -2,55 +2,90 @@
 
 Quick reference for UserTalk syntax rules and gotchas.
 
+For the full language tour and idioms, see [CLAUDE_PRIMER.md](CLAUDE_PRIMER.md).
+
 ---
 
 ## String Quotes
 
-**CRITICAL**: Double quotes for strings, single quotes for character constants!
+**CRITICAL**: Double quotes for strings, single quotes for character constants and OSTypes.
 
 ```usertalk
-sizeOf("hello")  // ✅ CORRECT - double quotes for strings
-sizeOf('hello')  // ❌ WRONG - syntax error (single quotes = char constant)
+sizeOf ("hello")    // ✅ CORRECT — double quotes for strings
+sizeOf ('hello')    // ❌ WRONG — syntax error (single quotes for single chars or 4-byte OSType only)
+typeof (x) == 'TEXT'  // ✅ CORRECT — 'TEXT' is a 4-byte OSType code
 ```
 
-**Why this matters:** This is the **opposite** of JavaScript/Python where `'x'` and `"x"` are equivalent. UserTalk treats single quotes as character constants (like C).
+This is the **opposite** of JavaScript/Python where `'x'` and `"x"` are equivalent. UserTalk treats single quotes as character constants (like C). A 4-byte single-quoted literal like `'TEXT'` is an OSType (a 4-byte unsigned integer commonly used for type tags).
 
 ---
 
 ## Comments
 
-### Block Comments (Safe Everywhere)
+UserTalk has **two** comment markers:
+
+1. `//` — single-line, to end of line (`\r`)
+2. `«…»` — multi-line, using MacRoman bytes 0xC7 and 0xC8
+
+**`/* */` is NOT a UserTalk comment marker.** Using `/* */` either fails to compile or, worse, silently parses as a division-multiplication expression and corrupts the script's return value. Never use it.
 
 ```usertalk
-/* This is a comment */
-local(x = 1)
+// ✅ Single-line comment at top level
+local (x = 1)
 
-/*
- * Multi-line comment
- * Works everywhere
- */
+on handler () {
+    // ✅ Single-line comment between statements inside a block — OK
+    local (x = 1);
+    return x}                            // ✅ Comment after closing brace — OK
+
+«this is a legacy multi-line comment that
+spans multiple lines using the MacRoman
+guillemet characters»
 ```
 
-### Inline Comments (Top-Level Only)
+### Comments inside `{ }` blocks
 
-**CRITICAL**: Inline `//` comments only work at top level, NOT inside code blocks!
+`//` is valid in most positions inside `{ }` blocks. The confirmed failure is when `//` appears on the same physical line *before* a closing `}` — this can interact with the parser's brace tracking. Safe pattern: put `//` between statements OR after the closing `}`, not in front of it.
+
+### Comments in yaml integration tests
+
+- `//` OK between statements in yaml `script:` blocks
+- `«…»` AVOID in yaml — the bytes 0xC7/0xC8 get mangled by YAML; OK in `.ut` files
+- `/* */` NEVER — not a UserTalk comment
+- `#` is a yaml comment outside scripts; UserTalk has no `#` comment
+
+See [CLAUDE_PRIMER.md](CLAUDE_PRIMER.md) § 4 and [testing_patterns.md](testing_patterns.md).
+
+---
+
+## Closing braces and semicolons
+
+Idiomatically, closing `}` braces are **inline at the end of the last statement** of a verb or bundle, NOT on their own line. Same for trailing `;`. This matches the outline ↔ text round-trip — outlines don't have free-standing braces.
 
 ```usertalk
-// ✅ CORRECT - top level comment
-local(x = 1)
+on f (x) {
+    local (y = x + 1);
+    return y}                            // ✅ idiomatic: } inline at end of last statement
 
-on handler() {
-	// ❌ WRONG - inline comment inside block causes parse errors!
-	return true
-}
-
-on handler() {
-	/* ✅ CORRECT - block comment works inside blocks */
-	return true
-}
+on f (x) {
+    local (y = x + 1);
+    return y
+}                                        // ⚠️ non-idiomatic but compiles
 ```
 
-**Reason**: UserTalk parser limitation - inline comments only work at file level, not inside code blocks.
+---
+
+## Verb call style: space before `(`
+
+UserLand UserTalk style: a space between the verb name and the opening paren of its parameter list.
+
+```usertalk
+string (foo)                             // ✅ idiomatic
+defined (path)                           // ✅ idiomatic
+return f ()                              // ✅ idiomatic
+
+string(foo)                              // compiles, but not the convention
+```
 
 ---
 
@@ -58,33 +93,42 @@ on handler() {
 
 ### Blank Lines Inside Blocks
 
-**CRITICAL**: Blank lines inside indented blocks must match the surrounding indentation level!
+Blank lines inside indented blocks must match the surrounding indentation level. The parser tracks indentation strictly.
 
 ```usertalk
-// ❌ WRONG - blank line with no indentation
-on handler() {
-	local(x = 1)
+// ✅ CORRECT — blank line matches surrounding indent (or is omitted entirely)
+on handler () {
+    local (x = 1);
+    return x}
 
-	return x  // Parse error - blank line above has wrong indentation
-}
+// ❌ WRONG — blank line with zero indentation inside a block
+on handler () {
+	local (x = 1)
 
-// ✅ CORRECT - blank line matches indentation
-on handler() {
-	local(x = 1)
-
-	return x  // Blank line above has same indentation as surrounding code
-}
-
-// ✅ SIMPLEST - avoid blank lines inside blocks entirely
-on handler() {
-	local(x = 1)
-	return x
-}
+	return x}                            // parse error: blank line above has wrong indentation
 ```
 
-**Reason**: UserTalk file parser requires indentation level to match previous line, even for blank lines.
+**Best practice**: use compact formatting without blank lines inside `{ }` blocks. Blank lines are for separating top-level constructs.
 
-**Best practice**: Use compact formatting without blank lines inside handlers/blocks.
+### Outline structure rules
+
+Scripts are stored as outlines. Indentation encodes parent-child relationships in the outline hierarchy. Each line's indentation can differ from the line above by **at most one level** (same, +1, or -1). Never skip levels.
+
+Sub-indented comments are a valid Frontier convention for change logs:
+
+```usertalk
+on myVerb (s)                            // level 0
+    // 3/24/26 by JES                    // level 1 (+1 from on-line)
+        // Added new feature.            // level 2 (+1 from comment above)
+    // 8/16/98 by DW                     // level 1 (back to comment block)
+        // Original implementation       // level 2 (+1)
+    local (x = s);                       // level 1 (back to code)
+    return x
+```
+
+Never jump +2 or more levels — creates malformed outline structure.
+
+See [docs/ODB_SCRIPT_EDITING.md](../ODB_SCRIPT_EDITING.md) for the full indentation rules.
 
 ---
 
@@ -94,7 +138,7 @@ on handler() {
 
 UserTalk was designed for outline editing in the original Frontier environment:
 - Indentation was automatic (handled by outline editor)
-- Braces `{`, `}`, and semicolons `;` were rarely typed manually
+- Braces `{`, `}`, and semicolons `;` were rarely typed manually — added on stringification
 - Text-based editing was not the primary workflow
 
 Modern text-based development requires awareness of these parser constraints.
@@ -103,6 +147,9 @@ Modern text-based development requires awareness of these parser constraints.
 
 ## See Also
 
-- **typeof() behavior:** [TYPEOF.md](TYPEOF.md)
-- **File operations:** [FILE_AND_DB.md](FILE_AND_DB.md)
-- **Test patterns:** [docs/TESTING_GUIDE.md](../TESTING_GUIDE.md) § UserTalk Test Patterns
+- [CLAUDE_PRIMER.md](CLAUDE_PRIMER.md) — language tour, idioms, failure-mode decoder
+- [TYPEOF.md](TYPEOF.md) — `typeof ()` semantics and OSType codes
+- [records_and_tables.md](records_and_tables.md) — container types and access syntax
+- [strings_and_text.md](strings_and_text.md) — string representations, 255-byte landmine
+- [FILE_AND_DB.md](FILE_AND_DB.md) — file/DB verb path requirements
+- [docs/TESTING_GUIDE.md](../TESTING_GUIDE.md) § UserTalk Syntax Guide

--- a/docs/usertalk/comments_and_whitespace.md
+++ b/docs/usertalk/comments_and_whitespace.md
@@ -1,0 +1,42 @@
+# Comments and Whitespace
+
+Stub. The deep dive on `//` and `«…»` comment forms, outline vs text-source storage of comments, and the `\r`-as-canonical-line-terminator rules. Flesh out as questions arise.
+
+---
+
+## Status
+
+**STUB — TODO**. Most of the content already exists scattered across:
+
+- `CLAUDE_PRIMER.md` § 4 — comments inside yaml `script:` blocks
+- `strings_and_text.md` — line endings, `\r` canonical, `\n` post-#586
+- `SYNTAX.md` — top-level vs inside-block `//` rules, `«…»` legacy comments, **CORRECTED to remove the false `/* */` claim**
+- `../ODB_SCRIPT_EDITING.md` — indentation, sub-indented comment blocks, dated-change-comment convention
+- Agent def `usertalk-engineer.md` — parser constraints (no inline `//` inside blocks — though recent probing in CLAUDE_PRIMER.md drafting suggests this is overstated; `//` works in more positions than the agent def implies)
+
+## Key facts to consolidate
+
+- `//` consumes text to end-of-line. Valid in most positions including inside `{ }` blocks; the only confirmed failure mode is when `//` and `}` collide on the same physical line in some structural arrangements.
+- `«…»` are legacy multi-line comments (bytes 0xC7/0xC8 in MacRoman). AVOID inside yaml `script:` blocks (YAML may mangle the bytes); OK in `.ut` files.
+- **`/* */` is NOT a UserTalk comment.** Never use it. Causes either a compile error or (worse) silently miscompiles by parsing as a division-multiplication expression.
+- `#` is not a UserTalk comment either.
+- `\r` (CR, 0x0D) is the canonical line terminator. The ODB stores scripts with CR. `script.newScriptObject ()` normalizes CRLF/LF → CR on install.
+- LF (`\n`) support was added in #586 for ease of working with files from Unix tools, but mixing CR and LF in the same script is unsafe.
+- Outline-stored comments use `isComment=true` on the outline heading; the `//` prefix is stripped on import and added back on export. The text-source form always includes `//`.
+
+## TODO topics
+
+- Exact rule for `//` near closing `}` — probe and document
+- Comment-line attributes in the outline (`flcomment`, etc.)
+- Outline vs flat-text divergence: stringification adds `//` and structural braces; importing strips them — round-trip subtleties from #621
+- Em-dash / extended-character handling in script source
+- Whitespace inside `( )` parameter lists — UserLand convention (space after the verb but not inside the parens? Or inside too?)
+
+---
+
+## See also
+
+- `CLAUDE_PRIMER.md`
+- `SYNTAX.md`
+- `strings_and_text.md`
+- `../ODB_SCRIPT_EDITING.md`

--- a/docs/usertalk/debugging_workflow.md
+++ b/docs/usertalk/debugging_workflow.md
@@ -1,0 +1,375 @@
+# UserTalk Debugging Workflow
+
+Pulled in when: a yaml test returns the wrong value, a handler doesn't seem to dispatch, you need to know what's actually in a table at runtime, or you're tracking a verb to its source. The primer's Section 5 names the tools; this file is the burndown-time deep dive.
+
+The framing: **the protocol UserTalk debugger is the primary tool** for "why?" questions. This is the UserTalk-side cousin of the global "debugger-first for control flow" rule (which in C-land means LLDB). Logging-style probes (`msg ()`, return-and-inspect) are the fallback, not the default.
+
+The full protocol reference is `../DEBUGGING_GUIDE.md` under "UserTalk Debugging via Protocol". This file curates that reference for integration-test burndown and adds worked examples.
+
+---
+
+## 1. When to reach for which tool
+
+A decision tree before you start probing:
+
+| Question | First move | Fallback |
+|---|---|---|
+| "Why did this test return the wrong value?" | `script/eval` to repro in isolation (5-second probe) | `debug/run` + `debug/getLocals` if the eval still surprises you |
+| "Why isn't this verb being called?" | `debug/setBreakpoint` on line 1 of the handler, then drive the dispatch path | Grep the dispatch table; check `parentOf ()` of the verb name |
+| "What's actually in this table at runtime?" | `script/eval` with `for adrM in @t {...}` walker | `debug/getLocals` if it's a local of a suspended thread |
+| "Where is this verb defined?" | `string (verbValue)` to dump the source via `script/eval` | grep `.ut` files; compare with the ODB-resident copy |
+| "Did this handler dispatch at all?" | `debug/setBreakpoint` line 1, drive the trigger | `msg ()` at handler entry — but only if you can't get the debugger to bite |
+| "What's the call stack at this point?" | `debug/getStack` | inspect `system.compiler.stack` (legacy approach, fragile) |
+| "Does this variable change unexpectedly?" | `debug/setWatchpoint` on the variable name | re-read with `script/eval` after each suspected mutation |
+
+The shape of the rule: **eval first if it's a value question, breakpoint first if it's a control-flow question**. Don't bring the debugger to a one-line "what does `nameOf` return for this?" check.
+
+---
+
+## 2. Protocol mode setup
+
+Read-only session (the default):
+
+```bash
+./frontier-cli/frontier-cli --protocol --skip-startup --system-root databases/Frontier.root
+```
+
+NDJSON in (one JSON object per line on stdin), NDJSON out (responses + unsolicited notifications on stdout). The protocol stream carries both `script/*` and `debug/*` ops — same session, same connection.
+
+For ODB **edits** (installing verbs, mutating tables), add `--allow-mutate`. Protocol mode has been read-only by default since #588 — this is a safety rail, not a bug.
+
+Suspension reasons you'll see in `debug/suspended` notifications:
+
+| Reason | Means |
+|---|---|
+| `entry` | Thread started via `debug/run` and is parked at the first statement, waiting for you to `debug/continue` or step |
+| `breakpoint` | Hit a line where `debug/setBreakpoint` was set |
+| `step` | Completed one `debug/step` (into / over / out) |
+| `watchpoint` | A `debug/setWatchpoint`-tracked variable changed value — the notification carries `oldValue` and `newValue` |
+| `interrupted` | A `debug/pause` request landed |
+
+---
+
+## 3. The 15 debugger operations
+
+This is the full inventory as of `../DEBUGGING_GUIDE.md`. Suspension and completion arrive as unsolicited notifications, not as `result` fields on the originating request — you read them off the stream as they come.
+
+### 3.1 `debug/run` — start a debug session
+
+```
+{"op":"debug/run","id":1,"params":{"expression":"examples.target ()"}}
+```
+
+Returns `{"threadId": N, "status": "started"}` immediately. The thread **suspends at entry** (first statement). You must `debug/continue` (or step) before it actually runs.
+
+### 3.2 `debug/continue` — resume
+
+```
+{"op":"debug/continue","id":2,"params":{"threadId":1}}
+```
+
+Resumes until the next stop event (breakpoint, watchpoint, step boundary, or completion).
+
+### 3.3 `debug/pause` — interrupt a running thread
+
+```
+{"op":"debug/pause","id":3,"params":{"threadId":1}}
+```
+
+Forces the thread to suspend at the next statement. Useful for runaway scripts.
+
+### 3.4 `debug/kill` — terminate
+
+```
+{"op":"debug/kill","id":4,"params":{"threadId":1}}
+```
+
+Hard-stops the thread. No locals returned, no completion success — gone.
+
+### 3.5 `debug/step` — single-step
+
+```
+{"op":"debug/step","id":5,"params":{"threadId":1,"direction":"over"}}
+```
+
+`direction` is one of `"into"`, `"over"`, `"out"`. Standard stepper semantics. The thread re-suspends with `reason: "step"`.
+
+### 3.6 `debug/setBreakpoint`
+
+```
+{"op":"debug/setBreakpoint","id":6,"params":{
+    "script":"system.temp.examples.target","line":5}}
+```
+
+Set or **toggle** a breakpoint. Calling `setBreakpoint` again on the same (script, line) clears it — there is no separate single-breakpoint clear op.
+
+Optional `condition`: `"varname op value"` where `op` is `==`, `!=`, `>`, `<`, `>=`, `<=`. Numeric compare if both sides parse as numbers, string compare otherwise.
+
+### 3.7 `debug/listBreakpoints`
+
+```
+{"op":"debug/listBreakpoints","id":7}
+```
+
+Returns all active breakpoints.
+
+### 3.8 `debug/clearBreakpoints`
+
+```
+{"op":"debug/clearBreakpoints","id":8}
+```
+
+Clears all of them. There is **no per-id clear** — to clear one, toggle by re-issuing the same `setBreakpoint`.
+
+### 3.9 `debug/setWatchpoint`
+
+```
+{"op":"debug/setWatchpoint","id":9,"params":{"variable":"x"}}
+```
+
+Watches a variable. When the value changes, the next suspension carries `reason: "watchpoint"` plus `variable`, `oldValue`, `newValue`. Toggle semantics — re-issue to clear that watchpoint specifically.
+
+### 3.10 `debug/listWatchpoints`
+
+```
+{"op":"debug/listWatchpoints","id":10}
+```
+
+### 3.11 `debug/clearWatchpoints`
+
+```
+{"op":"debug/clearWatchpoints","id":11}
+```
+
+All-clear; no per-id clear.
+
+### 3.12 `debug/getLocals`
+
+```
+{"op":"debug/getLocals","id":12,"params":{"threadId":1}}
+```
+
+Returns the locals of the suspended thread as a list of `{name, value, type}` records (value is stringified — same caveats as `string ()` on a value). Scope chain is locals → enclosing scopes → globals.
+
+### 3.13 `debug/getStack`
+
+```
+{"op":"debug/getStack","id":13,"params":{"threadId":1}}
+```
+
+Returns the call-stack frames. Each frame includes the script name and current line.
+
+### 3.14 `debug/getSource`
+
+```
+{"op":"debug/getSource","id":14,"params":{"script":"system.temp.examples.target","threadId":1}}
+```
+
+Returns the source with line numbers, breakpoint markers, and current-line marker. Loads from disk on demand if the script isn't in memory yet. `threadId` is optional — pass it to get the current-line marker.
+
+### 3.15 `debug/listThreads`
+
+```
+{"op":"debug/listThreads","id":15}
+```
+
+Returns all active debug threads. Multi-thread debugging: each `debug/run` makes an independent thread; address them by `threadId`.
+
+**Verify before relying on subtle behavior**: the op list above matches `../DEBUGGING_GUIDE.md` "All Protocol Operations" table at the time of writing. If headless adds a `debug/clearBreakpoint` (singular) or a `debug/reset`, the source of truth is that table.
+
+---
+
+## 4. Worked example: yaml test returning the wrong value
+
+You wrote this test:
+
+```yaml
+- name: "addition returns 5"
+  script: |
+    local (x = 2 + 3)
+    return x
+  expected_result: "5"
+```
+
+The test fails with `actual_result: "true"`. Classic #624 with-wrapper trap — but let's walk it as if we didn't know.
+
+### Step 1 — probe with `script/eval`
+
+```
+{"op":"script/eval","id":1,"params":{"expression":"local (x = 2 + 3)\rreturn x"}}
+```
+
+The response shows `result: "true"`, not `"5"`. Confirms the value is wrong at the same layer the yaml runner uses.
+
+### Step 2 — collapse to one line
+
+```
+{"op":"script/eval","id":2,"params":{"expression":"local (x = 2 + 3); return x"}}
+```
+
+This returns `result: "5"`. Now you've isolated the trigger: the multi-line form fails, the single-statement form works.
+
+### Step 3 — recognize the pattern
+
+The protocol wraps every `script:` block in `with system.temp.FrontierREPL.variables { ... }`. The `\r` between `local` and `return` opens a new top-level statement inside the `with`, so `x` is out of scope by the time `return` runs. `return x` then evaluates an undefined name, and the wrapper layer surfaces that as `true` (it doesn't surface the error — see issue #624).
+
+### Step 4 — fix the test
+
+Two options:
+
+```yaml
+# Option A: keep it as protocol mode, same-line with ;
+- name: "addition returns 5"
+  script: |
+    local (x = 2 + 3); return x
+  expected_result: "5"
+
+# Option B: switch to repl_mode, multi-line OK
+- name: "addition returns 5"
+  repl_mode: true
+  script: |
+    local (x = 2 + 3)
+    return x
+  expected_result: "5"
+```
+
+You did not need the debugger here. The `script/eval` probe was enough to reproduce, and the fix was at the test-shape level. **This is the common case for burndown** — most yaml mismatches resolve in one or two evals.
+
+---
+
+## 5. Worked example: "this handler doesn't run"
+
+Scenario: a slash-command handler at `system.handlers.slashCommands.help` is supposed to fire when the REPL receives `/help`, but you see no output. The handler compiles cleanly. So: is it being dispatched at all?
+
+### Step 1 — set a breakpoint at the entry
+
+```
+{"op":"debug/setBreakpoint","id":1,"params":{
+    "script":"system.handlers.slashCommands.help","line":1}}
+```
+
+### Step 2 — drive the dispatch path
+
+In a separate request (or via the actual REPL), trigger the slash command. If the dispatch goes through `script/eval`, you can fire it inline:
+
+```
+{"op":"debug/run","id":2,"params":{
+    "expression":"system.handlers.dispatchSlashCommand (\"/help\")"}}
+```
+
+You get `{"threadId":2, "status":"started"}` and a `debug/suspended` notification with `reason: "entry"`. Continue:
+
+```
+{"op":"debug/continue","id":3,"params":{"threadId":2}}
+```
+
+### Step 3 — read the evidence
+
+Two outcomes:
+
+- **A `debug/suspended` arrives with `reason: "breakpoint"` at line 1 of the handler.** Dispatch is working. Step into with `debug/step direction=into` and watch what does or doesn't happen — likely the handler is running but its output isn't reaching where you expected. Inspect with `debug/getLocals`. Walk with `debug/step`.
+- **No breakpoint hit, completion fires instead.** The handler is not being dispatched. Bug is in the dispatch table or name resolution, not the handler body. Now switch to inspecting `system.handlers.slashCommands` to confirm the entry exists, and breakpoint on the dispatch function itself.
+
+### Step 4 — if it's a dispatch bug, breakpoint earlier
+
+```
+{"op":"debug/setBreakpoint","id":4,"params":{
+    "script":"system.handlers.dispatchSlashCommand","line":1}}
+{"op":"debug/run","id":5,"params":{
+    "expression":"system.handlers.dispatchSlashCommand (\"/help\")"}}
+```
+
+Step through, watch the name lookup, see whether it finds `help` in its handler table.
+
+The point: the debugger answered "did this run?" definitively. No `msg ("here")` sprinkling.
+
+---
+
+## 6. Worked example: "what's in this table?"
+
+You're staring at `examples.target` and you have no idea what shape it is. The fastest dump:
+
+```
+{"op":"script/eval","id":1,"params":{
+    "expression":"local (s = \"\"); for adrM in @examples.target {s = s + nameOf (adrM^) + \"=\" + adrM^ + \"; \"}; return s"}}
+```
+
+The result is a flat key=value dump.
+
+Caveats:
+
+- **Polymorphic members.** If `adrM^` is itself a table or record, `+` concatenation will fail or produce `'tabl'`-style garbage. To handle that, branch on `typeof (adrM^)`:
+
+```
+local (s = "");
+for adrM in @examples.target {
+    local (t = typeof (adrM^));
+    if t == 'tabl' {s = s + nameOf (adrM^) + "=<table>; "}
+    else {s = s + nameOf (adrM^) + "=" + adrM^ + "; "}};
+return s
+```
+
+- **Records.** If you suspect the value is a record, table iteration won't work. Switch to value iteration: `for v in examples.target { ... }`. See `records_and_tables.md`.
+- **Suspended-thread locals.** If the table you want is a `local` inside a suspended thread, `debug/getLocals` gets you the top level. To walk a table local in depth, set a breakpoint after it's populated and step.
+
+---
+
+## 7. Worked example: "where is this verb defined?"
+
+You suspect a glue script has been modified or you want to see what's between the `on` line and the `kernel ()` call. Use `string ()` on the **value**, not the address:
+
+```
+{"op":"script/eval","id":1,"params":{"expression":"string (string.upper)"}}
+```
+
+Response: `"on upper (s) {\r\tkernel (string.upper)}"` — the script source, complete with `\r` line terminators.
+
+**The common mistake**: `string (@string.upper)`. That returns the literal string `"@string.upper"` — the stringified form of the address value. `string ()` operates on its argument; an address stringifies to its dotted path. To dereference an address and inspect what's there, use `string (adr^)`.
+
+If the verb's source is enormous or you want line numbers, `debug/getSource` is better:
+
+```
+{"op":"debug/getSource","id":2,"params":{"script":"string.upper"}}
+```
+
+Returns each line with `num`, `text`, and any breakpoint/current markers.
+
+---
+
+## 8. Common pitfalls during debugging
+
+- **`dialog.alert ()` doesn't work in headless.** Don't waste cycles on it. Surface values via `return` or write to a temp object you can read back via `script/eval`.
+- **`string (@addr)` doesn't dereference.** Always `string (adr^)` or `string (value)`. This is the same gotcha as in the primer's Section 2.3 — it shows up in debugging just as often.
+- **`log_info ()` is C-kernel logging, not UserTalk-side.** You cannot call `log_info ()` from a script. From UserTalk, use `msg ()` (writes to the status line) or — better — `return` the value and read it via the protocol layer.
+- **The debugger suspends threads on entry by default.** A `debug/run` that you never `debug/continue` will sit there forever. If you wanted "just run this script in debug mode and let it complete," you still need an explicit continue after the entry suspension.
+- **Toggle vs clear.** `debug/setBreakpoint` is a toggle. There is no per-id clear op for breakpoints or watchpoints — only `clearBreakpoints` / `clearWatchpoints` (all of them) or re-issuing the same `setBreakpoint` / `setWatchpoint` to flip that specific one off.
+- **`getLocals` returns stringified values.** `value` is `string ()`-form, not a typed object. To inspect a table local in depth, breakpoint after population and probe with `script/eval` using the actual path.
+- **`script` paths use dotted notation.** Leading `@` is stripped automatically by the debugger, but be consistent — `system.temp.examples.target` and `@system.temp.examples.target` are equivalent in `debug/setBreakpoint`. The dotted form is conventional.
+- **Variable lookups search the full scope chain.** `getLocals`, conditional breakpoints, and watchpoint variable resolution all search locals → enclosing scopes → globals. A watchpoint on `x` will fire on any `x` in scope at the suspension point.
+
+---
+
+## 9. When the debugger isn't enough
+
+A handful of cases where the debugger doesn't help and you need older tools:
+
+1. **Pre-compilation inspection.** The debugger needs a compiled script. To see what the source looks like before compilation, read the `.ut` file directly and compare against the ODB-resident form via `string (script.path)`.
+2. **Outline-level investigation.** When you suspect post-export reformatting is hiding something — comments dropped, indentation lost, brace placement changed — walk the raw outline node-by-node:
+   ```
+   op.firstSummit ();
+   op.fullExpand ();
+   op.go (flatdown, 1);
+   local (txt = op.getLineText ())
+   ```
+   This bypasses the export pass entirely. Useful when the exported source looks fine but the runtime behavior is off, or when you're debugging the exporter itself.
+3. **C-kernel crashes.** If the debugger session itself dies or you're seeing SIGSEGV from a verb body, you're past UserTalk and into LLDB territory. See `../DEBUGGING_GUIDE.md` Sections 1-4 for the LLDB workflow.
+4. **Cross-thread state inspection.** The protocol debugger exposes one thread at a time; if a bug is racy, you may need C-level instrumentation (logging at GIL acquire/release, or LLDB watchpoints in the runtime).
+
+---
+
+## 10. Cross-references
+
+- `../DEBUGGING_GUIDE.md` — the full protocol debugger reference (Section "UserTalk Debugging via Protocol"); also LLDB / git-bisect / C-level patterns. This file is the UserTalk-focused subset.
+- `CLAUDE_PRIMER.md` — entry-point primer; Section 5 names the debugger and points here.
+- `testing_patterns.md` — yaml-test-specific debugging (the `with`-wrapper trap, `repl_mode`, eval-trap history).
+- `records_and_tables.md` — when the table-walker dump from Section 6 hits a polymorphic member and you need to recurse correctly.

--- a/docs/usertalk/operators_and_idioms.md
+++ b/docs/usertalk/operators_and_idioms.md
@@ -1,0 +1,323 @@
+# Operators and Idioms
+
+Pulled in when: an operator doesn't behave the way you'd expect from another language, you can't remember which verb does a substring check, you want to know whether `with` is safe in this context, or you're hunting an idiomatic one-liner.
+
+The primer (`CLAUDE_PRIMER.md`) gives the five idioms you'll write 90% of the time. This file is the rest of the operator surface — comparison, logical, arithmetic, address, `contains`, pattern matching, the `with` block, and a greatest-hits idiom list.
+
+---
+
+## Comparison operators
+
+UserTalk supports both **symbol** and **word** forms. They compile identically. UserLand convention is the symbol forms.
+
+| Symbol | Word | Meaning |
+|---|---|---|
+| `==` | `equals` | Equal |
+| `!=` | `notEquals` | Not equal |
+| `<` | `lessThan` | Less than |
+| `<=` | `lessThanOrEqual` | Less than or equal |
+| `>` | `greaterThan` | Greater than |
+| `>=` | `greaterThanOrEqual` | Greater than or equal |
+
+```
+if examples.count == 0 {...}                   // ✓ idiomatic
+if examples.count equals 0 {...}               // compiles, non-idiomatic
+```
+
+There is **no `===`** (no JavaScript-style strict-equality). UserTalk will coerce across types for cross-type comparison — exactly which coercions happen is not well-specified at the language level. When the two operands might be different types and the answer matters, `typeof ()` both sides first:
+
+```
+if typeof (a) == typeof (b) && a == b {...}    // explicit type-then-value check
+```
+
+A common burndown trap: comparing a numeric `1` against a stringified `"1"` from protocol JSON. Add explicit `string ()` or `number ()` coercion when crossing the protocol boundary.
+
+### Equality on tables, records, lists, addresses
+
+- **Tables**: `==` on two table values is rarely meaningful — most table comparisons should compare addresses (`@a == @b`) or contents (walk both).
+- **Addresses**: `@x == @y` is path-string equality, NOT "do these resolve to the same object."
+- **Records and lists**: `==` is a value comparison; member-by-member equality.
+
+If you need deep-equal semantics, write a helper. The built-in `==` doesn't try hard.
+
+---
+
+## Logical operators
+
+Same symbol/word duality as comparisons:
+
+| Symbol | Word |
+|---|---|
+| `&&` | `and` |
+| `\|\|` | `or` |
+| `!` | `not` |
+
+```
+if defined (@examples.foo) && examples.foo > 0 {...}
+if !found {...}
+```
+
+Short-circuit evaluation works as you'd expect — `&&` stops on the first false, `||` stops on the first true. This means `defined (@x) && x^ > 0` is safe when `x^` would error on a missing target.
+
+---
+
+## Arithmetic operators
+
+| Op | Meaning |
+|---|---|
+| `+` | Add (numeric) or concat (string) — see below |
+| `-` | Subtract / negate |
+| `*` | Multiply |
+| `/` | Divide |
+| `%` | Modulo |
+| `^` | Power (when applied to two numbers — NOT to be confused with the address-dereference suffix) |
+| `++` | Pre/post increment on a numeric variable |
+| `--` | Pre/post decrement on a numeric variable |
+
+### `+` is context-sensitive
+
+- `number + number` → numeric addition
+- `string + anything` → concatenation (the right operand is coerced to a string)
+- `anything + string` → concatenation
+
+There is **no `&` operator** for concatenation (that's AppleScript / VBScript / SQL). Use `+`:
+
+```
+local (s = "hello, " + userName + "!");        // ✓
+local (s = "count = " + examples.count);       // ✓ — examples.count gets stringified
+```
+
+If both operands are numeric but you wanted concatenation, force a string first:
+
+```
+local (s = string (a) + string (b))            // ✓ "12" + "34" = "1234"
+local (n = a + b)                              // ✗ this is 12 + 34 = 46
+```
+
+### `^` is ambiguous between power and dereference — context disambiguates
+
+`a ^ b` between two numeric expressions is power. `adr^` as a postfix on an address is dereference. The parser distinguishes by position; you almost never see real ambiguity. If a script is doing math on a value also used as an address, name those variables clearly.
+
+---
+
+## Address operators
+
+The two operators that define UserTalk's relationship to the ODB.
+
+### `@` — address-of
+
+`@x.y.z` produces an `addressType` value naming the path `x.y.z`. It does NOT resolve the path. The address is well-formed as long as the **parent path** exists:
+
+```
+local (adr1 = @examples.foo)                   // ✓ — address value; defined whether examples.foo exists or not
+local (adr2 = @examples.foo.bar)               // ✓ if examples.foo is a table (parent path resolves)
+local (adr3 = @nonexistent.thing.leaf)         // address value, but defined (adr3) is false
+```
+
+See `CLAUDE_PRIMER.md` § 2.2 and `records_and_tables.md` for the full `defined ()` semantics.
+
+### `^` — dereference
+
+`adr^` resolves the address and produces the value at that location. Runtime error if no object exists there:
+
+```
+local (val = adr^)                             // value at adr — errors if missing
+```
+
+Wrap in `try { ... }` if the target might not exist, or check `defined (adr^)` first.
+
+### Common use cases
+
+| Pattern | Why |
+|---|---|
+| `dialog.ask ("?", @result)` | Output parameter — verb writes back through the address |
+| `local (adrThing = @examples.bar)` | Hold a reference for repeated dereference (cheaper than re-resolving) |
+| `verb (@bigTable)` | Pass by address instead of copying the table value |
+| `for adrM in @t {...}` | Table iteration — visitor is the address of each member |
+
+---
+
+## The `contains` operator (and friends)
+
+`contains`, `beginsWith`, `endsWith` are **infix string operators**. There is **no `string.contains` verb**.
+
+```
+if userInput contains "yes" {...}              // ✓
+if filename endsWith ".ut" {...}               // ✓
+if path beginsWith "/Users/" {...}             // ✓
+```
+
+NOT:
+
+```
+if string.contains (userInput, "yes") {...}    // ✗ no such verb
+```
+
+These are plain substring tests — no wildcards, no regex. For wildcards, see `string.patternMatch` below.
+
+`contains` also works on lists and (sometimes) records — it tests for value membership, not substring. Confirm with `typeof ()` first if you're not sure what you're holding.
+
+---
+
+## Pattern matching
+
+`string.patternMatch (pattern, source)` does wildcard matching:
+
+- `*` matches any sequence of characters (zero or more)
+- `?` matches a single character
+
+```
+local (pos = string.patternMatch ("*.ut", "foo.ut"))      // pos == 1 (matched at position 1)
+local (pos = string.patternMatch ("foo*", "foobar"))      // pos == 1
+local (pos = string.patternMatch ("*bar", "foobar"))      // pos == 4
+local (pos = string.patternMatch ("xyz", "foobar"))       // pos == 0 (no match)
+```
+
+**The return is a 1-based position, NOT a boolean.** Zero means no match; anything else is the position. Don't write `if string.patternMatch (...)` and expect Python-style truthiness — write `if string.patternMatch (...) > 0`.
+
+For simple substring checks (no wildcards), use `contains`, which is cheaper and clearer.
+
+---
+
+## Assignment vs equality
+
+`=` is **assignment** in statement position. `==` is **equality**. UserTalk does not have BASIC-style "single `=` is equality in expressions." Always:
+
+```
+x = 5                                          // assignment
+if x == 5 {...}                                // equality test
+```
+
+Mixing these up usually gives a compile error rather than a silent bug, because `=` in an `if` condition is a syntax error — but be deliberate.
+
+---
+
+## The `with` block
+
+`with path.to.table { ... }` brings all top-level members of the table into local scope inside the block:
+
+```
+with examples.colors {
+    local (val = red);                         // reads examples.colors.red
+    log (green)}                               // reads examples.colors.green
+```
+
+Useful for reading several members of the same table without repeating the prefix.
+
+### Risks
+
+**Shadowing.** Inside the block, names from the table shadow your outer locals:
+
+```
+local (x = "outer");
+with examples.colors {
+    x = "blue"}                                // if examples.colors.x exists, this writes to examples.colors.x
+                                                // — NOT to your local x
+log (x)                                        // your local x is still "outer"
+```
+
+If you have a `with` over a table you didn't fully audit, you might be writing to ODB members instead of locals. Use a different variable name in the outer scope, or avoid `with` over tables with unknown contents.
+
+**The catastrophic anti-pattern**: `with` over a system table followed by `delete`:
+
+```
+with clock {delete (@now)}                     // ✗ deletes system.verbs.builtins.clock.now
+                                                // — a glue script in the system root
+```
+
+`@now` inside the `with` resolves under `clock`, not at the top level. This has historically corrupted Frontier installs. Don't `delete` inside a `with` unless you've manually expanded the path and you're sure.
+
+**Protocol-mode interaction.** Every `script:` block in protocol-mode yaml tests is wrapped in `with system.temp.FrontierREPL.variables { ... }`. Your script's top-level `local`s become members of that table, with all the shadowing risks above. This is the source of issue #624 (P0). Full details: `testing_patterns.md`.
+
+---
+
+## The `;` separator
+
+`;` separates statements at the same outline level. It's how you put multiple statements on one logical line:
+
+```
+local (x = 1); local (y = 2); return x + y
+```
+
+In outline-stored scripts, the outline indentation also encodes block structure — but the stringified form uses `;` AND `{` / `}` to encode the same structure for the compiler. When you write inline UserTalk in a yaml `script:` block, you're writing the **stringified** form, so use `;` and `{` / `}` explicitly.
+
+This matters for the `with`-wrapper trap (#624): `local (x = 1)\rreturn x` does NOT survive the wrapper, because the wrapper drops scope across `\r`. Use `;` to keep statements glued: `local (x = 1); return x`.
+
+---
+
+## `nameOf`, `typeof`, `sizeOf`, `string`
+
+These four inspection verbs all operate on **values**, not addresses. When you hold an address, dereference first with `^`:
+
+| Verb | What it returns | On an address (no `^`) |
+|---|---|---|
+| `nameOf (adr^)` | The member name in its parent table | `nameOf (adr)` returns the local variable name — usually not what you want |
+| `typeof (val)` | OSType code (e.g. `'TEXT'`, `'tabl'`, `'reco'`, `'list'`, `'addr'`) | `typeof (@x)` always returns `'addr'` (the value's type IS address) |
+| `sizeOf (val)` | Member/character count | Doesn't really apply — sizeOf on an address value is meaningless |
+| `string (val)` | Stringified value (script source, number-as-text, etc.) | `string (@x.y)` returns the dotted path `"@x.y"` — NOT the value at that path |
+
+The `string (val)` vs `string (@addr)` distinction is the most common slip — see `CLAUDE_PRIMER.md` § 2.3.
+
+`typeof ()` returns an OSType (`'TEXT'`), **not a descriptive string** (`"string"`). Compare with the matching `*Type` constant from `system.compiler.language.constants`, or against a literal OSType:
+
+```
+if typeof (val) == stringType {...}            // ✓ stringType is the constant 'TEXT'
+if typeof (val) == 'TEXT' {...}                // ✓ also works
+if typeof (val) == "string" {...}              // ✗ always false — RHS is a multi-char string, not an OSType
+```
+
+---
+
+## Idioms (greatest hits)
+
+Ten one-liners (or near one-liners) that show off idiomatic UserTalk. Most of these solve "I want to be safe about something that might not exist" or "I want a quick walk of a structure."
+
+```
+// 1. Conditional assignment with default — when defined-or-default matters
+if defined (@examples.foo) {local (val = examples.foo)} else {local (val = "default")}
+
+// 2. Safe member read via try
+try {local (val = examples.foo.bar)} else {local (val = "missing")}
+
+// 3. Count members matching a predicate
+local (n = 0); for adrM in @examples.things {if adrM^ contains "match" {n = n + 1}}; return n
+
+// 4. Build a comma-joined string of member names
+local (s = ""); for adrM in @examples.t {s = s + nameOf (adrM^) + ", "}; return s
+
+// 5. Test a verb is callable before calling
+if defined (@system.verbs.builtins.string.upper) {return string.upper ("hi")}
+
+// 6. Sum a list of numbers
+local (total = 0); for n in {1, 2, 3, 4} {total = total + n}; return total
+
+// 7. Find first member whose value equals X
+local (adrFound = nil); for adrM in @examples.t {if adrM^ == "X" {adrFound = adrM; break}}; return adrFound
+
+// 8. Stringify a typeof for human-readable logging (OSType → text)
+local (t = typeof (val)); if t == stringType {return "string"} else {if t == tableType {return "table"} else {return "other"}}
+
+// 9. Create-if-missing pattern for a sub-table
+if !defined (examples.thing) {new (tableType, @examples.thing)}
+
+// 10. Compare by name across two tables — assumes ordered iteration
+local (ok = true); for adrM in @examples.t1 {if !defined (examples.t2.[nameOf (adrM^)]) {ok = false; break}}; return ok
+```
+
+**On idiom 7**: `break` exits the innermost loop. UserTalk also has `continue` (skip to next iteration). Both work in `for` and `loop`.
+
+**On idiom 8**: a `case` statement reads better than nested `if`/`else`. Used here to keep the example to one line.
+
+**On idiom 9**: `new (tableType, @path)` creates the table at `@path`. The parent (`examples`) must exist; this verb does NOT create intermediate parent tables.
+
+**On idiom 10**: this is technically a name-presence comparison, not a deep equality. Real "structures equal?" needs a recursive walk.
+
+---
+
+## See also
+
+- `CLAUDE_PRIMER.md` — load first. Section 2 covers the five idioms you'll write most often
+- `records_and_tables.md` — when you need the full picture on tables vs records vs lists vs addresses, and on iteration patterns
+- `strings_and_text.md` — string-specific operators, Pascal-string vs `Handle` truncation, escaping rules (stub at time of writing)
+- `testing_patterns.md` — the protocol-mode `with`-wrapper trap (#624) and yaml integration test constraints
+- `debugging_workflow.md` — when an operator behaves unexpectedly and you want to step through it

--- a/docs/usertalk/records_and_tables.md
+++ b/docs/usertalk/records_and_tables.md
@@ -1,0 +1,284 @@
+# Records, Tables, Lists, and Addresses
+
+Pulled in when: you hit `Can't find a sub-table named X`, you need to walk an unknown structure, or you're not sure what a verb returns.
+
+This is the doc that disambiguates the four container/reference types and the access syntax for each. The primer's "five idioms" section is the fast-path; this is the full picture.
+
+---
+
+## Type taxonomy
+
+All UserTalk types are defined in `system.compiler.language.constants` as `string4` (4-byte OSType) scalars whose names end in `Type`. The four shapes you'll touch most:
+
+| Constant | OSType | Shape | When you'll see it |
+|---|---|---|---|
+| `tableType` | `'tabl'` | Named-member container, dotted-name access, may be persisted in ODB | The workhorse. `system.*`, `workspace.*`, anything in `.root` files |
+| `recordType` | `'reco'` | Insertion-ordered, ordinal-access, no dotted-name read | Rare. Returned by some verbs that emit ordered key/value sequences |
+| `listType` | `'list'` | Positional array, value-iteration | Function args (sometimes), parsed sequences |
+| `addressType` | `'addr'` | Reference to a location in the ODB | Output parameters, "address of" via `@`, dereference with `^` |
+
+You can always check at runtime with `typeof (value)` — but be aware that **the protocol JSON serialization** maps OSType codes to strings, so `result_type` in protocol replies shows up as `"unknown"` for `'reco'` and `'tabl'`, with the OSType in `result.value`.
+
+---
+
+## Tables (`tableType`)
+
+The default container in UserTalk. Most of `system.*` and all of `workspace.*` are tables.
+
+### Literal & creation
+
+Tables don't have a literal syntax — you create one with `new ()`:
+
+```
+new (tableType, @examples.myTable);
+examples.myTable.alpha = 1;
+examples.myTable.beta = "two"}
+```
+
+Members are added by simple assignment to a previously nonexistent path.
+
+### Member access
+
+Dotted-name addressing is the normal path:
+
+```
+examples.myTable.alpha           // ✓ read by name
+examples.myTable.alpha = 99      // ✓ write by name
+```
+
+When the name is dynamic, comes from a variable, or shadows a global/keyword, use bracket form:
+
+```
+local (n = "alpha");
+local (val = examples.myTable.[n])         // ✓ dynamic name from variable
+local (typVal = constants.["stringType"])     // ✓ bracket form to avoid global collision
+```
+
+### Uniqueness
+
+Member names **must be unique** within a table. (Exception: tables holding XML representations have special name-collision handling — see `usertalk-engineer.md` if you're touching XML.)
+
+### Iteration
+
+Two canonical patterns, situationally chosen:
+
+```
+// Pattern 1: single-layer walk. Visitor is the ADDRESS of each member.
+for adrMember in @examples.myTable {
+    local (val = adrMember^);                  // dereference for value
+    local (name = nameOf (adrMember^));        // member name (NOT nameOf(adrMember))
+    log (name + " = " + val)}
+
+// Pattern 2: index walk. Useful for tree-walking or when you need the position.
+for i = 1 to sizeOf (examples.myTable) {
+    local (adrSubitem = @examples.myTable[i]);
+    ...}
+```
+
+**Critical**: in pattern 1, the iteration target is the **address** of the table (`@examples.myTable`), not the table value (`examples.myTable`). Passing the value gives you `This operation is not supported for table values.`
+
+**Why `nameOf (adrMember^)` and not `nameOf (adrMember)`**: inside the loop, `adrMember` is the local variable holding an address. `nameOf (adrMember)` returns the local variable's name (the string `"adrMember"`). `nameOf (adrMember^)` dereferences first and returns the name of the **member** in the parent table.
+
+### Sort order — headless ≠ legacy Mac
+
+Legacy Mac Frontier: tables auto-sort alphabetically by member name unless a script explicitly sets a non-alpha sort order. Sort order is per-table, per-thread.
+
+Headless build: tables iterate in **insertion order**. No alpha-sort applied.
+
+**Implication**: integration tests that depend on iteration order may pass in headless and fail in production Mac (or vice versa). When iteration order matters for a test, either sort explicitly or assert on a sorted form.
+
+### Polymorphic members
+
+Table members can be any UserTalk type — strings, numbers, scripts, outlines, nested tables, records, addresses, anything. Don't assume member values are scalars when walking unknown structure; `typeof (adrMember^)` to be sure.
+
+---
+
+## Records (`recordType`)
+
+The "I want preserved insertion order" container. Used infrequently — tables are the default.
+
+### Literal & creation
+
+```
+local (r = {"key1": "value1", "key2": "value2"})       // ✓ curly braces, colon-separated
+new (recordType, @examples.myRecord)                 // ✓ programmatic creation
+```
+
+**Curly braces**, not square brackets. Square brackets aren't a UserTalk syntax at all. (The agent definition's earlier `["k": "v"]` notation is incorrect.)
+
+### Member access — the gotcha
+
+**Records have no dotted-name access.** `r.key1` does NOT read the value named `"key1"`. There is no syntax for "get record member by name." Access is ordinal-only, via iteration:
+
+```
+for x in r {
+    log (x)}                                  // x is set to each VALUE in insertion order
+```
+
+The visitor is the **value** (not an address). Order is **preserved** from how the record was constructed.
+
+If you need name-keyed access, **don't use records — use tables**.
+
+### Insertion order
+
+Records preserve the order in which members were added. Iteration follows that order:
+
+```
+local (r = {"zebra": 1, "apple": 2, "middle": 3});
+for x in r {log (x)}                          // logs: 1, 2, 3 (insertion order)
+```
+
+### Mutation — the second gotcha
+
+Records are mutable (in the UserTalk sense — you can change them), but **you cannot assign a record member by name**. There's no `r.key = value` syntax that works on records.
+
+To add a member, use the `+` operator:
+
+```
+r = r + {"newKey": "newValue"}                // ✓ adds member
+```
+
+`+` also merges two records.
+
+**Name-collision behavior of `+` (quirky)**:
+
+```
+local (r = {"a": 1});
+r = r + {"a": 99};                             // SILENT NO-OP — r still has "a" = 1
+```
+
+Adding a member whose name already exists is a **silent no-op**: size doesn't change, value doesn't update. This appears to be both legacy Mac and headless behavior. Likely a historical bug that was never caught because records were rarely used in production at UserLand.
+
+**If you need to update an existing key**, you cannot do it with records. Convert to a table or recreate the record from scratch.
+
+### Duplicate-name literals — unspecified
+
+In headless, `{"a": 1, "a": 2}` creates a record with **two members both named `"a"`** (size 2, iterates both values). On legacy Mac, names "must be" unique. This is divergent and unspecified; don't rely on it.
+
+### Polymorphic members
+
+Like tables and lists: any UserTalk type in any slot.
+
+### When to use a record vs a table
+
+Pick record when:
+- You need members in **insertion order** (no alpha-sort, no thread-local sort state)
+- You're mirroring an external ordered key/value structure (JSON-ish input, ordered headers)
+
+Pick table when:
+- You need to read/update by name (the common case)
+- You're persisting to the ODB
+- You need name-uniqueness enforcement (somewhat)
+
+When in doubt, use a table.
+
+---
+
+## Lists / arrays (`listType`)
+
+Positional array. The third container type.
+
+### Literal & creation
+
+```
+local (xs = {1, 2, 3});                       // ✓ curly braces, comma-separated
+local (mixed = {"a", 42, true, @workspace});  // ✓ mixed types fine
+```
+
+Same curly-brace syntax as records, but no `key:` prefix — bare values separated by commas.
+
+The parser distinguishes record from list by whether literals have `"key":` prefix on each element.
+
+### Iteration
+
+```
+for x in xs {
+    log (x)}                                   // x is the VALUE in order
+```
+
+The visitor is the **value** (not an address, unlike table iteration). Order is positional.
+
+### Index access
+
+Lists are 1-indexed for `sizeOf` and the index form, similar to tables. (The agent definition's claim of 0-indexed lists may not match current headless behavior — verify before relying on indexing.)
+
+### Polymorphic members
+
+Same as records and tables: any type, any slot.
+
+---
+
+## Addresses (`addressType`)
+
+A reference to a location in the ODB, not the value at that location.
+
+### Creating an address
+
+```
+local (adr = @examples.foo.bar);                // address-of operator
+local (adr2 = @examples.myTable.alpha);
+```
+
+`@x.y.z` builds an address value naming `x.y.z`. **It does not resolve the path.** The address is well-formed even if `x.y.z` doesn't exist.
+
+### Dereferencing
+
+```
+local (val = adr^);                            // get the value at this address
+```
+
+If the address doesn't point to anything, `adr^` errors at runtime — `Can't evaluate the expression because the name X hasn't been defined.`
+
+### `defined` on addresses — what it really means
+
+`defined ()` checks **address validity**, not target presence. An address is valid if either (1) it points to a real object, OR (2) the parent path exists, making the address a creatable location.
+
+```
+defined (@examples.foo)              // true if examples.foo points to a real object
+defined (@examples.notYetCreated)    // true if examples exists — even if .notYetCreated doesn't
+defined (@bogus.parent.leaf)         // false — parent path doesn't resolve
+defined (examples.foo.bar)           // ✓ resolves path; runtime error if missing — wrap in try{...}
+defined (adr^)                       // ✓ dereferences; true iff a real object lives there now
+```
+
+When you want "is there actually something here right now?" use `defined (adr^)`. When you want "is it OK to write to this address?" use `defined (@adr)`. See issue #625 for the docs-clarification follow-up.
+
+### What's at the end of an address?
+
+When `adr = @examples.foo.bar`:
+- `system` and `foo` are **always tables** (they have sub-paths through them)
+- `bar` can be **any UserTalk type** — table, record, list, string, number, script, outline, etc.
+
+Always `typeof (adr^)` before assuming what kind of value you're holding.
+
+### Why verbs take addresses
+
+Output parameters: a verb that writes back to its caller's variable takes the variable's address:
+
+```
+local (result);
+dialog.ask ("What's your name?", @result);   // verb writes "Jake" into result
+log (result)
+```
+
+This is also how some verbs avoid copying large values — they take the address of the source and operate in place.
+
+---
+
+## Quick reference: which form for which type?
+
+| You have… | Type | Read named member | Iterate |
+|---|---|---|---|
+| A table at `@t` | `tableType` | `t.name` or `t.[var]` | `for adrM in @t { adrM^ }` |
+| A record value `r` | `recordType` | **not possible by name** | `for x in r { ... }` (x is value) |
+| A list value `xs` | `listType` | `xs[i]` | `for x in xs { ... }` (x is value) |
+| An address `adr` | `addressType` | `adr^` then continue | `adr^` to get the value, then iterate per its type |
+
+---
+
+## See also
+
+- `CLAUDE_PRIMER.md` — the entry-point primer; Section 2 covers the table/list iteration idioms at a glance
+- `values_and_types.md` — full type taxonomy reference (stub; expand as topics come up)
+- `usertalk-engineer.md` (agent def) — comprehensive language reference loaded by the sub-agent; **note**: the records section there has errors (square-bracket literal syntax) being corrected
+- `feedback_usertalk_comments.md` (in memory) — `«…»` parse errors in yaml tests

--- a/docs/usertalk/scripts_vs_handlers.md
+++ b/docs/usertalk/scripts_vs_handlers.md
@@ -1,0 +1,37 @@
+# Scripts vs Handlers
+
+Stub. The "what's the difference between a script with top-level statements and a script with `on foo ()` handlers?" reference. Flesh out as questions arise.
+
+---
+
+## Status
+
+**STUB — TODO**. Adjacent content lives in:
+
+- `CLAUDE_PRIMER.md` § 1 (the "verb dispatch through the ODB" mental-model row)
+- `verb_invocation_patterns.md` — glue scripts as the "verbs are scripts at an ODB path" story
+- `operators_and_idioms.md` — `with` block scoping
+- `../ODB_SCRIPT_EDITING.md` — installing scripts via `script.newScriptObject`
+- Agent def `usertalk-engineer.md` — execution model, scope precedence
+
+## TODO topics
+
+- `on foo (a, b) { … }` syntax — declaring a named handler
+- Top-level statements outside any `on` — evaluated when the script runs (used in `system.startup.startupScript` etc.)
+- Calling a script via address: `adrScript^ (args)` — auto-load, auto-compile, auto-invoke the first handler
+- Multiple handlers in one script — visibility rules between handlers in the same script
+- Comment-line markers (`«`, `//`) and `flcomment=true` outline attribute
+- The dated-change-comment convention (newest first, indented under eponymous handler)
+- Script vs verb vs handler — vocabulary disambiguation
+- Late-binding verb resolution (compiles clean, fails at dispatch — see `testing_patterns.md` for the testing implications)
+- Persistent globals (`global (foo)`, `persistent (bar)`) — when to use, ODB storage
+- `local (x = initialValue)` initialization patterns
+
+---
+
+## See also
+
+- `CLAUDE_PRIMER.md`
+- `verb_invocation_patterns.md`
+- `../ODB_SCRIPT_EDITING.md`
+- `testing_patterns.md` — handler-needs-end-to-end-execution section

--- a/docs/usertalk/strings_and_text.md
+++ b/docs/usertalk/strings_and_text.md
@@ -1,0 +1,234 @@
+# Strings and Text in UserTalk
+
+Load this when a string is getting truncated, an escape isn't doing what you expect, encoding is mangling things, or you're staring at "Cant coerce the string X to a character" and need to know what shape the verb really wants.
+
+Cross-references for things this file deliberately doesn't repeat:
+
+- `CLAUDE_PRIMER.md` — entry point and quoting basics
+- `operators_and_idioms.md` — `+` for concat, `contains` / `beginsWith` / `endsWith`
+- `../ODB_SCRIPT_EDITING.md` — `string.trimWhiteSpace` requirement before installing, `PSTRING` vs `BIGSTRING` in C kernel
+- `../TESTING_GUIDE.md` — single-quote vs double-quote error patterns
+
+---
+
+## 1. Two string representations
+
+UserTalk has two string flavors that look identical at the script level but behave differently at the boundary with C:
+
+1. **Pascal string** (`PSTRING`) — a 1-byte length prefix followed by up to **255 content bytes**. This is the dominant form for short strings, function parameters, and many verb returns. Max content length: **255**. Length 256 is unrepresentable in this form.
+
+2. **`Handle`** (sometimes called `bigstring` in older kernel contexts) — heap-allocated, arbitrary-length. Used for script bodies, file contents, large WP text bodies, anything that obviously can't fit in 255 bytes.
+
+The runtime sometimes converts between these silently. The boundary cases are where bugs hide: a script-level value that's been a `Handle` all along can be passed to a verb that internally re-marshals it as a `PSTRING`, and you lose bytes 256+ with no error.
+
+You cannot directly inspect which form a value currently holds from script — `typeof (s)` is `'TEXT'` for both. The distinction only matters when something truncates or when reading kernel source.
+
+---
+
+## 2. The 255-byte truncation landmine
+
+Many verbs that take a string parameter marshal it through the Pascal-string form. If your content exceeds 255 bytes, it gets **silently truncated** — no error, no log line, just shorter output. Related historical bugs: PRs #580, #481.
+
+The pattern that bites:
+
+```
+local (s = "");
+for adrM in @examples.bigTable {
+    s = s + adrM^ + "\r"};
+someVerb (s)                                  // s is 1200 bytes; verb sees 255
+```
+
+The string built fine. Concatenation in UserTalk produces a `Handle`-backed value once it outgrows 255. The truncation only happens when the verb on the receiving side coerces back to `PSTRING`.
+
+### How to defend
+
+- **Check `sizeOf (s)` before passing to a verb you don't trust:**
+
+    ```
+    if sizeOf (s) > 255 {
+        scriptError ("too long for someVerb: " + sizeOf (s) + " bytes")}
+    ```
+
+- **Use file I/O for long content.** Round-trip through disk is awkward but reliable:
+
+    ```
+    file.writeWholeFile ("/tmp/buf.txt", s);
+    local (back = file.readWholeFile ("/tmp/buf.txt"))
+    ```
+
+- **In C kernel code: prefer `Handle` over `PSTRING`** for verbs that may receive long strings. See `../ODB_SCRIPT_EDITING.md` for the `PSTRING` vs `BIGSTRING` rule and the compile-time length validation discipline.
+
+If you're chasing a bug where a verb's output is exactly 255 bytes long, this is almost certainly what happened.
+
+---
+
+## 3. String literal forms
+
+Three quote forms exist. Two are useful; one is a trap.
+
+### 3.1 Double-quote — the only safe form
+
+```
+"hello"                                       // ASCII, the default
+"line one\rline two"                          // embedded CR
+"quote: \" inside"                            // escaped quote
+```
+
+This is the only literal form that's safe across all contexts including yaml integration tests. When in doubt, use double quotes.
+
+### 3.2 Single-quote — character constant OR OSType, never a string
+
+Single quotes do **not** make a string. They make either a 1-character constant or a 4-byte OSType code:
+
+```
+'X'                                           // 1-character constant
+'TEXT'                                        // 4-byte OSType (a `long` literal: 0x54455854)
+'hello'                                       // SYNTAX ERROR — neither 1 nor 4 chars
+```
+
+Common mistake:
+
+```
+string.upper ('hello')                        // ✗ 'hello' is 5 chars — syntax error
+string.upper ("hello")                        // ✓
+```
+
+The error message is `Character constant isnt correctly specified. Must be of the form 'c'.` — confusing if you were trying to write a string.
+
+`typeof` returns are OSTypes: `'TEXT'`, `'tabl'`, `'reco'`, `'list'`, `'long'`, `'bool'`. The protocol layer JSON-serializes these as 4-char strings, so in yaml expectations you write `"TEXT"`, not `stringType`.
+
+### 3.3 Guillemets `«…»` — legacy MacRoman quote form
+
+```
+«hello»                                       // works in .ut files; AVOID in yaml script: blocks
+```
+
+The bytes are MacRoman 0xC7 / 0xC8. They render as French-style double quotes. They function as a string literal in `.ut` files and the outline editor, but yaml's byte handling can mangle them in `script:` blocks. The same characters double as the **legacy comment delimiters** (`«this is a comment»`), so the meaning depends on parser state.
+
+Rule of thumb: never type guillemets into a yaml `script:` block. In `.ut` files they're fine, but `"..."` is cleaner.
+
+---
+
+## 4. Escape sequences
+
+Inside double-quoted strings:
+
+| Escape | Meaning |
+|---|---|
+| `\"` | literal double quote |
+| `\\` | backslash |
+| `\r` | CR (0x0D) — UserTalk's canonical line terminator |
+| `\n` | LF (0x0A) — see "Line endings" below |
+| `\t` | tab (0x09) |
+| `\xNN` | hex byte |
+
+`\r` is the one you reach for most — line breaks in script source and multi-line string output are CR-terminated.
+
+---
+
+## 5. Line endings: `\r` is canonical
+
+UserTalk's canonical line terminator is **CR** (`\r`, 0x0D), inherited from classic Mac. Scripts in the ODB are stored with CR. Multi-line string literals embed `\r` between lines. When you `return` a string with multiple lines and read it back through the protocol, the separator is `\r`.
+
+LF (`\n`) has historically been illegal in script source. The parser was relaxed in **#586** to treat bare LF as a line terminator inside `//` comments and as whitespace elsewhere — that change targets script source where the file got Unix-translated, not full escape-sequence equivalence with `\r`. Treat `\n` as parser-tolerated rather than first-class. Specifically:
+
+- Don't rely on `\n` inside a string literal to behave identically to `\r` everywhere downstream — some verbs walk the string looking for CR explicitly.
+- Don't mix CR and LF in the same source — pick one. The outline editor stores CR; if you import from Unix tooling, normalize before installing.
+- yaml `script:` block scalars (`|`) deliver LF line breaks to the protocol layer. This currently works because the protocol/parser path normalizes; do not take this as a guarantee that LF is interchangeable with CR at every layer.
+
+`script.newScriptObject ()` normalizes line endings (CRLF → CR, LF → CR) when installing scripts. Use it instead of raw `op.insert` so you don't store mixed terminators in the ODB.
+
+(Judgment call: the exact #586 boundary on `\n`-in-string-literals isn't documented in the PR title, only the parser side. If you hit a case where `\n` in a literal misbehaves, treat it as a probe item, not a doc bug.)
+
+---
+
+## 6. Most-used `string.*` verbs
+
+Quick reference. Full signatures in `docserver/`.
+
+| Verb | Returns | Notes |
+|---|---|---|
+| `string.length (s)` | char count | same as `sizeOf (s)` for strings |
+| `string.upper (s)` | string | ASCII case conversion |
+| `string.lower (s)` | string | ASCII case conversion |
+| `string.trimWhiteSpace (s)` | string | leading/trailing whitespace removed |
+| `string.patternMatch (pattern, s)` | long | wildcards `*` and `?`; returns 1-based match position, 0 = no match |
+| `string.replaceAll (s, find, replace)` | string | all occurrences |
+| `string.nthCharacter (s, n)` | char | 1-indexed |
+| `string.nthField (s, delimiter, n)` | string | split on delimiter, return nth (1-indexed) |
+| `string.countFields (s, delimiter)` | long | number of fields |
+| `string.padWithSpaces (s, width)` | string | right-pad to width |
+| `string.lowerWord (s)` | string | lowercase first word |
+| `string.upperFirstLetter (s)` | string | capitalize initial |
+
+`string.trimWhiteSpace (s)` is **required** before installing script source — trailing whitespace breaks compile. See `../ODB_SCRIPT_EDITING.md` for the install discipline.
+
+The infix operators `contains`, `beginsWith`, `endsWith` work on strings directly — no verb needed. See `operators_and_idioms.md`.
+
+---
+
+## 7. Common string-building idiom
+
+```
+local (s = "");
+for adrM in @examples.colors {
+    s = s + nameOf (adrM^) + ": " + adrM^ + "\r"};
+return s
+```
+
+Notes:
+
+- `nameOf (adrM^)` gives the **member name** (e.g. `"red"`). `nameOf (adrM)` would give `"adrM"` — almost never what you want.
+- `+` is overloaded for string concat. The right-hand side is coerced to string if it isn't already.
+- The accumulator outgrows `PSTRING` once you cross 255 bytes. Returning it through the protocol is fine; passing it to a length-sensitive verb is not. See section 2.
+
+For long output, either:
+
+- write to a file and return the path, or
+- split into segments and return a list / record, or
+- store under `system.temp.*` and have the caller read it back.
+
+---
+
+## 8. Encoding gotchas
+
+- UserTalk historically used **MacRoman**. The modern headless build uses UTF-8 in most contexts, but the encoding model is not always explicit at the boundary — verbs may or may not preserve high-bit bytes faithfully.
+- `«` (0xC7) and `»` (0xC8) are MacRoman characters that render as French-style double quotes. They double as both string-literal delimiters and the legacy comment form.
+- Em-dash, smart quotes, and other non-ASCII characters may be rejected as `illegal character` by some scanner paths — particularly older glue scripts. If a paste from a word processor breaks compile, suspect smart-quoted text or em-dash.
+- LF (`\n`) was historically illegal in script source; relaxed in #586 but not uniformly across all parser paths (see section 5).
+
+When in doubt: stick to ASCII in inline script bodies. For content that needs broader encoding, write to a file with `file.writeWholeFile ()` and read back with `file.readWholeFile ()` — those paths preserve bytes.
+
+---
+
+## 9. Inspection patterns
+
+```
+typeof (s)                                    // 'TEXT' for both PSTRING and Handle forms
+sizeOf (s)                                    // byte count — use this to check the 255 boundary
+string.length (s)                             // char count (same as sizeOf for ASCII)
+string (val)                                  // stringify a value (NOT an address)
+```
+
+Watch out for the address-vs-value trap from the primer: `string (val)` operates on the value. If you have an address, dereference: `string (adr^)`. `string (@some.path)` returns the literal string `"@some.path"`, not the value at that path.
+
+---
+
+## 10. Failure-mode quick decoder
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Character constant isnt correctly specified. Must be of the form 'c'.` | Used `'foo'` for a string | `"foo"` |
+| `Cant coerce the string X to a character.` | Passed multi-char string to verb expecting `char` | `'X'` for a real char constant, or use the 1-char string form the verb expects |
+| Output exactly 255 bytes long | `PSTRING` truncation at a verb boundary | Section 2 — file I/O or splitting |
+| `illegal character` on paste | Smart quotes, em-dash, or other non-ASCII bytes | Normalize to ASCII |
+| Compile fails on script with trailing whitespace | Missing `string.trimWhiteSpace` before install | Add the trim — `../ODB_SCRIPT_EDITING.md` |
+| String concat returns wrong type | Right-hand side is a non-stringifiable value (table address, etc.) | `string (val)` it first; dereference any addresses |
+
+---
+
+## 11. When to escalate
+
+- If you suspect a `PSTRING` truncation in C kernel code, that's a `system-architect` question.
+- If a verb's marshaling is mis-typed (declared `PSTRING` but should be `Handle`), file an issue and tag it as a 255-byte landmine.
+- If `\n` behaves inconsistently across paths, file a probe item — the #586 fix targets parser, not literal-escape semantics, and there may be follow-on work needed.

--- a/docs/usertalk/testing_patterns.md
+++ b/docs/usertalk/testing_patterns.md
@@ -1,0 +1,359 @@
+# YAML Integration Test Patterns
+
+Pulled in when: you're writing or debugging a yaml integration test, doing burndown, or you see a test pass with a wrong-looking result. This is the deep dive that the primer's Section 4 points to.
+
+The framework reference (file layout, runner flags, fixture rules) is `../TESTING_GUIDE.md`. The cross-agent rules (sequential, needs_guest_dbs, system.temp isolation) are in `../AI_SHARED_GUIDELINES.md`. This file is the **UserTalk-author's view of writing scripts that yaml tests will actually run correctly**.
+
+---
+
+## 1. The `with`-wrapper trap (tracked: #624)
+
+Protocol mode is the default test executor. It wraps every `script:` block in:
+
+```
+with system.temp.FrontierREPL.variables {
+    «your script here»}
+```
+
+That outer `with` block is a load-bearing source of subtle failures. Five concrete bites:
+
+### 1.1 Locals don't survive `\r` to a later `return`
+
+A multi-line script that declares a `local` on one line and `return`s it on the next silently returns `true` (the `with` block's status) instead of the intended value:
+
+```yaml
+- name: "local survives same-line"
+  script: 'local (x = 5); return x'
+  expected_success: true
+  expected_result: "5"                  # ✓ passes — x = 5
+
+- name: "local dropped across CR"
+  script: |
+    local (x = 5)
+    return x
+  expected_success: true
+  expected_result: "5"                  # ✗ FAILS — script returns true (boolean)
+```
+
+The `with` block's exit status bubbles up when the locals' scope is lost between statements. Filed as **#624 P0**.
+
+Until #624 is fixed, two workarounds:
+
+- **Same-line + `;`**: collapse `local` and `return` into one logical statement.
+- **`repl_mode: true`**: opt out of the protocol wrapper entirely for this test.
+
+```yaml
+- name: "multi-line OK in repl_mode"
+  repl_mode: true
+  script: |
+    local (x = 5)
+    return x
+  expected_success: true
+  expected_result: "5"                  # ✓ passes
+```
+
+### 1.2 `@addr` output parameters fail inside the wrapper
+
+Verbs that write back via an address argument can't reach the caller's local through the `with` block:
+
+```yaml
+- name: "unixshell capture — broken in protocol mode"
+  script: 'local (stdout); sys.unixShellCommand ("echo hi", @stdout); return stdout'
+  expected_success: true
+  expected_result: "hi\r"                # ✗ FAILS — stdout never written
+
+- name: "unixshell capture — fixed under repl_mode"
+  repl_mode: true
+  script: |
+    local (stdout)
+    sys.unixShellCommand ("echo hi", @stdout)
+    return stdout
+  expected_success: true
+  expected_result: "hi\r"                # ✓ passes
+```
+
+Any verb whose signature includes an `@addr` output parameter is suspect under protocol mode. When in doubt, run it `repl_mode: true`.
+
+### 1.3 `thread.evaluate` doesn't work in the wrapper
+
+Spawned threads run outside the `with` scope, so they can't see `local`s from the wrapped block and the wrapped block can't see what the thread wrote. Use `repl_mode: true` for any test that calls `thread.evaluate` or `thread.spawn`.
+
+### 1.4 Empty-string returns serialize as `null`
+
+A script that returns `""` comes back through the protocol JSON layer as `null`, not `""`. If you're testing a verb that legitimately returns an empty string, expect:
+
+```yaml
+expected_result: "null"                  # not "\"\"" — the protocol drops the empty string
+```
+
+Or — again — `repl_mode: true` to bypass the serialization.
+
+### 1.5 `target.set ()` / `target.clear ()` interference
+
+`with` establishes an implicit target context. Tests that explicitly set or clear the target inside the script may see those operations either masked by the outer `with` or interact with it in ways that depend on call order. If a target-manipulating test gives confusing results, switch to `repl_mode: true` and re-run.
+
+---
+
+## 2. `expected_success` vs `expected_result` — the boolean quoting trap
+
+This bites every burndown session. The two fields look symmetric and are not:
+
+```yaml
+expected_success: true                   # yaml BOOLEAN — matches protocol's success field
+expected_result: "true"                  # yaml STRING — compared to script's stringified return
+```
+
+`expected_result` is compared as a **string** against the protocol's stringification of the script's return value. If yaml parses the value as a non-string and the runner stringifies it inconsistently, the comparison silently fails.
+
+**Always quote `expected_result`.** Concrete forms:
+
+| What the script returns | `expected_result` value |
+|---|---|
+| Boolean `true` | `"true"` |
+| Long `5` | `"5"` |
+| String `"hello"` | `"hello"` |
+| OSType `'TEXT'` (e.g. from `typeof`) | `"TEXT"` |
+| OSType `'tabl'` | `"tabl"` |
+| Address `@x.y` | `"x.y"` |
+| Empty string `""` | `"null"` (see §1.4) |
+
+### The OSType result_type quirk
+
+When a script returns an OSType, the protocol response has `result_type: "unknown"` because JSON has no 4-byte-OSType type. The string form goes in `result.value`. So in tests:
+
+```yaml
+script: 'return typeof ("hello")'
+expected_success: true
+expected_result: "TEXT"                  # not "'TEXT'", not "stringType" — just the 4-byte code as string
+```
+
+Don't try to match `result_type` for OSType returns. Match the stringified `result.value`.
+
+---
+
+## 3. `repl_mode: true` — when and why
+
+Default test executor is protocol mode (`with`-wrapped, one persistent process per worker, NDJSON-multiplexed). `repl_mode: true` opts a single test out of that and runs it as a fresh REPL session: a new process, stdin-fed script, stdout-captured result.
+
+**Set `repl_mode: true` when**:
+
+- The verb takes `@addr` output parameters (§1.2)
+- The script has `local`/`return` on separate lines and you can't collapse to `;` (§1.1)
+- The script involves `thread.evaluate` / `thread.spawn` (§1.3)
+- You're testing `target.set ()` / `target.clear ()` behavior (§1.5)
+- The test depends on a specific empty-string vs null distinction (§1.4)
+
+**Costs**:
+
+- Slower (per-test process spawn vs. shared executor)
+- Doesn't get the protocol debugger's read-only safety net
+- More resource-hungry under parallel test runs
+
+**Convention**: when you set `repl_mode: true`, put a one-line comment in the test `description:` saying why — future-you (or another agent on burndown) will see why this test is special and not "fix" it by removing the flag:
+
+```yaml
+- name: "thread.evaluate completes"
+  description: "repl_mode because thread.evaluate doesn't see with-block locals (#624)"
+  repl_mode: true
+  script: ...
+```
+
+---
+
+## 4. File-level metadata
+
+These go at YAML root, BEFORE the `tests:` array. Each one trades performance for correctness on a specific axis:
+
+```yaml
+needs_guest_dbs: true
+sequential: true
+protocol_mode: false
+tests:
+  - name: ...
+```
+
+### `sequential: true`
+
+File runs in the main process, not a parallel worker. Set when:
+
+- Tests bind a TCP port (only one binder at a time)
+- Tests interact with the REPL's stdin/stdout
+- Tests have process-level side effects that another test in the same file might observe
+
+Cost: the whole file serializes against the rest of the suite. Use sparingly — file-level granularity, so one sequential test forces all tests in that file sequential.
+
+### `needs_guest_dbs: true`
+
+Runner copies sibling `.root` files and `Guest Databases/` into the worker's tmp dir before running. Set when:
+
+- The script calls `fileMenu.open ()` or any verb that resolves paths relative to `Frontier.getFilePath ()`
+- The test opens a database other than the system root
+
+Without this, the worker has no `Guest Databases/` directory and path-resolution falls back to the system root, masking the bug or producing confusing "file not found" errors.
+
+### `protocol_mode: false`
+
+Skip the protocol executor entirely; spawn a new process per test. Set when:
+
+- Tests block waiting for UI input (the protocol executor can't drive a blocking dialog)
+- Tests need fresh process state per case (caches, globals, daemon threads)
+- Tests deliberately exercise startup / shutdown paths
+
+This is heavier than `repl_mode: true` on individual tests because it applies file-wide. Prefer per-test `repl_mode: true` if only some cases need the fresh process.
+
+---
+
+## 5. `system.temp` ONLY — never `workspace`
+
+Test isolation rule. UserTalk has top-level tables (`system`, `workspace`, `user`, etc.) that persist across the test session. Mutating any of them outside `system.temp` corrupts the next test (and possibly the suite for the rest of the run).
+
+```
+new (tableType, @system.temp.fixture);   // ✓ scratch — cleared per process
+new (tableType, @workspace);             // ✗ DESTROYS workspace — never write this
+new (tableType, @workspace.fixture);     // ✗ pollutes a persistent table
+```
+
+`system.temp.*` is cleared per process start, so cleanup is technically optional. Cleanup is still good practice for readability:
+
+```yaml
+script: |
+  new (tableType, @system.temp.myFixture);
+  system.temp.myFixture.x = 42;
+  local (result = system.temp.myFixture.x);
+  delete (@system.temp.myFixture);
+  return result
+```
+
+The cross-agent rule (see `../AI_SHARED_GUIDELINES.md`) treats `new (tableType, @workspace)` as a tripwire — flag it in review.
+
+---
+
+## 6. Comments inside `script:` blocks
+
+The "no `//` inside blocks" caution from older docs is overstated. Verified recent probes:
+
+```
+if true {        // this comment is fine
+    return 42}
+```
+
+works. The `//` consumes to end-of-line and the `}` on the next physical line closes the block cleanly.
+
+What's actually unsafe:
+
+- **`/* ... */`** — not a UserTalk comment at all. Parses as `/` followed by `*` followed by `/`, silently miscompiling as a division-multiplication expression. NEVER use. (Primer Section 3.)
+- **`«…»`** in yaml `script:` blocks — the 0xC7 / 0xC8 bytes for the guillemets get mangled by YAML's encoding handling. The script fails to compile or compiles to something different from what you wrote. Safe in `.ut` files (preserved encoding), unsafe in yaml.
+- **`#`** inside `script:` block content — UserTalk has no `#` comment. `#` is a yaml comment only at the yaml indentation level, never inside the script text.
+
+Reference: `~/.claude/projects/-Users-jake-dev-jsavin-Frontier/memory/feedback_usertalk_comments.md`.
+
+When in doubt: put the `//` on its own line, not on the same line as a closing brace. That dodges any remaining edge cases in places where `//` and `}` might collide structurally.
+
+---
+
+## 7. The eval-trap history (#618)
+
+Before fix **#618**, `langruntraperror` returned `true` for compile errors. The consequence:
+
+- A script with a syntax error compiled, failed silently, and reported `success: true` to the protocol layer.
+- Roughly **108 tests** were silently passing — they "succeeded" only because the bug masked the compile failure.
+
+After #618:
+
+- Compile errors surface as `success: false` with a useful error string.
+- The previously-silent-passing tests now correctly fail, and **#620** is the umbrella tracking their cleanup or correction (most are skipped pending burndown).
+
+What this means for you on burndown:
+
+- If a test was "passing" before #618 and "failing" after, the after state is the truth. Don't restore the old expected_success by adjusting the expectation — fix the script.
+- If a test is in the #620-skip set, opening it means re-deriving the intent from the script, fixing the syntax, and confirming the *real* behavior is what the test wants to assert.
+
+---
+
+## 8. Behavioral assertions, not source inspection
+
+Tests must assert on **the computed behavior of the verb**, not on the **text of the script**. The forbidden pattern:
+
+```yaml
+# ✗ DO NOT do this — passes against a no-op compile, proves nothing
+script: |
+  local (src = string (system.verbs.builtins.help.showHelp));
+  return indexOf (src, "stdout") > 0
+expected_result: "true"
+```
+
+This test passes if the source contains the substring — even if the verb is broken, has been deleted, or never executes. A no-op compile still passes the assertion.
+
+The correct form drives the verb and checks the **result or side effect**:
+
+```yaml
+# ✓ behavioral — calls the verb, asserts on what it actually does
+script: |
+  local (output);
+  help.showHelp (@output);
+  return indexOf (output, "Usage:") > 0
+expected_result: "true"
+```
+
+Forbidden patterns to flag on review:
+
+- `indexOf (string (someVerb), "...") > 0`
+- Regex matching against the script body via `string.patternMatch` or `regex.*`
+- Any assertion that would still pass if the verb were replaced with `on f () {return true}`
+
+The general principle: the test should fail if the verb stops doing its job. Source inspection passes regardless of the verb's job.
+
+---
+
+## 9. Handler scripts need end-to-end execution tests
+
+UserTalk verb resolution is **late-binding**: a handler that calls a non-existent verb compiles cleanly and only fails at the point of the call, at runtime.
+
+```
+on showHelp () {
+    stdout ("Usage: ...")}        // ← `stdout` doesn't exist as a verb; compiles fine
+```
+
+A test that only confirms the handler **compiles** is worthless for this class of bug:
+
+```yaml
+# ✗ insufficient — script.compile returns true even if the handler will crash on first call
+script: 'return script.compile (string (system.verbs.builtins.help.showHelp))'
+expected_result: "true"
+```
+
+The handler must be **executed through its production dispatch path** — REPL, menu dispatcher, slash command system, whatever invokes it in the real product — and the test must assert on an observable side effect of that execution.
+
+**Motivating incident**: PR #582 shipped a `help.ut` handler that called a non-existent `stdout` verb. The integration tests verified each handler compiled but never executed any of them. The bug shipped. PR #583 caught it during end-to-end testing.
+
+**Reference**: `tests/integration/test_cases/repl_palette.yaml` for an example of end-to-end handler testing — it drives the REPL through its real dispatch path and asserts on emitted output.
+
+For any verb you add or modify that's invoked through a dispatcher: at least one test must exercise the **dispatch + execution** chain, not just the compile.
+
+---
+
+## 10. Quick checklist for a new yaml test
+
+Before declaring a test done, walk this list:
+
+- [ ] `expected_result` is **quoted** (string), even for `"true"` / `"5"` / `"TEXT"`
+- [ ] No `/* ... */` anywhere in the script
+- [ ] No `«…»` in yaml `script:` blocks
+- [ ] Multi-line scripts: either same-line + `;`, or `repl_mode: true`
+- [ ] All scratch state goes under `system.temp.*`
+- [ ] If the verb takes `@addr` output: `repl_mode: true`
+- [ ] If the test opens a guest database: `needs_guest_dbs: true` at file root
+- [ ] If the test binds a port / drives REPL stdin: `sequential: true` at file root
+- [ ] Assertion is on the verb's computed value or side effect, not on the script text
+- [ ] For dispatched handlers: at least one end-to-end execution path covered
+
+---
+
+## See also
+
+- `CLAUDE_PRIMER.md` — entry-point primer; Section 4 is the fast-path on yaml integration tests
+- `records_and_tables.md` — when fixture data uses tables/records and you hit type confusion
+- `debugging_workflow.md` — protocol UserTalk debugger when a test misbehaves and you need to step through it
+- `../TESTING_GUIDE.md` — full test framework reference (file layout, runner flags, fixture rules)
+- `../AI_SHARED_GUIDELINES.md` — cross-agent rules: `system.temp` isolation, integration-test expectations for verb changes
+- `~/.claude/projects/-Users-jake-dev-jsavin-Frontier/memory/feedback_usertalk_comments.md` — `«…»` parse errors in yaml tests

--- a/docs/usertalk/values_and_types.md
+++ b/docs/usertalk/values_and_types.md
@@ -1,0 +1,41 @@
+# Values and Types
+
+Stub. The full type taxonomy reference; intended as the "what *is* a `scriptType`?" / "what's the difference between `numberType` and `longType`?" lookup. Flesh out as questions arise.
+
+---
+
+## Status
+
+**STUB — TODO**. Most of what's needed is currently scattered across:
+
+- `CLAUDE_PRIMER.md` § 1, 2.5 — mental model + iteration distinction
+- `records_and_tables.md` — `tableType`, `recordType`, `listType`, `addressType` deep-dive
+- `strings_and_text.md` — `'TEXT'` string representations
+- `operators_and_idioms.md` — `typeof ()`, `sizeOf ()`, `nameOf ()` usage
+- `TYPEOF.md` — typeof semantics, OSType code lookup table, "never change typeof to return strings" historical note
+- Agent def `usertalk-engineer.md` — 28-type summary, the 10 most common (numberType, stringType, booleanType, addressType, arrayType, recordType, tableType, outlineType, scriptType, wptextType)
+
+Consolidate here when:
+- A burndown task surfaces a type confusion not covered by the above
+- A reader asks "what's the difference between `numberType`, `longType`, `floatType`?" (these may overlap or differ subtly)
+- Coercion rules need documenting
+
+## TODO topics
+
+- Full enumeration of the 28 types
+- Numeric subtypes: `longType` vs `floatType` vs `numberType` — coercion and storage
+- Date/time types: `dateType` + the `date.set` parameter-order trap (already in `../TESTING_GUIDE.md`)
+- File-related types: `filespecType` (`'fss '` — note trailing space), `binaryType`, `bigstring`
+- UI types that may be headless-no-ops: window/menu/dialog types
+- Coercion rules across types
+- When `typeof (value)` returns one OSType but `system.compiler.language.constants.*` claims another — divergence
+- Type predicates: `defined ()`, `typeof () == sometype` patterns
+
+---
+
+## See also
+
+- `CLAUDE_PRIMER.md`
+- `records_and_tables.md`
+- `TYPEOF.md`
+- `SYNTAX.md`

--- a/docs/usertalk/verb_invocation_patterns.md
+++ b/docs/usertalk/verb_invocation_patterns.md
@@ -1,0 +1,211 @@
+# Verb Invocation Patterns
+
+Pulled in when: a verb call errors with "wrong number of parameters", behavior diverges from the docserver reference, or you're tracking down why `string (string.length)` looks different from what you expect.
+
+The premise: a UserTalk "verb" isn't one thing. `string.length` is a three-layer dispatch — ODB path, glue script, C kernel — and burndown bugs cluster at the seams between layers. Knowing which layer is in play (and which one is lying to you) is the actual skill.
+
+The primer's Section 1 says "UserTalk is dispatch-by-name through the ODB" in one line. This file unpacks that line into the diagnostic toolkit.
+
+---
+
+## 1. The three layers
+
+A verb call like `string.length ("hello")` traverses three layers, in order:
+
+### Layer 1: name resolution
+
+`string.length` is a dotted path. The runtime walks `system.paths` looking for a table where the dotted path resolves. In practice that's `system.verbs.builtins.string.length`. The value at that path is a `scriptType` — a compiled UserTalk script object stored in the ODB.
+
+Name resolution doesn't care about parameters or behavior; it just produces a script value.
+
+### Layer 2: glue script execution
+
+The `scriptType` object compiles (if not already cached) and runs with the call-site's arguments. Most glue scripts are thin pass-throughs:
+
+```
+on length (s) {kernel (string.length)}
+```
+
+Some glue scripts do real work — parameter validation, default-value injection, type coercion, post-processing of the kernel's return. The `on <name> (...)` declaration in the glue script is the **authoritative parameter list** for what UserTalk callers can pass.
+
+### Layer 3: C kernel implementation
+
+`kernel (<callname>)` is a special form that hands control to the C verb table. The callname argument is not arbitrary — it identifies an entry in the dispatch table that the headless build registered at startup. The C implementation lives somewhere under `Common/source/` — often in a file named after the verb family (`stringverbs.c`, `tableverbs.c`, etc.) or in a `*_headless.c` companion.
+
+The C implementation reads its parameters off the parameter list the glue script forwarded. If the glue script's `on` line and the C implementation's parameter reads don't agree on count or order, you get the "wrong number of parameters" runtime error.
+
+---
+
+## 2. Why this layering causes burndown bugs
+
+Three failure modes recur often enough to be worth naming:
+
+1. **Glue/kernel signature drift.** The glue script's `on` line says `(s, n, opts)` but the C kernel only reads two parameters. Caller passes three, glue forwards three, kernel errors. Or vice versa.
+2. **Headless overload.** A verb has a Mac-era C implementation that took complex types (a `filespecType`, a `WindowPtr`, an `RGBColor`). The headless build registers a different implementation under the same name with a simpler signature. The glue script may or may not have been updated to match.
+3. **Docserver vs reality.** The docserver was generated from the legacy Mac codebase. Some verbs have been stubbed, no-op'd, or signature-changed in the headless build and the docserver still shows the old shape.
+
+Whenever a verb's behavior surprises you, the first question is **which layer is wrong** — not "what's the bug in the kernel."
+
+---
+
+## 3. Discovering a verb's actual signature
+
+Walk the layers, top down:
+
+### Step 1 — read the glue script
+
+```
+local (s = string (string.length))
+```
+
+This returns the script source text. The `on <name> (...)` line at the top is the parameter list as UserTalk sees it. The body shows you whether it's a thin `kernel ()` pass-through or has its own logic.
+
+Remember: `string (verb.path)` takes the **value**, not the address. `string (@string.length)` returns the stringified address — useless for inspection. See the primer Section 2.3.
+
+### Step 2 — find the C kernel implementation
+
+If the glue script ends in `kernel (someName)`, grep `Common/source` for that callname. The grep target is the literal symbol inside `kernel ()` — often it matches the verb path (`string.length`) but not always. Some kernel callnames are short tags like `getstringlength` that bear no obvious relation to the ODB path.
+
+The C function dispatched to is typically a `boolean` returning function that reads parameters off a parameter list (`getstringvalue (hparam1, &h)` or similar) and pushes a return via `setbooleanvalue` / `setstringvalue` / etc.
+
+### Step 3 — check for a headless overload
+
+Search `*_headless.c` files for the same callname or for `ADD_VERB` registrations naming the verb. The headless build registers verbs through a different table than legacy Mac; a verb can be present in both with different signatures, and the headless registration wins at runtime in the headless build.
+
+A symptom that points at this: docserver says the verb takes 4 parameters, glue script `on` line says 4, but the call errors at 4 and works at 3. The headless C dropped a parameter; the glue script may not have been updated.
+
+---
+
+## 4. The `kernel ()` bridge
+
+`kernel (callname)` inside a glue script invokes the C verb table entry registered under `callname`. A few properties of `kernel ()` worth knowing:
+
+- The callname is **not** a UserTalk identifier resolution — it's a symbolic tag into the C dispatch table. You can't redefine it from UserTalk.
+- The callname doesn't have to match the verb's ODB path. `string.upper` could in principle dispatch to a callname like `uppercasestring`. In practice most verbs use matching names, but don't assume.
+- The kernel call reads its parameters from the **current glue script's parameter list** — whatever the glue's `on` line declared, scoped at the time of the `kernel ()` call.
+- The kernel call returns into the glue script's expression context. Glue scripts often end with `kernel (...)` as the last expression so its return becomes the glue's return.
+
+A glue that does more than pass through:
+
+```
+on length (s, fastPath=false) {
+    if fastPath {
+        return (sizeOf (s))};
+    return (kernel (string.length))}
+```
+
+When you see a glue like this, the C kernel is only one of two paths. Failures in the glue path won't reach the kernel; failures in the kernel won't trip glue-side validation.
+
+---
+
+## 5. Address-versus-script-reference gotchas
+
+A class of bug that consistently bites:
+
+```
+local (s = string (string.length));      // ✓ value form — returns the script's source text
+local (s = string (@string.length));     // ✗ returns the stringified address "system.verbs.builtins.string.length"
+```
+
+`@string.length` is an address VALUE. `string ()` doesn't dereference — it stringifies. The address stringifies to its dotted path. You'll get back a string that looks superficially plausible but is not the script source. `typeof ()` on the result is `'TEXT'`, not `'scpt'`.
+
+Always dereference when you have an address and want to inspect the target:
+
+```
+local (adr = @string.length);
+local (s = string (adr^))                // ✓ dereference, then inspect
+```
+
+This is the same value-vs-address rule the primer covers for `string ()` / `typeof ()` / `nameOf ()`. Verb introspection is the place it stings most often because the verb path naturally reads like a callable.
+
+---
+
+## 6. Calling a verb dynamically by address
+
+You can store a verb reference as an address and invoke through it:
+
+```
+local (adr = @string.length);
+local (n = adr^ ("hello"))               // ✓ dereference then call
+```
+
+The `adr^` produces the script value; the `(...)` then calls it. This is how dispatch tables, callback registrations, and some menu wiring work — store the address, dereference and call at invocation time.
+
+If you forget the `^`:
+
+```
+local (n = adr ("hello"))                // ✗ tries to call an addressType value — runtime error
+```
+
+---
+
+## 7. When a verb fails with "name hasn't been defined"
+
+Error: `Can't call the script because the name X hasn't been defined.`
+
+The likely causes, in roughly decreasing frequency:
+
+1. **System root not loaded.** Verbs live under `system.verbs.builtins.*`; without `--system-root databases/Frontier.root` on the `frontier-cli` invocation, that subtree doesn't exist and name resolution comes up empty. This is the #1 cause and worth checking first every time.
+2. **Late-binding miss.** UserTalk compiles a script even when a called name doesn't yet resolve — failures only surface when the script runs and the name still doesn't resolve. The compile-time check is purely syntactic. Use the protocol debugger to step to the failing call. See `debugging_workflow.md`.
+3. **Path-leaf collision with a global or keyword.** If your verb path ends in a leaf like `stringType`, `contains`, `tableType` — the parser sees the global, not your member. Bracket form bypasses: `@my.path.["myMember"]`. The primer Section 2.4 covers this.
+4. **Verb is in the `.ut` file but not installed in the ODB.** Editing a `.ut` file alone doesn't install anything. Install via protocol with `script.newScriptObject` and `fileMenu.save`. See `../ODB_SCRIPT_EDITING.md`.
+
+If none of these explain it, the verb may have been renamed or removed in headless. Check the docserver, then verify against `system.verbs.builtins` walked at runtime.
+
+---
+
+## 8. Decoder: "wrong number of parameters"
+
+Error: `Can't call X because there aren't enough parameters.` (Or "too many.")
+
+The diagnostic sequence:
+
+1. **Read the glue script** — `string (verb.path)` and look at the `on <name> (...)` line. Note required vs default-valued parameters.
+2. **Check for a headless overload** — grep `*_headless.c` for the callname inside the glue's `kernel ()` invocation. Compare the parameter reads in the C code against the glue's `on` line.
+3. **Confirm the call site** — count what you're actually passing. UserTalk's "too few" message can fire on an off-by-one in a comma-separated literal that's harder to eyeball than you'd think.
+4. **Suspect recent refactoring.** If the verb was touched recently, the glue and the C may have diverged. `git log -- Common/source/<file>` and `git log -- usertalk_scripts/Frontier.root/system/verbs/builtins/<path>.ut` tell you who moved last.
+
+A specific anti-pattern: a glue script declares a parameter with a default value (`on length (s, mode="fast")`), the caller relies on the default, and the kernel implementation doesn't know about `mode` and reads only one parameter. The default lets the call shape look right but the kernel does the wrong thing. Read the glue body, not just the `on` line.
+
+---
+
+## 9. Headless overload patterns
+
+Some verbs that took UI-flavored parameters on legacy Mac have been simplified or stubbed in headless. Treat the list below as **patterns to look for**, not authoritative claims — verify each against the current code before relying on the behavior.
+
+- **`dialog.alert ()` and friends.** On Mac, pops a UI alert. In headless, may be a no-op or return immediately without surfacing output. Don't rely on it to communicate results — return values or write to a temp path you can read back. The primer Section 5 makes the same point.
+- **File verbs.** On Mac, some accept `filespecType` parameters that carry resource fork metadata, alias info, etc. In headless, many accept plain string paths instead. The glue may have been kept signature-compatible by stringifying internally, or it may have been changed. Read it.
+- **Menu verbs.** On Mac, attach behaviors to actual menus. In headless, may operate purely on data structures (`menu.list`, `menu.describe`) without any UI side effect. Behavioral assertions on these need to inspect the data, not "did the menu update."
+- **Window/editor verbs.** On Mac, manipulate live windows. In headless, often stubbed, no-op'd, or restricted to a virtual window list.
+
+The asymmetry: a verb that's a no-op in headless still **succeeds** — the call returns cleanly, just without the side effect you wanted. Tests that wait for an alert dialog will hang. Tests that assert on a return value will get the no-op's default (usually `true`).
+
+When porting an integration test that worked on Mac, the most productive first hypothesis for an unexplained failure is "this verb is a headless overload that no-ops."
+
+---
+
+## 10. Adding a kernel verb (summary)
+
+The full SOP is in `../VERB_IMPLEMENTATION_GUIDE.md` and `../ODB_SCRIPT_EDITING.md`. Pulling it together for context:
+
+1. Implement the C function in the appropriate `Common/source/*verbs*.c` file.
+2. Register in `headless_*_verbs.c` — enum, switch case, `ADD_VERB` call.
+3. Register in `kernelverbs.r`.
+4. Write the glue script and place it under `usertalk_scripts/Frontier.root/system/verbs/builtins/...`.
+5. Install in the ODB via protocol (`script.newScriptObject` + `fileMenu.save`). Editing the `.ut` file alone isn't enough.
+6. Sync the `.ut` file so source-control reflects the ODB state.
+7. Write integration tests that drive the verb end-to-end through the dispatch path.
+
+The protocol-based ODB editing workflow is the only supported way to install a verb. Do not edit `.root` files directly.
+
+---
+
+## 11. Cross-references
+
+- `CLAUDE_PRIMER.md` — the entry primer; Section 1 names the dispatch model, Section 2.3 covers `string ()` value-vs-address
+- `debugging_workflow.md` — protocol debugger for stepping through verb dispatch and inspecting kernel/glue boundaries
+- `records_and_tables.md` — how `system.verbs.builtins.*` is laid out as nested tables; what `string ()` does to non-script values
+- `../VERB_RESOLUTION_ARCHITECTURE.md` — name resolution and dispatch details at the C level; `langhandlercall ()` / `langgethandlercode ()` paths
+- `../VERB_IMPLEMENTATION_GUIDE.md` — kernel verb implementation in C, the full registration walk
+- `../ODB_SCRIPT_EDITING.md` — installing glue scripts via protocol, `script.newScriptObject`, `.ut` sync
+- `docserver/` — verb-by-verb reference; **caveat**: generated from Mac sources, may not reflect headless overloads


### PR DESCRIPTION
## Summary

Adds a load-eagerly UserTalk primer (`docs/usertalk/CLAUDE_PRIMER.md`) plus eight deeper docs covering records/tables, operators, strings, verb invocation, testing patterns, debugging workflow, and three stubs for later expansion. Corrects errors in the existing `docs/usertalk/SYNTAX.md` and `.claude/agents/usertalk-engineer.md`. Adds anchors in `CLAUDE.md` and `docs/AI_SHARED_GUIDELINES.md` so future sessions find the primer.

Implements the plan at `planning/discussions/usertalk-primer-plan.md` (Plan 1). Motivation: stop main-session Claude from probing-and-experimenting for basic UserTalk idioms during integration test burndown.

## What's in here

**Primer** (entry-point, ~250 lines, load eagerly):
- `docs/usertalk/CLAUDE_PRIMER.md` (216 lines) — mental model, 5 idioms, failure-mode decoder, yaml integration test guide, tools section, pointers to deeper docs

**Deeper docs** (load on demand from the primer):
- `records_and_tables.md` (284 lines) — type taxonomy, record literal `{"k": v}`, table iteration `for adrM in @t`, record's no-name-access trap, headless-vs-Mac sort order divergence
- `testing_patterns.md` (359 lines) — yaml `with`-wrapper trap (#624), `repl_mode`, `expected_result` string quoting, eval-trap history (#618), behavioral assertions, handler end-to-end testing
- `debugging_workflow.md` (375 lines) — protocol UserTalk debugger as primary investigation tool, full op reference verified against `docs/DEBUGGING_GUIDE.md`, four worked burndown examples
- `operators_and_idioms.md` (323 lines) — comparison/logical/arithmetic/address operators, `contains`/`beginsWith`/`endsWith`, `with` block risks, 10 idiom one-liners
- `strings_and_text.md` (234 lines) — Pascal-string vs Handle, 255-byte truncation landmine, quote forms, escape sequences, `\r` canonical line terminator
- `verb_invocation_patterns.md` (211 lines) — three-layer dispatch (name resolution / glue / kernel), signature discovery, headless overload decoder

**Stubs** (TODO markers, expand as topics arise):
- `values_and_types.md`, `scripts_vs_handlers.md`, `comments_and_whitespace.md`

**Corrections to existing docs**:
- `docs/usertalk/SYNTAX.md` — removed false claim that `/* */` is a safe comment marker; corrected `//`-inside-block rules; updated examples to UserLand style (space before `(`, inline closing `}`)
- `.claude/agents/usertalk-engineer.md` — fixed record literal syntax (`{"k": v}` not `["k": v]`); records don't support dotted-name access; iteration differs between list/record (value-iter) and table (address-iter); softened the "no `//` inside blocks" rule which probing showed was overstated

**Anchors**:
- `CLAUDE.md` § "UserTalk Critical Facts" — new subsection "UserTalk language primer (load before .ut or yaml-script work)" pointing at the primer
- `docs/AI_SHARED_GUIDELINES.md` § "UserTalk and Integration Test Constraints" — "Before writing UserTalk" pointer + corrected `//` rules + #624 with-wrapper note

## Issues filed during probe-and-confirm

Two issues filed while probing the live runtime to verify primer claims:

- **#624 (P0)** — Protocol mode: `local` scope dropped across `\r` in `script/eval`; script silently returns `true` (boolean) instead of the intended value. Reproducer: `local (x = 5)\rreturn x` returns `true`, `local (x = 5); return x` returns `5`. Risk: integration tests passing for the wrong reason during burndown.
- **#625 (P2)** — Docs clarification: `defined (@addr)` semantics. The verb checks address VALIDITY (parent path exists), not target existence. Easy to misuse; documented in this PR's primer and `records_and_tables.md`.

## Style conventions

All UserTalk examples in the new docs follow UserLand conventions (re-validated against your guidance during drafting):

- Space before `(` in verb calls: `string (foo)`, not `string(foo)`
- Closing `}` and trailing `;` inline at end of last statement
- Double quotes for strings; `'X'` is a char constant, `'TEXT'` is a 4-byte OSType
- Records use curly braces `{"k": v}`; square brackets aren't a UserTalk literal form
- `examples.*` paths in hypothetical examples (not `system.*`, which is reserved); `system.temp.*` only where the test-fixture convention applies

## Testing

Pure docs change. Doc-validation pre-commit hook passes (all references resolved). Skipping full unit/integration test run per the project's TDD exception for "pure docs, config-only with no behavioral surface" — no code paths changed.

## Test plan

- [ ] Confirm primer loads cleanly in a fresh Claude Code session (eager-load cost is small per the design)
- [ ] Confirm the failure-mode decoder helps with a real burndown task
- [ ] Re-read in Obsidian (target editor) to check rendering — tables, headings, code blocks
- [ ] Review the SYNTAX.md and agent-def corrections to confirm they match your understanding
- [ ] Open a follow-up to flesh out the three stubs as topics surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
