### PR TITLE
fix(tcp): accept STREAM_ACCEPTED in read/write verb state checks

### DIFF
--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -846,7 +846,14 @@ boolean tcp_read_stream(long stream_id, long bytes_to_read, Handle *data_out) {
 
     /* Acquire stream reference (TOCTOU protection) */
     stream = tcp_stream_acquire(stream_id);
-    if (!stream || stream->state != STREAM_CONNECTED) {
+
+    /* Accept both STREAM_CONNECTED (client-initiated connect) and STREAM_ACCEPTED
+     * (server-side accept inside a listener callback). Both represent a fully-
+     * established TCP socket where read/write are valid. tcp_status_stream (~line
+     * 1874) follows the same pattern. Without this, scripts using tcp.listenStream
+     * callbacks cannot read incoming bytes or write responses, rendering the
+     * listener primitive useless. Issue #129. */
+    if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
         if (stream)
             tcp_stream_release(stream);
         *data_out = nil;
@@ -958,7 +965,10 @@ boolean tcp_write_stream(long stream_id, Handle hdata) {
 
     /* Acquire stream reference (TOCTOU protection) */
     stream = tcp_stream_acquire(stream_id);
-    if (!stream || stream->state != STREAM_CONNECTED) {
+
+    /* Accept both STREAM_CONNECTED and STREAM_ACCEPTED states. See the matching
+     * check in tcp_read_stream (~line 849) for the full rationale. Issue #129. */
+    if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
         if (stream)
             tcp_stream_release(stream);
         tcp_set_error(TCP_ERR_INVALID_STREAM, "Stream not connected");

--- a/tests/integration/test_cases/tcp_server_verbs.yaml
+++ b/tests/integration/test_cases/tcp_server_verbs.yaml
@@ -818,3 +818,153 @@ tests:
   #   expected_success: true
   #   expected_result: "true"
     notes: "Phase 3 - Behavioral spec: privileged ports (<1024) require root/admin privileges"
+
+# ============================================================================
+# CATEGORY 9: Regression tests for #129 (callback-side read/write)
+# ============================================================================
+#
+# Issue #129: tcp.readStream and tcp.writeStream rejected server-accepted
+# streams inside tcp.listenStream callbacks with "Stream not connected",
+# because the verb state-check at tcpverbs.c:849 / :961 only accepted
+# STREAM_CONNECTED. tcp_accept_thread sets STREAM_ACCEPTED (enum 3, distinct
+# from STREAM_CONNECTED=1) for server-side accepted sockets, so callbacks
+# could see the stream id but neither read incoming bytes nor write a
+# response. The fix accepts both states; tcp_status_stream (~line 1874)
+# already had this pattern. Tests below cover read, write, round-trip, and
+# the negative case (closed streams still reject).
+
+  - name: "tcp.readStream - server callback reads client data (#129)"
+    description: "Regression for #129. Inside a tcp.listenStream callback, the accepted server-side stream is in STREAM_ACCEPTED state. tcp.readStream must accept this state, not reject it as 'Stream not connected'. The test wraps the verb call in try/else: pre-fix the verb errors and readSucceeded stays false; post-fix the verb returns (possibly empty) data and readSucceeded becomes true. We do NOT assert payload bytes here because tcp.readStream is non-blocking and may return empty if the client write hasn't drained to the recv buffer yet — that timing concern is orthogonal to the state-check bug we're guarding."
+    timeout: 10
+    script: |
+      new(tableType, @system.temp.tcpSrv28);
+      system.temp.tcpSrv28.fired = false;
+      system.temp.tcpSrv28.readSucceeded = false;
+      script.newScriptObject("on myHandler(sid, refcon) {\r  try {\r    local(d = tcp.readStream(sid, 1024));\r    system.temp.tcpSrv28.readSucceeded = true};\r  system.temp.tcpSrv28.fired = true;\r  tcp.closeStream(sid);\r  return true}", @system.temp.tcpSrv28.myHandler);
+
+      local(listenID = tcp.listenStream(9028, 5, @system.temp.tcpSrv28.myHandler));
+      local(clientStream = tcp.openStream(tcp.addressEncode("127.0.0.1"), 9028));
+
+      tcp.writeStream(clientStream, "hello-from-129");
+
+      local(deadline = clock.ticks() + 300);
+      while (not system.temp.tcpSrv28.fired) and (clock.ticks() < deadline) {
+        clock.ticks()
+      };
+
+      local(verbWorked = system.temp.tcpSrv28.readSucceeded);
+
+      tcp.closeStream(clientStream);
+      tcp.closeListen(listenID);
+      delete(@system.temp.tcpSrv28);
+
+      return verbWorked
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #129 - callback-side tcp.readStream on STREAM_ACCEPTED. Verb-level regression check via try/else; deliberately does not assert payload bytes (see description)."
+
+  - name: "tcp.writeStream - server callback writes response data (#129)"
+    description: "Regression for #129. Inside a tcp.listenStream callback, tcp.writeStream must succeed on the accepted (STREAM_ACCEPTED) server stream. The test wraps the verb call in try/else: pre-fix the verb errors and writeSucceeded stays false; post-fix the verb succeeds and writeSucceeded becomes true. We do NOT assert that the client receives the exact bytes here, because client-side tcp.readStream is non-blocking and its accumulation semantics are orthogonal to the state-check bug under test."
+    timeout: 10
+    script: |
+      new(tableType, @system.temp.tcpSrv29);
+      system.temp.tcpSrv29.fired = false;
+      system.temp.tcpSrv29.writeSucceeded = false;
+      script.newScriptObject("on myHandler(sid, refcon) {\r  try {\r    tcp.writeStream(sid, \"response-from-129\");\r    system.temp.tcpSrv29.writeSucceeded = true};\r  system.temp.tcpSrv29.fired = true;\r  tcp.closeStream(sid);\r  return true}", @system.temp.tcpSrv29.myHandler);
+
+      local(listenID = tcp.listenStream(9029, 5, @system.temp.tcpSrv29.myHandler));
+      local(clientStream = tcp.openStream(tcp.addressEncode("127.0.0.1"), 9029));
+
+      local(deadline = clock.ticks() + 300);
+      while (not system.temp.tcpSrv29.fired) and (clock.ticks() < deadline) {
+        clock.ticks()
+      };
+
+      local(verbWorked = system.temp.tcpSrv29.writeSucceeded);
+
+      tcp.closeStream(clientStream);
+      tcp.closeListen(listenID);
+      delete(@system.temp.tcpSrv29);
+
+      return verbWorked
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #129 - callback-side tcp.writeStream on STREAM_ACCEPTED. Verb-level regression check via try/else; deliberately does not assert client-side payload bytes (see description)."
+
+  - name: "tcp.readStream/writeStream - bidirectional round-trip in callback (#129)"
+    description: "Regression for #129. Realistic listener primitive shape: inside the same callback, BOTH tcp.readStream and tcp.writeStream must succeed on the STREAM_ACCEPTED server stream. Pre-fix: both verbs error (state-check rejects STREAM_ACCEPTED), so neither flag flips. Post-fix: both verbs return successfully and both flags become true. Each verb is wrapped in its own try/else so a failure of one is independently detectable from the other."
+    timeout: 10
+    script: |
+      new(tableType, @system.temp.tcpSrv30);
+      system.temp.tcpSrv30.fired = false;
+      system.temp.tcpSrv30.readSucceeded = false;
+      system.temp.tcpSrv30.writeSucceeded = false;
+      script.newScriptObject("on myHandler(sid, refcon) {\r  try {\r    local(d = tcp.readStream(sid, 1024));\r    system.temp.tcpSrv30.readSucceeded = true};\r  try {\r    tcp.writeStream(sid, \"pong\");\r    system.temp.tcpSrv30.writeSucceeded = true};\r  system.temp.tcpSrv30.fired = true;\r  tcp.closeStream(sid);\r  return true}", @system.temp.tcpSrv30.myHandler);
+
+      local(listenID = tcp.listenStream(9030, 5, @system.temp.tcpSrv30.myHandler));
+      local(clientStream = tcp.openStream(tcp.addressEncode("127.0.0.1"), 9030));
+
+      tcp.writeStream(clientStream, "ping");
+
+      local(deadline = clock.ticks() + 300);
+      while (not system.temp.tcpSrv30.fired) and (clock.ticks() < deadline) {
+        clock.ticks()
+      };
+
+      local(bothVerbsWorked = system.temp.tcpSrv30.readSucceeded and system.temp.tcpSrv30.writeSucceeded);
+
+      tcp.closeStream(clientStream);
+      tcp.closeListen(listenID);
+      delete(@system.temp.tcpSrv30);
+
+      return bothVerbsWorked
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #129 - both read and write verbs must succeed on STREAM_ACCEPTED in a single callback"
+
+  - name: "tcp.readStream - closed stream after callback still rejects (#129 negative)"
+    description: "Guards against the #129 fix being too permissive. After the callback closes the accepted stream via tcp.closeStream(sid), the captured stream id is in STREAM_CLOSING/STREAM_CLOSED state. tcp.readStream from outside the callback must still ERROR with 'Stream not connected'. If the fix accidentally permitted reads on closed streams (e.g., by widening the check too far), this test would fail."
+    timeout: 10
+    script: |
+      new(tableType, @system.temp.tcpSrv31);
+      system.temp.tcpSrv31.fired = false;
+      system.temp.tcpSrv31.serverStream = -1;
+      script.newScriptObject("on myHandler(sid, refcon) {\r  system.temp.tcpSrv31.serverStream = sid;\r  tcp.closeStream(sid);\r  system.temp.tcpSrv31.fired = true;\r  return true}", @system.temp.tcpSrv31.myHandler);
+
+      local(listenID = tcp.listenStream(9031, 5, @system.temp.tcpSrv31.myHandler));
+      local(clientStream = tcp.openStream(tcp.addressEncode("127.0.0.1"), 9031));
+
+      local(deadline = clock.ticks() + 300);
+      while (not system.temp.tcpSrv31.fired) and (clock.ticks() < deadline) {
+        clock.ticks()
+      };
+
+      // Note: the saved serverStream sid could theoretically be reused by the
+      // stream pool after tcp.closeStream brings refcount to 0. In this isolated
+      // test no concurrent connections arrive, so the slot stays free and the
+      // sid still maps to the closed stream (which tcp_get_stream filters out
+      // by sockfd<0 and STREAM_CLOSING). If a future test in this file changes
+      // that assumption, this test could become flaky-toward-FAIL (false fail),
+      // not flaky-toward-PASS, because closedRejected would stay false.
+      local(closedRejected = false);
+      try {
+        tcp.readStream(system.temp.tcpSrv31.serverStream, 1024);
+        closedRejected = false
+      }
+      else {
+        closedRejected = true
+      };
+
+      tcp.closeStream(clientStream);
+      tcp.closeListen(listenID);
+      delete(@system.temp.tcpSrv31);
+
+      if closedRejected {
+        return "true"
+      }
+      else {
+        return "false"
+      }
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #129 - negative test: closed/closing streams must still reject"


### PR DESCRIPTION
## Summary

**Critical-path fix.** `tcp.readStream` and `tcp.writeStream` rejected server-accepted streams with "Stream not connected" inside `tcp.listenStream` callbacks, even though the TCP socket was fully established. This rendered the listener primitive useless — callbacks could see the stream id (via `getPeerAddress`, `statusStream`) but couldn't read the incoming bytes or write a response.

**Root cause**: state-check at `Common/source/tcpverbs.c:849` (`tcp_read_stream`) and `:961` (`tcp_write_stream`) tested `state != STREAM_CONNECTED`, but `tcp_accept_thread` at line 1444 sets `stream->state = STREAM_ACCEPTED` (enum value 3, distinct from `STREAM_CONNECTED=1`) for the server-side accepted stream.

**Fix**: expand both checks to accept BOTH STREAM_CONNECTED and STREAM_ACCEPTED, mirroring `tcp_status_stream` at line 1874 which already groups both states identically.

PR 2 of 3 in the #120 (tcp.* burndown) chain.

## Verification

**Pre-implementation audit** (read-only, dispatched separately before the C touch): only the 2 known sites need this fix. No other `state == STREAM_CONNECTED` checks in `tcpverbs.c` have the same bug; the variant verbs (read_until_*, write_string/file_to_stream) don't gate at all — separately tracked as #666.

**Behavioral tests added** to `tests/integration/test_cases/tcp_server_verbs.yaml` Category 9 (ports 9028-9031):

1. `tcp.readStream - server callback reads client data (#129)`
2. `tcp.writeStream - server callback writes to client (#129)`
3. `tcp.readStream + writeStream - bidirectional round-trip in callback (#129)`
4. `tcp.readStream - closed stream after callback still rejects (#129 negative)` — guards against the fix being too permissive

All 4 pass in isolation AND in the full suite at HEAD. Tests use `try/else` around individual verb calls to isolate state-check vs payload-timing concerns.

**Direct probes** via `--protocol --skip-startup`: read/write verbs return real data inside listener callbacks.

**Suite-level result**: 46 → 52 failures in the integration suite. The +6 are NOT regressions from this fix — they are **batch-mode contamination** (task #130's surface area) that the fix unblocked tests to reach. Diagnostic agent confirmed:
- All 6 new failures live in `tcp_verbs_network.yaml`
- All 6 PASS in isolation (verified via `--select`)
- All 6 PASS when `tcp_verbs_network.yaml` runs alone (12/12)
- All 6 FAIL only when `tcp_client_verbs.yaml` runs before them (cross-file contamination)
- Both files already have `sequential: true`; the contamination is cross-file process state, exactly the shape PR #648 fixed for `db_migration`

Zero new C-level regressions, zero races, zero fix-exposed bugs.

## /gate review (all 3 reviewers, no trivial-threshold skip)

- **bar-raiser** ✓ PASS, 2 P2 observations:
  - P2-01: TCP variant verbs lack state-gating (pre-existing, filed as **#666**)
  - P2-02: Negative test #4 slot-reuse race (annotated inline before push)
- **security** ✓ CLEAN — no new attack surface, TOCTOU window unchanged, refcount/release path verified correct, callback executes on main thread with GIL
- **concurrency** ✓ CLEAN — state-write at accept-thread happens under `TCP_LOCK`, read at fix sites also under `TCP_LOCK` (via `tcp_stream_acquire`), happens-before established by language guarantee. Accept thread releases TCP_LOCK before `tcp_enqueue_callback` → no nested-lock deadlock.

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 498/498
- [x] Integration tests: `cd tests && make test-integration` — 52 fail; +6 vs baseline are batch-contamination (tracked as #130), all verified to pass in isolation
- [x] 4 new TDD behavioral tests pass in isolation AND in full suite
- [x] Negative test #4 still rejects closed streams (guards against over-permissive widening)
- [x] Build clean: `make -C frontier-cli`
- [x] Canonical Virgin.root md5 unchanged throughout

Closes #129. Part of #120. Follows-up #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
