### PR TITLE
fix(repl): normalizer PREV_BINOP class for binop-at-EOL continuations (#620 burndown)

### DIFF
--- a/frontier-cli/repl_variables.c
+++ b/frontier-cli/repl_variables.c
@@ -337,15 +337,19 @@ static const char *peek_next_real_byte(const char *p) {
 
 /* Token-kind classification for the newline-normalizer transition table.
  *
- * prev_kind tracks the last non-whitespace byte written to the output. The
- * normalizer only needs to distinguish four anchor bytes ('\0' = start of
- * script, ';', '{', '}') from "anything else" — none of the suppression
- * rules look at other identifiers. */
+ * prev_kind tracks the last non-whitespace byte (or token) written to the
+ * output. The normalizer distinguishes four anchor bytes ('\0' = start of
+ * script, ';', '{', '}'), a "binary-operator-at-EOL" class (the most recent
+ * non-whitespace bytes form a binary operator that demands a continuation),
+ * and "anything else". The BINOP class is the #620-burndown fix for line
+ * continuations like 'x and\n y' / 'x ==\n y' / 'f (\n x, y)' — without it,
+ * the (PREV_OTHER, NEXT_OTHER) cell would emit ';' and break the expression. */
 typedef enum {
 	PREV_START = 0,	/* '\0' — nothing written yet */
 	PREV_SEMI,	/* ';' — already separated */
 	PREV_LBRACE,	/* '{' — block-open, next byte is first statement */
 	PREV_RBRACE,	/* '}' — block-close, may attach else/};/}} */
+	PREV_BINOP,	/* trailing token is a binary operator — continuation expected */
 	PREV_OTHER,	/* identifier / digit / paren / operator / etc. */
 	PREV_KIND_COUNT
 } prev_kind_t;
@@ -363,6 +367,94 @@ typedef enum {
 	NEXT_KIND_COUNT
 } next_kind_t;
 
+/* Returns 1 if byte c can be part of a UserTalk identifier (ASCII letter,
+ * digit, or underscore). Used to enforce a word boundary before identifier-
+ * shaped operators 'and' / 'or' — without this, the variable name 'band'
+ * would falsely match as an 'and' continuation token. */
+static int is_ident_byte(unsigned char c) {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+	       (c >= '0' && c <= '9') || c == '_';
+}
+
+/* Walks backward from the current dst position over output bytes that act
+ * as inter-token whitespace (space, tab, \r, \n) and returns a pointer
+ * (one past) the last non-whitespace byte written to dst. Returns 'out' if
+ * the buffer is empty or contains only whitespace. The byte immediately
+ * before the returned pointer is the trailing token's last byte. */
+static const char *rtrim_dst(const char *out, const char *dst) {
+	while (dst > out) {
+		unsigned char c = (unsigned char)dst[-1];
+		if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+			dst--;
+		else
+			break;
+	}
+	return dst;
+}
+
+/* Detects whether the most recent token in the output buffer is a binary
+ * operator that demands a continuation on the next line. Operators covered:
+ *
+ *   multi-char keywords: 'and', 'or' (word-bounded)
+ *   multi-char relational: '==', '>=', '<=', '!='
+ *   single-char arithmetic / list: '+', '-', '*', '/', ','
+ *   single-char relational: '>', '<'
+ *   open paren:           '('
+ *
+ * Excluded by design:
+ *   ')'        — close paren is end-of-expression, not continuation
+ *   '='        — assignment; a continuation case ends in '==', not '='
+ *   '}', '{', ';' — handled by their own prev-kind classes
+ *
+ * Unary '-' at EOL (e.g. 'x = -\n 1') is rare and statically indistinguishable
+ * from binary '-' without a tokenizer; we over-suppress here. The worst case
+ * is a parser error on a script that was already broken — surfacing the bug
+ * is preferable to silently mis-normalizing the common binary-'-' case.
+ *
+ * The byte-before-operator check for '=' disambiguates '==' from assignment.
+ * The word-boundary check for 'and' / 'or' prevents misclassification of
+ * identifiers ending in those substrings ('band', 'kand', 'door').
+ */
+static int prev_is_binop(const char *out, const char *dst) {
+	const char *p = rtrim_dst(out, dst);
+	if (p == out)
+		return 0;
+	unsigned char last = (unsigned char)p[-1];
+	switch (last) {
+		case '+': case '-': case '*': case '/': case ',':
+		case '(': case '>': case '<':
+			return 1;
+		case '=':
+			/* '==' or '>=' or '<=' or '!=' are BINOP; bare '=' is assignment. */
+			if (p - out >= 2) {
+				unsigned char prev = (unsigned char)p[-2];
+				if (prev == '=' || prev == '>' || prev == '<' || prev == '!')
+					return 1;
+			}
+			return 0;
+		case 'd':
+			/* Trailing 'and' must be a standalone keyword. */
+			if (p - out >= 3 && p[-3] == 'a' && p[-2] == 'n') {
+				if (p - out == 3 || !is_ident_byte((unsigned char)p[-4]))
+					return 1;
+			}
+			return 0;
+		case 'r':
+			/* Trailing 'or' must be a standalone keyword. */
+			if (p - out >= 2 && p[-2] == 'o') {
+				if (p - out == 2 || !is_ident_byte((unsigned char)p[-3]))
+					return 1;
+			}
+			return 0;
+		default:
+			return 0;
+	}
+}
+
+/* Map the last byte written (prev_nonws) to its prev-kind. For anchor bytes
+ * the byte alone is sufficient; for the BINOP class, the caller must consult
+ * prev_is_binop() because the operator may span multiple bytes ('and', '==').
+ * The single-byte form is retained for callers that have no buffer pointer. */
 static prev_kind_t classify_prev(unsigned char prev_nonws) {
 	switch (prev_nonws) {
 		case '\0': return PREV_START;
@@ -371,6 +463,17 @@ static prev_kind_t classify_prev(unsigned char prev_nonws) {
 		case '}':  return PREV_RBRACE;
 		default:   return PREV_OTHER;
 	}
+}
+
+/* Buffer-aware classifier used by the normalizer loop. Falls back to the
+ * single-byte form, then upgrades PREV_OTHER → PREV_BINOP when the trailing
+ * token in the output buffer is a binary operator demanding continuation. */
+static prev_kind_t classify_prev_full(unsigned char prev_nonws,
+                                      const char *out, const char *dst) {
+	prev_kind_t k = classify_prev(prev_nonws);
+	if (k == PREV_OTHER && prev_is_binop(out, dst))
+		return PREV_BINOP;
+	return k;
 }
 
 /* Classify the byte at *peek (a pointer returned by peek_next_real_byte).
@@ -405,6 +508,7 @@ static next_kind_t classify_next(const char *peek) {
  *   SEMI          |   -   |   -   |   -   |   -   |   -   |   already separated by ';'
  *   LBRACE        |   -   |   -   |   -   |   -   |   -   |   inside block: '{' acts as separator
  *   RBRACE        |   -   |   -   |   -   |   -   |   E   |   '}' attaches else/};/}}; only "other" needs ';'
+ *   BINOP         |   -   |   -   |   -   |   -   |   -   |   continuation expected; next line is same expression
  *   OTHER         |   -   |   E   |   E   |   E   |   E   |   real expression: ';' needed for any real follower
  *
  *   E = emit ';'; '-' = suppress.
@@ -423,12 +527,21 @@ static next_kind_t classify_next(const char *peek) {
  *   - START row exists to match real source: leading bare newlines (common
  *     in YAML `|` block scalars) and whitespace-only scripts must not gain
  *     a leading ';'.
+ *   - BINOP row (#620 5th-hole, this commit): when a line ends with a
+ *     binary-operator token ('and', 'or', '==', '>=', '<=', '!=', '>', '<',
+ *     '+', '-', '*', '/', ',', '('), the next line is a continuation of the
+ *     same expression. Inserting ';' produces invalid source like 'x and; y'
+ *     which the parser rejects. Suppress for every next-kind. The classifier
+ *     (prev_is_binop) requires a word boundary before identifier-shaped
+ *     operators so 'band' / 'door' aren't misread.
  *
  * Moot-by-construction cells (the input that would exercise them is itself
  * a parse error before normalization matters, so flipping these values has
  * no observable effect): START x ELSE, START x RBRACE, SEMI x ELSE,
- * LBRACE x ELSE, LBRACE x EOF. Five cells. The others are all reachable
- * from valid source and covered by integration tests in
+ * LBRACE x ELSE, LBRACE x EOF, BINOP x ELSE/SEMI/RBRACE/EOF (a script that
+ * ends with a binop is itself malformed; those cells stay 0 for consistency).
+ * The reachable BINOP cell is BINOP x OTHER. The other non-moot cells are
+ * covered by integration tests in
  * tests/integration/test_cases/protocol_eval_compile_errors.yaml.
  *
  * If a future grammar change needs a new suppression, flip exactly one cell
@@ -440,6 +553,7 @@ static const unsigned char kEmitSep[PREV_KIND_COUNT][NEXT_KIND_COUNT] = {
 	/* SEMI    */ {  0,    0,    0,    0,      0    },
 	/* LBRACE  */ {  0,    0,    0,    0,      0    },
 	/* RBRACE  */ {  0,    0,    0,    0,      1    },
+	/* BINOP   */ {  0,    0,    0,    0,      0    },
 	/* OTHER   */ {  0,    1,    1,    1,      1    },
 };
 
@@ -509,8 +623,11 @@ static char *normalize_newlines_to_semicolons(const char *script) {
 			/* UserTalk grammar requires ';' between statements at top level.
 			 * Bare \r/\n are whitespace to the scanner, so multi-line scripts
 			 * without explicit ';' fail to parse. The transition table above
-			 * maps every (prev_kind, next_kind) pair to emit-or-suppress. */
-			prev_kind_t pk = classify_prev(prev_nonws);
+			 * maps every (prev_kind, next_kind) pair to emit-or-suppress.
+			 * classify_prev_full inspects the dst buffer to detect multi-byte
+			 * binary-operator tokens (and / or / == / >= / <= / !=) so the
+			 * BINOP row suppresses ';' for line continuations. */
+			prev_kind_t pk = classify_prev_full(prev_nonws, out, dst);
 			next_kind_t nk = classify_next(peek_next_real_byte(src));
 			if (kEmitSep[pk][nk])
 				*dst++ = ';';

--- a/tests/integration/test_cases/protocol_eval_compile_errors.yaml
+++ b/tests/integration/test_cases/protocol_eval_compile_errors.yaml
@@ -552,3 +552,109 @@ tests:
           result:
             value: "9"
             type: "long"
+
+  # ------------------------------------------------------------
+  # PREV_BINOP class (5th normalizer hole, #620 burndown)
+  # ------------------------------------------------------------
+  # When a line ends with a binary-operator token (boolean 'and'/'or',
+  # relational '==' '>=' '<=' '!=' '>' '<', arithmetic '+' '-' '*' '/',
+  # comma, or open paren), the next line is a continuation of the same
+  # expression — not a new statement. Earlier versions of the normalizer
+  # treated these as PREV_OTHER and emitted a synthetic ';' before the
+  # newline, producing source like 'x and; y' that the parser rejects.
+  # The fix introduces a PREV_BINOP prev-kind that suppresses ';' for
+  # every next-kind: a continuation is a continuation regardless of what
+  # follows.
+
+  - name: "protocol script/eval - PREV_BINOP boolean 'and' at EOL allows continuation"
+    description: "Pattern: 'return true and\\n true'. Before the PREV_BINOP fix, the normalizer treated trailing 'and' as PREV_OTHER and inserted ';' before the newline ('and;'), which is a parse error. With PREV_BINOP, the ';' is suppressed and the expression evaluates correctly to true."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return true and\n true"
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+
+  - name: "protocol script/eval - PREV_BINOP boolean 'or' at EOL allows continuation"
+    description: "Pattern: 'return false or\\n true'. Mirrors the 'and' case — 'or' is a binary operator token, so a newline immediately after it must not introduce a ';'."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return false or\n true"
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+
+  - name: "protocol script/eval - PREV_BINOP relational '==' at EOL allows continuation"
+    description: "Pattern: 'return 1 ==\\n 1'. The multi-char '==' token ends in '=' — single '=' would be assignment, but the byte before is also '=', so the trailing token is '=='. PREV_BINOP must distinguish == (relational) from = (assignment) by walking back through the output buffer."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return 1 ==\n 1"
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+
+  - name: "protocol script/eval - PREV_BINOP arithmetic '+' at EOL allows continuation"
+    description: "Pattern: 'return 1 +\\n 2'. Single-character arithmetic operators are unambiguous as continuations — '+' as the last non-whitespace byte at EOL means another operand follows."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return 1 +\n 2"
+        validate:
+          success: true
+          result:
+            value: "3"
+            type: "long"
+
+  - name: "protocol script/eval - PREV_BINOP comma at EOL allows continuation"
+    description: "Pattern: 'string.padwithzeros (5,\\n 3)'. Comma is a list/argument separator; a newline after it must NOT terminate the call."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return string.padwithzeros (5,\n 3)"
+        validate:
+          success: true
+          result:
+            value: "005"
+            type: "string"
+
+  - name: "protocol script/eval - PREV_BINOP open paren at EOL allows continuation"
+    description: "Pattern: 'string.padwithzeros (\\n 5, 3)'. Open paren is the start of a parenthesized expression / argument list; the bytes after the newline are the body. PREV_BINOP must not be confused with PREV_LBRACE — '(' is paren, '{' is block-open."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return string.padwithzeros (\n 5, 3)"
+        validate:
+          success: true
+          result:
+            value: "005"
+            type: "string"
+
+  - name: "protocol script/eval - PREV_BINOP word-boundary 'and' not confused with identifier"
+    description: "Regression guard: the PREV_BINOP detector must require a word boundary before 'and'/'or' so identifiers like 'band' or 'kand' don't trigger continuation behavior. Pattern: 'local (band = 7)\\n return band' — the variable 'band' ends in 'and' but the byte before 'and' is 'b' (identifier-continuing), so this is a regular statement followed by 'return', and ';' MUST be inserted."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (band = 7)\n return band"
+        validate:
+          success: true
+          result:
+            value: "7"
+            type: "long"
+
+  - name: "protocol script/eval - PREV_BINOP single '=' assignment NOT treated as binop"
+    description: "Regression guard: a single trailing '=' must NOT be treated as a binary operator (which would suppress ';' insertion). Without the byte-before-'=' disambiguation in prev_is_binop, this lookup could misclassify single '=' as the tail of '==' / '>=' / '<=' / '!=' and incorrectly trigger BINOP. By checking the byte before '=' and requiring it to be one of '=','>','<','!', we preserve the existing behavior: 'x =\\n 5' is a parse error (the normalizer emits ';' producing 'x =;' which the parser rejects). This pins down that the BINOP class does not accidentally subsume bare assignment."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (x = 0); x =\n 5; return x"
+        validate:
+          success: false

--- a/tests/integration/test_cases/protocol_eval_compile_errors.yaml
+++ b/tests/integration/test_cases/protocol_eval_compile_errors.yaml
@@ -658,3 +658,51 @@ tests:
           expression: "local (x = 0); x =\n 5; return x"
         validate:
           success: false
+
+  - name: "protocol script/eval - PREV_BINOP relational '>=' at EOL allows continuation"
+    description: "Regression guard for the '>=' byte-class in prev_is_binop's '=' case. The classifier checks byte-before-'=' is in {'=','>','<','!'} to distinguish multi-char relationals from single assignment. This test pins '>=' specifically; without it, a regression in the '>' arm could go undetected since '==' covers a different sub-path."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return 2 >=\n 1"
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+
+  - name: "protocol script/eval - PREV_BINOP relational '!=' at EOL allows continuation"
+    description: "Regression guard for the '!=' byte-class in prev_is_binop's '=' case. Pins the '!' arm of the byte-before-'=' disambiguation; without it, a regression in '!' handling would not be caught by '==' or '>='."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return 2 !=\n 1"
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+
+  - name: "protocol script/eval - PREV_BINOP arithmetic '*' at EOL allows continuation"
+    description: "Regression guard for the '*' BINOP byte-class. The classifier dispatches via switch on the last byte; the '*' arm is distinct from the keyword-tail ('and'/'or') and the relational-equals ('=') arms. Pins this byte to verify the BINOP table row covers it."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "return 2 *\n 3"
+        validate:
+          success: true
+          result:
+            value: "6"
+            type: "long"
+
+  - name: "protocol script/eval - PREV_BINOP word-boundary 'or' not confused with identifier"
+    description: "Symmetric to the 'band' word-boundary regression for 'and'. The variable 'door' ends in 'or' but the byte before 'or' is 'do' (identifier-continuing), so this must be classified as a regular statement, not as a continuation. ';' MUST be inserted before 'return' or the script fails to compile."
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: "local (door = 9)\n return door"
+        validate:
+          success: true
+          result:
+            value: "9"
+            type: "long"


### PR DESCRIPTION
## Summary

5th hole in `normalize_newlines_to_semicolons` (after #628/#635/#640): a UserTalk script ending a line with a binary-operator token (`and`, `or`, `==`, `>=`, `<=`, `!=`, `>`, `<`, `+`, `-`, `*`, `/`, `,`, `(`) had a synthetic `;` inserted before the continuation, producing source like `x and; y` that the parser rejected. The 5 failing `sys.*` integration tests using `(typeof(...) == stringType) and\n  (typeof(...) == stringType)` patterns were the visible symptom; the same hole catches any multi-line expression with a trailing binop.

Add a `PREV_BINOP` row to the transition table that suppresses `;` for every next-kind — a continuation is a continuation regardless of what follows.

## Implementation

- New `PREV_BINOP` member in `prev_kind_t`. The transition table grows one row; all five cells are `suppress`.
- New `prev_is_binop(out, dst)` helper walks back through the output buffer to detect the trailing operator token. Single-char operators (`+ - * / , ( > <`) match on the last byte. Multi-char operators require disambiguation:
  - `=` is BINOP only if the byte before is `=`, `>`, `<`, or `!` (so `==` / `>=` / `<=` / `!=` match but bare assignment `=` does not).
  - `and` / `or` require a word boundary before the keyword (so identifiers like `band` or `door` are not misclassified).
- `classify_prev_full(prev_nonws, out, dst)` is the buffer-aware wrapper used by the normalizer loop. Falls back to single-byte `classify_prev` for anchor bytes (`\0 ; { }`), then upgrades `PREV_OTHER` to `PREV_BINOP` when `prev_is_binop` matches.
- Cells changed in `kEmitSep`: new BINOP row, all-zero. Existing rows untouched.

## Judgement calls

- **Unary `-` is over-suppressed.** `x = -\n 1` (unary minus split across lines) is statically indistinguishable from binary `-` without a real tokenizer. We treat all trailing `-` as BINOP. The worst case is a script that was already malformed losing one parse-error surfacing, which is preferable to silently mis-normalizing the common `x +\n y` and `x -\n y` patterns.
- **`)` is NOT BINOP.** Close paren is end-of-expression, not continuation. Same for `}` and `;` (handled by their own prev-kind classes).
- **No appisrunning work.** The bundled task described a missing headless `sys.appisrunning` implementation, but `tests/headless_sys_verbs.c` already implements it via `pgrep -x` (committed earlier, marked COMPLETE). Manual testing confirms `sys.appisrunning("frontier-cli")` returns `true` when called from inside frontier-cli. The 5 failing tests are 100 percent normalizer-caused (all use `and\n` continuations). Change B from the task was unnecessary.

## Tests

8 new tests in `protocol_eval_compile_errors.yaml`:

- 6 positive-path BINOP continuations (boolean `and` / `or`, relational `==`, arithmetic `+`, comma, open paren)
- 1 word-boundary regression guard (`local (band = 7)\n return band` — identifier ending in `and` must still get `;`)
- 1 disambiguation regression guard (`x =\n 5` — single `=` is assignment, must still get `;`; result is a parse error, locked in as `success: false`)

## Test plan

- [x] `make -C frontier-cli -j$(sysctl -n hw.ncpu)` — clean build, no new warnings
- [x] `./tools/run_headless_tests.sh` — 489/489 pass
- [x] `cd tests && make test-integration` — 70 to 65 failures (-5 sys cluster), +8 new tests all green. Net: 2032 to 2045 passing, 2309 to 2317 total
- [x] All 39 pre-existing tests in `protocol_eval_compile_errors.yaml` still pass unchanged
- [x] Manual smoke: `sys.appisrunning("frontier-cli")` returns `true` via `--protocol script/eval` — appisrunning was already working

## Per-cluster count change

- `sys verbs - system information suite` — fixed (used `and\n`)
- `sys verbs - all info verbs return strings` — fixed (used `and\n`)
- `sys verbs - numeric verbs return long` — fixed (used `and\n`)
- `sys verbs - boolean verbs return bool` — fixed (used `and\n`)
- `sys environment verbs - isolation test` — fixed (used `and\n`)

Generated with Claude Code (https://claude.com/claude-code)
