### PR TITLE
fix(lang): balance langpush/popsourcecode in langfunctioncall failure branch (#659 Phase 1)

### DIFF
--- a/Common/source/langvalue.c
+++ b/Common/source/langvalue.c
@@ -8313,6 +8313,7 @@ boolean langfunctioncall (hdltreenode hcallernode, hdlhashtable htable, hdlhashn
 	register boolean fl;
 	hdlhashtable hlocaltable;
 	tyvaluerecord osacode;
+	boolean flpushedsource = false; /*#659: track push so failure path can pop*/
 
         if (hcode == nil) { /*can only be a kernel call -- or an error*/
 #if defined(FRONTIER_HEADLESS)
@@ -8377,19 +8378,24 @@ boolean langfunctioncall (hdltreenode hcallernode, hdlhashtable htable, hdlhashn
 	if (fl && hcallernode)
 		fl = langdebuggercall (hcallernode); /*user killed the script*/
 	
-	if (fl)
+	if (fl) {
 		fl = langpushsourcecode (htable, hnode, bsname);
-	
+		flpushedsource = fl;
+		}
+
 	if (fl && !(**htable).fllocaltable)
 		fl = langsetthisvalue (hlocaltable, htable, bsname);
-	
+
 	if (!fl) {
-		
+
+		if (flpushedsource) /*#659: balance push when later step failed*/
+			langpopsourcecode ();
+
 		disposehashtable (hlocaltable, false);
-		
+
 		return (false);
 		}
-	
+
 	hmagictable = hlocaltable; /*evaluatelist uses this as its local symbol table*/
 	
 	/*


### PR DESCRIPTION
# fix(lang): balance langpush/popsourcecode in langfunctioncall failure branch

Phase 1 of issue #659. Closes the langvalue.c push/pop asymmetry independently of the broader multi-frame-stack work (Phase 2 deferred to #662).

## The bug

`Common/source/langvalue.c::langfunctioncall` pushed a source-code stack frame at line ~8381, then called `langsetthisvalue` at line ~8384. If `langsetthisvalue` failed, the function returned via the `if (!fl)` branch at line ~8386 without popping the source-code stack — leaking a frame per failure.

## Why it matters

- **In full Frontier builds**: each leaked frame consumes one `scriptsourcestack` slot until `langcheckstacklimit` starts rejecting pushes, surfacing as "Can't compile this script" cascade failures.
- **In headless builds**: the push callback is a noop (`cb_noop_sourcecode` in `langstartup.c:1200`), so no real frame is consumed — the leak is dormant today in the headless path.

The fix balances the push with a flag-guarded pop on the failure branch.

## Fix

Single file, +12/-6:
- `Common/source/langvalue.c`: introduce `flpushedsource` (initialized false, set true inside the `if (fl)` push guard). Failure branch pops if `flpushedsource` is true, then returns.

```
 Common/source/langvalue.c | 18 ++++++++++++------
 1 file changed, 12 insertions(+), 6 deletions(-)
```

## What this enables

- Pre-merges Phase 2 (#662) — the headless callback chain that exposes the bug as a cascade.
- Removes a latent memory-corruption risk in full Frontier builds.
- Pre-existing PR3 design constraint on `tryErrorScript` snapshot timing remains (tracked in #662).

## /gate review summary

| Reviewer | Verdict | P0 | P1 | P2 |
|---|---|---|---|---|
| bar-raiser | PASS WITH NOTES | 0 | 0 | 3 |
| security | APPROVE | 0 | 0 | 1 |
| concurrency | skipped (auto: no triggers — diff is langvalue.c only) | | | |

All P2 items are polish/follow-ups (issue marker comments, harmless `flpushedsource` leak after early return, behavioral test gap that requires Phase 2). One security P2 surfaced a pre-existing latent issue (`scriptpopsourcerecord` lacks underflow guard) — filed as #663.

## Deferred (each filed as issue)

- **#662**: Phase 2 — chain `debug_push_sourcecode` through `headless_pushsourcecode` + fix `tryErrorScript` snapshot timing. Two real blockers found during investigation: (a) chaining cascades 10 html_framework_tests failures when batched, (b) snapshot is captured at function-entry stamping BEFORE the named-script frame would be pushed (pre-existing PR3 design constraint).
- **#663**: Defensive depth — add underflow guard to `scriptpopsourcerecord` so future imbalance bugs degrade to benign no-ops instead of memory corruption.

## Test plan

- [x] TDD exception: pure single-site fix; tests that would exercise the gap need Phase 2 infrastructure (deferred to #662). The strengthened assertions are parked in reflog (branch `worktree-fix-langfunctioncall-asymmetry`, commit `b9a08c47f`).
- [x] Unit tests: 493/493 pass.
- [x] Integration tests: 2110/2360 pass (43 baseline failures — all `html.*` + `tcp.*` env-dependent, matches develop baseline ± normal flake).
- [x] Build clean: `make -C frontier-cli` no new warnings.
- [x] All pre-existing PR1/PR2/PR3 tests (error_location.yaml, error_causedby.yaml, error_display.yaml) pass.

## Chain context

PR A (#661, refactor) merged. PR B (this PR) ships Phase 1 of #659. PR C follows (multi-threaded test harness, closes #660).

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
