### PR TITLE
docs(usertalk): remove lessThanOrEqual/greaterThanOrEqual word forms

### DIFF
--- a/docs/usertalk/operators_and_idioms.md
+++ b/docs/usertalk/operators_and_idioms.md
@@ -15,9 +15,9 @@ UserTalk supports both **symbol** and **word** forms. They compile identically. 
 | `==` | `equals` | Equal |
 | `!=` | `notEquals` | Not equal |
 | `<` | `lessThan` | Less than |
-| `<=` | `lessThanOrEqual` | Less than or equal |
+| `<=` | (none) | Less than or equal |
 | `>` | `greaterThan` | Greater than |
-| `>=` | `greaterThanOrEqual` | Greater than or equal |
+| `>=` | (none) | Greater than or equal |
 
 ```
 if examples.count == 0 {...}                   // ✓ idiomatic

--- a/frontier-cli/repl_variables.c
+++ b/frontier-cli/repl_variables.c
@@ -417,10 +417,8 @@ static int prev_matches_keyword(const char *out, const char *p,
  *   keyword boolean:      'and', 'or' (word-bounded)
  *   symbolic relational:  '==', '>=', '<=', '!='
  *   keyword relational:   'equals', 'notEquals', 'lessThan', 'greaterThan'
- *                         (note: 'lessThanOrEqual' / 'greaterThanOrEqual'
- *                         are documented but NOT accepted by the parser as
- *                         infix operators — confirmed empirically — so they
- *                         are intentionally not included here)
+ *                         (the UserTalk parser does not accept word forms
+ *                         of '<=' / '>=', so none are listed here)
  *   keyword string/list:  'contains', 'beginsWith', 'endsWith'
  *   single-char arith:    '+', '-', '*', '/', '%'
  *   list separator:       ','

--- a/tests/integration/test_cases/protocol_eval_compile_errors.yaml
+++ b/tests/integration/test_cases/protocol_eval_compile_errors.yaml
@@ -771,8 +771,7 @@ tests:
   # Completes PREV_BINOP coverage for every UserTalk infix operator
   # documented in docs/usertalk/operators_and_idioms.md:
   #   - symbolic arithmetic: '%' (modulo)
-  #   - keyword comparison: equals, notEquals, lessThan, greaterThan,
-  #     lessThanOrEqual, greaterThanOrEqual
+  #   - keyword comparison: equals, notEquals, lessThan, greaterThan
   #   - keyword string/list infix: contains, beginsWith, endsWith
   # Each operator at EOL must suppress the synthetic ';' so the next
   # line continues the expression instead of being parsed as a new
@@ -837,13 +836,6 @@ tests:
           result:
             value: "true"
             type: "boolean"
-
-  # Note: docs/usertalk/operators_and_idioms.md lists 'lessThanOrEqual' and
-  # 'greaterThanOrEqual' as word forms of '<=' / '>=', but the UserTalk
-  # parser does NOT actually accept those as infix operators (verified
-  # empirically — '1 lessThanOrEqual 1' compiles and returns 1, not true).
-  # They are intentionally omitted from prev_is_binop until either the
-  # parser is extended or the docs are corrected.
 
   - name: "protocol script/eval - PREV_BINOP keyword 'contains' at EOL allows continuation"
     description: "Pattern: 'return \"foo\" contains\\n \"f\"'. Substring infix operator. Ends in 's' — shares last byte with 'equals'/'notEquals' so helper must compare full bytes."


### PR DESCRIPTION
## Summary

- The UserTalk parser does not actually accept `lessThanOrEqual` or `greaterThanOrEqual` as infix operators. `docs/usertalk/operators_and_idioms.md` claimed otherwise. Empirically: `1 lessThanOrEqual 1` returns `1`, not `true` — the parser silently treats the trailing token as garbage and yields the LHS value.
- Replaces the two false table rows with `(none)` so the documented operator surface stays complete but the false-equivalence claim is gone.
- Cleans up the now-stale follow-up notes that PR #648 left in `protocol_eval_compile_errors.yaml` and `repl_variables.c` explaining why those tokens were omitted from `prev_is_binop`.

## Notes

- Docs/comment-only change — no behavioral surface, qualifies for trivial-threshold /gate skip per global CLAUDE.md.
- No production UserTalk script in the codebase uses these word forms; nothing breaks.
- Adding actual parser support would be a separate, larger initiative (scanner + grammar + tests + `prev_is_binop` extension). Not done here; not currently needed.

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 489/489
- [x] Integration tests: `cd tests && make test-integration` — 48 failures, all pre-existing tcp.*/html.* baseline. Zero regressions.
- [x] Build clean: `make -C frontier-cli` succeeds (the C-side change is a comment-block edit).
- [x] YAML still parses: `python3 -c "import yaml; yaml.safe_load(open(...))"` clean.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
