### PR TITLE
fix: --lock-opened-roots flag for safe loaded-root sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ The unit and integration commands above are also listed in the Quick Reference s
 
 **Edit `databases/Virgin.root`** for changes that should persist in builds. `Virgin.root` is the source of truth — `make dist` copies it to `dist/Frontier.root`. Edits to `databases/Frontier.root` are local only and overwritten.
 
-**Always use `--protocol` mode for ODB edits, never `-e`.** Protocol supports multi-step operations without shell escaping issues. Pair with `--allow-mutate` when the edit must persist — `--protocol --system-root` defaults to **read-only** since #588, so `fileMenu.save()` will fail without it.
+**Always use `--protocol` mode for ODB edits, never `-e`.** Protocol supports multi-step operations without shell escaping issues. Protocol mode opens the system root read-write by default (issue #127 restored the legacy default); use `--lock-opened-roots` for inspection-only sessions — in-memory mutations evaluate normally, but the on-exit save is suppressed.
 
 **Always use `script.newScriptObject` / `op.newOutlineObject`** to install scripts — never raw `op.insert`. These verbs handle line ending normalization (LF/CRLF → CR).
 

--- a/Common/SystemHeaders/standard.h
+++ b/Common/SystemHeaders/standard.h
@@ -343,6 +343,22 @@ typedef Pattern xppattern;
 
 extern boolean flcominitialized; /* set up in lang.c */
 
+/* Returns true if env var `name` is set to a value other than "" or "0".
+ * Use for boolean flag-style env vars: empty / "0" / unset are all false.
+ *
+ * `static inline` so it works in any TU that includes standard.h without
+ * needing a dedicated env_util.c and matching makefile entries in both the
+ * CLI and tests builds.
+ *
+ * Note: FRONTIER_OPEN_READONLY (main.c::hydrate_system_root_database) uses
+ * any-value-is-on semantics (even "0" enables it) for pre-existing
+ * back-compat reasons -- do not retrofit env_truthy() onto that call site
+ * without a deliberate semantic-change decision. */
+static inline boolean env_truthy(const char *name) {
+	const char *v = getenv(name);
+	return (boolean)(v != NULL && v[0] != '\0' && strcmp(v, "0") != 0);
+}
+
 #endif
 
 #endif

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -717,6 +717,20 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 		return (false);
 	}
 
+	/* Issue #127: --lock-opened-roots / FRONTIER_LOCK_OPENED_ROOTS=1 forces
+	 * every loaded-from-disk guest DB read-only, regardless of the user's
+	 * db.open(path, readonly) flag. Newly created roots (db.new /
+	 * file.save / file.saveAs / db.compactDatabase) are unaffected --
+	 * those paths don't go through dbopenverb.
+	 *
+	 * env_truthy() (Common/SystemHeaders/standard.h) shares the truthiness
+	 * contract with cli_parser.c so the CLI flag and the dbopenverb env
+	 * check agree on what counts as enabled. */
+	if (!odbrec.flreadonly && env_truthy("FRONTIER_LOCK_OPENED_ROOTS")) {
+		log_debug(LOG_COMP_DB, "dbopenverb: FRONTIER_LOCK_OPENED_ROOTS in effect, forcing readonly=true");
+		odbrec.flreadonly = true;
+	}
+
 	log_debug(LOG_COMP_DB, "dbopenverb: readonly=%d", odbrec.flreadonly);
 
 	/* Auto-migration: If opening a v6 database in read-write mode, migrate to v7.

--- a/docs/CLI_USAGE_GUIDE.md
+++ b/docs/CLI_USAGE_GUIDE.md
@@ -78,8 +78,7 @@ To run `frontier-cli` from any directory, either:
 | | `--non-interactive` | | Alias for `--batch` |
 | `-v` | `--verbose` | | Enable verbose output |
 | | `--debug` | | Enable debug mode |
-| | `--read-only` | | Open `--system-root` read-only; refuse all writes (default for `--protocol`) |
-| | `--allow-mutate` | | Opt `--protocol --system-root` back into read-write (e.g. for installs) |
+| | `--lock-opened-roots` | | Suppress save-on-exit for every loaded-from-disk DB; in-memory mutations still work. Also `FRONTIER_LOCK_OPENED_ROOTS=1` |
 | `-h` | `--help` | | Show help message |
 | | `--version` | | Show version information |
 

--- a/docs/ODB_SCRIPT_EDITING.md
+++ b/docs/ODB_SCRIPT_EDITING.md
@@ -33,12 +33,12 @@ For **editing** (changes that persist to the .root file), use the stage-and-conf
 tools/edit_virgin_root.sh
 ```
 
-The wrapper copies `databases/Virgin.root` to `/tmp/frontier-edit-<hash>/Virgin.root`, spawns `frontier-cli --protocol --skip-startup --allow-mutate --system-root <staged>`, and prompts before promoting the changed copy back over the canonical file. A killed session or runaway script cannot corrupt the source — worst case you discard the staged copy. See `tools/edit_virgin_root.sh --help` and issue #644 for the rationale.
+The wrapper copies `databases/Virgin.root` to `/tmp/frontier-edit-<hash>/Virgin.root`, spawns `frontier-cli --protocol --skip-startup --system-root <staged>`, and prompts before promoting the changed copy back over the canonical file. A killed session or runaway script cannot corrupt the source — worst case you discard the staged copy. See `tools/edit_virgin_root.sh --help` and issue #644 for the rationale.
 
 **Emergency / experts only** — if you genuinely need to edit the canonical file in place (e.g., recovery work, scripted batch edits where the prompt would be in the way), invoke frontier-cli directly:
 
 ```bash
-frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
+frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
 ```
 
 A leaked or killed session against the canonical file can corrupt `databases/Virgin.root` locally — recover via `git checkout databases/Virgin.root`.
@@ -81,7 +81,7 @@ tools/edit_virgin_root.sh
 (Emergency / experts only — direct invocation against the canonical file:)
 
 ```bash
-frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
+frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
 ```
 
 ```json
@@ -222,7 +222,7 @@ tools/edit_virgin_root.sh
 Emergency / experts only — direct invocation against the canonical file:
 
 ```bash
-frontier-cli --protocol --skip-startup --allow-mutate --system-root databases/Virgin.root
+frontier-cli --protocol --skip-startup --system-root databases/Virgin.root
 ```
 
 ```json

--- a/docs/usertalk/CLAUDE_PRIMER.md
+++ b/docs/usertalk/CLAUDE_PRIMER.md
@@ -204,7 +204,7 @@ Full walkthrough with burndown-relevant examples: `debugging_workflow.md`.
 
 Then NDJSON in, NDJSON out. One-shot expressions; great for "what does this verb return on this input?" Per-eval, the protocol wraps in the `with` block — same caveats as yaml tests.
 
-For ODB **edits**, add `--allow-mutate`. `--protocol --system-root` defaults to read-only since #588.
+For ODB **edits**, protocol mode opens the system root read-write by default (issue #127). Use `--lock-opened-roots` to evaluate mutations in memory without persisting them to disk (suitable for inspection-only sessions).
 
 ### `string ()`, `typeof ()`, `nameOf ()` for inspection
 

--- a/docs/usertalk/debugging_workflow.md
+++ b/docs/usertalk/debugging_workflow.md
@@ -28,7 +28,7 @@ The shape of the rule: **eval first if it's a value question, breakpoint first i
 
 ## 2. Protocol mode setup
 
-Read-only session (the default):
+Default-RW session:
 
 ```bash
 ./frontier-cli/frontier-cli --protocol --skip-startup --system-root databases/Frontier.root
@@ -36,7 +36,7 @@ Read-only session (the default):
 
 NDJSON in (one JSON object per line on stdin), NDJSON out (responses + unsolicited notifications on stdout). The protocol stream carries both `script/*` and `debug/*` ops — same session, same connection.
 
-For ODB **edits** (installing verbs, mutating tables), add `--allow-mutate`. Protocol mode has been read-only by default since #588 — this is a safety rail, not a bug.
+Protocol mode opens the system root read-write by default (issue #127 restored the legacy default). To evaluate mutations in memory without persisting them to disk (useful for probes, tests, and inspection-only sessions), add `--lock-opened-roots`.
 
 Suspension reasons you'll see in `debug/suspended` notifications:
 

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -340,11 +340,10 @@ dist: $(TARGET)
 # Use before shipping: make dist && make clean-root
 clean-root: dist
 	@echo "Running userland.cleanRoot on dist/Frontier.root..."
-	@# --allow-mutate opts back into read-write: the issue #588 default for
-	@# --protocol --system-root is read-only, but cleanRoot is an explicit
-	@# install path that needs to persist its mutations to the dist file.
+	@# Protocol mode is now default-RW (issue #127); no opt-in flag needed
+	@# for cleanRoot to persist its mutations to the dist file.
 	@echo '{"op":"script/eval","id":1,"params":{"expression":"userland.cleanRoot()"}}' \
-		| $(DIST_DIR)/frontier-cli --protocol --allow-mutate --system-root $(DIST_DIR)/Frontier.root 2>&1 \
+		| $(DIST_DIR)/frontier-cli --protocol --system-root $(DIST_DIR)/Frontier.root 2>&1 \
 		| tee $(DIST_DIR)/cleanroot.log > /dev/null; \
 	if grep -q '"success":true' $(DIST_DIR)/cleanroot.log; then \
 		echo "cleanRoot completed successfully."; \

--- a/frontier-cli/README.md
+++ b/frontier-cli/README.md
@@ -25,7 +25,7 @@ Frontier CLI is a command-line client for running UserTalk scripts without the l
 ### Current Capabilities
 - Execute UserTalk scripts from files or inline code.
 - Headless operation using the shared test adapters (`FRONTIER_HEADLESS`, `shell_api_headless`).
-- Load the canonical system root database in read-only mode via `--system-root` to expose runtime tables for scripts.
+- Load the canonical system root database via `--system-root` to expose runtime tables for scripts.
 - Verbose and debug logging toggles.
 - Buildable with sanitizers for development use.
 
@@ -88,7 +88,7 @@ Passing database (`-d`, `-q`, `--migrate`) or server (`--server`, `--websocket`,
     -e "1 + 1"
 ```
 
-The system root is opened read-only. The CLI will log descriptive warnings if the file cannot be located, read, or if optional tables (e.g., `system.misc`, `system.menus`) are missing. The headless loader hydrates the tables it needs in memory so script execution can continue, but the warnings are useful cues that the legacy database still needs migration work.
+The system root is opened read-write by default. Use `--lock-opened-roots` (or `FRONTIER_LOCK_OPENED_ROOTS=1` in the environment) to suppress save-on-exit for inspection-only sessions — in-memory mutations still evaluate, but they aren't persisted back to disk. The CLI will log descriptive warnings if the file cannot be located, read, or if optional tables (e.g., `system.misc`, `system.menus`) are missing. The headless loader hydrates the tables it needs in memory so script execution can continue, but the warnings are useful cues that the legacy database still needs migration work.
 
 ## Examples
 
@@ -111,8 +111,7 @@ The system root is opened read-only. The CLI will log descriptive warnings if th
 | `-h, --help` | Show help message | Available |
 | `--version` | Show build/version info | Available |
 | `--system-root PATH` | Load a system root database before running scripts | Available |
-| `--read-only` | Open `--system-root` read-only; refuse all writes (default for `--protocol`) | Available |
-| `--allow-mutate` | Opt `--protocol --system-root` back into read-write mode | Available |
+| `--lock-opened-roots` | Suppress save-on-exit for every loaded-from-disk DB; in-memory mutations still work. Also `FRONTIER_LOCK_OPENED_ROOTS=1` | Available |
 | `-d, --database FILE` | Select database for operations | Disabled (planned) |
 | `-q, --query QUERY` | Execute database query | Disabled (planned) |
 | `-m, --migrate` | Migrate database in place | Disabled (planned) |

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -37,6 +37,7 @@
 
 #include "cli_parser.h"
 #include "cli_utils.h"
+#include "standard.h"			/* env_truthy() */
 #include "../Common/headers/logging.h"
 
 /*
@@ -209,16 +210,6 @@ boolean cli_validate_options(const cli_options_t* options) {
 		}
 	}
 
-	/* --read-only and --allow-mutate are mutually exclusive: a request to
-	 * both forbid and permit writes is contradictory and almost certainly a
-	 * scripting bug. Refusing here keeps the operator's intent explicit
-	 * rather than silently picking one. */
-	if (options->read_only && options->allow_mutate) {
-		log_error(LOG_COMP_GENERAL,
-			"Error: --read-only and --allow-mutate cannot be combined");
-		return false;
-	}
-
 	// Note: Conflict validation for positional .root argument is handled in cli_parse_arguments()
 	// when we detect a .root file and system_root is already set.
 
@@ -252,8 +243,7 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 	/* Long-only option codes (no short alias). 256+ keeps them out of the
 	 * single-character optstring while remaining valid getopt return values. */
 	enum {
-		OPT_READ_ONLY = 256,
-		OPT_ALLOW_MUTATE,
+		OPT_LOCK_OPENED_ROOTS = 256,
 	};
 
 	// Define long options
@@ -273,8 +263,7 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 		{"skip-startup", no_argument, 0, 'S'},
 		{"protocol", no_argument, 0, 'P'},
 		{"ws-port", optional_argument, 0, 'W'},
-		{"read-only", no_argument, 0, OPT_READ_ONLY},
-		{"allow-mutate", no_argument, 0, OPT_ALLOW_MUTATE},
+		{"lock-opened-roots", no_argument, 0, OPT_LOCK_OPENED_ROOTS},
 		{"help", no_argument, 0, 'h'},
 		{"version", no_argument, 0, 'V'},
 		{0, 0, 0, 0}
@@ -513,8 +502,7 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 			case 'D':  options->debug = true; break;
 			case 'S':  options->skip_startup = true; break;
 			case 'P':  options->protocol_mode = true; break;
-			case OPT_READ_ONLY:    options->read_only = true; break;
-			case OPT_ALLOW_MUTATE: options->allow_mutate = true; break;
+			case OPT_LOCK_OPENED_ROOTS: options->lock_opened_roots = true; break;
 			case 'h':  options->show_help = true; break;
 			case 'V':  options->show_version = true; break;
 
@@ -606,6 +594,38 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 
 	free(filtered_argv);
 
+	/* Environment <-> CLI flag synchronization for --lock-opened-roots (issue #127).
+	 *
+	 * The env var FRONTIER_LOCK_OPENED_ROOTS lets the integration test runner
+	 * and other ephemeral consumers opt every loaded-from-disk DB into
+	 * read-only-on-save without threading a CLI flag through every spawn
+	 * site.
+	 *
+	 * Sync rules so non-CLI consumers (e.g., dbopenverb in
+	 * Common/source/dbverbs.c, which has no link to the CLI parser state)
+	 * can read a single source of truth via getenv():
+	 *
+	 *   - If env is set truthy (non-empty and not "0"), it enables the flag.
+	 *   - If --lock-opened-roots was passed on the CLI, the flag is
+	 *     authoritative: setenv() unconditionally so any descendant code
+	 *     path that consults FRONTIER_LOCK_OPENED_ROOTS sees "1", even if
+	 *     the inherited env had FRONTIER_LOCK_OPENED_ROOTS=0. Without this
+	 *     overwrite, the CLI flag would lock the system root while
+	 *     dbopenverb's env check would still permit guest-DB writes --
+	 *     inconsistent state. The explicit CLI flag always wins.
+	 *
+	 * Validation in cli_validate_options() runs after. */
+	{
+		/* env_truthy() lives in Common/SystemHeaders/standard.h; reusing it
+		 * here keeps the FRONTIER_LOCK_OPENED_ROOTS truthiness contract in
+		 * lockstep with dbverbs.c's enforcement check. */
+		if (env_truthy("FRONTIER_LOCK_OPENED_ROOTS"))
+			options->lock_opened_roots = true;
+
+		if (options->lock_opened_roots)
+			setenv("FRONTIER_LOCK_OPENED_ROOTS", "1", 1);
+	}
+
 	// Validate the parsed options
 	return cli_validate_options(options);
 
@@ -689,8 +709,7 @@ void cli_print_options(const cli_options_t* options) {
 	printf("  Force Overwrite: %s\n", options->force_overwrite ? "yes" : "no");
 	printf("  Skip Startup: %s\n", options->skip_startup ? "yes" : "no");
 	printf("  Protocol Mode: %s\n", options->protocol_mode ? "yes" : "no");
-	printf("  Read-Only: %s\n", options->read_only ? "yes" : "no");
-	printf("  Allow Mutate: %s\n", options->allow_mutate ? "yes" : "no");
+	printf("  Lock Opened Roots: %s\n", options->lock_opened_roots ? "yes" : "no");
 	printf("  WebSocket Port: %d\n", options->ws_port);
 	printf("  Verbose: %s\n", options->verbose ? "yes" : "no");
 	printf("  Debug: %s\n", options->debug ? "yes" : "no");

--- a/frontier-cli/cli_parser.h
+++ b/frontier-cli/cli_parser.h
@@ -60,8 +60,11 @@ typedef struct {
 	boolean force_overwrite;	// Force overwrite existing output file (-f/--force)
 	boolean skip_startup;		// Skip startup scripts (--skip-startup)
 	boolean protocol_mode;		// NDJSON protocol mode (--protocol)
-	boolean read_only;			// Open system root read-only (--read-only); blocks all writes
-	boolean allow_mutate;		// Force read-write opt-in for --protocol --system-root (--allow-mutate)
+	boolean lock_opened_roots;	// Treat every loaded-from-disk DB as read-only on save
+								// (--lock-opened-roots / FRONTIER_LOCK_OPENED_ROOTS=1).
+								// In-memory mutations still work, only disk writes are
+								// suppressed. Newly created roots (file.save / file.saveAs /
+								// db.compactDatabase) are unaffected. Issue #127.
 	int ws_port;				// WebSocket server port (--ws-port), 0 = disabled
 	boolean show_help;			// Show help flag
 	boolean show_version;		// Show version flag

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -60,6 +60,7 @@
 #include "../Common/headers/memory.h"
 #include "../Common/headers/strings.h"
 #include "../Common/headers/tablestructure.h"
+#include "../Common/headers/tableinternal.h"
 #include "../Common/headers/shell_api.h"
 #include "../Common/headers/db.h"
 #include "../Common/headers/file.h"
@@ -146,23 +147,19 @@ boolean cli_should_skip_startup(void) {
 /*
  * Decide whether to open the system root read-only based on parsed CLI flags.
  *
- * Policy (issue #588):
- *   --read-only            -> always read-only (explicit operator request)
- *   --allow-mutate         -> always read-write (explicit opt-in)
- *   otherwise + --protocol -> read-only by default (protects canonical roots
- *                             during inspection / scripted probes; matches the
- *                             primary use case)
- *   otherwise              -> read-write (preserve legacy -e / REPL behavior)
- *
- * Validation in cli_validate_options() rejects --read-only + --allow-mutate
- * together, so the explicit branches never disagree.
+ * Policy:
+ *   --lock-opened-roots    -> suppress save-on-exit for loaded-from-disk DBs
+ *                             (issue #127). In-memory mutations still
+ *                             evaluate; only the disk persist is skipped.
+ *                             Newly created roots (file.save / file.saveAs /
+ *                             db.compactDatabase) are unaffected — those
+ *                             paths don't go through the on-exit save.
+ *   otherwise              -> read-write (legacy Frontier semantics: every
+ *                             system root and guest DB is mutable by default,
+ *                             including under --protocol).
  */
 static boolean cli_compute_effective_read_only(const cli_options_t *opts) {
-	if (opts->read_only)
-		return true;
-	if (opts->allow_mutate)
-		return false;
-	if (opts->protocol_mode)
+	if (opts->lock_opened_roots)
 		return true;
 	return false;
 }
@@ -361,7 +358,9 @@ static boolean load_system_root_database(const char* path);
 static void unload_system_root_database(void);
 static void save_system_root_on_exit(void);
 static boolean ensure_named_subtable(hdlhashtable parent, const unsigned char *name, hdlhashtable *out, boolean mark_dont_save);
+static boolean ensure_named_subtable_ex(hdlhashtable parent, const unsigned char *name, hdlhashtable *out, boolean mark_dont_save, boolean *out_created);
 static boolean hydrate_system_root_database(const char* path, boolean read_only);
+static void clear_post_hydration_dirty_flags(hdlhashtable ht);
 static boolean read_root_table_address(const char *path, dbaddress *adr_out, short *version_out);
 static void log_system_subtable_status(const char *phase,
 									   hdlhashtable system,
@@ -596,6 +595,14 @@ int main(int argc, char* argv[]) {
 			log_error(LOG_COMP_GENERAL, "Error: startup scripts failed for: %s", system_root_to_load);
 			/* Continue despite startup script errors - they're not fatal */
 		}
+
+		/* Note: dirty bits set by startup scripts are intentionally preserved
+		 * here. Under the legacy (default) policy those mutations are
+		 * user-visible state (e.g., REPL menubar installation persisting
+		 * into system.menus.data) and SHOULD save on exit. Ephemeral
+		 * consumers that don't want this should pass --lock-opened-roots,
+		 * which skips save_system_root_on_exit() via
+		 * g_system_root_read_only. */
 	}
 
 	// Start WebSocket server if --ws-port was specified
@@ -845,10 +852,12 @@ static void print_usage(const char* program_name) {
 	printf("  --ws-port PORT		   Start WebSocket server on PORT (localhost only, no auth).\n");
 	printf("						   WARNING: Any local process or browser page (including file://)\n");
 	printf("						   can access the ODB while the server is running.\n");
-	printf("  --read-only			   Open --system-root read-only; refuse all writes (fileMenu.save\n");
-	printf("						   etc. fail with a read-only error). Default for --protocol mode.\n");
-	printf("  --allow-mutate		   Opt --protocol --system-root back into read-write mode (use\n");
-	printf("						   for install paths like cleanRoot or ODB script editing).\n");
+	printf("  --lock-opened-roots	   Suppress save-on-exit for every loaded-from-disk system root\n");
+	printf("						   and guest DB; fileMenu.save() etc. fail with a read-only\n");
+	printf("						   error. In-memory mutations still evaluate; only the disk\n");
+	printf("						   persist is skipped. Newly created roots (file.save /\n");
+	printf("						   file.saveAs / db.compactDatabase) are unaffected.\n");
+	printf("						   Also enabled by FRONTIER_LOCK_OPENED_ROOTS=1.\n");
 	printf("  -h, --help			   Show this help message\n");
 	printf("  --version				   Show version information\n");
 	printf("\n");
@@ -871,6 +880,11 @@ static void print_usage(const char* program_name) {
 	printf("  FRONTIER_LOG_LEVEL	   Set global log level (TRACE, DEBUG, INFO, WARN, ERROR)\n");
 	printf("  FRONTIER_LOG_COMPONENT   Filter logs by component (db, hash, lang, etc.)\n");
 	printf("  FRONTIER_HEADLESS_RUN_STARTUP	 Set to 0 to skip system.startup scripts (default: run)\n");
+	printf("  FRONTIER_LOCK_OPENED_ROOTS  Set to any non-empty value other than \"0\" to enable\n");
+	printf("						   --lock-opened-roots without passing the flag (useful for\n");
+	printf("						   test runners and ephemeral consumers). Unset and \"0\" both\n");
+	printf("						   disable. The CLI flag, when passed, takes precedence and\n");
+	printf("						   overrides the environment.\n");
 	printf("\n");
 
 	printf("Examples:\n");
@@ -1008,13 +1022,21 @@ static void cleanup_frontier_runtime(void) {
 	 * Killed debug threads leave pushed hash table scopes in the chain,
 	 * making hashpack traversal crash on stale pointers. This is a
 	 * fundamental limitation of killing scripts mid-execution. */
-	/* Read-only opens (--read-only, or default for --protocol) deliberately
-	 * skip the on-exit save: the goal of #588 is that inspecting a canonical
-	 * .root file leaves it untouched on disk. The lower-layer flreadonly bit
-	 * already shorts dbflushheader, but skipping the save here is the
-	 * intent-level guarantee — the operator asked for read-only, so honor
-	 * it at every layer. */
-	if (g_system_root_loaded && debug_is_safe_to_save() && !g_system_root_read_only) {
+	/* --lock-opened-roots deliberately skips the on-exit save: the operator
+	 * explicitly asked for read-only-on-save, so honor it at every layer.
+	 * The lower-layer flreadonly bit already shorts dbflushheader, but
+	 * skipping the save here is the intent-level guarantee.
+	 *
+	 * Issue #127: legacy Frontier persisted every system root mutation by
+	 * default. The save runs whenever the root was opened RW; tests and
+	 * other ephemeral consumers opt OUT via --lock-opened-roots /
+	 * FRONTIER_LOCK_OPENED_ROOTS (which routes through
+	 * g_system_root_read_only above). The dirty-bit short-circuit inside
+	 * save_system_root_on_exit() handles the case where no actual mutation
+	 * occurred -- nothing gets rewritten then. */
+	if (g_system_root_loaded
+		&& debug_is_safe_to_save()
+		&& !g_system_root_read_only) {
 		save_system_root_on_exit();
 	}
 
@@ -1060,8 +1082,16 @@ static void cleanup_frontier_runtime(void) {
 	g_initialized = false;
 }
 
-/* Finds or creates a named subtable under a parent table. */
-static boolean ensure_named_subtable(hdlhashtable parent, const unsigned char *name, hdlhashtable *out, boolean mark_dont_save) {
+/* Finds or creates a named subtable under a parent table.
+ *
+ * If `out_created` is non-NULL, it is set to true iff the table did not
+ * exist and was created by this call. This lets hydration distinguish a
+ * genuine in-memory mutation (which should drive a persist) from an
+ * idempotent find (which should not). See issue #127. */
+static boolean ensure_named_subtable_ex(hdlhashtable parent, const unsigned char *name, hdlhashtable *out, boolean mark_dont_save, boolean *out_created) {
+	if (out_created != NULL)
+		*out_created = false;
+
 	if (parent == nil || name == NULL) {
 		return false;
 	}
@@ -1084,6 +1114,8 @@ static boolean ensure_named_subtable(hdlhashtable parent, const unsigned char *n
 		if (out != NULL) {
 			*out = table;
 		}
+		if (out_created != NULL)
+			*out_created = true;
 		return true;
 	}
 
@@ -1095,6 +1127,92 @@ static boolean ensure_named_subtable(hdlhashtable parent, const unsigned char *n
 	}
 
 	return false;
+}
+
+/* Backwards-compatible wrapper for callers that don't care whether the
+ * subtable was found or newly created. */
+static boolean ensure_named_subtable(hdlhashtable parent, const unsigned char *name, hdlhashtable *out, boolean mark_dont_save) {
+	return ensure_named_subtable_ex(parent, name, out, mark_dont_save, NULL);
+}
+
+/* Visitor refcon for clear_post_hydration_dirty_flags_visit. */
+typedef struct {
+	long ctcleared;
+} cleardirtyrefcon;
+
+static boolean clear_post_hydration_dirty_flags_visit(hdlhashnode hnode, ptrvoid refcon);
+
+/* Recursively clear fldirty/flsubsdirty on `ht` and all of its in-memory
+ * subtables, and clear dirty on any non-table externals (outlines, wpdocs).
+ *
+ * Cost: O(in-memory nodes in roottable). Walk is bounded by what hydration
+ * link-phase loaded (compiler / environment / charsets / temp /
+ * system.menus.data subtrees plus any external table reached via
+ * augment_database_tables_with_efp). Negligible relative to other hydration
+ * costs. Bounded by `flinmemory` recursion guard at the visitor -- does not
+ * force-load on-disk subtables.
+ *
+ * Rationale (issue #127): hydration link-phase work (linksystemtablestructure,
+ * menudata_ensure_root, headless_init_system_paths, resolve_system_paths,
+ * augment_database_tables_with_efp, ensure_named_subtable) does hashinsert /
+ * hashassign on subtables to wire in-memory EFP / compiler / environment
+ * tables into the loaded system table. Those hashinserts mark the host tables
+ * dirty via langsymbolchanged -> dirtyhashtable. The injected tables
+ * themselves are flagged fldontsave (so their value is not persisted), but
+ * the dirtying of the host table they live in is what then drives
+ * save_system_root_on_exit() to rewrite the whole file on shutdown -- even
+ * when no user-visible mutation occurred.
+ *
+ * Since hydration just loaded this tree from disk, NOTHING in it should be
+ * considered dirty at this point. Walk and clear, so subsequent exit-time
+ * save logic can trust the dirty bits and short-circuit when no user
+ * mutation happened.
+ *
+ * In-memory only -- we never force-load on-disk tables for the sole purpose
+ * of clearing flags they don't have.
+ */
+static void clear_post_hydration_dirty_flags(hdlhashtable ht) {
+	if (ht == nil)
+		return;
+
+	(**ht).fldirty = false;
+	(**ht).flsubsdirty = false;
+
+	cleardirtyrefcon refcon = {0};
+	hashtablevisit(ht, &clear_post_hydration_dirty_flags_visit, &refcon);
+}
+
+static boolean clear_post_hydration_dirty_flags_visit(hdlhashnode hnode, ptrvoid refcon) {
+	cleardirtyrefcon *rc = (cleardirtyrefcon *) refcon;
+	tyvaluerecord val = (**hnode).val;
+
+	if (val.valuetype != externalvaluetype)
+		return true;
+
+	hdlexternalvariable hv = (hdlexternalvariable) val.data.externalvalue;
+	if (hv == nil)
+		return true;
+
+	if (istablevariable(hv)) {
+		/* Only recurse into in-memory subtables. On-disk subtables can't be
+		 * dirty (they haven't been loaded), so there's nothing to clear, and
+		 * we must not force-load them just to clean flags. */
+		if ((**hv).flinmemory) {
+			hdlhashtable subt = (hdlhashtable) (**hv).variabledata;
+			if (subt != nil)
+				clear_post_hydration_dirty_flags(subt);
+		}
+	} else {
+		/* Non-table external (outline, wpdoc, menu, picture, etc.). Clear
+		 * dirty so a freshly-loaded value doesn't trigger a save. Ignore
+		 * failure: this is best-effort hygiene for in-memory objects. */
+		if (langexternalisdirty((hdlexternalhandle) hv)) {
+			(void) langexternalsetdirty((hdlexternalhandle) hv, false);
+			rc->ctcleared++;
+		}
+	}
+
+	return true;
 }
 
 /* Logs the current state of system subtables for debugging hydration issues. */
@@ -1153,8 +1271,8 @@ static boolean hydrate_system_root_database(const char* path, boolean read_only)
 	 * or the original path now containing the migrated v7 data, with v6 backed up to .v6.root).
 	 *
 	 * Read-only mode honors any of:
-	 *   - the explicit `read_only` parameter (driven by --read-only / default
-	 *     for --protocol, see cli_compute_effective_read_only)
+	 *   - the explicit `read_only` parameter (driven by --lock-opened-roots,
+	 *     see cli_compute_effective_read_only)
 	 *   - FRONTIER_OPEN_READONLY=1 environment override (back-compat with
 	 *     pre-flag scripts; harmless when the flag is already set).
 	 * Either gate is sufficient — neither false-overrides the other. */
@@ -1294,19 +1412,26 @@ static boolean hydrate_system_root_database(const char* path, boolean read_only)
 		goto cleanup;
 	}
 
+	/* Track whether any optional table was *actually created* (vs. found
+	 * pre-existing). Persisting is only needed for genuine creations; an
+	 * idempotent find must not trigger a full system-table rewrite (the
+	 * Virgin.root drift issue #127). */
 	boolean created_optional = false;
+	boolean did_create = false;
 	if (systemtable != nil) {
-		if (resourcestable == nil && ensure_named_subtable(systemtable, nameresourcestable, &resourcestable, false))
+		if (resourcestable == nil && ensure_named_subtable_ex(systemtable, nameresourcestable, &resourcestable, false, &did_create) && did_create)
 			created_optional = true;
 
-		if (pathstable == nil && ensure_named_subtable(systemtable, namepathstable, &pathstable, false))
+		if (pathstable == nil && ensure_named_subtable_ex(systemtable, namepathstable, &pathstable, false, &did_create) && did_create)
 			created_optional = true;
 
 		hdlhashtable menustable = nil;
 		bigstring bsmenus;
 		copyctopstring("menus", bsmenus);
-		if (ensure_named_subtable(systemtable, bsmenus, &menustable, false)) {
-			if (menubartable == nil && ensure_named_subtable(menustable, namemenubartable, &menubartable, false))
+		if (ensure_named_subtable_ex(systemtable, bsmenus, &menustable, false, &did_create)) {
+			if (did_create)
+				created_optional = true;
+			if (menubartable == nil && ensure_named_subtable_ex(menustable, namemenubartable, &menubartable, false, &did_create) && did_create)
 				created_optional = true;
 			/*
 			 * Eager projection-root creation. Without this, a fresh
@@ -1320,17 +1445,19 @@ static boolean hydrate_system_root_database(const char* path, boolean read_only)
 			hdlhashtable datatable = nil;
 			bigstring bsdata;
 			copyctopstring("data", bsdata);
-			if (ensure_named_subtable(menustable, bsdata, &datatable, false))
+			if (ensure_named_subtable_ex(menustable, bsdata, &datatable, false, &did_create) && did_create)
 				created_optional = true;
 		}
 
 		hdlhashtable macintoshtable = nil;
 		bigstring bsmacintosh;
 		copyctopstring("macintosh", bsmacintosh);
-		if (ensure_named_subtable(systemtable, bsmacintosh, &macintoshtable, false)) {
+		if (ensure_named_subtable_ex(systemtable, bsmacintosh, &macintoshtable, false, &did_create)) {
+			if (did_create)
+				created_optional = true;
 			bigstring bsobjectmodel;
 			copyctopstring("objectmodel", bsobjectmodel);
-			if (objectmodeltable == nil && ensure_named_subtable(macintoshtable, bsobjectmodel, &objectmodeltable, false))
+			if (objectmodeltable == nil && ensure_named_subtable_ex(macintoshtable, bsobjectmodel, &objectmodeltable, false, &did_create) && did_create)
 				created_optional = true;
 		}
 	}
@@ -1400,6 +1527,13 @@ static boolean hydrate_system_root_database(const char* path, boolean read_only)
 	 * 2. system.paths is populated and resolved
 	 * 3. Database tables are augmented with EFP implementations
 	 * This avoids running scripts during v6->v7 migration when database state is incomplete. */
+
+	/* Issue #127 -- clear dirty bits that the link-phase work above set as a
+	 * side effect of hashinsert/hashassign. The tree was just loaded from
+	 * disk; nothing in it should be considered dirty at this point. Without
+	 * this, save_system_root_on_exit() rewrites the entire file on every
+	 * shutdown even when no user mutation occurred (~1.2 MB drift). */
+	clear_post_hydration_dirty_flags(hroot);
 
 	ok = true;
 
@@ -1664,31 +1798,55 @@ static boolean load_system_root_database(const char* path) {
 
 /* Saves the system root database to disk before unloading.
  * Called during cleanup to persist any changes made during script execution
- * (e.g., user.databases entries created by finishInstall during first-run). */
+ * (e.g., user.databases entries created by finishInstall during first-run).
+ *
+ * Issue #127: this short-circuits to a no-op when the in-memory tree is
+ * fully clean. Hydration pre-clears the dirty bits set by link-phase
+ * hashinserts (see clear_post_hydration_dirty_flags), so the only way the
+ * root reaches save with dirty bits set is via genuine user mutation. */
 static void save_system_root_on_exit(void) {
 	dbaddress root_adr;
 	db_context ctx;
+	dbaddress prior_view = nildbaddress;
 
 	if (databasedata == nil || rootvariable == nil) {
 		return;
 	}
 
-	/* Note: We intentionally do NOT check dbdirtymask here.
-	 *
-	 * The dbdirtymask flag tracks disk-level allocation changes (new blocks
-	 * allocated/released), but in-memory table modifications (e.g., new entries
-	 * added via hashinsert) set fldirty on hash tables WITHOUT setting dbdirtymask.
-	 * This means in-memory changes can exist that dbdirtymask doesn't reflect.
-	 *
-	 * tablesavesystemtable() is efficient when nothing is dirty — it walks the
-	 * in-memory tree checking fldirty/flsubsdirty and no-ops for clean tables.
-	 * The cost of an unnecessary walk is minimal compared to losing data. */
+	/* Propagate sub-dirty flags up so we can trust roottable->flsubsdirty. */
+	tablepreflightsubsdirtyflag((hdlexternalvariable) rootvariable);
+
+	cli_log_debug("save_system_root_on_exit: entry roottable=%p fldirty=%d flsubsdirty=%d",
+	              (void *)roottable,
+	              roottable ? (**roottable).fldirty : -1,
+	              roottable ? (**roottable).flsubsdirty : -1);
+
+	if (roottable != nil
+		&& !(**roottable).fldirty
+		&& !(**roottable).flsubsdirty) {
+		/* Nothing changed since hydration -- skip the entire save path.
+		 * No tablesavesystemtable (avoids rewriting all reachable blocks),
+		 * no dbflushreleasestack (no allocations to flush), no dbsetview
+		 * (avoids a misleading header rewrite). */
+		cli_log_info("save_system_root_on_exit: tree clean, skipping save");
+		return;
+	}
 
 	cli_log_info("Saving system root database before exit");
 
-	/* Save the root table using v7 format */
+	/* Remember the prior view so we can avoid an unnecessary header flush. */
+	dbgetview(cancoonview, &prior_view);
+
+	/* Save the root table using v7 format.
+	 *
+	 * adapter_repack=true forces a full repack: every reachable block is
+	 * rewritten under the current format mode (64-bit). This is required
+	 * for save correctness when the on-disk tree mixes addresses across
+	 * format generations or when adapter logic must normalize them. Without
+	 * repack, the save can leave stale dbaddresses dangling in subtrees
+	 * whose owners weren't visited (e.g., user.inetd.listens). Issue #127. */
 	{
-		db_format_mode mode = {true, false};  /* 64-bit, no adapter_repack */
+		db_format_mode mode = {true, true};  /* 64-bit, adapter_repack */
 		db_format_mode_push(&mode);
 
 		if (!tablesavesystemtable(rootvariable, &root_adr)) {
@@ -1706,9 +1864,11 @@ static void save_system_root_on_exit(void) {
 	if (!dbflushreleasestack_context(&ctx))
 		cli_log_warn("save_system_root_on_exit: dbflushreleasestack_context failed");
 
-	/* Update views[0] to point to the saved root table;
-	 * dbsetview already flushes the header to disk. */
-	dbsetview(cancoonview, root_adr);
+	/* Update views[0] to point to the saved root table only if the address
+	 * actually changed. dbsetview rewrites the file header, so skipping it
+	 * when the view is unchanged avoids touching the header pages. */
+	if (root_adr != prior_view)
+		dbsetview(cancoonview, root_adr);
 
 	cli_log_info("System root database saved successfully");
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -603,6 +603,11 @@ test-debug:
 	@echo "Running debug protocol tests..."
 	@./debug_protocol_test.sh
 
+# Run system root copy-on-write idempotency tests (shell-based, issue #127)
+test-cow-idempotent:
+	@echo "Running system root copy-on-write idempotency tests..."
+	@./system_root_readonly_idempotent_test.sh
+
 # Run pre-commit hook tests (fixture-based; no project tooling needed)
 test-hooks:
 	@../tools/hooks/tests/test_c_indent_hook.sh
@@ -613,7 +618,7 @@ check-license:
 	@python3 ../tools/relicense_headers.py --check
 
 # Run all tests (unit + integration + CLI migration + custom args + debug + hooks + license check)
-test-all: test test-integration test-migrate-flag test-custom-args test-debug test-hooks check-license
+test-all: test test-integration test-migrate-flag test-custom-args test-debug test-cow-idempotent test-hooks check-license
 	@echo "All test suites completed"
 
 $(STRINGS_COMPILER):

--- a/tests/headless_filemenu_verbs.c
+++ b/tests/headless_filemenu_verbs.c
@@ -114,17 +114,17 @@ static boolean filemenu_save_systemroot(void) {
 
     log_debug(LOG_COMP_DB, "filemenu_save_systemroot: saving system root database");
 
-    /* Refuse to save when the system root was opened read-only (--read-only
-     * or default for --protocol). The CLI symbol is dynamically resolved so
+    /* Refuse to save when the system root was opened read-only
+     * (--lock-opened-roots). The CLI symbol is dynamically resolved so
      * test binaries that don't link main.o still compile; a missing
      * definition there is fine because tests don't reach this verb on a
-     * read-only DB. See issue #588. */
+     * read-only DB. See issues #127 and #588. */
     extern boolean cli_is_system_root_read_only(void) __attribute__((weak));
     if (cli_is_system_root_read_only && cli_is_system_root_read_only()) {
         log_verb_error(LOG_COMP_DB,
             "filemenu_save_systemroot: system root opened read-only; refusing save");
-        langerrormessage(PSTRING("\x43",
-            "Can't save: system root is read-only (use --allow-mutate to opt in)"));
+        langerrormessage(PSTRING("\x24",
+            "Can't save: system root is read-only"));
         return false;
     }
 

--- a/tests/integration/protocol_readonly_tests.sh
+++ b/tests/integration/protocol_readonly_tests.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 #
-# Integration tests for --protocol read-only behavior (issue #588).
+# Integration tests for --protocol read/write behavior under issue #127.
+#
+# Issue #127 restores the legacy default: --protocol --system-root opens
+# read-write. The previous #588 default (RO unless --allow-mutate) was
+# removed because it inverted legacy Frontier semantics and required test
+# infrastructure to thread an opt-in through every spawn site.
 #
 # Verifies:
-#  1. Default: --protocol --system-root opens read-only; no-op script does
-#     not modify the .root file.
-#  2. --allow-mutate: opt-in to read-write mode; fileMenu.save() succeeds
-#     and modifies the file on disk.
-#  3. Default with mutation: fileMenu.save() returns success:false with
-#     a "read-only" error message — the file is not modified.
-#  4. --read-only and --allow-mutate together: rejected at argv parse.
-#  5. --read-only outside protocol mode: still honored (defense in depth).
+#  1. Default --protocol with no-op script + --lock-opened-roots: file
+#     unchanged.
+#  2. Default --protocol with fileMenu.save(): file changes (default-RW
+#     persists the save).
+#  3. --lock-opened-roots + fileMenu.save(): save reports failure and the
+#     file is not modified (lock blocks the save path).
+#  4. --lock-opened-roots outside protocol mode (-e): still honored.
 #
 # Each test stages a fresh copy of Virgin.root in tests/tmp/ to avoid
 # touching the canonical database under databases/.
@@ -34,6 +38,9 @@ NC='\033[0m'
 PASS=0
 FAIL=0
 TOTAL=0
+
+# Clear inherited lock env so the test exercises the CLI flag directly.
+unset FRONTIER_LOCK_OPENED_ROOTS
 
 if [ ! -x "$CLI" ]; then
 	echo -e "${RED}Error: frontier-cli not found at $CLI${NC}"
@@ -81,111 +88,93 @@ _record_test() {
 }
 
 echo "=============================================="
-echo "Protocol Read-Only Tests (issue #588)"
+echo "Protocol Read/Write Tests (issue #127)"
 echo "=============================================="
 echo
 
 # -----------------------------------------------------------------------
-# Test 1: --protocol --system-root (no flags) — file unchanged after no-op.
-# This is the core regression: previously the CLI re-saved the file even
-# when no mutation was requested.
+# Test 1: --protocol --lock-opened-roots no-op — file unchanged.
+# This is the "ephemeral inspection" path tests run on by default.
 # -----------------------------------------------------------------------
 {
-	db=$(_stage_db "test1_default_readonly")
+	db=$(_stage_db "test1_lock_noop")
 	before=$(_md5 "$db")
 	out=$(echo '{"id":1,"op":"script/eval","params":{"expression":"1+1"}}' \
-		| "$CLI" --protocol --skip-startup --system-root "$db" 2>&1)
+		| "$CLI" --protocol --skip-startup --lock-opened-roots --system-root "$db" 2>&1)
 	after=$(_md5 "$db")
 	if [ "$before" = "$after" ]; then
-		_record_test "default --protocol leaves DB unchanged after no-op" pass
+		_record_test "--protocol --lock-opened-roots leaves DB unchanged after no-op" pass
 	else
-		_record_test "default --protocol leaves DB unchanged after no-op" fail \
+		_record_test "--protocol --lock-opened-roots leaves DB unchanged after no-op" fail \
 			"md5 changed: $before -> $after"
 	fi
 }
 
 # -----------------------------------------------------------------------
-# Test 2: --allow-mutate + protocol with fileMenu.save() — file changes.
-# This confirms the install/build path (clean-root, ODB editing) still
-# works when explicitly opted in.
+# Test 2: default --protocol with fileMenu.save() — file changes.
+# Confirms the install/build path (clean-root, ODB editing) works without
+# any opt-in flag under the issue #127 default.
 # -----------------------------------------------------------------------
 {
-	db=$(_stage_db "test2_allow_mutate")
+	db=$(_stage_db "test2_default_save")
 	before=$(_md5 "$db")
 	# Touch a value, then save. The save should succeed and persist.
 	out=$(printf '%s\n%s\n' \
-		'{"id":1,"op":"script/eval","params":{"expression":"new(stringType,@workspace.testReadOnly588); workspace.testReadOnly588=\"changed\"; return true"}}' \
+		'{"id":1,"op":"script/eval","params":{"expression":"new(stringType,@workspace.testPersist127); workspace.testPersist127=\"changed\"; return true"}}' \
 		'{"id":2,"op":"script/eval","params":{"expression":"fileMenu.save()"}}' \
-		| "$CLI" --protocol --skip-startup --allow-mutate --system-root "$db" 2>&1)
+		| "$CLI" --protocol --skip-startup --system-root "$db" 2>&1)
 	after=$(_md5 "$db")
 	if [ "$before" != "$after" ] && echo "$out" | grep -q '"id":2.*"success":true'; then
-		_record_test "--allow-mutate permits fileMenu.save() to persist" pass
+		_record_test "default --protocol permits fileMenu.save() to persist" pass
 	else
-		_record_test "--allow-mutate permits fileMenu.save() to persist" fail \
+		_record_test "default --protocol permits fileMenu.save() to persist" fail \
 			"md5 unchanged or save failed. before=$before after=$after out=$out"
 	fi
 }
 
 # -----------------------------------------------------------------------
-# Test 3: default --protocol with fileMenu.save() — error returned and
-# file unchanged. Failure is loud (success:false), not silent.
+# Test 3: --lock-opened-roots + fileMenu.save() — save reports failure and
+# file is unchanged. Lock turns on the lower-layer flreadonly bit, so
+# fileMenu.save() returns success:false with a read-only error.
 # -----------------------------------------------------------------------
 {
-	db=$(_stage_db "test3_default_blocks_save")
+	db=$(_stage_db "test3_lock_blocks_save")
 	before=$(_md5 "$db")
 	out=$(echo '{"id":1,"op":"script/eval","params":{"expression":"fileMenu.save()"}}' \
-		| "$CLI" --protocol --skip-startup --system-root "$db" 2>&1)
+		| "$CLI" --protocol --skip-startup --lock-opened-roots --system-root "$db" 2>&1)
 	after=$(_md5 "$db")
 	# Save must report failure AND file must not have changed.
 	if [ "$before" = "$after" ] && echo "$out" | grep -q '"id":1' \
 		&& echo "$out" | grep -qi "read-only"; then
-		_record_test "default --protocol refuses fileMenu.save() with read-only error" pass
+		_record_test "--lock-opened-roots refuses fileMenu.save() with read-only error" pass
 	else
-		_record_test "default --protocol refuses fileMenu.save() with read-only error" fail \
+		_record_test "--lock-opened-roots refuses fileMenu.save() with read-only error" fail \
 			"md5 changed=$([ \"$before\" != \"$after\" ] && echo yes || echo no), out=$out"
 	fi
 }
 
 # -----------------------------------------------------------------------
-# Test 4: --read-only and --allow-mutate together are rejected.
-# -----------------------------------------------------------------------
-{
-	db=$(_stage_db "test4_conflict")
-	# Use --batch to force exit on argv parse error rather than dropping
-	# into a REPL (some CLIs don't bail until an op arrives). The CLI
-	# should print an error and exit non-zero.
-	out=$("$CLI" --read-only --allow-mutate --skip-startup --system-root "$db" -e "1" 2>&1)
-	rc=$?
-	if [ "$rc" -ne 0 ] && echo "$out" | grep -qiE "read-only.*allow-mutate|allow-mutate.*read-only|cannot.*combined"; then
-		_record_test "--read-only + --allow-mutate is rejected" pass
-	else
-		_record_test "--read-only + --allow-mutate is rejected" fail \
-			"rc=$rc out=$out"
-	fi
-}
-
-# -----------------------------------------------------------------------
-# Test 5: --read-only honored outside --protocol (defense in depth).
+# Test 4: --lock-opened-roots honored outside --protocol (-e mode).
 # Even with -e mode and an explicit fileMenu.save(), the file should not
-# change when --read-only is set.
+# change when --lock-opened-roots is set.
 # -----------------------------------------------------------------------
 {
-	db=$(_stage_db "test5_read_only_outside_protocol")
+	db=$(_stage_db "test4_lock_opened_roots_outside_protocol")
 	before=$(_md5 "$db")
-	out=$("$CLI" --read-only --skip-startup --system-root "$db" \
+	out=$("$CLI" --lock-opened-roots --skip-startup --system-root "$db" \
 		-e "fileMenu.save()" 2>&1)
 	after=$(_md5 "$db")
 	if [ "$before" = "$after" ]; then
-		_record_test "--read-only honored in -e mode (file unchanged)" pass
+		_record_test "--lock-opened-roots honored in -e mode (file unchanged)" pass
 	else
-		_record_test "--read-only honored in -e mode (file unchanged)" fail \
+		_record_test "--lock-opened-roots honored in -e mode (file unchanged)" fail \
 			"md5 changed: $before -> $after; out=$out"
 	fi
 }
 
 echo
 echo "=============================================="
-echo "Protocol Read-Only Tests: $PASS/$TOTAL passed"
+echo "Protocol Read/Write Tests: $PASS/$TOTAL passed"
 if [ $FAIL -eq 0 ]; then
 	echo -e "${GREEN}All tests passed${NC}"
 	rm -rf "$TMP_DIR"

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -116,8 +116,23 @@ class FrontierCLI:
             if batch_mode:
                 cmd.append('--batch')
 
-            # Merge environment variables with current environment
+            # Merge environment variables with current environment.
+            #
+            # FRONTIER_LOCK_OPENED_ROOTS=1 (issue #127): treat the staged system root
+            # and every loaded-from-disk guest DB as read-only. Tests stage
+            # databases as disposable copies under tests/tmp/results/db/, so
+            # disk persistence is never required across processes -- in-memory
+            # mutations still evaluate as expected, only the save-on-exit is
+            # suppressed. Without this, every CLI invocation rewrites the
+            # staged Virgin.root and trips the drift-detection warning in
+            # tools/run_integration_tests.sh (PR #555). Drift detection still
+            # fires for tests that explicitly persist (fileMenu.save on guest
+            # DBs etc.), just less aggressively.
+            #
+            # Tests that need to write to the system root must override by
+            # passing env={'FRONTIER_LOCK_OPENED_ROOTS': '0'} on the execute() call.
             process_env = os.environ.copy()
+            process_env.setdefault('FRONTIER_LOCK_OPENED_ROOTS', '1')
             if env:
                 process_env.update(env)
 
@@ -204,8 +219,11 @@ class FrontierCLI:
         if self.system_root:
             cmd.extend(['--system-root', self.system_root])
 
-        # Merge environment variables with current environment
+        # Merge environment variables with current environment.
+        # FRONTIER_LOCK_OPENED_ROOTS=1: protect staged Virgin.root from drift; see
+        # comment in execute() above. Caller can override with env arg.
         process_env = os.environ.copy()
+        process_env.setdefault('FRONTIER_LOCK_OPENED_ROOTS', '1')
         # Force interactive mode for testing (ensures prompts are shown)
         process_env['FRONTIER_FORCE_INTERACTIVE'] = '1'
         if env:
@@ -274,7 +292,10 @@ class FrontierCLI:
         # - TERM=dumb: Makes linenoise use simple fgets() instead of raw mode
         #   editing, eliminating character-by-character echo and ANSI escapes
         # - FRONTIER_FORCE_INTERACTIVE: Ensures dialog verbs use stdio prompts
+        # - FRONTIER_LOCK_OPENED_ROOTS=1 (issue #127): protect staged Virgin.root
+        #   from drift; see comment in FrontierCLI.execute() above.
         process_env = os.environ.copy()
+        process_env.setdefault('FRONTIER_LOCK_OPENED_ROOTS', '1')
         process_env['FRONTIER_PLAIN_REPL'] = '1'
         process_env['TERM'] = 'dumb'
         process_env['FRONTIER_FORCE_INTERACTIVE'] = '1'
@@ -363,18 +384,24 @@ class ProtocolExecutor:
         self._stderr_file = None
         self._next_id = 1
 
-    def start(self):
+    def start(self, env_overrides: Optional[Dict[str, str]] = None):
         """Spawn the frontier-cli --protocol subprocess.
 
-        --allow-mutate: opt back into read-write so tests can call
-        fileMenu.save(), workspace assignments, etc. Issue #588 made
-        --protocol --system-root default to read-only to protect canonical
-        roots during inspection. Integration tests run against staged
-        copies under tests/tmp/results/db/ — mutating those copies is
-        intentional, the staging layer (tools/run_integration_tests.sh)
-        treats them as disposable.
+        Protocol mode now uses legacy default-RW (issue #127): tests can
+        call fileMenu.save(), workspace assignments, etc. without opting
+        in. Integration tests run against staged copies under
+        tests/tmp/results/db/ — mutating those copies is intentional, the
+        staging layer (tools/run_integration_tests.sh) treats them as
+        disposable. Tests that must NOT persist on-disk should set
+        FRONTIER_LOCK_OPENED_ROOTS=1 in their env (or rely on the env
+        defaults set by FrontierCLI.execute()).
+
+        env_overrides: per-instance environment overrides. Used by
+        run_protocol_test() to spawn a dedicated executor for protocol_ops
+        tests whose YAML declares an `environment:` block (e.g.
+        FRONTIER_LOCK_OPENED_ROOTS=0 to enable on-disk saves).
         """
-        cmd = [self.cli_path, '--protocol', '--skip-startup', '--allow-mutate']
+        cmd = [self.cli_path, '--protocol', '--skip-startup']
         if self.system_root:
             cmd.extend(['--system-root', self.system_root])
 
@@ -382,6 +409,20 @@ class ProtocolExecutor:
         # (using a file avoids pipe buffer deadlocks)
         self._stderr_file = tempfile.NamedTemporaryFile(
             mode='w+', prefix='frontier_protocol_stderr_', suffix='.log', delete=False)
+
+        # Merge environment to inject FRONTIER_LOCK_OPENED_ROOTS=1 (issue #127):
+        # treat the staged system root and every loaded-from-disk guest DB as
+        # read-only for the long-lived protocol batch process. Mirrors the
+        # FrontierCLI.execute() / execute_repl() / execute_interactive() pattern.
+        # Tests that need to write to the system root carry an explicit
+        # `environment:` block in YAML; script-mode tests are forced out of
+        # the protocol batch by _is_protocol_compatible() and run via the
+        # per-process executor. protocol_ops tests with an environment block
+        # use a dedicated short-lived executor (see run_protocol_test()).
+        process_env = os.environ.copy()
+        process_env.setdefault('FRONTIER_LOCK_OPENED_ROOTS', '1')
+        if env_overrides:
+            process_env.update(env_overrides)
 
         try:
             self._proc = subprocess.Popen(
@@ -391,6 +432,7 @@ class ProtocolExecutor:
                 stderr=self._stderr_file,
                 text=True,
                 bufsize=1,  # Line buffered
+                env=process_env,
             )
         except Exception:
             self._close_stderr_file()
@@ -1009,10 +1051,31 @@ class TestRunner:
         # entries may remain in workspace. This is acceptable for now — tests
         # use unique prefixes and check specific paths, so stale entries from
         # prior runs don't cause false failures.
-        if self.protocol_executor is None or not self.protocol_executor.is_alive:
-            return TestResult(
-                test.name, False,
-                error="Protocol executor not available (required for protocol_ops tests)")
+        #
+        # Issue #127: If the test declares an `environment:` block, spawn a
+        # dedicated short-lived executor so the per-test env overrides (e.g.
+        # FRONTIER_LOCK_OPENED_ROOTS=0 for save-path tests) apply. The shared
+        # batch executor is started with FRONTIER_LOCK_OPENED_ROOTS=1 by
+        # default and can't accept per-test overrides at send time.
+        dedicated_executor: Optional[ProtocolExecutor] = None
+        if test.environment:
+            dedicated_executor = ProtocolExecutor(
+                cli_path=self.cli.cli_path,
+                system_root=self.protocol_executor.system_root if self.protocol_executor else None,
+            )
+            try:
+                dedicated_executor.start(env_overrides=test.environment)
+            except Exception as e:
+                return TestResult(
+                    test.name, False,
+                    error=f"Failed to start dedicated protocol executor: {e}")
+            executor = dedicated_executor
+        else:
+            if self.protocol_executor is None or not self.protocol_executor.is_alive:
+                return TestResult(
+                    test.name, False,
+                    error="Protocol executor not available (required for protocol_ops tests)")
+            executor = self.protocol_executor
 
         try:
             for step_idx, step in enumerate(test.protocol_ops):
@@ -1034,14 +1097,14 @@ class TestRunner:
                     msg['params'] = params
 
                 try:
-                    resp = self.protocol_executor.send_raw(msg, timeout=test.timeout)
+                    resp = executor.send_raw(msg, timeout=test.timeout)
                 except TimeoutError:
                     return TestResult(
                         test.name, False,
                         error=f"Timeout at {step_desc}: op={op}")
                 except RuntimeError as e:
                     try:
-                        self.protocol_executor._restart()
+                        executor._restart()
                     except Exception as restart_err:
                         logging.warning("Protocol executor restart failed: %s", restart_err)
                     return TestResult(
@@ -1060,7 +1123,13 @@ class TestRunner:
         except Exception as e:
             return TestResult(test.name, False, error=f"Unexpected error: {e}")
         finally:
-            self.protocol_executor.reset()
+            if dedicated_executor is not None:
+                try:
+                    dedicated_executor.stop()
+                except Exception:
+                    pass
+            elif self.protocol_executor is not None:
+                self.protocol_executor.reset()
 
     @staticmethod
     def _validate_protocol_response(resp: dict, validate: dict, step_desc: str) -> Optional[str]:

--- a/tests/integration/test_cases/db_compact.yaml
+++ b/tests/integration/test_cases/db_compact.yaml
@@ -56,6 +56,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - basic round-trip preserves data"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Compact a populated guest DB to a new path; data should be intact (verb auto-closes srcPath on success)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -84,6 +86,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - shrinks file after large deletion"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Write bulk data, delete it, compact — destination must be smaller than source"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -121,6 +125,8 @@ tests:
     expected_result: "true"
 
   - name: "db.compactDatabase - kept data survives after compaction"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "After delete + compact, the kept value is readable in dst"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -150,6 +156,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - source on-disk file unchanged after compaction"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "After auto-close + reopen, source still has its data (compaction does not modify source bytes)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -174,6 +182,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - destination is independently openable after src closes"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Compacted DB is a complete file, openable after the source is closed and deleted"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -201,6 +211,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - source is auto-closed on success (no explicit db.close needed)"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "After successful compact, srcPath is no longer in the open db list — calling db.close on it errors, confirming auto-close fired"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -232,6 +244,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - unsaved mutations appear in destination"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Values set but not saved before compact still appear in dst (verb saves source first)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -284,6 +298,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - destination without .root extension is auto-coerced"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Passing a destination without .root extension should append it (matches db.new / db.open)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -310,6 +326,8 @@ tests:
   # ========================================================================
 
   - name: "db.compactDatabase - on failure, pre-existing destination is preserved untouched"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Failure (e.g. existing dst) does not write through to dst — the pre-existing content is intact"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -354,6 +372,8 @@ tests:
     expected_result: "error_caught"
 
   - name: "db.compactDatabase - error when destination already exists"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Refuses to overwrite an existing destination file"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");

--- a/tests/integration/test_cases/db_verbs.yaml
+++ b/tests/integration/test_cases/db_verbs.yaml
@@ -67,6 +67,8 @@ tests:
   # Test 3: db.setvalue - Write simple string value
   # ========================================================================
   - name: "db.setvalue - write string to root"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create DB, open it, set a string value (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -82,6 +84,8 @@ tests:
   # Test 4: db.getvalue - Read back string value
   # ========================================================================
   - name: "db.getvalue - read string from root"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Set and get a string value (self-contained test)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -98,6 +102,8 @@ tests:
   # Test 5: db.defined - Check existence of value
   # ========================================================================
   - name: "db.defined - check existing value"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Verify that a value exists after setting it (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -126,6 +132,8 @@ tests:
   # Test 6: db.setvalue - Write numeric value
   # ========================================================================
   - name: "db.setvalue - write number to root"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create DB and set a numeric value (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -138,6 +146,8 @@ tests:
     expected_result: "true"
 
   - name: "db.getvalue - read number from root"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Set and get a numeric value (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -154,6 +164,8 @@ tests:
   # Test 7: db.newtable - Create table
   # ========================================================================
   - name: "db.newtable - create table at root"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create DB and add a new table (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -169,6 +181,8 @@ tests:
   # Test 8: db.istable - Check if address is a table
   # ========================================================================
   - name: "db.istable - verify table type"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create table and verify it is a table (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -182,6 +196,8 @@ tests:
     expected_result: "true"
 
   - name: "db.istable - verify string is not a table"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create string and verify it is not a table (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -198,6 +214,8 @@ tests:
   # Test 9: db.setvalue - Write values into table
   # ========================================================================
   - name: "db.setvalue - write to nested table"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create table and set values inside it (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -216,6 +234,8 @@ tests:
   # Test 10: db.countitems - Count items in table
   # ========================================================================
   - name: "db.countitems - count table items"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create table with items and count them (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -235,6 +255,8 @@ tests:
   # Test 11: db.getnthitem - Enumerate table items
   # ========================================================================
   - name: "db.getnthitem - get first item name"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create table and get first item name (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -251,6 +273,8 @@ tests:
     expected_result: "item1"
 
   - name: "db.getnthitem - get second item name"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create table and get second item name (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -267,6 +291,8 @@ tests:
     expected_result: "item2"
 
   - name: "db.getnthitem - get third item name"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create table and get third item name (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -286,6 +312,8 @@ tests:
   # Test 12: db.getmoddate - Get modification date
   # ========================================================================
   - name: "db.getmoddate - get item modification date"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create value and get its modification date (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -302,6 +330,8 @@ tests:
   # Test 13: db.delete - Delete value
   # ========================================================================
   - name: "db.delete - delete string value"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create and delete a value (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -315,6 +345,8 @@ tests:
     expected_result: "true"
 
   - name: "db.defined - verify deletion"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create value, delete it, verify it's gone (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -332,6 +364,8 @@ tests:
   # Test 14: db.save - Save changes to disk
   # ========================================================================
   - name: "db.save - save database changes"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create DB, write data, save to disk (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -363,6 +397,8 @@ tests:
   # Test 16: Reopen and verify persistence
   # ========================================================================
   - name: "db.open - reopen saved database"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create, save, close, then reopen (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -378,6 +414,8 @@ tests:
     expected_result: "true"
 
   - name: "db.getvalue - verify persisted value"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Test full persistence cycle: create, save, close, reopen, read"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -394,6 +432,8 @@ tests:
     expected_result: "42"
 
   - name: "db.countitems - verify persisted table"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Test table persistence: create, populate, save, close, reopen, count"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -413,6 +453,8 @@ tests:
     expected_result: "3"
 
   - name: "db.defined - verify deletion persisted"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Test delete persistence: create, delete, save, close, reopen, verify gone"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -469,6 +511,8 @@ tests:
     expected_result: "true"
 
   - name: "db.setvalue - write to v7 database"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create v7 DB and set value (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -481,6 +525,8 @@ tests:
     expected_result: "true"
 
   - name: "db.getvalue - read from v7 database"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create v7 DB, write value, read it back (self-contained)"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -562,6 +608,8 @@ tests:
     expected_result: "true"
 
   - name: "Issue #264 - multiple close/reopen cycles with data persistence"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Data persists across multiple close/reopen cycles in same script"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");

--- a/tests/integration/test_cases/dist_stability.yaml
+++ b/tests/integration/test_cases/dist_stability.yaml
@@ -47,6 +47,10 @@ tests:
 
   - name: "guest db open + system root save - no corruption"
     description: "Open a guest database, then save the system root. Verifies that guest db mount points under system.compiler.files (marked fldontsave) don't corrupt the system root during save."
+    # Issue #127: test verifies the write-path (fileMenu.save of system root);
+    # override runner's default FRONTIER_LOCK_OPENED_ROOTS=1 injection.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "dist_guest_save_test.root");
@@ -60,6 +64,10 @@ tests:
 
   - name: "guest db lifecycle - open, write, save guest, save system, close, reopen"
     description: "Full lifecycle: open guest db, write data, save both guest and system root, close, reopen, verify data. This is the pattern that Frontier.tools.install() exercises."
+    # Issue #127: test verifies the write-path (fileMenu.save of system root
+    # and guest DB write operations); override runner's default.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "dist_lifecycle.root");
@@ -107,6 +115,9 @@ tests:
 
   - name: "fileMenu.save - system root save returns true"
     description: "Basic smoke test that fileMenu.save() on the system root completes without error"
+    # Issue #127: test verifies the write-path; override runner's default.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       return fileMenu.save()
     expected_success: true
@@ -114,6 +125,9 @@ tests:
 
   - name: "fileMenu.save - save after creating new table doesn't crash"
     description: "Create a new table in the system root, save, verify no crash. Exercises the pack path for new in-memory externals with hdatabase set via langexternalsetdatabase."
+    # Issue #127: test verifies the write-path; override runner's default.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       new(tableType, @system.temp.saveStability);
       system.temp.saveStability.data = "test";

--- a/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
+++ b/tests/integration/test_cases/error_recovery_concurrency_tests.yaml
@@ -251,6 +251,8 @@ tests:
     timeout: 5
 
   - name: "closeall - access after close fails"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: |
       After db.close(), attempting to read from a closed guest database
       should fail, confirming the handle is released. Uses db.open/db.close
@@ -271,6 +273,8 @@ tests:
     timeout: 5
 
   - name: "closeall - reopen after close succeeds"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: |
       After fileMenu.closeall(), reopening a previously closed database
       should succeed, confirming no lingering file locks.

--- a/tests/integration/test_cases/filemenu_verbs.yaml
+++ b/tests/integration/test_cases/filemenu_verbs.yaml
@@ -302,6 +302,10 @@ tests:
 
   - name: "fileMenu.save - save system root (no params)"
     description: "Calling fileMenu.save() with no parameters saves the system root database"
+    # Issue #127: test verifies the write-path; must override runner's default
+    # FRONTIER_LOCK_OPENED_ROOTS=1 injection so the save actually executes.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       return fileMenu.save()
     expected_success: true
@@ -314,6 +318,10 @@ tests:
       of system table externals would switch databasedata to the guest database,
       causing dbread failures on sibling externals (e.g. menus at addresses
       valid only in the system root).
+    # Issue #127: test verifies the write-path; must override runner's default
+    # FRONTIER_LOCK_OPENED_ROOTS=1 injection so the save actually executes.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
       local(dbPath = tmpDir + "/" + "filemenu_save_regression.root");
@@ -429,6 +437,8 @@ tests:
   # ========================================================================
 
   - name: "fileMenu.saveCopy - save system root to new file"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "saveCopy creates a copy of the system root database"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -439,6 +449,8 @@ tests:
     expected_result: "true"
 
   - name: "fileMenu.saveCopy - original database unchanged after copy"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "After saveCopy, the system root is still fully usable"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -449,6 +461,8 @@ tests:
     expected_result: "true"
 
   - name: "fileMenu.saveCopy - new file is independently openable"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "The copied database can be opened and contains system table"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -462,6 +476,8 @@ tests:
     expected_result: "true"
 
   - name: "fileMenu.saveAs - aliases to same behavior as saveCopy"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "saveAs and saveCopy are interchangeable"
     script: |
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");

--- a/tests/integration/test_cases/guest_db_externals.yaml
+++ b/tests/integration/test_cases/guest_db_externals.yaml
@@ -173,6 +173,10 @@ tests:
       external whose data is on disk in the source (guest) database.
       Previously failed with dbrefhandle FAILED when the pack context used
       the destination database instead of the source.
+    # Issue #127: test verifies the write-path (fileMenu.save of system
+    # root); override runner's default FRONTIER_LOCK_OPENED_ROOTS=1.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       local (sysdir = file.folderFromPath(Frontier.getFilePath()));
       local (guestpath = sysdir + "StartupTasks.root");

--- a/tests/integration/test_cases/persistence_save_tests.yaml
+++ b/tests/integration/test_cases/persistence_save_tests.yaml
@@ -27,6 +27,8 @@ tests:
   # ========================================================================
 
   - name: "protocol filemenu.save - save system root via script/eval"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Call filemenu.save() through protocol script/eval and verify success"
     protocol_ops:
       - op: "script/eval"
@@ -39,6 +41,8 @@ tests:
         description: "save system root via protocol"
 
   - name: "protocol filemenu.save - create value then save via protocol"
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     description: "Create a value via odb/set, then save system root via script/eval"
     protocol_ops:
       - op: "odb/set"
@@ -163,6 +167,11 @@ tests:
       Modify a value in the system root (system.temp), open and
       modify a guest database, save the system root, save the guest DB,
       close/reopen the guest DB, and verify both values survived.
+    # Issue #127: test verifies the write-path (fileMenu.save on both
+    # system root and guest DB); override runner's default
+    # FRONTIER_LOCK_OPENED_ROOTS=1.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       try {delete(@system.temp.persist_dual_db)} else {1};
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -187,6 +196,10 @@ tests:
     description: >
       Interleave modifications between system root and guest DB to stress
       the database context switching during pack/save operations.
+    # Issue #127: test verifies the write-path; override runner's default
+    # FRONTIER_LOCK_OPENED_ROOTS=1.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       try {delete(@system.temp.persist_interleaved)} else {1};
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");
@@ -355,6 +368,10 @@ tests:
     description: >
       Full shutdown sequence: save system root, save all guest DBs,
       close all guest DBs. Verifies the complete clean shutdown path.
+    # Issue #127: test verifies the write-path; override runner's default
+    # FRONTIER_LOCK_OPENED_ROOTS=1.
+    environment:
+      FRONTIER_LOCK_OPENED_ROOTS: "0"
     script: |
       try {delete(@system.temp.persist_full_shutdown)} else {1};
       local(tmpDir = "{FRONTIER_TEST_TMP_DIR}");

--- a/tests/integration/test_cases/startup_script_execution.yaml
+++ b/tests/integration/test_cases/startup_script_execution.yaml
@@ -17,8 +17,8 @@
 #   5. user.databases table is created if not already defined
 #
 # EXECUTION NOTE:
-# These tests run in the persistent protocol executor process (--skip-startup +
-# --allow-mutate). Calling startup.startupScript() within a test sets
+# These tests run in the persistent protocol executor process (--skip-startup,
+# default-RW under issue #127). Calling startup.startupScript() within a test sets
 # system.temp.Frontier for the lifetime of that process. Tests are self-contained:
 # each script checks its own observable state in one atomic operation.
 # sequential: true prevents parallel runs from racing on system.temp.Frontier.

--- a/tests/system_root_readonly_idempotent_test.sh
+++ b/tests/system_root_readonly_idempotent_test.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+#
+# Regression test for issue #127: --lock-opened-roots / FRONTIER_LOCK_OPENED_ROOTS
+# keeps loaded-from-disk system root reads idempotent on disk.
+#
+# Legacy Frontier opens every system root and guest database read-write by
+# default; in-process mutations persist back to disk on shutdown. Tests and
+# other ephemeral consumers opt OUT of save-on-exit via:
+#   --lock-opened-roots          (CLI flag)
+#   FRONTIER_LOCK_OPENED_ROOTS=1 (environment variable, picked up by the runner)
+#
+# In-memory mutations still evaluate (so `workspace.x = 1` returns 1) -- only
+# the on-disk save is suppressed. Newly created roots (file.save / file.saveAs
+# / db.compactDatabase) are unaffected, since they're created, not loaded.
+#
+# The cases below cover the matrix of read-only / read-write defaults and
+# how --lock-opened-roots and --protocol interact.
+#
+# Tests use staged copies under /tmp -- they never touch the canonical
+# databases/Virgin.root.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+SOURCE_DB="$PROJECT_ROOT/databases/Virgin.root"
+
+# Clear FRONTIER_LOCK_OPENED_ROOTS from our environment so the test exercises
+# the CLI flag behavior directly. The integration runner sets the var; this
+# stand-alone shell test must not inherit it or every "without --lock-opened-roots"
+# case below would silently mask the actual default-RW contract.
+unset FRONTIER_LOCK_OPENED_ROOTS
+
+if [ ! -x "$CLI" ]; then
+    echo "Error: frontier-cli not found at $CLI" >&2
+    exit 1
+fi
+if [ ! -f "$SOURCE_DB" ]; then
+    echo "Error: source database not found at $SOURCE_DB" >&2
+    exit 1
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+# Portable md5: use md5 on macOS, md5sum on Linux.
+md5_of() {
+    if command -v md5 >/dev/null 2>&1; then
+        md5 -q "$1"
+    else
+        md5sum "$1" | awk '{print $1}'
+    fi
+}
+
+# Snapshot the canonical Virgin.root md5 BEFORE any frontier-cli runs.
+# The final assertion compares against this rather than a hard-coded hash
+# so the test doesn't break for unrelated reasons every time the canonical
+# DB legitimately changes (ODB script edits, verb additions, etc.).
+CANONICAL_MD5_BEFORE="$(md5_of "$SOURCE_DB")"
+
+STAGE_DIR="$(mktemp -d -t frontier-cow-test-XXXXXX)"
+trap 'rm -rf "$STAGE_DIR"' EXIT
+
+stage_copy() {
+    local name="$1"
+    local dest="$STAGE_DIR/$name"
+    cp "$SOURCE_DB" "$dest"
+    echo "$dest"
+}
+
+assert_md5_unchanged() {
+    local label="$1"
+    local before="$2"
+    local after="$3"
+
+    if [ "$before" = "$after" ]; then
+        echo -e "  ${GREEN}PASS${NC}: $label (md5 stable: $before)"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "  ${RED}FAIL${NC}: $label"
+        echo "    before: $before"
+        echo "    after:  $after"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+assert_md5_changed() {
+    local label="$1"
+    local before="$2"
+    local after="$3"
+
+    if [ "$before" != "$after" ]; then
+        echo -e "  ${GREEN}PASS${NC}: $label (md5 changed as expected)"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "  ${RED}FAIL${NC}: $label -- md5 should have changed but did not"
+        echo "    md5: $before"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# Test 1: --lock-opened-roots -e 'sizeOf(system)' -- pure read, no mutate, no save.
+echo "==> Test 1: --lock-opened-roots -e 'sizeOf(system)' must not modify Virgin.root"
+DB1="$(stage_copy "virgin_eval.root")"
+MD5_BEFORE_1="$(md5_of "$DB1")"
+"$CLI" --lock-opened-roots --system-root "$DB1" -e 'sizeOf(system)' >/dev/null 2>&1 || true
+MD5_AFTER_1="$(md5_of "$DB1")"
+assert_md5_unchanged "--lock-opened-roots -e 'sizeOf(system)' is idempotent" "$MD5_BEFORE_1" "$MD5_AFTER_1"
+
+# Test 2a: --protocol --system-root (no flags) -- default-RW per #127.
+# A no-op script may still bump the on-disk image because the save runs on
+# exit; mutate explicitly and verify the change persists.
+echo "==> Test 2a: --protocol --system-root (no flags) is default-RW (#127)"
+DB2A="$(stage_copy "virgin_protocol_default.root")"
+MD5_BEFORE_2A="$(md5_of "$DB2A")"
+PROTOCOL_INPUT_MUTATE=$(cat <<'PROTOEOF'
+{"id":1,"op":"script/eval","params":{"expression":"workspace.protoflag = 11"}}
+{"id":2,"op":"shutdown","params":{}}
+PROTOEOF
+)
+printf '%s\n' "$PROTOCOL_INPUT_MUTATE" | "$CLI" --protocol --skip-startup --system-root "$DB2A" >/dev/null 2>&1 || true
+MD5_AFTER_2A="$(md5_of "$DB2A")"
+assert_md5_changed "--protocol default-RW persists mutation" "$MD5_BEFORE_2A" "$MD5_AFTER_2A"
+
+# Test 2b: --protocol --lock-opened-roots -- lock suppresses the save.
+echo "==> Test 2b: --protocol --lock-opened-roots must not modify Virgin.root"
+DB2B="$(stage_copy "virgin_protocol_lock.root")"
+MD5_BEFORE_2B="$(md5_of "$DB2B")"
+printf '%s\n' "$PROTOCOL_INPUT_MUTATE" | "$CLI" --protocol --skip-startup --lock-opened-roots --system-root "$DB2B" >/dev/null 2>&1 || true
+MD5_AFTER_2B="$(md5_of "$DB2B")"
+assert_md5_unchanged "--protocol --lock-opened-roots: lock suppresses save" "$MD5_BEFORE_2B" "$MD5_AFTER_2B"
+
+# Test 3: --lock-opened-roots REPL '/exit' only -- no mutate, no save.
+echo "==> Test 3: --lock-opened-roots REPL /exit must not modify Virgin.root"
+DB3="$(stage_copy "virgin_repl.root")"
+MD5_BEFORE_3="$(md5_of "$DB3")"
+printf '/exit\n' | "$CLI" --lock-opened-roots --system-root "$DB3" >/dev/null 2>&1 || true
+MD5_AFTER_3="$(md5_of "$DB3")"
+assert_md5_unchanged "--lock-opened-roots REPL /exit is idempotent" "$MD5_BEFORE_3" "$MD5_AFTER_3"
+
+# Test 4: default-RW -e mutation -- must persist (legacy contract).
+echo "==> Test 4 (positive): -e 'workspace.testflag = 42' must persist by default"
+DB4="$(stage_copy "virgin_mutate.root")"
+MD5_BEFORE_4="$(md5_of "$DB4")"
+"$CLI" --system-root "$DB4" -e 'workspace.testflag = 42' >/dev/null 2>&1 || true
+MD5_AFTER_4="$(md5_of "$DB4")"
+assert_md5_changed "default-RW: mutation writes to disk" "$MD5_BEFORE_4" "$MD5_AFTER_4"
+
+# Re-open and verify the value round-trips through disk.
+READBACK="$("$CLI" --system-root "$DB4" -e 'workspace.testflag' 2>/dev/null | tail -1 | tr -d '[:space:]')"
+if [ "$READBACK" = "42" ]; then
+    echo -e "  ${GREEN}PASS${NC}: workspace.testflag persisted across processes (read back 42)"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "  ${RED}FAIL${NC}: workspace.testflag did not persist; readback='$READBACK'"
+    FAILED=$((FAILED + 1))
+fi
+
+# Test 5: --lock-opened-roots -- in-memory mutation only, no disk save.
+# Reopen and verify workspace.locktestval is undefined (because save was suppressed).
+echo "==> Test 5: --lock-opened-roots evaluates but does not persist"
+DB5="$(stage_copy "virgin_lock_mutate.root")"
+MD5_BEFORE_5="$(md5_of "$DB5")"
+"$CLI" --lock-opened-roots --system-root "$DB5" -e 'workspace.locktestval = 1' >/dev/null 2>&1 || true
+MD5_AFTER_5="$(md5_of "$DB5")"
+assert_md5_unchanged "--lock-opened-roots in-memory mutation does not persist (md5)" "$MD5_BEFORE_5" "$MD5_AFTER_5"
+
+READBACK5="$("$CLI" --system-root "$DB5" -e 'defined(workspace.locktestval)' 2>/dev/null | tail -1 | tr -d '[:space:]')"
+if [ "$READBACK5" = "false" ]; then
+    echo -e "  ${GREEN}PASS${NC}: workspace.locktestval was not persisted (defined=false)"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "  ${RED}FAIL${NC}: workspace.locktestval unexpectedly persisted; defined='$READBACK5'"
+    FAILED=$((FAILED + 1))
+fi
+
+# Test 6: no flags + -e mutation -- legacy default-RW contract, must persist.
+echo "==> Test 6 (positive): -e 'workspace.legacyflag = 7' must persist by default"
+DB6="$(stage_copy "virgin_default_mutate.root")"
+MD5_BEFORE_6="$(md5_of "$DB6")"
+"$CLI" --system-root "$DB6" -e 'workspace.legacyflag = 7' >/dev/null 2>&1 || true
+MD5_AFTER_6="$(md5_of "$DB6")"
+assert_md5_changed "default-RW: -e mutation persists" "$MD5_BEFORE_6" "$MD5_AFTER_6"
+
+READBACK6="$("$CLI" --system-root "$DB6" -e 'workspace.legacyflag' 2>/dev/null | tail -1 | tr -d '[:space:]')"
+if [ "$READBACK6" = "7" ]; then
+    echo -e "  ${GREEN}PASS${NC}: workspace.legacyflag persisted (read back 7)"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "  ${RED}FAIL${NC}: workspace.legacyflag did not persist; readback='$READBACK6'"
+    FAILED=$((FAILED + 1))
+fi
+
+# Belt-and-braces: re-opening DB4 read-only with --lock-opened-roots after the
+# mutation must also be idempotent.
+MD5_AFTER_MUTATE="$(md5_of "$DB4")"
+"$CLI" --lock-opened-roots --system-root "$DB4" -e 'workspace.testflag' >/dev/null 2>&1 || true
+MD5_AFTER_RECHECK="$(md5_of "$DB4")"
+assert_md5_unchanged "--lock-opened-roots re-open of mutated DB is idempotent" "$MD5_AFTER_MUTATE" "$MD5_AFTER_RECHECK"
+
+# Final canonical-protection assertion. None of the above should ever have
+# opened the canonical Virgin.root, but assert anyway. The expected value is
+# the md5 snapshotted at script start -- compared this way the test catches
+# real drift without breaking whenever the canonical DB legitimately changes.
+ACTUAL_CANONICAL="$(md5_of "$SOURCE_DB")"
+if [ "$CANONICAL_MD5_BEFORE" = "$ACTUAL_CANONICAL" ]; then
+    echo -e "  ${GREEN}PASS${NC}: canonical Virgin.root md5 unchanged ($ACTUAL_CANONICAL)"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "  ${RED}FAIL${NC}: canonical Virgin.root md5 drifted!"
+    echo "    before: $CANONICAL_MD5_BEFORE"
+    echo "    after:  $ACTUAL_CANONICAL"
+    FAILED=$((FAILED + 1))
+fi
+
+echo ""
+echo "==============================================="
+echo "Results: $PASSED passed, $FAILED failed"
+echo "==============================================="
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tools/edit_virgin_root.sh
+++ b/tools/edit_virgin_root.sh
@@ -4,10 +4,11 @@
 # via frontier-cli's protocol mode.
 #
 # Problem (issue #644): the documented ODB-edit workflow points
-# `--allow-mutate` directly at `databases/Virgin.root`. A forgotten session,
-# a runaway script, or a mid-write kill can leave the canonical .root file
-# corrupted locally with no automatic recovery. PR #643's agent hit this in
-# practice — Virgin.root grew from 20MB to 31MB due to a leaked session.
+# `frontier-cli --protocol` directly at `databases/Virgin.root`. A forgotten
+# session, a runaway script, or a mid-write kill can leave the canonical
+# .root file corrupted locally with no automatic recovery. PR #643's agent
+# hit this in practice — Virgin.root grew from 20MB to 31MB due to a leaked
+# session.
 #
 # This wrapper interposes a staging step:
 #
@@ -27,10 +28,13 @@
 #   --help        Print usage and exit 0.
 #   --dry-run     Stage the copy but do NOT spawn frontier-cli. Useful for
 #                 testing the wrapper itself.
-#   --read-only   Omit --allow-mutate from the spawned frontier-cli. Lets
-#                 operators do read-only inspection without the wrapper's
-#                 promotion ceremony. (Equivalent to running the CLI
-#                 directly in inspection mode, but staged for consistency.)
+#   --read-only   Pass --lock-opened-roots to the spawned frontier-cli.
+#                 Lets operators do read-only inspection without the
+#                 wrapper's promotion ceremony. (Equivalent to running the
+#                 CLI directly in inspection mode, but staged for
+#                 consistency.) Kept as --read-only on the wrapper for
+#                 operator-facing clarity; --lock-opened-roots is the
+#                 underlying CLI flag.
 #
 # On Ctrl-C during the editor session the staged temp dir is left in place
 # for inspection.
@@ -71,10 +75,11 @@ Options:
   --help        Show this help and exit.
   --dry-run     Stage the copy but do not spawn frontier-cli. Cleans up the
                 staged temp dir on exit. Use this to smoke-test the wrapper.
-  --read-only   Spawn frontier-cli without --allow-mutate. The session is
-                read-only by the CLI's own defense (issue #588) regardless,
-                but this flag also disables the promotion prompt at the end
-                since the staged copy cannot have been changed.
+  --read-only   Spawn frontier-cli with --lock-opened-roots. The session
+                evaluates mutations in memory but the on-exit save is
+                suppressed, and this flag also disables the promotion
+                prompt at the end since the staged copy cannot have been
+                changed on disk.
 
 Examples:
   tools/edit_virgin_root.sh
@@ -174,7 +179,7 @@ STAGE_DIR="$(mktemp -d -t "frontier-edit-${BEFORE_MD5:0:12}-XXXXXXXX")" || {
 STAGED_ROOT="$STAGE_DIR/Virgin.root"
 
 # EXIT trap for cleanup. Sets STAGE_PRESERVE=1 to skip removal on the
-# "rejected promotion" and "--read-only changed" forensic branches.
+# "rejected promotion" and "--read-only changed" (lock-bypass) forensic branches.
 STAGE_PRESERVE=0
 cleanup_stage() {
     if [ "$STAGE_PRESERVE" -eq 0 ] && [ -n "${STAGE_DIR:-}" ] && [ -d "$STAGE_DIR" ]; then
@@ -225,14 +230,14 @@ fi
 # ---------------------------------------------------------------------------
 
 CLI_ARGS=(--protocol --skip-startup --system-root "$STAGED_ROOT")
-if [ "$READ_ONLY" -eq 0 ]; then
-    CLI_ARGS=(--allow-mutate "${CLI_ARGS[@]}")
+if [ "$READ_ONLY" -eq 1 ]; then
+    CLI_ARGS=(--lock-opened-roots "${CLI_ARGS[@]}")
 fi
 
 if [ "$READ_ONLY" -eq 1 ]; then
-    echo "Spawning frontier-cli in read-only mode (no --allow-mutate)."
+    echo "Spawning frontier-cli in --read-only mode (--lock-opened-roots)."
 else
-    echo "Spawning frontier-cli with --allow-mutate against the staged copy."
+    echo "Spawning frontier-cli (default-RW) against the staged copy."
 fi
 echo "Command: $CLI ${CLI_ARGS[*]}"
 echo
@@ -270,10 +275,10 @@ if [ "$BEFORE_MD5" = "$AFTER_MD5" ]; then
 fi
 
 if [ "$READ_ONLY" -eq 1 ]; then
-    # This shouldn't happen — read-only mode means the CLI shouldn't write —
-    # but if it does, treat it as a hard error and preserve the staged copy
-    # for forensics.
-    err "staged copy changed despite --read-only — refusing to promote"
+    # This shouldn't happen — --lock-opened-roots means the CLI shouldn't
+    # write to disk — but if it does, treat it as a hard error and preserve
+    # the staged copy for forensics.
+    err "staged copy changed despite --read-only (--lock-opened-roots) — refusing to promote"
     err "staged copy left at: $STAGED_ROOT"
     STAGE_PRESERVE=1
     exit 4


### PR DESCRIPTION
## Summary

- Resolves Virgin.root size drift (~1.2 MB per `--system-root` invocation) by short-circuiting `save_system_root_on_exit` when the in-memory tree is clean, after scrubbing spurious dirty bits set during hydration link-phase injections (`linksystemtablestructure`, `headless_init_system_paths`, etc.).
- Adds `--lock-opened-roots` (and `FRONTIER_LOCK_OPENED_ROOTS` env var) as the single flag for inspection-only sessions. Removes `--allow-mutate` and `--read-only` from PR #588 — they were either redundant or functionally identical under current code. Protocol mode no longer defaults to read-only.
- The CLI flag is authoritative: passing `--lock-opened-roots` always exports the env var, so guest-DB opens via `dbopenverb` see the same intent even if the env was pre-set to `0`.
- Restores legacy "mutable by default" semantics for every loaded-from-disk DB. Newly-created roots (`file.save` / `file.saveAs` / `db.compactDatabase` / `db.new`) are unaffected.
- Integration test runner injects `FRONTIER_LOCK_OPENED_ROOTS=1` by default in per-process AND protocol executors. 42 tests across 9 yaml files carry `environment: {FRONTIER_LOCK_OPENED_ROOTS: "0"}` for legitimate write paths (`db_verbs`, `db_compact`, `filemenu_verbs`, `dist_stability`, `guest_db_externals`, `persistence_save_tests`, `error_recovery_concurrency_tests`, `startup_script_execution`).

## Notes

- New `tests/system_root_readonly_idempotent_test.sh` encodes the full matrix (12 assertions across 6 named test sections). Canonical-protection assertion captures `md5` at script start and compares end-of-run, avoiding the hard-coded constant brittleness.
- New `env_truthy()` helper in `Common/SystemHeaders/standard.h` unifies the `FRONTIER_LOCK_OPENED_ROOTS` truthiness check across `cli_parser.c` and `dbverbs.c`. Pre-existing `FRONTIER_OPEN_READONLY` semantic intentionally left asymmetric.
- Local /gate: bar-raiser (2 rounds), security (2 rounds), concurrency (2 rounds) all PASS. Round 1 found 3 P1s + 5 P2s — all addressed inline; round 2 confirmed all closed and surfaced no new findings.
- Follow-up tracked: #649 — replace `FRONTIER_LOCK_OPENED_ROOTS` env-var-as-cross-module-signal with a `cli_runtime_flags_t` accessor in `shell_api`. Tracked separately so this PR can stay focused on the user-visible fix.

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 489/489
- [x] Integration tests: `cd tests && make test-integration` — 48 failures, all pre-existing tcp.*/html.* baseline. Zero regressions.
- [x] Idempotent shell test: `bash tests/system_root_readonly_idempotent_test.sh` — 12/12
- [x] Manual probe matrix verified:
  - `--lock-opened-roots -e 'sizeOf(system)'` → md5 unchanged
  - `--lock-opened-roots -e 'workspace.x = 1'` → md5 unchanged (in-memory only)
  - default `-e 'workspace.x = 1'` → md5 changes (legacy default-RW save)
  - `FRONTIER_LOCK_OPENED_ROOTS=0 --lock-opened-roots ...` → both system and guest DBs respect the lock (P1 from /gate round 1 verified end-to-end)
  - `--protocol --system-root <path>` mutation → md5 changes (no more RO default)
  - `--protocol --lock-opened-roots --system-root <path>` mutation → md5 unchanged

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
