### PR TITLE
feat(test-runner): add --select flag for individual test filtering

### DIFF
--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -1476,14 +1476,16 @@ class TestRunner:
             f.write('\n')
 
 
-def _collect_test_names(yaml_paths: List[str]) -> set:
-    """Scan YAML files and return the set of all test names found.
+def _collect_test_names_per_file(yaml_paths: List[str]) -> Dict[str, set]:
+    """Scan YAML files and return a map of file path -> set of test names.
 
-    Used by --select to validate that every selector matches at least one
-    test before launching workers. Parse errors are surfaced as warnings;
-    the file is skipped (its tests won't be discoverable by --select).
+    Used by --select to (a) validate that every selector matches at least
+    one test before launching workers, and (b) drop files with zero matches
+    from dispatch so workers don't pay per-file DB-copy cost for nothing.
+    Parse errors are surfaced as warnings; the file is skipped (its tests
+    won't be discoverable by --select).
     """
-    names = set()
+    per_file: Dict[str, set] = {}
     for path in yaml_paths:
         try:
             with open(path, encoding='utf-8') as f:
@@ -1491,12 +1493,22 @@ def _collect_test_names(yaml_paths: List[str]) -> set:
         except (OSError, yaml.YAMLError) as e:
             print(f"Warning: failed to read test names from {path}: {e}",
                   file=sys.stderr)
+            per_file[path] = set()
             continue
-        if not isinstance(data, dict):
-            continue
-        for td in data.get('tests', []) or []:
-            if isinstance(td, dict):
-                names.add(td.get('name', 'Unnamed Test'))
+        names: set = set()
+        if isinstance(data, dict):
+            for td in data.get('tests', []) or []:
+                if isinstance(td, dict):
+                    names.add(td.get('name', 'Unnamed Test'))
+        per_file[path] = names
+    return per_file
+
+
+def _collect_test_names(yaml_paths: List[str]) -> set:
+    """Scan YAML files and return the union of all test names found."""
+    names: set = set()
+    for file_names in _collect_test_names_per_file(yaml_paths).values():
+        names |= file_names
     return names
 
 
@@ -1560,10 +1572,15 @@ def main():
 
     # Resolve --select into a set; verify every selector matches at least one
     # test name in the provided files (fail fast on typos / stale names).
+    # Then drop files with zero matches so workers don't pay per-file
+    # DB-copy / Guest-Databases-copytree cost only to filter to nothing.
     selectors = None
     if args.select:
         selectors = set(args.select)
-        all_names = _collect_test_names(valid_files)
+        names_per_file = _collect_test_names_per_file(valid_files)
+        all_names: set = set()
+        for file_names in names_per_file.values():
+            all_names |= file_names
         unmatched = sorted(s for s in selectors if s not in all_names)
         if unmatched:
             print("Error: --select names did not match any test in the given files:",
@@ -1571,6 +1588,8 @@ def main():
             for name in unmatched:
                 print(f"  - {name!r}", file=sys.stderr)
             return 1
+        valid_files = [f for f in valid_files
+                       if names_per_file.get(f, set()) & selectors]
 
     # === Sequential mode (j=1) or single file ===
     if args.workers == 1 or len(valid_files) == 1:

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -691,7 +691,8 @@ def _run_file_worker(args: tuple) -> dict:
     Uses ProtocolExecutor for compatible tests, falls back to FrontierCLI for others.
     Returns a serializable dict (for multiprocessing).
     """
-    yaml_path, cli_path, system_root, test_root_dir, protocol_batch, verbose, worker_id = args
+    (yaml_path, cli_path, system_root, test_root_dir, protocol_batch, verbose,
+     worker_id, selectors) = args
 
     # Load file-level metadata (sequential, needs_guest_dbs, protocol_mode)
     meta = load_file_metadata(yaml_path)
@@ -749,7 +750,11 @@ def _run_file_worker(args: tuple) -> dict:
         with open(yaml_path, 'r') as f:
             data = yaml.safe_load(f)
 
-        test_cases = [TestCase(td) for td in data.get('tests', [])]
+        test_dicts = data.get('tests', [])
+        if selectors:
+            test_dicts = [td for td in test_dicts
+                          if td.get('name', 'Unnamed Test') in selectors]
+        test_cases = [TestCase(td) for td in test_dicts]
         results = []
 
         for test in test_cases:
@@ -919,20 +924,27 @@ class TestRunner:
     """Main test runner that executes test cases."""
 
     def __init__(self, cli: FrontierCLI, verbose: bool = False, test_root_dir: Optional[str] = None,
-                 protocol_executor: Optional[ProtocolExecutor] = None):
+                 protocol_executor: Optional[ProtocolExecutor] = None,
+                 selectors: Optional[set] = None):
         self.cli = cli
         self.verbose = verbose
         self.test_root_dir = test_root_dir or str(Path.cwd())
         self.results: List[TestResult] = []
         self.protocol_executor = protocol_executor
+        # Optional set of test names to filter by (None = no filtering).
+        self.selectors = selectors
 
     def load_test_file(self, yaml_path: str) -> List[TestCase]:
-        """Load test cases from YAML file."""
+        """Load test cases from YAML file, applying --select filter if set."""
         with open(yaml_path, 'r') as f:
             data = yaml.safe_load(f)
 
         test_cases = []
         for test_data in data.get('tests', []):
+            if self.selectors is not None:
+                name = test_data.get('name', 'Unnamed Test')
+                if name not in self.selectors:
+                    continue
             test_cases.append(TestCase(test_data))
 
         return test_cases
@@ -1464,6 +1476,30 @@ class TestRunner:
             f.write('\n')
 
 
+def _collect_test_names(yaml_paths: List[str]) -> set:
+    """Scan YAML files and return the set of all test names found.
+
+    Used by --select to validate that every selector matches at least one
+    test before launching workers. Parse errors are surfaced as warnings;
+    the file is skipped (its tests won't be discoverable by --select).
+    """
+    names = set()
+    for path in yaml_paths:
+        try:
+            with open(path, encoding='utf-8') as f:
+                data = yaml.safe_load(f)
+        except (OSError, yaml.YAMLError) as e:
+            print(f"Warning: failed to read test names from {path}: {e}",
+                  file=sys.stderr)
+            continue
+        if not isinstance(data, dict):
+            continue
+        for td in data.get('tests', []) or []:
+            if isinstance(td, dict):
+                names.add(td.get('name', 'Unnamed Test'))
+    return names
+
+
 def _find_test_root(test_files: List[str]) -> str:
     """Find project root by walking up from the first test file."""
     if test_files:
@@ -1490,6 +1526,10 @@ def main():
                        help='Disable NDJSON protocol, use per-process execution')
     parser.add_argument('-j', '--workers', type=int, default=0,
                        help='Number of parallel workers (0 = auto, 1 = sequential)')
+    parser.add_argument('--select', action='append', default=None, metavar='TEST_NAME',
+                       help='Run only tests whose name exactly matches TEST_NAME. '
+                            'Pass multiple times to select multiple tests. '
+                            'File arguments are still required.')
 
     args = parser.parse_args()
 
@@ -1518,6 +1558,20 @@ def main():
         print("No valid test files found", file=sys.stderr)
         return 1
 
+    # Resolve --select into a set; verify every selector matches at least one
+    # test name in the provided files (fail fast on typos / stale names).
+    selectors = None
+    if args.select:
+        selectors = set(args.select)
+        all_names = _collect_test_names(valid_files)
+        unmatched = sorted(s for s in selectors if s not in all_names)
+        if unmatched:
+            print("Error: --select names did not match any test in the given files:",
+                  file=sys.stderr)
+            for name in unmatched:
+                print(f"  - {name!r}", file=sys.stderr)
+            return 1
+
     # === Sequential mode (j=1) or single file ===
     if args.workers == 1 or len(valid_files) == 1:
         executor = None
@@ -1530,7 +1584,7 @@ def main():
                 executor = None
 
         runner = TestRunner(cli, verbose=args.verbose, test_root_dir=test_root_dir,
-                            protocol_executor=executor)
+                            protocol_executor=executor, selectors=selectors)
         runner.cleanup_test_artifacts()
 
         seq_start = time.time()
@@ -1572,7 +1626,7 @@ def main():
         for i, f in enumerate(parallel_files):
             worker_args.append((
                 f, args.cli, args.system_root, test_root_dir,
-                args.batch, args.verbose, i
+                args.batch, args.verbose, i, selectors
             ))
 
         print(f"\nRunning {len(parallel_files)} test file(s) across {min(args.workers, len(parallel_files))} worker(s)...")
@@ -1623,7 +1677,7 @@ def main():
                 executor = None
 
         runner = TestRunner(cli, verbose=args.verbose, test_root_dir=test_root_dir,
-                            protocol_executor=executor)
+                            protocol_executor=executor, selectors=selectors)
         for f in sequential_files:
             runner.run_test_file(f)
 


### PR DESCRIPTION
## Summary

- Adds `--select <test name>` to `tests/integration/runner.py` for running individual tests by exact name match.
- Repeatable: pass multiple `--select` flags to run a hand-picked set.
- Pre-flight validates every selector matches at least one test in the supplied YAML files; unmatched names produce a clear error and a non-zero exit before any workers spin up.
- File arguments still required — keeps the runner from having to crawl the entire `test_cases/` tree.

## Motivation

Debugging a single flaky integration test currently means running the entire YAML file (often 50+ tests) or writing a one-off script. `--select` is a 1-line ergonomic upgrade for that loop.

## Behavior

- No `--select` passed → existing behavior, unchanged.
- One or more `--select` passed → only tests whose `name:` field matches one of the selectors run.
- No selector matches anything in the given files → error listing the unmatched selectors, exit 1.

## Implementation notes

- Filter happens at YAML-load time in both code paths (`_run_file_worker` for parallel mode, `TestRunner.load_test_file` for sequential), so it composes cleanly with file metadata (`sequential`, `needs_guest_dbs`, `protocol_mode`) and existing executor routing.
- `_collect_test_names()` is a lightweight YAML scan used only for the pre-flight matching check.
- Worker arg tuple gained one element (`selectors`); both call sites updated.

## Test plan

No pytest scaffolding exists for `runner.py` itself, so behavioral verification is manual. Reproduction below was executed locally before push.

### 1. Baseline — no `--select` (existing behavior preserved)

```bash
python3 tests/integration/runner.py --cli ./frontier-cli/frontier-cli \
  tests/integration/test_cases/sys_processor_tests.yaml
```

Result: 52 tests run (42 passed / 6 skipped / 4 pre-existing failures unrelated to this change).

### 2. Filter to two specific tests in a single file (sequential path)

```bash
python3 tests/integration/runner.py --cli ./frontier-cli/frontier-cli \
  --select "sys.osversion - returns OS version string" \
  --select "sys.machine - returns machine architecture" \
  tests/integration/test_cases/sys_processor_tests.yaml
```

Result: Total 2, both passed.

### 3. Filter across two files (parallel worker path)

```bash
python3 tests/integration/runner.py --cli ./frontier-cli/frontier-cli \
  --select "sys.osversion - returns OS version string" \
  --select "sys.getenvironmentvariable - get PATH variable" \
  tests/integration/test_cases/sys_processor_tests.yaml \
  tests/integration/test_cases/sys_environment_verbs.yaml
```

Result: 2 workers, 1 test each, both passed.

### 4. Unmatched selector — clear error, non-zero exit

```bash
python3 tests/integration/runner.py --cli ./frontier-cli/frontier-cli \
  --select "does not exist anywhere" \
  tests/integration/test_cases/sys_processor_tests.yaml
```

Result:

```
Error: --select names did not match any test in the given files:
  - 'does not exist anywhere'
```

Exit code: 1.

### 5. Full integration suite — no regression

```bash
cd tests && make test-integration
```

Result: Total 2309, Passed 2034, Skipped 207, Failed 68. Failures are the pre-existing TCP/listenStream set unrelated to this change; within the documented ±2 envelope from `develop`.

## Round 2 — drop zero-match files from dispatch (commit 63e3156a)

Addresses /gate bar-raiser P2: when `--select` matched in some files but not others, every file in `valid_files` was still dispatched to a worker. Each worker paid the per-worker DB-copy and (optional) Guest-Databases `copytree` cost BEFORE filtering down to zero tests and returning nothing.

`_collect_test_names_per_file()` (new helper) returns `Dict[str, set]` of file -> names-in-that-file. `main()` uses it both to validate selectors globally and to filter `valid_files` to those with at least one matching test.

### Verification — matches in only one of two files

```bash
python3 tests/integration/runner.py --cli ./frontier-cli/frontier-cli \
  --select "sys.osversion - returns OS version string" \
  tests/integration/test_cases/sys_processor_tests.yaml \
  tests/integration/test_cases/sys_environment_verbs.yaml
```

Before r2: 2 files dispatched, 2 workers spun up, the `sys_environment_verbs` worker performed a DB copy and returned 0 results.

After r2: only `sys_processor_tests.yaml` enters dispatch — drops into the `len(valid_files) == 1` sequential branch. Total 1, passed 1.

### Verification — parallel path with one file dropped

```bash
python3 tests/integration/runner.py --cli ./frontier-cli/frontier-cli -j 4 \
  --select "sys.osversion - returns OS version string" \
  --select "sys.getenvironmentvariable - get PATH variable" \
  tests/integration/test_cases/sys_processor_tests.yaml \
  tests/integration/test_cases/sys_environment_verbs.yaml \
  tests/integration/test_cases/string_verbs.yaml
```

Output: `Running 2 test file(s) across 2 worker(s)...` — `string_verbs.yaml` correctly dropped. Total 2, passed 2.

### Full suite re-run (after r2)

```
Total:   2309
Passed:  2031
Skipped: 207
Failed:  71
```

Identical to documented baseline (2031/71/207/2309). All four prior `--select` scenarios above still produce identical output to round 1.

## Risk

Minimal. The flag is purely additive: when `--select` is absent, `selectors` is `None` and both code paths short-circuit the filter. No changes to executor routing, worker plumbing semantics (just one new tuple element), or test-case construction.

Co-Authored-By: Claude Opus 4.7 (1M context) noreply@anthropic.com

