### PR TITLE
fix(tests): rewrite html.* tests to use bracket form for #-prefixed names

### DIFF
--- a/tests/integration/test_cases/html_framework_tests.yaml
+++ b/tests/integration/test_cases/html_framework_tests.yaml
@@ -119,7 +119,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#title = \"Test Page\"", @pageTable)
       return pageTable.title == "Test Page"
@@ -132,7 +132,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#priority = 10", @pageTable)
       return pageTable.priority == 10
@@ -145,7 +145,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#published = true", @pageTable)
       return pageTable.published == true
@@ -158,7 +158,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#count = 5 + 5", @pageTable)
       return pageTable.count == 10
@@ -171,7 +171,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#timestamp = clock.now()", @pageTable)
       return defined(pageTable.timestamp)
@@ -184,7 +184,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#template = @websites.samples.default", @pageTable)
       return defined(pageTable.template) and (pageTable.indirectTemplate == true)
@@ -197,7 +197,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("author = \"John Doe\"", @pageTable)
       return pageTable.author == "John Doe"
@@ -214,7 +214,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(text = "#title = \"My Page\"\r#author = \"John\"\r<p>Content here</p>")
       local(result = html.rundirectives(text, @pageTable))
@@ -233,7 +233,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       user.html.prefs.directivesOnlyAtBeginning = true
 
@@ -250,7 +250,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       user.html.prefs.directivesOnlyAtBeginning = false
 
@@ -267,7 +267,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(text = "<p>Plain HTML content</p>")
       local(result = html.rundirectives(text, @pageTable))
@@ -282,7 +282,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(result = html.rundirectives("", @pageTable))
       return result == ""
@@ -295,7 +295,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(text = "#title = \"Test\"\r<p>Content</p>")
       local(result = html.rundirectives(text, @pageTable))
@@ -314,7 +314,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(outline)
       lang.new(outlineType, @outline)
@@ -334,7 +334,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(outline)
       lang.new(outlineType, @outline)
@@ -355,7 +355,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       local(outline)
       lang.new(outlineType, @outline)
@@ -482,7 +482,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
       pageTable.renderedtext = "<p>See [[#glossPatch about|About Us]]</p>"
 
       user.html.prefs.useGlossPatcher = true
@@ -498,7 +498,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
       pageTable.renderedtext = "[[#glossPatch home|Home]] and [[#glossPatch about|About]]"
 
       user.html.prefs.useGlossPatcher = true
@@ -514,7 +514,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
       pageTable.renderedtext = "[[#glossPatch contact|]]"
 
       user.html.prefs.useGlossPatcher = true
@@ -530,7 +530,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
       local(original = "[[#glossPatch about|About]]")
       pageTable.renderedtext = original
 
@@ -547,7 +547,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
       local(original = "<p>Plain HTML content</p>")
       pageTable.renderedtext = original
 
@@ -637,7 +637,7 @@ tests:
       local(pageTable)
       lang.new(tableType, @pageTable)
       pageTable.adrObject = @websites.samples.default
-      pageTable.ftpsite = @websites."#ftpSite"
+      pageTable.ftpsite = @websites.["#ftpSite"]
 
       html.rundirective("#year = 2020 + 6", @pageTable)
       return pageTable.year == 2026


### PR DESCRIPTION
## Summary

Rewrites all 22 occurrences of dot-quoted-string member access for `#`-prefixed leaf names in `tests/integration/test_cases/html_framework_tests.yaml` to the canonical bracket form:

- `@websites."#ftpSite"` becomes `@websites.["#ftpSite"]`

### Why

The protocol `script/eval` path cannot compile UserTalk expressions of the form `@table."#leaf"`. The dot-quoted-string member access fails parsing inside the with-wrapper, the same way `@x.y.stringType` does when a leaf name collides with a global constant or keyword. The canonical idiom for any leaf with special characters or keyword collisions is the bracket form `@x.y.["leaf"]`, documented in `docs/usertalk/CLAUDE_PRIMER.md` and the project CLAUDE.md.

### Scope

Tests-only diff. No C, UT, or runner changes. 22 occurrences across 22 distinct `html.*` integration tests (one per test).

### Counts (full integration suite, `cd tests && make test-integration`)

Before:

- Total 2321, Passed 2052, Skipped 207, Failed 62

After:

- Total 2321, Passed 2064, Skipped 207, Failed 50

Net: 14 `html.*` tests flipped from fail to pass. One unrelated tcp test (`tcp.listenStream - concurrent connections`) appeared in the failure delta and passes in isolation — a known flaky/timing-sensitive test, not a regression from this YAML change.

### Cluster A overlap (still failing after the rewrite)

13 `html.*` tests still fail because they exercise behavior beyond the leaf-name member access — escaped-string handling, MacRoman curly characters, and the directive-evaluation path inside `html.rundirective` / `html.runoutlinedirectives` / `html.cleanforexport`. Those are kernel-bypass / MacRoman-literal issues (Cluster A) and out of scope for this YAML-only fix. Examples still failing:

- `html.rundirectives - multiple directives` and related (escaped quotes in directive strings)
- `html.cleanforexport - Mac curly single/double quotes`
- `html - complete page generation workflow`
- `html - preference inheritance chain`
- `html - cleanforexport in publishing pipeline`
- `html.glossarypatcher - multiple patches`

## Test plan

- [x] Targeted: each of the 22 rewritten tests confirmed via `runner.py --select` against `dist/Frontier.root`
- [x] Full suite: 62 fail before, 50 fail after, no new failures attributable to this change
- [x] Diff verified: only 22 lines changed in one yaml file
