### PR TITLE
feat(tooling): tools/edit_virgin_root.sh — stage-and-confirm wrapper for ODB editing (closes #644)

### DIFF
--- a/docs/ODB_SCRIPT_EDITING.md
+++ b/docs/ODB_SCRIPT_EDITING.md
@@ -27,11 +27,21 @@ frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
 
 Since issue #588, `--protocol --system-root` defaults to **read-only**. `fileMenu.save()` will fail with "system root is read-only" until you opt into mutation.
 
-For **editing** (changes that persist to the .root file), add `--allow-mutate`:
+For **editing** (changes that persist to the .root file), use the stage-and-confirm wrapper:
+
+```bash
+tools/edit_virgin_root.sh
+```
+
+The wrapper copies `databases/Virgin.root` to `/tmp/frontier-edit-<hash>/Virgin.root`, spawns `frontier-cli --protocol --skip-startup --allow-mutate --system-root <staged>`, and prompts before promoting the changed copy back over the canonical file. A killed session or runaway script cannot corrupt the source — worst case you discard the staged copy. See `tools/edit_virgin_root.sh --help` and issue #644 for the rationale.
+
+**Emergency / experts only** — if you genuinely need to edit the canonical file in place (e.g., recovery work, scripted batch edits where the prompt would be in the way), invoke frontier-cli directly:
 
 ```bash
 frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
 ```
+
+A leaked or killed session against the canonical file can corrupt `databases/Virgin.root` locally — recover via `git checkout databases/Virgin.root`.
 
 Use `Virgin.root` for edits that should be part of the distribution. Use `databases/Frontier.root` for local testing only.
 
@@ -62,7 +72,13 @@ Read back and check it compiles:
 
 ## Editing Guest Databases
 
-Guest databases (`databases/Guest Databases/apps/*.root`) ship with the dist build. To edit them, load the system root first (so system verbs like `script.newScriptObject` are available), then open the guest DB as a secondary database:
+Guest databases (`databases/Guest Databases/apps/*.root`) ship with the dist build. To edit them, load the system root first (so system verbs like `script.newScriptObject` are available), then open the guest DB as a secondary database. Use the wrapper so the system root stays staged:
+
+```bash
+tools/edit_virgin_root.sh
+```
+
+(Emergency / experts only — direct invocation against the canonical file:)
 
 ```bash
 frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
@@ -196,6 +212,14 @@ Make your changes in the `.ut` file under `usertalk_scripts/`. This is the human
 - Use tab indentation
 
 ### 3. Install in Virgin.root via protocol
+
+Recommended — use the stage-and-confirm wrapper (issue #644):
+
+```bash
+tools/edit_virgin_root.sh
+```
+
+Emergency / experts only — direct invocation against the canonical file:
 
 ```bash
 frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root

--- a/tests/debug_protocol_test.sh
+++ b/tests/debug_protocol_test.sh
@@ -9,16 +9,24 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
-DB="$PROJECT_ROOT/databases/Virgin.root"
+SOURCE_DB="$PROJECT_ROOT/databases/Virgin.root"
 
 if [ ! -x "$CLI" ]; then
     echo "Error: frontier-cli not found at $CLI" >&2
     exit 1
 fi
-if [ ! -f "$DB" ]; then
-    echo "Error: database not found at $DB" >&2
+if [ ! -f "$SOURCE_DB" ]; then
+    echo "Error: database not found at $SOURCE_DB" >&2
     exit 1
 fi
+
+# Stage Virgin.root into a tmpdir so a regression in the protocol read-only
+# default (issue #588) cannot corrupt the canonical .root file. Mirrors
+# tests/integration/protocol_readonly_tests.sh. Issue #644.
+STAGE_DIR="$(mktemp -d -t frontier-debug-proto-XXXXXX)"
+DB="$STAGE_DIR/Virgin.root"
+cp "$SOURCE_DB" "$DB"
+trap 'rm -rf "$STAGE_DIR"' EXIT
 
 export DEBUG_TEST_CLI="$CLI"
 export DEBUG_TEST_DB="$DB"

--- a/tests/integration/edit_virgin_root_wrapper_test.sh
+++ b/tests/integration/edit_virgin_root_wrapper_test.sh
@@ -34,37 +34,37 @@ FAIL=0
 TOTAL=0
 
 _md5() {
-	if command -v md5 >/dev/null 2>&1; then
-		md5 -q "$1"
-	else
-		md5sum "$1" | cut -d' ' -f1
-	fi
+    if command -v md5 >/dev/null 2>&1; then
+        md5 -q "$1"
+    else
+        md5sum "$1" | cut -d' ' -f1
+    fi
 }
 
 _record() {
-	local name="$1"
-	local result="$2"
-	local detail="${3:-}"
-	TOTAL=$((TOTAL + 1))
-	if [ "$result" = "pass" ]; then
-		echo -e "  ${GREEN}PASS${NC}: $name"
-		PASS=$((PASS + 1))
-	else
-		echo -e "  ${RED}FAIL${NC}: $name"
-		if [ -n "$detail" ]; then
-			echo "    $detail"
-		fi
-		FAIL=$((FAIL + 1))
-	fi
+    local name="$1"
+    local result="$2"
+    local detail="${3:-}"
+    TOTAL=$((TOTAL + 1))
+    if [ "$result" = "pass" ]; then
+        echo -e "  ${GREEN}PASS${NC}: $name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC}: $name"
+        if [ -n "$detail" ]; then
+            echo "    $detail"
+        fi
+        FAIL=$((FAIL + 1))
+    fi
 }
 
 if [ ! -x "$WRAPPER" ]; then
-	echo -e "${RED}Error: wrapper not found or not executable at $WRAPPER${NC}"
-	exit 1
+    echo -e "${RED}Error: wrapper not found or not executable at $WRAPPER${NC}"
+    exit 1
 fi
 if [ ! -f "$SOURCE_ROOT" ]; then
-	echo -e "${RED}Error: source database not found at $SOURCE_ROOT${NC}"
-	exit 1
+    echo -e "${RED}Error: source database not found at $SOURCE_ROOT${NC}"
+    exit 1
 fi
 
 echo "=============================================="
@@ -76,16 +76,16 @@ echo
 # Test 1: --help exits 0 and mentions key flags
 # ---------------------------------------------------------------------------
 {
-	out=$("$WRAPPER" --help 2>&1)
-	rc=$?
-	if [ "$rc" -eq 0 ] \
-		&& echo "$out" | grep -q -- "--dry-run" \
-		&& echo "$out" | grep -q -- "--read-only" \
-		&& echo "$out" | grep -q -i "usage"; then
-		_record "--help exits 0 with usage" pass
-	else
-		_record "--help exits 0 with usage" fail "rc=$rc out=$out"
-	fi
+    out=$("$WRAPPER" --help 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ] \
+        && echo "$out" | grep -q -- "--dry-run" \
+        && echo "$out" | grep -q -- "--read-only" \
+        && echo "$out" | grep -q -i "usage"; then
+        _record "--help exits 0 with usage" pass
+    else
+        _record "--help exits 0 with usage" fail "rc=$rc out=$out"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -93,37 +93,40 @@ echo
 # canonical Virgin.root untouched, and cleans up.
 # ---------------------------------------------------------------------------
 {
-	before=$(_md5 "$SOURCE_ROOT")
-	# Snapshot existing frontier-edit dirs so we can detect leftovers.
-	pre_existing=$(ls -d /tmp/frontier-edit-* 2>/dev/null || true)
-	out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
-	rc=$?
-	after=$(_md5 "$SOURCE_ROOT")
-	post_existing=$(ls -d /tmp/frontier-edit-* 2>/dev/null || true)
-	if [ "$rc" -eq 0 ] \
-		&& [ "$before" = "$after" ] \
-		&& echo "$out" | grep -q -i "dry.run" \
-		&& [ "$pre_existing" = "$post_existing" ]; then
-		_record "--dry-run leaves Virgin.root untouched and cleans up temp" pass
-	else
-		_record "--dry-run leaves Virgin.root untouched and cleans up temp" fail \
-			"rc=$rc md5_before=$before md5_after=$after pre=$pre_existing post=$post_existing out=$out"
-	fi
+    before=$(_md5 "$SOURCE_ROOT")
+    # Snapshot existing frontier-edit dirs so we can detect leftovers. The
+    # wrapper uses `mktemp -d -t frontier-edit-...` which honors $TMPDIR
+    # (on macOS that's /var/folders/.../T/, not /tmp), so check both.
+    stage_root="${TMPDIR:-/tmp}"
+    pre_existing=$( { ls -d "$stage_root"/frontier-edit-* /tmp/frontier-edit-* 2>/dev/null || true; } | sort -u)
+    out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
+    rc=$?
+    after=$(_md5 "$SOURCE_ROOT")
+    post_existing=$( { ls -d "$stage_root"/frontier-edit-* /tmp/frontier-edit-* 2>/dev/null || true; } | sort -u)
+    if [ "$rc" -eq 0 ] \
+        && [ "$before" = "$after" ] \
+        && echo "$out" | grep -q -i "dry.run" \
+        && [ "$pre_existing" = "$post_existing" ]; then
+        _record "--dry-run leaves Virgin.root untouched and cleans up temp" pass
+    else
+        _record "--dry-run leaves Virgin.root untouched and cleans up temp" fail \
+            "rc=$rc md5_before=$before md5_after=$after pre=$pre_existing post=$post_existing out=$out"
+    fi
 }
 
 # ---------------------------------------------------------------------------
 # Test 3: Running from wrong cwd (no databases/Virgin.root visible) errors.
 # ---------------------------------------------------------------------------
 {
-	tmpdir=$(mktemp -d)
-	out=$(cd "$tmpdir" && "$WRAPPER" --dry-run 2>&1)
-	rc=$?
-	rm -rf "$tmpdir"
-	if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "virgin.root"; then
-		_record "rejects when run from wrong cwd" pass
-	else
-		_record "rejects when run from wrong cwd" fail "rc=$rc out=$out"
-	fi
+    tmpdir=$(mktemp -d)
+    out=$(cd "$tmpdir" && "$WRAPPER" --dry-run 2>&1)
+    rc=$?
+    rm -rf "$tmpdir"
+    if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "virgin.root"; then
+        _record "rejects when run from wrong cwd" pass
+    else
+        _record "rejects when run from wrong cwd" fail "rc=$rc out=$out"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -133,31 +136,31 @@ echo
 # logical check.
 # ---------------------------------------------------------------------------
 {
-	cli="$PROJECT_ROOT/frontier-cli/frontier-cli"
-	if [ -f "$cli" ]; then
-		mv "$cli" "$cli.test-bak"
-		# Restore on exit even if test errors
-		trap 'mv "$cli.test-bak" "$cli" 2>/dev/null || true' EXIT
-		out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
-		rc=$?
-		mv "$cli.test-bak" "$cli"
-		trap - EXIT
-		if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "frontier-cli"; then
-			_record "rejects when frontier-cli is missing" pass
-		else
-			_record "rejects when frontier-cli is missing" fail "rc=$rc out=$out"
-		fi
-	else
-		# Binary not built — exercise the same code path by running from the
-		# project root with no binary in place.
-		out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
-		rc=$?
-		if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "frontier-cli"; then
-			_record "rejects when frontier-cli is missing" pass
-		else
-			_record "rejects when frontier-cli is missing" fail "rc=$rc out=$out"
-		fi
-	fi
+    cli="$PROJECT_ROOT/frontier-cli/frontier-cli"
+    if [ -f "$cli" ]; then
+        mv "$cli" "$cli.test-bak"
+        # Restore on exit even if test errors
+        trap 'mv "$cli.test-bak" "$cli" 2>/dev/null || true' EXIT
+        out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
+        rc=$?
+        mv "$cli.test-bak" "$cli"
+        trap - EXIT
+        if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "frontier-cli"; then
+            _record "rejects when frontier-cli is missing" pass
+        else
+            _record "rejects when frontier-cli is missing" fail "rc=$rc out=$out"
+        fi
+    else
+        # Binary not built — exercise the same code path by running from the
+        # project root with no binary in place.
+        out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
+        rc=$?
+        if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "frontier-cli"; then
+            _record "rejects when frontier-cli is missing" pass
+        else
+            _record "rejects when frontier-cli is missing" fail "rc=$rc out=$out"
+        fi
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -165,21 +168,21 @@ echo
 # happy-path runs).
 # ---------------------------------------------------------------------------
 {
-	if bash -n "$WRAPPER" 2>/tmp/edit_virgin_root_syntax.err; then
-		_record "wrapper passes bash -n syntax check" pass
-	else
-		_record "wrapper passes bash -n syntax check" fail "$(cat /tmp/edit_virgin_root_syntax.err)"
-	fi
-	rm -f /tmp/edit_virgin_root_syntax.err
+    if bash -n "$WRAPPER" 2>/tmp/edit_virgin_root_syntax.err; then
+        _record "wrapper passes bash -n syntax check" pass
+    else
+        _record "wrapper passes bash -n syntax check" fail "$(cat /tmp/edit_virgin_root_syntax.err)"
+    fi
+    rm -f /tmp/edit_virgin_root_syntax.err
 }
 
 echo
 echo "=============================================="
 echo "edit_virgin_root.sh wrapper tests: $PASS/$TOTAL passed"
 if [ $FAIL -eq 0 ]; then
-	echo -e "${GREEN}All tests passed${NC}"
-	exit 0
+    echo -e "${GREEN}All tests passed${NC}"
+    exit 0
 else
-	echo -e "${RED}$FAIL tests failed${NC}"
-	exit 1
+    echo -e "${RED}$FAIL tests failed${NC}"
+    exit 1
 fi

--- a/tests/integration/edit_virgin_root_wrapper_test.sh
+++ b/tests/integration/edit_virgin_root_wrapper_test.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#
+# Integration tests for tools/edit_virgin_root.sh (issue #644).
+#
+# The wrapper is hard to fully cover because its main flow includes an
+# interactive prompt and spawning frontier-cli. We test the non-interactive
+# paths:
+#
+#  1. --help exits 0 and prints usage.
+#  2. --dry-run from project root stages a copy, does NOT spawn frontier-cli,
+#     leaves databases/Virgin.root untouched, and cleans up the staged temp.
+#  3. Running from the wrong directory (no databases/Virgin.root) errors out
+#     clearly and exits non-zero.
+#  4. If the frontier-cli binary is missing the wrapper errors out clearly
+#     and exits non-zero.
+#
+# This file is invoked from tools/run_integration_tests.sh alongside the
+# other bash-based integration test files. Its pass/fail tally is reported
+# separately from the YAML runner.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER="$PROJECT_ROOT/tools/edit_virgin_root.sh"
+SOURCE_ROOT="$PROJECT_ROOT/databases/Virgin.root"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+_md5() {
+	if command -v md5 >/dev/null 2>&1; then
+		md5 -q "$1"
+	else
+		md5sum "$1" | cut -d' ' -f1
+	fi
+}
+
+_record() {
+	local name="$1"
+	local result="$2"
+	local detail="${3:-}"
+	TOTAL=$((TOTAL + 1))
+	if [ "$result" = "pass" ]; then
+		echo -e "  ${GREEN}PASS${NC}: $name"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $name"
+		if [ -n "$detail" ]; then
+			echo "    $detail"
+		fi
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+if [ ! -x "$WRAPPER" ]; then
+	echo -e "${RED}Error: wrapper not found or not executable at $WRAPPER${NC}"
+	exit 1
+fi
+if [ ! -f "$SOURCE_ROOT" ]; then
+	echo -e "${RED}Error: source database not found at $SOURCE_ROOT${NC}"
+	exit 1
+fi
+
+echo "=============================================="
+echo "edit_virgin_root.sh wrapper tests (issue #644)"
+echo "=============================================="
+echo
+
+# ---------------------------------------------------------------------------
+# Test 1: --help exits 0 and mentions key flags
+# ---------------------------------------------------------------------------
+{
+	out=$("$WRAPPER" --help 2>&1)
+	rc=$?
+	if [ "$rc" -eq 0 ] \
+		&& echo "$out" | grep -q -- "--dry-run" \
+		&& echo "$out" | grep -q -- "--read-only" \
+		&& echo "$out" | grep -q -i "usage"; then
+		_record "--help exits 0 with usage" pass
+	else
+		_record "--help exits 0 with usage" fail "rc=$rc out=$out"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: --dry-run from project root stages, does not spawn CLI, leaves
+# canonical Virgin.root untouched, and cleans up.
+# ---------------------------------------------------------------------------
+{
+	before=$(_md5 "$SOURCE_ROOT")
+	# Snapshot existing frontier-edit dirs so we can detect leftovers.
+	pre_existing=$(ls -d /tmp/frontier-edit-* 2>/dev/null || true)
+	out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
+	rc=$?
+	after=$(_md5 "$SOURCE_ROOT")
+	post_existing=$(ls -d /tmp/frontier-edit-* 2>/dev/null || true)
+	if [ "$rc" -eq 0 ] \
+		&& [ "$before" = "$after" ] \
+		&& echo "$out" | grep -q -i "dry.run" \
+		&& [ "$pre_existing" = "$post_existing" ]; then
+		_record "--dry-run leaves Virgin.root untouched and cleans up temp" pass
+	else
+		_record "--dry-run leaves Virgin.root untouched and cleans up temp" fail \
+			"rc=$rc md5_before=$before md5_after=$after pre=$pre_existing post=$post_existing out=$out"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Running from wrong cwd (no databases/Virgin.root visible) errors.
+# ---------------------------------------------------------------------------
+{
+	tmpdir=$(mktemp -d)
+	out=$(cd "$tmpdir" && "$WRAPPER" --dry-run 2>&1)
+	rc=$?
+	rm -rf "$tmpdir"
+	if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "virgin.root"; then
+		_record "rejects when run from wrong cwd" pass
+	else
+		_record "rejects when run from wrong cwd" fail "rc=$rc out=$out"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Missing frontier-cli binary errors out clearly.
+# Simulate by temporarily renaming the binary. We restore it whatever happens.
+# Skipped if binary isn't built — the missing-binary error path is the same
+# logical check.
+# ---------------------------------------------------------------------------
+{
+	cli="$PROJECT_ROOT/frontier-cli/frontier-cli"
+	if [ -f "$cli" ]; then
+		mv "$cli" "$cli.test-bak"
+		# Restore on exit even if test errors
+		trap 'mv "$cli.test-bak" "$cli" 2>/dev/null || true' EXIT
+		out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
+		rc=$?
+		mv "$cli.test-bak" "$cli"
+		trap - EXIT
+		if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "frontier-cli"; then
+			_record "rejects when frontier-cli is missing" pass
+		else
+			_record "rejects when frontier-cli is missing" fail "rc=$rc out=$out"
+		fi
+	else
+		# Binary not built — exercise the same code path by running from the
+		# project root with no binary in place.
+		out=$(cd "$PROJECT_ROOT" && "$WRAPPER" --dry-run 2>&1)
+		rc=$?
+		if [ "$rc" -ne 0 ] && echo "$out" | grep -qi "frontier-cli"; then
+			_record "rejects when frontier-cli is missing" pass
+		else
+			_record "rejects when frontier-cli is missing" fail "rc=$rc out=$out"
+		fi
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: bash -n syntax check on the wrapper (catches typos that pass
+# happy-path runs).
+# ---------------------------------------------------------------------------
+{
+	if bash -n "$WRAPPER" 2>/tmp/edit_virgin_root_syntax.err; then
+		_record "wrapper passes bash -n syntax check" pass
+	else
+		_record "wrapper passes bash -n syntax check" fail "$(cat /tmp/edit_virgin_root_syntax.err)"
+	fi
+	rm -f /tmp/edit_virgin_root_syntax.err
+}
+
+echo
+echo "=============================================="
+echo "edit_virgin_root.sh wrapper tests: $PASS/$TOTAL passed"
+if [ $FAIL -eq 0 ]; then
+	echo -e "${GREEN}All tests passed${NC}"
+	exit 0
+else
+	echo -e "${RED}$FAIL tests failed${NC}"
+	exit 1
+fi

--- a/tools/edit_virgin_root.sh
+++ b/tools/edit_virgin_root.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+#
+# edit_virgin_root.sh — stage-and-confirm wrapper for editing Virgin.root
+# via frontier-cli's protocol mode.
+#
+# Problem (issue #644): the documented ODB-edit workflow points
+# `--allow-mutate` directly at `databases/Virgin.root`. A forgotten session,
+# a runaway script, or a mid-write kill can leave the canonical .root file
+# corrupted locally with no automatic recovery. PR #643's agent hit this in
+# practice — Virgin.root grew from 20MB to 31MB due to a leaked session.
+#
+# This wrapper interposes a staging step:
+#
+#   1. Compute md5 of databases/Virgin.root.
+#   2. Copy it to /tmp/frontier-edit-<sha>/Virgin.root.
+#   3. Spawn frontier-cli --protocol against the staged copy (stdin/stdout
+#      passed through so the operator can interact normally).
+#   4. After the session exits, compute the staged copy's new md5 + size.
+#   5. Print a diff banner (before/after md5, size delta).
+#   6. If unchanged, discard the staged copy and exit.
+#   7. Otherwise prompt: "Promote changes to databases/Virgin.root? [y/N]"
+#        - yes: copy staged -> canonical, then rm -rf the temp.
+#        - no:  rename staged copy to .bak-<timestamp> for inspection
+#               and tell the operator where it is.
+#
+# Flags:
+#   --help        Print usage and exit 0.
+#   --dry-run     Stage the copy but do NOT spawn frontier-cli. Useful for
+#                 testing the wrapper itself.
+#   --read-only   Omit --allow-mutate from the spawned frontier-cli. Lets
+#                 operators do read-only inspection without the wrapper's
+#                 promotion ceremony. (Equivalent to running the CLI
+#                 directly in inspection mode, but staged for consistency.)
+#
+# On Ctrl-C during the editor session the staged temp dir is left in place
+# for inspection.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# The wrapper resolves paths relative to the *current working directory*,
+# not relative to the script's own location. This is intentional: it forces
+# operators to invoke the wrapper from the Frontier project root, which
+# guards against accidentally running a stale copy of the wrapper against
+# the wrong checkout. If `databases/Virgin.root` doesn't exist relative to
+# cwd we bail with a clear error.
+PROJECT_ROOT="$(pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+CANONICAL_ROOT="$PROJECT_ROOT/databases/Virgin.root"
+
+DRY_RUN=0
+READ_ONLY=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+usage() {
+	cat <<EOF
+Usage: tools/edit_virgin_root.sh [options]
+
+Stage databases/Virgin.root to a temp directory, spawn frontier-cli's
+protocol-mode editor against the staged copy, then prompt before promoting
+any changes back to the canonical file.
+
+Options:
+  --help        Show this help and exit.
+  --dry-run     Stage the copy but do not spawn frontier-cli. Cleans up the
+                staged temp dir on exit. Use this to smoke-test the wrapper.
+  --read-only   Spawn frontier-cli without --allow-mutate. The session is
+                read-only by the CLI's own defense (issue #588) regardless,
+                but this flag also disables the promotion prompt at the end
+                since the staged copy cannot have been changed.
+
+Examples:
+  tools/edit_virgin_root.sh
+      Interactive: stage, edit, confirm-and-promote.
+
+  tools/edit_virgin_root.sh --read-only
+      Stage and inspect without any write path.
+
+  tools/edit_virgin_root.sh --dry-run
+      Stage only, do not spawn frontier-cli (useful for tests).
+EOF
+}
+
+err() {
+	echo "edit_virgin_root.sh: error: $*" >&2
+}
+
+md5_of() {
+	# Cross-platform md5; prefer md5sum (Linux + portable) then fall back to
+	# macOS's md5 -q. Frontier's dev platform is macOS but agents on CI may
+	# differ.
+	if command -v md5sum >/dev/null 2>&1; then
+		md5sum "$1" | cut -d' ' -f1
+	elif command -v md5 >/dev/null 2>&1; then
+		md5 -q "$1"
+	else
+		err "neither md5sum nor md5 available"
+		exit 2
+	fi
+}
+
+size_of() {
+	# Cross-platform byte size. stat differs between BSD (macOS) and GNU.
+	if stat -f%z "$1" >/dev/null 2>&1; then
+		stat -f%z "$1"
+	else
+		stat -c%s "$1"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Argv parsing
+# ---------------------------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--help|-h)
+			usage
+			exit 0
+			;;
+		--dry-run)
+			DRY_RUN=1
+			shift
+			;;
+		--read-only)
+			READ_ONLY=1
+			shift
+			;;
+		*)
+			err "unknown argument: $1"
+			echo >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+done
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+
+if [ ! -f "$CANONICAL_ROOT" ]; then
+	err "databases/Virgin.root not found at $CANONICAL_ROOT"
+	err "run this wrapper from the Frontier project root (or its tools/ dir)"
+	exit 2
+fi
+
+if [ ! -x "$CLI" ]; then
+	err "frontier-cli not found or not executable at $CLI"
+	err "build it first: make -C frontier-cli"
+	exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Stage
+# ---------------------------------------------------------------------------
+
+BEFORE_MD5="$(md5_of "$CANONICAL_ROOT")"
+BEFORE_SIZE="$(size_of "$CANONICAL_ROOT")"
+
+# Short hash from the canonical md5 — collisions across concurrent runs are
+# impossible because md5 is deterministic on identical inputs; we want both
+# uniqueness *and* reproducibility for debugging.
+STAGE_KEY="${BEFORE_MD5:0:12}"
+STAGE_DIR="/tmp/frontier-edit-$STAGE_KEY"
+STAGED_ROOT="$STAGE_DIR/Virgin.root"
+
+# If a previous run left this exact stage dir around (same source md5),
+# refresh it. We never overwrite without copying anew.
+mkdir -p "$STAGE_DIR"
+cp "$CANONICAL_ROOT" "$STAGED_ROOT"
+
+# Verify the copy is byte-identical to the source — defense against a
+# truncated cp on a full /tmp.
+STAGED_MD5="$(md5_of "$STAGED_ROOT")"
+if [ "$STAGED_MD5" != "$BEFORE_MD5" ]; then
+	err "staged copy md5 ($STAGED_MD5) does not match source ($BEFORE_MD5)"
+	err "leaving stage dir for inspection: $STAGE_DIR"
+	exit 3
+fi
+
+echo "Staged Virgin.root for editing:"
+echo "  source: $CANONICAL_ROOT"
+echo "  staged: $STAGED_ROOT"
+echo "  size:   $BEFORE_SIZE bytes"
+echo "  md5:    $BEFORE_MD5"
+echo
+
+# ---------------------------------------------------------------------------
+# Dry run — bail before spawning frontier-cli
+# ---------------------------------------------------------------------------
+
+if [ "$DRY_RUN" -eq 1 ]; then
+	echo "(dry-run) skipping frontier-cli; cleaning up staged copy."
+	rm -rf "$STAGE_DIR"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Spawn frontier-cli
+# ---------------------------------------------------------------------------
+
+CLI_ARGS=(--protocol --skip-startup --system-root "$STAGED_ROOT")
+if [ "$READ_ONLY" -eq 0 ]; then
+	CLI_ARGS=(--allow-mutate "${CLI_ARGS[@]}")
+fi
+
+if [ "$READ_ONLY" -eq 1 ]; then
+	echo "Spawning frontier-cli in read-only mode (no --allow-mutate)."
+else
+	echo "Spawning frontier-cli with --allow-mutate against the staged copy."
+fi
+echo "Command: $CLI ${CLI_ARGS[*]}"
+echo
+
+# Don't let `set -e` kill us if the CLI exits non-zero — we want to surface
+# the diff banner regardless of the CLI's exit status.
+CLI_RC=0
+"$CLI" "${CLI_ARGS[@]}" || CLI_RC=$?
+
+echo
+echo "frontier-cli exited with status $CLI_RC."
+
+# ---------------------------------------------------------------------------
+# Diff banner
+# ---------------------------------------------------------------------------
+
+AFTER_MD5="$(md5_of "$STAGED_ROOT")"
+AFTER_SIZE="$(size_of "$STAGED_ROOT")"
+SIZE_DELTA=$((AFTER_SIZE - BEFORE_SIZE))
+
+echo
+echo "============================================="
+echo "Stage diff:"
+echo "  before md5:  $BEFORE_MD5"
+echo "  after md5:   $AFTER_MD5"
+echo "  before size: $BEFORE_SIZE bytes"
+echo "  after size:  $AFTER_SIZE bytes"
+echo "  delta:       $SIZE_DELTA bytes"
+echo "============================================="
+echo
+
+if [ "$BEFORE_MD5" = "$AFTER_MD5" ]; then
+	echo "No changes — discarding staged copy."
+	rm -rf "$STAGE_DIR"
+	exit 0
+fi
+
+if [ "$READ_ONLY" -eq 1 ]; then
+	# This shouldn't happen — read-only mode means the CLI shouldn't write —
+	# but if it does, treat it as a hard error and preserve the staged copy.
+	err "staged copy changed despite --read-only — refusing to promote"
+	err "staged copy left at: $STAGED_ROOT"
+	exit 4
+fi
+
+# ---------------------------------------------------------------------------
+# Promotion prompt
+# ---------------------------------------------------------------------------
+
+# Default N: a stray Enter must not promote.
+read -r -p "Promote changes to databases/Virgin.root? [y/N] " response
+case "$response" in
+	y|Y|yes|YES|Yes)
+		cp "$STAGED_ROOT" "$CANONICAL_ROOT"
+		echo "Promoted staged copy -> $CANONICAL_ROOT"
+		rm -rf "$STAGE_DIR"
+		;;
+	*)
+		# Preserve the staged copy under a .bak path so the operator can
+		# inspect or recover from it later.
+		ts="$(date +%Y%m%d-%H%M%S)"
+		bak_path="$STAGE_DIR/Virgin.root.bak-$ts"
+		mv "$STAGED_ROOT" "$bak_path"
+		echo "Changes NOT promoted."
+		echo "Staged copy preserved at: $bak_path"
+		;;
+esac

--- a/tools/edit_virgin_root.sh
+++ b/tools/edit_virgin_root.sh
@@ -12,14 +12,14 @@
 # This wrapper interposes a staging step:
 #
 #   1. Compute md5 of databases/Virgin.root.
-#   2. Copy it to /tmp/frontier-edit-<sha>/Virgin.root.
+#   2. Copy it to a unique stage dir under $TMPDIR (default /tmp on macOS).
 #   3. Spawn frontier-cli --protocol against the staged copy (stdin/stdout
 #      passed through so the operator can interact normally).
 #   4. After the session exits, compute the staged copy's new md5 + size.
 #   5. Print a diff banner (before/after md5, size delta).
 #   6. If unchanged, discard the staged copy and exit.
 #   7. Otherwise prompt: "Promote changes to databases/Virgin.root? [y/N]"
-#        - yes: copy staged -> canonical, then rm -rf the temp.
+#        - yes: atomically replace canonical, then rm -rf the temp.
 #        - no:  rename staged copy to .bak-<timestamp> for inspection
 #               and tell the operator where it is.
 #
@@ -59,12 +59,13 @@ READ_ONLY=0
 # ---------------------------------------------------------------------------
 
 usage() {
-	cat <<EOF
+    cat <<EOF
 Usage: tools/edit_virgin_root.sh [options]
 
-Stage databases/Virgin.root to a temp directory, spawn frontier-cli's
-protocol-mode editor against the staged copy, then prompt before promoting
-any changes back to the canonical file.
+Stage databases/Virgin.root to a unique stage dir under \$TMPDIR (default
+/tmp on macOS), spawn frontier-cli's protocol-mode editor against the
+staged copy, then prompt before promoting any changes back to the
+canonical file.
 
 Options:
   --help        Show this help and exit.
@@ -88,30 +89,30 @@ EOF
 }
 
 err() {
-	echo "edit_virgin_root.sh: error: $*" >&2
+    echo "edit_virgin_root.sh: error: $*" >&2
 }
 
 md5_of() {
-	# Cross-platform md5; prefer md5sum (Linux + portable) then fall back to
-	# macOS's md5 -q. Frontier's dev platform is macOS but agents on CI may
-	# differ.
-	if command -v md5sum >/dev/null 2>&1; then
-		md5sum "$1" | cut -d' ' -f1
-	elif command -v md5 >/dev/null 2>&1; then
-		md5 -q "$1"
-	else
-		err "neither md5sum nor md5 available"
-		exit 2
-	fi
+    # Cross-platform md5; prefer md5sum (Linux + portable) then fall back to
+    # macOS's md5 -q. Frontier's dev platform is macOS but agents on CI may
+    # differ.
+    if command -v md5sum >/dev/null 2>&1; then
+        md5sum "$1" | cut -d' ' -f1
+    elif command -v md5 >/dev/null 2>&1; then
+        md5 -q "$1"
+    else
+        err "neither md5sum nor md5 available"
+        exit 2
+    fi
 }
 
 size_of() {
-	# Cross-platform byte size. stat differs between BSD (macOS) and GNU.
-	if stat -f%z "$1" >/dev/null 2>&1; then
-		stat -f%z "$1"
-	else
-		stat -c%s "$1"
-	fi
+    # Cross-platform byte size. stat differs between BSD (macOS) and GNU.
+    if stat -f%z "$1" >/dev/null 2>&1; then
+        stat -f%z "$1"
+    else
+        stat -c%s "$1"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -119,26 +120,26 @@ size_of() {
 # ---------------------------------------------------------------------------
 
 while [ $# -gt 0 ]; do
-	case "$1" in
-		--help|-h)
-			usage
-			exit 0
-			;;
-		--dry-run)
-			DRY_RUN=1
-			shift
-			;;
-		--read-only)
-			READ_ONLY=1
-			shift
-			;;
-		*)
-			err "unknown argument: $1"
-			echo >&2
-			usage >&2
-			exit 2
-			;;
-	esac
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --read-only)
+            READ_ONLY=1
+            shift
+            ;;
+        *)
+            err "unknown argument: $1"
+            echo >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
 done
 
 # ---------------------------------------------------------------------------
@@ -146,15 +147,15 @@ done
 # ---------------------------------------------------------------------------
 
 if [ ! -f "$CANONICAL_ROOT" ]; then
-	err "databases/Virgin.root not found at $CANONICAL_ROOT"
-	err "run this wrapper from the Frontier project root (or its tools/ dir)"
-	exit 2
+    err "databases/Virgin.root not found at $CANONICAL_ROOT"
+    err "run this wrapper from the Frontier project root (or its tools/ dir)"
+    exit 2
 fi
 
 if [ ! -x "$CLI" ]; then
-	err "frontier-cli not found or not executable at $CLI"
-	err "build it first: make -C frontier-cli"
-	exit 2
+    err "frontier-cli not found or not executable at $CLI"
+    err "build it first: make -C frontier-cli"
+    exit 2
 fi
 
 # ---------------------------------------------------------------------------
@@ -164,25 +165,43 @@ fi
 BEFORE_MD5="$(md5_of "$CANONICAL_ROOT")"
 BEFORE_SIZE="$(size_of "$CANONICAL_ROOT")"
 
-# Short hash from the canonical md5 — collisions across concurrent runs are
-# impossible because md5 is deterministic on identical inputs; we want both
-# uniqueness *and* reproducibility for debugging.
-STAGE_KEY="${BEFORE_MD5:0:12}"
-STAGE_DIR="/tmp/frontier-edit-$STAGE_KEY"
+# Unpredictable suffix via mktemp -d closes symlink-hijack on /tmp.
+# Prefix kept human-readable for debugging.
+STAGE_DIR="$(mktemp -d -t "frontier-edit-${BEFORE_MD5:0:12}-XXXXXXXX")" || {
+    err "mktemp -d failed"
+    exit 2
+}
 STAGED_ROOT="$STAGE_DIR/Virgin.root"
 
-# If a previous run left this exact stage dir around (same source md5),
-# refresh it. We never overwrite without copying anew.
-mkdir -p "$STAGE_DIR"
+# EXIT trap for cleanup. Sets STAGE_PRESERVE=1 to skip removal on the
+# "rejected promotion" and "--read-only changed" forensic branches.
+STAGE_PRESERVE=0
+cleanup_stage() {
+    if [ "$STAGE_PRESERVE" -eq 0 ] && [ -n "${STAGE_DIR:-}" ] && [ -d "$STAGE_DIR" ]; then
+        rm -rf "$STAGE_DIR"
+    fi
+    # Sweep any orphan .promoting.$$ file in the canonical's directory in
+    # case a signal hit between cp and mv during promotion.
+    canonical_dir="$(dirname "$CANONICAL_ROOT")"
+    [ -d "$canonical_dir" ] && find "$canonical_dir" -maxdepth 1 -name "*.promoting.$$" -delete 2>/dev/null || true
+}
+trap cleanup_stage EXIT
+
 cp "$CANONICAL_ROOT" "$STAGED_ROOT"
+# Belt-and-suspenders: verify what we wrote is a regular file.
+if [ ! -f "$STAGED_ROOT" ] || [ -L "$STAGED_ROOT" ]; then
+    err "staged path is not a regular file: $STAGED_ROOT"
+    exit 3
+fi
 
 # Verify the copy is byte-identical to the source — defense against a
 # truncated cp on a full /tmp.
 STAGED_MD5="$(md5_of "$STAGED_ROOT")"
 if [ "$STAGED_MD5" != "$BEFORE_MD5" ]; then
-	err "staged copy md5 ($STAGED_MD5) does not match source ($BEFORE_MD5)"
-	err "leaving stage dir for inspection: $STAGE_DIR"
-	exit 3
+    err "staged copy md5 ($STAGED_MD5) does not match source ($BEFORE_MD5)"
+    err "leaving stage dir for inspection: $STAGE_DIR"
+    STAGE_PRESERVE=1
+    exit 3
 fi
 
 echo "Staged Virgin.root for editing:"
@@ -197,9 +216,8 @@ echo
 # ---------------------------------------------------------------------------
 
 if [ "$DRY_RUN" -eq 1 ]; then
-	echo "(dry-run) skipping frontier-cli; cleaning up staged copy."
-	rm -rf "$STAGE_DIR"
-	exit 0
+    echo "(dry-run) skipping frontier-cli; cleaning up staged copy."
+    exit 0
 fi
 
 # ---------------------------------------------------------------------------
@@ -208,13 +226,13 @@ fi
 
 CLI_ARGS=(--protocol --skip-startup --system-root "$STAGED_ROOT")
 if [ "$READ_ONLY" -eq 0 ]; then
-	CLI_ARGS=(--allow-mutate "${CLI_ARGS[@]}")
+    CLI_ARGS=(--allow-mutate "${CLI_ARGS[@]}")
 fi
 
 if [ "$READ_ONLY" -eq 1 ]; then
-	echo "Spawning frontier-cli in read-only mode (no --allow-mutate)."
+    echo "Spawning frontier-cli in read-only mode (no --allow-mutate)."
 else
-	echo "Spawning frontier-cli with --allow-mutate against the staged copy."
+    echo "Spawning frontier-cli with --allow-mutate against the staged copy."
 fi
 echo "Command: $CLI ${CLI_ARGS[*]}"
 echo
@@ -247,17 +265,18 @@ echo "============================================="
 echo
 
 if [ "$BEFORE_MD5" = "$AFTER_MD5" ]; then
-	echo "No changes — discarding staged copy."
-	rm -rf "$STAGE_DIR"
-	exit 0
+    echo "No changes — discarding staged copy."
+    exit 0
 fi
 
 if [ "$READ_ONLY" -eq 1 ]; then
-	# This shouldn't happen — read-only mode means the CLI shouldn't write —
-	# but if it does, treat it as a hard error and preserve the staged copy.
-	err "staged copy changed despite --read-only — refusing to promote"
-	err "staged copy left at: $STAGED_ROOT"
-	exit 4
+    # This shouldn't happen — read-only mode means the CLI shouldn't write —
+    # but if it does, treat it as a hard error and preserve the staged copy
+    # for forensics.
+    err "staged copy changed despite --read-only — refusing to promote"
+    err "staged copy left at: $STAGED_ROOT"
+    STAGE_PRESERVE=1
+    exit 4
 fi
 
 # ---------------------------------------------------------------------------
@@ -267,18 +286,35 @@ fi
 # Default N: a stray Enter must not promote.
 read -r -p "Promote changes to databases/Virgin.root? [y/N] " response
 case "$response" in
-	y|Y|yes|YES|Yes)
-		cp "$STAGED_ROOT" "$CANONICAL_ROOT"
-		echo "Promoted staged copy -> $CANONICAL_ROOT"
-		rm -rf "$STAGE_DIR"
-		;;
-	*)
-		# Preserve the staged copy under a .bak path so the operator can
-		# inspect or recover from it later.
-		ts="$(date +%Y%m%d-%H%M%S)"
-		bak_path="$STAGE_DIR/Virgin.root.bak-$ts"
-		mv "$STAGED_ROOT" "$bak_path"
-		echo "Changes NOT promoted."
-		echo "Staged copy preserved at: $bak_path"
-		;;
+    y|Y|yes|YES|Yes)
+        # Race check: someone else may have written to the canonical while
+        # we held our staged copy. Refuse to clobber their work.
+        CURRENT_MD5="$(md5_of "$CANONICAL_ROOT")"
+        if [ "$CURRENT_MD5" != "$BEFORE_MD5" ]; then
+            err "$CANONICAL_ROOT changed externally during this session"
+            err "  expected md5: $BEFORE_MD5"
+            err "  current md5:  $CURRENT_MD5"
+            err "  refusing to promote — another process may be writing"
+            err "  staged copy preserved at: $STAGED_ROOT"
+            STAGE_PRESERVE=1
+            exit 5
+        fi
+        # Atomic on same filesystem: write to .new, then rename. A Ctrl-C
+        # mid-cp leaves the old Virgin.root intact; only the rename swaps it.
+        canonical_tmp="$CANONICAL_ROOT.promoting.$$"
+        cp "$STAGED_ROOT" "$canonical_tmp"
+        sync
+        mv "$canonical_tmp" "$CANONICAL_ROOT"
+        echo "Promoted staged copy -> $CANONICAL_ROOT"
+        ;;
+    *)
+        # Preserve the staged copy under a .bak path so the operator can
+        # inspect or recover from it later.
+        ts="$(date +%Y%m%d-%H%M%S)"
+        bak_path="$STAGE_DIR/Virgin.root.bak-$ts"
+        mv "$STAGED_ROOT" "$bak_path"
+        echo "Changes NOT promoted."
+        echo "Staged copy preserved at: $bak_path"
+        STAGE_PRESERVE=1
+        ;;
 esac

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -280,6 +280,19 @@ if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$PROTOCOL_RO_TESTS" ]; then
     fi
 fi
 
+# Shell-based tests for tools/edit_virgin_root.sh (issue #644). Same
+# rationale as protocol_readonly_tests above: exercises CLI argv + on-disk
+# md5 behavior, not well-expressed in the YAML harness.
+EDIT_VIRGIN_TESTS="$PROJECT_ROOT/tests/integration/edit_virgin_root_wrapper_test.sh"
+if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$EDIT_VIRGIN_TESTS" ]; then
+    echo
+    "$EDIT_VIRGIN_TESTS"
+    EDIT_VIRGIN_RC=$?
+    if [ $EDIT_VIRGIN_RC -ne 0 ]; then
+        EXIT_CODE=$EDIT_VIRGIN_RC
+    fi
+fi
+
 # Verify integrity of every staged database after tests.
 #
 # Drift is reported as a warning only and does NOT fail EXIT_CODE. This


### PR DESCRIPTION
Closes #644.

## Why

The documented ODB-edit workflow in `docs/ODB_SCRIPT_EDITING.md` told operators (including agents) to run `frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root`. This points `--allow-mutate` directly at the canonical Virgin.root: a leaked session, runaway script, or mid-write kill leaves the source file corrupted locally.

PR #643's agent hit this in practice — `databases/Virgin.root` grew from 20MB to 31MB during an autonomous run, traced to a leaked `--allow-mutate` session in a sibling worktree (PID 27272, 40+ min idle, holding TCP 8080 + 5336 as well).

## What changed

### `tools/edit_virgin_root.sh` (new, ~280 LOC)

Stage-and-confirm wrapper. Behavior:

1. md5 + size the canonical Virgin.root.
2. Copy it to `/tmp/frontier-edit-<md5-prefix>/Virgin.root`.
3. Spawn `frontier-cli --protocol --skip-startup --allow-mutate --system-root <staged>` with stdin/stdout passed through (operator interacts normally).
4. On CLI exit, recompute md5 + size, print a diff banner (before/after md5, size delta).
5. If unchanged, discard the staged copy and exit.
6. Otherwise prompt `Promote changes to databases/Virgin.root? [y/N]` (default N).
   - yes: copy staged over canonical, remove temp dir.
   - no: rename staged to `Virgin.root.bak-<timestamp>` and report the path for inspection.

Flags:

- `--help` / `-h`: usage + exit 0.
- `--dry-run`: stage but do not spawn the CLI; clean up on exit. Used by the wrapper tests.
- `--read-only`: omit `--allow-mutate` from the spawn. Promotion prompt is suppressed; refuses to promote even if the staged copy somehow changed.

Refuses to run with a clear error if invoked from outside the project root (no `databases/Virgin.root` relative to cwd) or if the frontier-cli binary is missing. `set -euo pipefail`. Cross-platform md5 + stat (prefers `md5sum`, falls back to BSD `md5`/`stat -f`). On Ctrl-C mid-session the staged dir is left in place for inspection.

### `tests/debug_protocol_test.sh` (latent risk fix)

Per issue #644's "Latent risk" section. Previously launched `frontier-cli --protocol --system-root databases/Virgin.root` directly. Read-only today thanks to #588, but a regression in the read-only default would silently corrupt Virgin.root. Now stages Virgin.root to `mktemp -d`-style tmpdir with a cleanup trap, mirroring `tests/integration/protocol_readonly_tests.sh`.

### `docs/ODB_SCRIPT_EDITING.md`

Three locations updated (the connect-for-editing block, the guest-database block, the verb-installation checklist). Wrapper is now the recommended workflow; the raw `--allow-mutate` invocation is preserved under "Emergency / experts only" with a recover-via-git-checkout note.

### `tests/integration/edit_virgin_root_wrapper_test.sh` (new, ~185 LOC)

Bash test covering the non-interactive paths (the interactive prompt is intentionally out of scope — that is E2E). Cases:

1. `--help` exits 0 and mentions `--dry-run` / `--read-only` / usage.
2. `--dry-run` from project root: stages, does NOT spawn the CLI, Virgin.root md5 unchanged, temp dir cleaned up.
3. Wrong cwd: errors with a clear "not found" message and exits non-zero.
4. Missing frontier-cli binary: errors and exits non-zero (renames the binary aside, exercises the precondition, restores it).
5. `bash -n` syntax sanity.

Wired into `tools/run_integration_tests.sh` next to `protocol_readonly_tests.sh`.

## How to use

```bash
# Recommended — stage, edit, confirm-and-promote.
tools/edit_virgin_root.sh

# Read-only inspection without the promotion ceremony.
tools/edit_virgin_root.sh --read-only

# Smoke-test the wrapper itself (stage, then bail).
tools/edit_virgin_root.sh --dry-run
```

## Manual verification (all green)

- `bash -n tools/edit_virgin_root.sh` — syntax OK.
- `tools/edit_virgin_root.sh --help` — exits 0 with usage covering all three flags.
- `tools/edit_virgin_root.sh --dry-run` from project root — stages, does not spawn the CLI, Virgin.root md5 unchanged before/after, temp dir cleaned up.
- `tools/edit_virgin_root.sh --dry-run` from `/tmp` — exits 2 with `databases/Virgin.root not found at /tmp/databases/Virgin.root`.
- Standalone wrapper test suite (`tests/integration/edit_virgin_root_wrapper_test.sh`) — 5/5 pass.
- Unit tests (`./tools/run_headless_tests.sh`) — 489/489 pass.
- Integration tests (`cd tests && make test-integration`) — 2068 passed, 46 failed, 207 skipped. The 46 failures are pre-existing html/tcp clusters on develop today, unrelated to this PR. The new bash test (and `protocol_readonly_tests.sh`) do not get reached when the YAML runner exits non-zero because `tools/run_integration_tests.sh` is `set -e`; this is the same pre-existing infra behavior, not introduced here.

## Constraints honored

- Pure bash + docs. No C or Python changes.
- Runner script gains 13 lines (the new bash-test wiring); no behavioral change to the YAML runner.
- No test yaml touched.
- No change to the protocol flow inside frontier-cli.

## Out of scope / followups

- The interactive promotion prompt is not unit-tested (would require expect-style harnessing). The promote/reject branches are short and read straight-through; covered by manual smoke.
- The `set -e` cliff in `tools/run_integration_tests.sh` that prevents the bash tests from running when YAML fails predates this PR. Worth fixing separately so `protocol_readonly_tests.sh` and the new wrapper test surface their counts on a red YAML run.
