### PR TITLE
refactor: replace FRONTIER_LOCK_OPENED_ROOTS env-var-as-signal with shell_api accessor

### DIFF
--- a/Common/headers/shell_api.h
+++ b/Common/headers/shell_api.h
@@ -48,6 +48,14 @@ Boolean shell_api_is_headless(void);
 /* Convenience for tests/headless servers to install the strict implementation. */
 void shell_api_use_headless(void);
 
+/* Runtime flag accessors -- in-process source of truth for CLI runtime
+ * flags that downstream modules need to consult without linking back to the
+ * CLI parser. The CLI converges the env-var and CLI-flag inputs at parse
+ * time, then calls the setter once; everything else reads via the getter.
+ * See issue #649. */
+void shell_api_set_lock_opened_roots(boolean value);
+boolean shell_api_lock_opened_roots(void);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/Common/headers/shell_api.h
+++ b/Common/headers/shell_api.h
@@ -52,7 +52,12 @@ void shell_api_use_headless(void);
  * flags that downstream modules need to consult without linking back to the
  * CLI parser. The CLI converges the env-var and CLI-flag inputs at parse
  * time, then calls the setter once; everything else reads via the getter.
- * See issue #649. */
+ * See issue #649.
+ *
+ * Type note: `boolean` (lowercase) is intentional -- it matches the consumer
+ * types (cli_options_t.lock_opened_roots, dbopenverb return). The capital
+ * `Boolean` used in tyshellapi above is the Carbon-shim type for AppleEvent
+ * interop; don't "unify" them. */
 void shell_api_set_lock_opened_roots(boolean value);
 boolean shell_api_lock_opened_roots(void);
 

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -730,7 +730,7 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 	 * CLI flag into the accessor at startup, then everything else reads
 	 * here -- no per-call env_truthy() that could drift mid-session. */
 	if (!odbrec.flreadonly && shell_api_lock_opened_roots()) {
-		log_debug(LOG_COMP_DB, "dbopenverb: shell_api_lock_opened_roots in effect, forcing readonly=true");
+		log_debug(LOG_COMP_DB, "dbopenverb: lock_opened_roots in effect (--lock-opened-roots or FRONTIER_LOCK_OPENED_ROOTS), forcing readonly=true");
 		odbrec.flreadonly = true;
 	}
 

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -61,6 +61,7 @@
 #include "odbinternal.h"
 #include "db_format.h" /* migration helpers */
 #include "db.h" /* odb_context_guard */
+#include "shell_api.h" /* shell_api_lock_opened_roots() (#649) */
 
 /* DB_PATH_MAX is defined in db_format.h */
 
@@ -717,17 +718,19 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 		return (false);
 	}
 
-	/* Issue #127: --lock-opened-roots / FRONTIER_LOCK_OPENED_ROOTS=1 forces
-	 * every loaded-from-disk guest DB read-only, regardless of the user's
-	 * db.open(path, readonly) flag. Newly created roots (db.new /
-	 * file.save / file.saveAs / db.compactDatabase) are unaffected --
-	 * those paths don't go through dbopenverb.
+	/* Issue #127 / #649: --lock-opened-roots forces every loaded-from-disk
+	 * guest DB read-only, regardless of the user's db.open(path, readonly)
+	 * flag. Newly created roots (db.new / file.save / file.saveAs /
+	 * db.compactDatabase) are unaffected -- those paths don't go through
+	 * dbopenverb.
 	 *
-	 * env_truthy() (Common/SystemHeaders/standard.h) shares the truthiness
-	 * contract with cli_parser.c so the CLI flag and the dbopenverb env
-	 * check agree on what counts as enabled. */
-	if (!odbrec.flreadonly && env_truthy("FRONTIER_LOCK_OPENED_ROOTS")) {
-		log_debug(LOG_COMP_DB, "dbopenverb: FRONTIER_LOCK_OPENED_ROOTS in effect, forcing readonly=true");
+	 * shell_api_lock_opened_roots() is the authoritative in-process source
+	 * of truth (see Common/source/shell_api.c). cli_parser.c converges
+	 * the FRONTIER_LOCK_OPENED_ROOTS env var and the --lock-opened-roots
+	 * CLI flag into the accessor at startup, then everything else reads
+	 * here -- no per-call env_truthy() that could drift mid-session. */
+	if (!odbrec.flreadonly && shell_api_lock_opened_roots()) {
+		log_debug(LOG_COMP_DB, "dbopenverb: shell_api_lock_opened_roots in effect, forcing readonly=true");
 		odbrec.flreadonly = true;
 	}
 

--- a/Common/source/shell_api.c
+++ b/Common/source/shell_api.c
@@ -72,7 +72,13 @@ Boolean shell_api_is_headless(void) {
  * --lock-opened-roots flag into a single decision at parse time, then calls
  * shell_api_set_lock_opened_roots() exactly once. Other modules (e.g.,
  * dbopenverb in Common/source/dbverbs.c) read via shell_api_lock_opened_roots()
- * rather than re-reading the env, so the value cannot drift mid-session. */
+ * rather than re-reading the env, so the value cannot drift mid-session.
+ *
+ * Threading contract: single-writer at startup (before headless_threading_init
+ * spawns any worker threads), multi-reader after. No synchronization required
+ * under that contract -- POSIX thread-creation happens-before makes the write
+ * visible to all subsequent threads. Do NOT add a mid-session setter from a
+ * worker thread without revisiting this. */
 static boolean g_lock_opened_roots = false;
 
 void shell_api_set_lock_opened_roots(boolean value) {

--- a/Common/source/shell_api.c
+++ b/Common/source/shell_api.c
@@ -66,3 +66,19 @@ Boolean shell_api_is_headless(void) {
 
     return (api != NULL) ? api->is_headless : false;
 }
+
+/* Issue #649: in-process source of truth for --lock-opened-roots. The CLI
+ * parser converges the env-var FRONTIER_LOCK_OPENED_ROOTS and the
+ * --lock-opened-roots flag into a single decision at parse time, then calls
+ * shell_api_set_lock_opened_roots() exactly once. Other modules (e.g.,
+ * dbopenverb in Common/source/dbverbs.c) read via shell_api_lock_opened_roots()
+ * rather than re-reading the env, so the value cannot drift mid-session. */
+static boolean g_lock_opened_roots = false;
+
+void shell_api_set_lock_opened_roots(boolean value) {
+    g_lock_opened_roots = value;
+}
+
+boolean shell_api_lock_opened_roots(void) {
+    return g_lock_opened_roots;
+}

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -595,40 +595,35 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 
 	free(filtered_argv);
 
-	/* Environment <-> CLI flag synchronization for --lock-opened-roots (issue #127).
+	/* --lock-opened-roots: converge env-var + CLI-flag inputs, then publish
+	 * the single in-process decision via shell_api (issues #127, #649).
 	 *
-	 * The env var FRONTIER_LOCK_OPENED_ROOTS lets the integration test runner
-	 * and other ephemeral consumers opt every loaded-from-disk DB into
-	 * read-only-on-save without threading a CLI flag through every spawn
-	 * site.
+	 * Inputs:
+	 *   - FRONTIER_LOCK_OPENED_ROOTS env var (truthy = enable; lets the
+	 *     integration test runner and other ephemeral consumers opt every
+	 *     loaded-from-disk DB into read-only-on-save without threading a
+	 *     CLI flag through every spawn site).
+	 *   - --lock-opened-roots CLI flag (already folded into
+	 *     options->lock_opened_roots during getopt parsing).
 	 *
-	 * Sync rules so non-CLI consumers (e.g., dbopenverb in
-	 * Common/source/dbverbs.c, which has no link to the CLI parser state)
-	 * can read a single source of truth via getenv():
+	 * Convergence: if either input is enabled, options->lock_opened_roots
+	 * is true. The shell_api setter is then called once; downstream
+	 * modules (e.g., dbopenverb in Common/source/dbverbs.c) read via
+	 * shell_api_lock_opened_roots() and never re-parse the env, so the
+	 * value cannot drift mid-session.
 	 *
-	 *   - If env is set truthy (non-empty and not "0"), it enables the flag.
-	 *   - If --lock-opened-roots was passed on the CLI, the flag is
-	 *     authoritative: setenv() unconditionally so any descendant code
-	 *     path that consults FRONTIER_LOCK_OPENED_ROOTS sees "1", even if
-	 *     the inherited env had FRONTIER_LOCK_OPENED_ROOTS=0. Without this
-	 *     overwrite, the CLI flag would lock the system root while
-	 *     dbopenverb's env check would still permit guest-DB writes --
-	 *     inconsistent state. The explicit CLI flag always wins.
+	 * env_truthy() (Common/SystemHeaders/standard.h) is the shared
+	 * truthiness contract. The env var is read here exactly once; the
+	 * setenv-on-CLI-flag back-propagation was removed in Phase D of #649
+	 * because nothing in-process reads the env after parse time (child
+	 * processes spawned by sys.shell inherit the parent's env unchanged
+	 * and run their own parse-time read).
 	 *
 	 * Validation in cli_validate_options() runs after. */
 	{
-		/* env_truthy() lives in Common/SystemHeaders/standard.h; reusing it
-		 * here keeps the FRONTIER_LOCK_OPENED_ROOTS truthiness contract in
-		 * lockstep with dbverbs.c's enforcement check. */
 		if (env_truthy("FRONTIER_LOCK_OPENED_ROOTS"))
 			options->lock_opened_roots = true;
 
-		if (options->lock_opened_roots)
-			setenv("FRONTIER_LOCK_OPENED_ROOTS", "1", 1);
-
-		/* Issue #649: publish the converged decision to shell_api so
-		 * non-CLI consumers (e.g., dbopenverb) can read a single
-		 * in-process source of truth without re-parsing the env var. */
 		shell_api_set_lock_opened_roots(options->lock_opened_roots);
 	}
 

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -39,6 +39,7 @@
 #include "cli_utils.h"
 #include "standard.h"			/* env_truthy() */
 #include "../Common/headers/logging.h"
+#include "../Common/headers/shell_api.h"	/* shell_api_set_lock_opened_roots() */
 
 /*
  * Convert a kebab-case flag name to camelCase.
@@ -624,6 +625,11 @@ boolean cli_parse_arguments(int argc, char* argv[], cli_options_t* options) {
 
 		if (options->lock_opened_roots)
 			setenv("FRONTIER_LOCK_OPENED_ROOTS", "1", 1);
+
+		/* Issue #649: publish the converged decision to shell_api so
+		 * non-CLI consumers (e.g., dbopenverb) can read a single
+		 * in-process source of truth without re-parsing the env var. */
+		shell_api_set_lock_opened_roots(options->lock_opened_roots);
 	}
 
 	// Validate the parsed options

--- a/tests/core_tests.c
+++ b/tests/core_tests.c
@@ -24,11 +24,48 @@ static void test_shell_api_headless_mode(void) {
     assert(!shell_api_require(kShellCapabilityWindows, "window.open"));
 }
 
+/* Issue #649: shell_api_lock_opened_roots is the in-process source of truth
+ * for the --lock-opened-roots flag, replacing FRONTIER_LOCK_OPENED_ROOTS as a
+ * cross-module signal. The four tests below cover default state, set->get
+ * roundtrip in both directions, and idempotency. */
+
+static void test_shell_api_lock_opened_roots_default_false(void) {
+    /* The static initializer guarantees this is false; explicitly reset to
+     * defend the test against ordering with siblings that flip it. */
+    shell_api_set_lock_opened_roots(false);
+    assert(shell_api_lock_opened_roots() == false);
+}
+
+static void test_shell_api_lock_opened_roots_set_true_get_true(void) {
+    shell_api_set_lock_opened_roots(false);
+    shell_api_set_lock_opened_roots(true);
+    assert(shell_api_lock_opened_roots() == true);
+}
+
+static void test_shell_api_lock_opened_roots_set_false_get_false(void) {
+    shell_api_set_lock_opened_roots(true);
+    shell_api_set_lock_opened_roots(false);
+    assert(shell_api_lock_opened_roots() == false);
+}
+
+static void test_shell_api_lock_opened_roots_set_idempotent(void) {
+    shell_api_set_lock_opened_roots(true);
+    shell_api_set_lock_opened_roots(true);
+    assert(shell_api_lock_opened_roots() == true);
+    shell_api_set_lock_opened_roots(false);
+    shell_api_set_lock_opened_roots(false);
+    assert(shell_api_lock_opened_roots() == false);
+}
+
 int main(void) {
     TR_INIT("core_tests");
     TR_RUN(test_shell_api_capability_names);
     TR_RUN(test_shell_api_default_mode);
     TR_RUN(test_shell_api_headless_mode);
+    TR_RUN(test_shell_api_lock_opened_roots_default_false);
+    TR_RUN(test_shell_api_lock_opened_roots_set_true_get_true);
+    TR_RUN(test_shell_api_lock_opened_roots_set_false_get_false);
+    TR_RUN(test_shell_api_lock_opened_roots_set_idempotent);
     TR_SUMMARY();
     return TR_EXIT_CODE();
 }


### PR DESCRIPTION
## Summary

- Replaces `FRONTIER_LOCK_OPENED_ROOTS` env-var-as-cross-module-signal between `frontier-cli/cli_parser.c` and `Common/source/dbverbs.c` with a typed accessor pair in `shell_api`: `shell_api_set_lock_opened_roots(boolean)` / `shell_api_lock_opened_roots()`.
- Storage: file-static `g_lock_opened_roots = false` in `Common/source/shell_api.c`. Single-writer at startup (CLI parser, pre-thread-init); multi-reader after (`dbopenverb` under GIL). No synchronization needed under that contract.
- Env var `FRONTIER_LOCK_OPENED_ROOTS` is still honored at CLI parse time — operators and the test runner's spawn pattern continue to work. It's read exactly once now and converted into the accessor; no per-call `env_truthy()` that could drift mid-session.
- `setenv` back-propagation from CLI flag → env is removed. Nothing in-process reads env after parse time, and children spawned via UserTalk `sys.shell` inherit the parent's env unchanged from how the parent process started.

## Notes

- 4 commits, one per migration phase (A: accessor + tests / B: CLI writer / C: dbverbs reader / D: cleanup). Bisectable — each commit compiles, builds, and passes tests independently.
- 4 new unit tests in `tests/core_tests.c` cover the accessor's state-transition matrix (default-false, set-true, set-false, idempotent).
- Lower-case `boolean` is intentional — matches consumers (`cli_options_t.lock_opened_roots`, `dbopenverb` return). The capital `Boolean` used in `tyshellapi` above is the Carbon-shim type for AppleEvent interop; they coexist by design.
- Local /gate: bar-raiser, security, concurrency all PASS. Bar-raiser flagged 3 optional P2s (all comment/log-text clarifications), all folded into Phase D inline.

### Security analysis (from /gate security review)

The change is **net-positive** for security:
- Eliminates a TOCTOU window — previously, any in-process `unsetenv("FRONTIER_LOCK_OPENED_ROOTS")` between parse time and `dbopenverb` could silently unlock guest DBs mid-session. The static `boolean` cannot be cleared by env manipulation.
- Removes a `setenv()` call, which is not async-signal-safe and historically buggy on some platforms (glibc allocation, macOS thread-safety with concurrent getenv).
- Tightens the accessor surface — `shell_api_set_lock_opened_roots` has exactly one caller (CLI parser, parse time). No UserTalk verb glue, RPC handler, or protocol handler exposes the setter.

### Behavior change to note

The CLI flag `--lock-opened-roots` no longer back-propagates to the env var via `setenv`. If an operator passes `--lock-opened-roots` and the script then `sys.shell`'s a child `frontier-cli`, the child does NOT automatically inherit the lock. For child processes to lock too, pass the env var explicitly: `FRONTIER_LOCK_OPENED_ROOTS=1 frontier-cli`. Per /gate security: "the lost child-process inheritance is recoverable by the operator... not a regression against any documented contract."

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 493/493 (4 new accessor tests added)
- [x] Integration tests: `cd tests && make test-integration` — 45-48 failures, all pre-existing tcp.*/html.* baseline. Zero regressions.
- [x] Idempotent shell test: `bash tests/system_root_readonly_idempotent_test.sh` — 12/12 PASS
- [x] Manual probe matrix verified:
  - Default `-e 'workspace.x = 1'` → md5 changes (legacy default-RW)
  - `--lock-opened-roots` → md5 unchanged
  - `FRONTIER_LOCK_OPENED_ROOTS=1` → md5 unchanged (env picked up at parse time → accessor)
  - `FRONTIER_LOCK_OPENED_ROOTS=0 --lock-opened-roots` → md5 unchanged (CLI flag wins, accessor set true)
  - `--lock-opened-roots` + `db.open("guest", false)` + mutation → guest DB md5 unchanged too (P1 from PR #650 still working)

Closes #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
