### PR TITLE
test(repl): regression sweep for newline normalization after #635 (#620 burndown)

### DIFF
--- a/tests/integration/test_cases/protocol_eval_compile_errors.yaml
+++ b/tests/integration/test_cases/protocol_eval_compile_errors.yaml
@@ -217,3 +217,189 @@ tests:
           result:
             value: "two"
             type: "string"
+
+  # ============================================================
+  # Issue #620 burndown: newline-normalization regression sweep
+  # ============================================================
+  # Goal: lock in every composite/block grammar production where the
+  # closing '}' of a block is followed by a continuation or where the
+  # construct interacts with the protocol normalizer's bare-CR/LF -> ';'
+  # rewrite. The grammar (langparser.y) productions audited are:
+  #
+  #   - handlerheader bracketedstatementlist        (on f () { ... })
+  #   - loopheader bracketedstatementlist           (loop { ... }, while x { ... })
+  #   - forloopheader / forinloopheader             (for i = 1 to 3 { ... })
+  #   - ifheader bracketedstatementlist [elsetoken ...]
+  #   - bundleheader bracketedstatementlist         (bundle { ... })
+  #   - caseheader '{' casebody '}' [elsetoken ...]
+  #   - withheader bracketedstatementlist           (with table { ... })
+  #   - tryheader bracketedstatementlist [elsetoken ...]
+  #
+  # Only the three '... [elsetoken bracketedstatementlist]' forms
+  # (if/case/try) attach a continuation to the closing '}'. All other
+  # forms terminate at '}' — the next token starts a new statement and
+  # requires a ';' separator. The default normalizer behavior (insert
+  # ';' after '}' unless the lookahead sees else/;/}/EOF) is therefore
+  # correct for the other forms. These tests pin that down so any future
+  # change to the lookahead (e.g. broadening which tokens it suppresses
+  # ';' before) can't silently regress these constructs.
+
+  - name: "protocol script/eval - on handler def then call across newline (#620)"
+    description: "on f () { body } is a handler definition. After the closing '}', the next statement (the call site) requires ';'. Default normalizer behavior must insert one. Regression guard for the handlerheader bracketedstatementlist grammar production."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "on f () {\n  return 42\n}\nreturn f()"
+        validate:
+          success: true
+          result:
+            value: "42"
+            type: "long"
+
+  - name: "protocol script/eval - loop { body } across newlines (#620)"
+    description: "loop { body } body is a loopheader-bracketedstatementlist production. Closing '}' terminates the loop; the next statement (return) needs ';' between them, which the normalizer's default behavior provides. Includes break inside an if to exercise nested '}' boundaries."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (s = 0);\nlocal (i = 0);\nloop {\n  if i >= 3 {\n    break\n  };\n  s = s + i;\n  i = i + 1\n}\nreturn s"
+        validate:
+          success: true
+          result:
+            value: "3"
+            type: "long"
+
+  - name: "protocol script/eval - while header { body } across newlines (#620)"
+    description: "while cond { body } reuses loopheader (whiletoken expr) production. Same '}\\nreturn' attachment pattern as the loop test. Regression guard."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (s = 0);\nlocal (i = 0);\nwhile i < 3 {\n  s = s + i;\n  i = i + 1\n}\nreturn s"
+        validate:
+          success: true
+          result:
+            value: "3"
+            type: "long"
+
+  - name: "protocol script/eval - for i = 1 to 3 across newlines (#620)"
+    description: "forloopheader-bracketedstatementlist production. Closing '}' is terminal; default ';' insertion before return is correct."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (s = 0);\nfor i = 1 to 3 {\n  s = s + i\n}\nreturn s"
+        validate:
+          success: true
+          result:
+            value: "6"
+            type: "long"
+
+  - name: "protocol script/eval - with table { body } across newlines (#620)"
+    description: "withheader-bracketedstatementlist production. The 'with' block has no else continuation. Closing '}' is terminal; '}' followed by '\\nreturn' must gain a ';'."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (r = 0);\nwith system.temp {\n  r = 7\n}\nreturn r"
+        validate:
+          success: true
+          result:
+            value: "7"
+            type: "long"
+
+  - name: "protocol script/eval - bundle { body } across newlines (#620)"
+    description: "bundleheader-bracketedstatementlist production groups statements without changing scope. Closing '}' is terminal; '}' before '\\nreturn' must get ';'."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (s = 0);\nbundle {\n  s = s + 1;\n  s = s + 2\n}\nreturn s"
+        validate:
+          success: true
+          result:
+            value: "3"
+            type: "long"
+
+  - name: "protocol script/eval - try without else across newlines (#620)"
+    description: "try { body } with NO else clause is a separate production (tryheader bracketedstatementlist, no elsetoken). The closing '}' is terminal — next statement requires ';'. Lookahead must NOT find 'else' here, because there isn't one — it's a return."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (s = 1);\ntry {\n  s = 2\n}\nreturn s"
+        validate:
+          success: true
+          result:
+            value: "2"
+            type: "long"
+
+  - name: "protocol script/eval - case without else, multiple clauses (#620)"
+    description: "case header { ... } without an else clause. Inside casebody, case clauses are separated by ';' (grammar: casebody ';' expr optionalstatementlist). The closing '}' between one clause's body and the next clause's label needs a ';' inserted — the default normalizer behavior provides it. Without correct insertion, the parser cannot distinguish the second clause label from a stray expression."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (n = 2);\nlocal (r = \"\");\ncase n {\n  1 {\n    r = \"one\"\n  };\n  2 {\n    r = \"two\"\n  }\n}\nreturn r"
+        validate:
+          success: true
+          result:
+            value: "two"
+            type: "string"
+
+  # ------------------------------------------------------------
+  # Whitespace and comment edge cases for the }-else lookahead
+  # ------------------------------------------------------------
+  # The peek loop in normalize_newlines_to_semicolons skips spaces, tabs,
+  # CR, LF, '//' line comments, and UTF-8 '«...»' curly comments to find
+  # the next real token after '}'. These tests pin down the corners.
+
+  - name: "protocol script/eval - blank lines between } and else (#620)"
+    description: "Multiple blank lines between try's closing '}' and 'else' must still attach. The peek loop's whitespace skip is greedy across CR/LF runs."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (r = \"ok\");\ntry {\n  local (x = 1 / 0)\n}\n\n\nelse {\n  r = \"caught\"\n}\nreturn r"
+        validate:
+          success: true
+          result:
+            value: "caught"
+            type: "string"
+
+  - name: "protocol script/eval - leading newlines at start of script (#620)"
+    description: "Script that begins with bare CR/LF characters. prev_nonws starts at '\\0' which is in the no-insert guard, so leading newlines don't get spurious ';' prepended. Regression guard for the start-of-script case."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "\n\nlocal (x = 5)\nreturn x"
+        validate:
+          success: true
+          result:
+            value: "5"
+            type: "long"
+
+  - name: "protocol script/eval - // comment at very end of script, no trailing newline (#620)"
+    description: "A '//' line comment as the final token in the script, with no trailing newline. Exercises the EOF-during-comment-skip path. The scanner ignores the comment; the result is the value returned before it."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (x = 5);\nreturn x\n// trailing comment"
+        validate:
+          success: true
+          result:
+            value: "5"
+            type: "long"
+
+  - name: "protocol script/eval - whitespace-only script does not crash (#620)"
+    description: "A script consisting of only spaces, tabs, and bare newlines must not crash the normalizer or the parser. Documents whatever the normalizer produces — currently returns success: true with the with-wrapper's default truthy value (no user code ran). The exact value is incidental; what matters is the absence of a crash."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "   \n\n   "
+        validate:
+          success: true
+
+  - name: "protocol script/eval - string literal containing }\\nelse documents pre-existing scanner gap (#620)"
+    description: "DOCUMENTS A KNOWN PRE-EXISTING LIMITATION (not a normalizer bug, tracked separately): the normalizer does not track string-literal state, so a '}\\nelse' inside a string literal triggers the lookahead and suppresses ';'. Additionally, the langscan parsepopchar swallows bare LF following any byte (CRLF -> CR convention), so the LF inside the string disappears entirely. Net observed behavior: the string content collapses to '}else {' (7 chars) — the '\\n' is gone. This test pins down the current observed output so any future change (string-state tracking in the normalizer OR LF preservation in the scanner) shows up as a test-update, not a silent semantic shift."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (s = \"}\nelse {\");\nreturn s"
+        validate:
+          success: true
+          result:
+            value: "}else {"
+            type: "string"

--- a/tests/integration/test_cases/protocol_eval_compile_errors.yaml
+++ b/tests/integration/test_cases/protocol_eval_compile_errors.yaml
@@ -293,11 +293,11 @@ tests:
             type: "long"
 
   - name: "protocol script/eval - with table { body } across newlines (#620)"
-    description: "withheader-bracketedstatementlist production. The 'with' block has no else continuation. Closing '}' is terminal; '}' followed by '\\nreturn' must gain a ';'."
+    description: "withheader-bracketedstatementlist production. The 'with' block has no else continuation. Closing '}' is terminal; '}' followed by '\\nreturn' must gain a ';'. Test uses a non-mutating witness — assigns to local 'q' inside the with block so the namespace push/pop exercises the production without writing into system.temp."
     protocol_ops:
       - op: "script/eval"
         params:
-          expression: "local (r = 0);\nwith system.temp {\n  r = 7\n}\nreturn r"
+          expression: "local (r = 0);\nwith system.temp {\n  local (q = 7);\n  r = q\n}\nreturn r"
         validate:
           success: true
           result:
@@ -314,6 +314,18 @@ tests:
           success: true
           result:
             value: "3"
+            type: "long"
+
+  - name: "protocol script/eval - fileloop { body } across newlines (#620)"
+    description: "fileloopheader-bracketedstatementlist production (langparser.y:652 — fileloop (var in fspec) {...}). No else continuation; closing '}' is terminal; '}' before '\\nreturn' must gain a ';'. Wrapped in 'if false' so the parser exercises the production without touching the filesystem (compile-time coverage, not behavioral iteration)."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (n = 0);\nif false {\n  fileloop (f in @system.temp) {\n    n = n + 1}}\nreturn n"
+        validate:
+          success: true
+          result:
+            value: "0"
             type: "long"
 
   - name: "protocol script/eval - try without else across newlines (#620)"
@@ -393,7 +405,7 @@ tests:
           success: true
 
   - name: "protocol script/eval - string literal containing }\\nelse documents pre-existing scanner gap (#620)"
-    description: "DOCUMENTS A KNOWN PRE-EXISTING LIMITATION (not a normalizer bug, tracked separately): the normalizer does not track string-literal state, so a '}\\nelse' inside a string literal triggers the lookahead and suppresses ';'. Additionally, the langscan parsepopchar swallows bare LF following any byte (CRLF -> CR convention), so the LF inside the string disappears entirely. Net observed behavior: the string content collapses to '}else {' (7 chars) — the '\\n' is gone. This test pins down the current observed output so any future change (string-state tracking in the normalizer OR LF preservation in the scanner) shows up as a test-update, not a silent semantic shift."
+    description: "DOCUMENTS A KNOWN PRE-EXISTING LIMITATION (not a normalizer bug, tracked separately): the normalizer in repl_variables.c does not track string-literal state, so a '}\\nelse' inside a string literal triggers the '}' lookahead from #635 and suppresses ';' insertion. The observed net behavior is that the string content appears to collapse to '}else {' (7 chars) — the '\\n' has been dropped somewhere in the pipeline. Best current hypothesis is that the scanner consumes the bare LF as part of its CR/LF normalization, but this has not been verified end-to-end. File a follow-up issue if the exact scanner behavior needs to be pinned down. This test locks in the current OBSERVED output as the contract; any future change (string-state tracking in the normalizer, scanner LF preservation, or both) will surface as a test-update rather than a silent semantic shift."
     protocol_ops:
       - op: "script/eval"
         params:


### PR DESCRIPTION
## Sweep summary

Audited every composite/block grammar production in `Common/source/langparser.y` for cases where the protocol-mode bare-CR/LF -> `;` rewrite (`normalize_newlines_to_semicolons` in `frontier-cli/repl_variables.c`) could break the parse or silently change semantics.

**Grammar productions checked:**

- `handlerheader bracketedstatementlist` (`on f () { ... }`)
- `loopheader bracketedstatementlist` (`loop { ... }`, `while x { ... }`)
- `forloopheader` / `forinloopheader` (`for i = 1 to 3 { ... }`)
- `ifheader bracketedstatementlist [elsetoken ...]`
- `bundleheader bracketedstatementlist` (`bundle { ... }`)
- `caseheader '{' casebody '}' [elsetoken ...]`
- `withheader bracketedstatementlist` (`with table { ... }`)
- `tryheader bracketedstatementlist [elsetoken ...]`

Only the three `elsetoken` forms (if / case / try) attach a continuation to the closing `}`. All other forms terminate at `}` and require `;` before the next statement. The current `}` lookahead in `normalize_newlines_to_semicolons` only suppresses `;` when the peek finds `else` / `;` / `}` / EOF, so the default behavior is correct for the non-else forms.

There is no `loop { ... } while expr` (do-while) form, so no other `}\nkeyword` attachment pattern exists.

## What was added

14 regression-guard tests in `tests/integration/test_cases/protocol_eval_compile_errors.yaml`:

**Block constructs that need `;` after `}`** (pinning down correct default behavior):

- `on f () {...}` then call across newline
- `loop { body }` across newlines (with nested `if {break}`)
- `while cond { body }` across newlines
- `for i = 1 to 3 { body }` across newlines
- `with table { body }` across newlines
- `bundle { body }` across newlines
- `try { body }` (no else) across newlines
- `case n { 1 {...}; 2 {...} }` (no else, multiple clauses)

**Edge cases for the `}`-else lookahead:**

- Blank lines between `}` and `else`
- Leading newlines at start of script
- `//` comment at very end (no trailing newline)
- Whitespace-only script (no crash)

**Known limitation documented:**

- String literal containing `}\nelse {` --- pins down current observed output (`}else {`, length 7) so any future fix to the string-literal-state gap shows up as a deliberate test update. NOT a normalizer fix --- tracked separately.

## What was risky / out of scope

- **String-literal state tracking** in the normalizer is a known pre-existing P2 gap. Not fixed here.
- **UTF-8 `«...»` curly comments in protocol input**: the kernel scanner (`Common/source/langscan.c`) only recognizes the single-byte MacRoman `chcomment = 0xC7` form. UTF-8 `«` (0xC2 0xAB) does not parse as a comment at the scanner level, so its handling in the normalizer's peek loop is defensive forward-compat (not currently reachable as valid input). Out of scope: not a normalizer bug.

## Verification

- Build: `make -C frontier-cli -j$(sysctl -n hw.ncpu)` --- clean
- Unit: `./tools/run_headless_tests.sh` --- 489 / 489 pass (no change)
- Integration: `cd tests && make test-integration` --- 2299 total, 1972 passed, 207 skipped, 120 failed. All 29/29 tests in `protocol_eval_compile_errors.yaml` pass (15 existing + 14 new). The 120 failures are pre-existing TCP/callback/html infrastructure issues unrelated to this sweep.
