### PR TITLE
fix(tcp): reset rate-limit window on script/clearContext

### DIFF
--- a/Common/headers/tcpverbs.h
+++ b/Common/headers/tcpverbs.h
@@ -164,6 +164,12 @@ boolean tcp_get_stats(long listener_id, bigstring stats_out);
 boolean tcp_init_context(void);
 boolean tcp_shutdown_context(void);
 
+/* Reset the tcp connection rate-limit sliding window. Called by
+ * frontier-cli's script/clearContext handler so the long-lived protocol
+ * subprocess does not accumulate cross-test rate-limit pressure. See
+ * tcpverbs.c for the full contract. Issue #130. */
+void tcp_reset_rate_limit_window(void);
+
 /* Callback Queue Processing
  * Must be called periodically from main thread to process TCP callbacks.
  * Each callback is enqueued as a one-shot process via newprocess/addprocess.

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -574,6 +574,39 @@ static boolean tcp_check_rate_limit(void) {
     return true;
 }
 
+/* Reset the tcp connection rate-limit sliding window and telemetry counter.
+ *
+ * Intended to be called from script/clearContext (a test-runner reset
+ * boundary) so the long-lived protocol subprocess does not accumulate
+ * cross-test rate-limit pressure. Without this reset, tests in earlier
+ * yaml files that fire many connection attempts can poison the window for
+ * ~1 second, causing subsequent tcp tests in the same process to
+ * spuriously fail with "Connection rate limit exceeded" until the
+ * timestamps age out. Issue #130.
+ *
+ * Does NOT touch:
+ *   - connections_per_sec: user-set policy that must persist
+ *   - streams[] / active_count / listeners[]: structural resources managed
+ *     by their own acquire/release/close lifecycle
+ *   - total_connections / failed_connections: lifetime telemetry, not
+ *     behavior-gating
+ *
+ * DOES reset rate_limited_count because it counts window trips, not lifetime
+ * trips. Keeping it across the reset would misrepresent the cleared window
+ * (the counter would suggest the limiter has fired, even though the window
+ * is now empty).
+ *
+ * Thread safety: takes TCP_LOCK. Safe to call from any thread that does
+ * not already hold TCP_LOCK. */
+void tcp_reset_rate_limit_window(void) {
+    TCP_LOCK();
+    memset(g_tcp_context.connection_timestamps_us, 0,
+           sizeof(g_tcp_context.connection_timestamps_us));
+    g_tcp_context.timestamp_write_pos = 0;
+    g_tcp_context.rate_limited_count = 0;
+    TCP_UNLOCK();
+}
+
 /* ========================================================================
  * Phase 1B: Address Operations (No Network I/O)
  * ======================================================================== */

--- a/frontier-cli/op_handler.c
+++ b/frontier-cli/op_handler.c
@@ -46,6 +46,7 @@
 #include "../Common/headers/langexternal.h"
 #include "../Common/headers/memory.h"
 #include "../Common/headers/langinternal.h"
+#include "../Common/headers/tcpverbs.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -576,6 +577,11 @@ static void handle_clear_context(long id, transport_t *transport) {
 	langerrordisable = 0;
 	langerrorlogdisable = 0;
 	fllangerror = false;
+
+	/* Issue #130: reset the tcp connection rate-limit sliding window so
+	 * earlier tests' connection bursts do not poison subsequent tests in
+	 * the same long-lived protocol session. */
+	tcp_reset_rate_limit_window();
 
 	send_ack(id, transport);
 }

--- a/tests/integration/test_cases/tcp_phase2_verbs.yaml
+++ b/tests/integration/test_cases/tcp_phase2_verbs.yaml
@@ -639,3 +639,156 @@ tests:
     expected_success: true
     expected_result: "true"
     notes: "Phase 2 - Error handling for closed stream"
+
+  # ===========================================================================
+  # Issue #130: TCP connection rate-limit sliding-window reset across
+  # script/clearContext.
+  #
+  # Background: the integration test runner reuses a single long-lived
+  # protocol subprocess across yaml files (see ProtocolExecutor in
+  # tests/integration/runner.py). Between tests it issues
+  # script/clearContext. Without resetting the tcp rate-limit window,
+  # a yaml file that fires many tcp.openStream calls in a tight loop
+  # (e.g. tcp_client_verbs.yaml) poisons the sliding window for
+  # roughly one second of wall-clock time, causing the next file's
+  # tcp tests to fail with "Connection rate limit exceeded" until
+  # the timestamps age out.
+  #
+  # Default rate limit is 10 connections/sec (TCP_DEFAULT_RATE_LIMIT in
+  # Common/headers/tcpverbs.h). All three tests below fire enough
+  # connections in a tight loop to saturate that window.
+  #
+  # These tests rely on the script/clearContext boundary, so they use
+  # protocol_ops rather than a single `script:` body -- only the
+  # protocol shape exposes clearContext mid-test.
+  # ===========================================================================
+
+  - name: "tcp rate-limit window resets across script/clearContext (#130)"
+    description: |
+      Regression for #130. First eval saturates the rate-limit window by
+      firing 15 tcp.openStream calls to a closed port. The second eval,
+      after an intervening script/clearContext, fires a single
+      tcp.openStream and reports which failure mode it hit. Pre-fix the
+      window is still poisoned and the second eval returns "rate_limited".
+      Post-fix the window is empty and the second eval returns
+      "connection_failed" (the real closed-port error).
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: |
+            local(i, rateLimited = 0);
+            for i = 1 to 15 {
+              try {
+                local(s = tcp.openStream("127.0.0.1", 65530));
+                tcp.closeStream(s)
+              }
+              else {
+                if string.patternMatch("rate limit", tryError) > 0 {
+                  rateLimited = rateLimited + 1
+                }
+              }
+            };
+            return rateLimited > 0
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+        description: "saturate rate-limit window"
+
+      - op: "script/clearContext"
+        validate:
+          success: true
+        description: "reset boundary (must clear tcp rate-limit window for #130)"
+
+      - op: "script/eval"
+        params:
+          expression: |
+            try {
+              local(s = tcp.openStream("127.0.0.1", 65530));
+              tcp.closeStream(s);
+              return "unexpected_success"
+            }
+            else {
+              if string.patternMatch("rate limit", tryError) > 0 {
+                return "rate_limited"
+              };
+              return "connection_failed"
+            }
+        validate:
+          success: true
+          result:
+            value: "connection_failed"
+            type: "string"
+        description: "post-clearContext openStream must NOT see rate-limit error"
+
+  - name: "tcp rate-limit still fires within a single eval (positive control #130)"
+    description: |
+      Positive control: confirms the rate limiter still works after the
+      #130 fix. Fires 15 tcp.openStream calls inside one eval (no
+      intervening clearContext) and asserts at least one tripped the
+      limit. Guards against accidentally disabling the rate limiter.
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: |
+            local(i, rateLimited = 0);
+            for i = 1 to 15 {
+              try {
+                local(s = tcp.openStream("127.0.0.1", 65530));
+                tcp.closeStream(s)
+              }
+              else {
+                if string.patternMatch("rate limit", tryError) > 0 {
+                  rateLimited = rateLimited + 1
+                }
+              }
+            };
+            return rateLimited > 0
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"
+
+  - name: "tcp rate-limit accumulates across statements in same eval (positive control #130)"
+    description: |
+      Positive control: the rate limiter is cumulative across statements
+      within a single eval -- only script/clearContext resets it. Fires
+      6 openStream calls (well under the limit), then 9 more in a
+      second loop. Total = 15 attempts. At least one must trip the limit.
+      If the fix accidentally reset the window between every statement
+      (or every verb call), this would report zero rate-limited attempts.
+    protocol_ops:
+      - op: "script/eval"
+        params:
+          expression: |
+            local(i, rateLimited = 0);
+            for i = 1 to 6 {
+              try {
+                local(s = tcp.openStream("127.0.0.1", 65530));
+                tcp.closeStream(s)
+              }
+              else {
+                if string.patternMatch("rate limit", tryError) > 0 {
+                  rateLimited = rateLimited + 1
+                }
+              }
+            };
+            for i = 1 to 9 {
+              try {
+                local(s = tcp.openStream("127.0.0.1", 65530));
+                tcp.closeStream(s)
+              }
+              else {
+                if string.patternMatch("rate limit", tryError) > 0 {
+                  rateLimited = rateLimited + 1
+                }
+              }
+            };
+            return rateLimited > 0
+        validate:
+          success: true
+          result:
+            value: "true"
+            type: "boolean"


### PR DESCRIPTION
## Summary

**Critical-path fix.** The long-lived `ProtocolExecutor` subprocess in `tests/integration/runner.py` accumulates state in `g_tcp_context.connection_timestamps_us[]` across `script/clearContext` boundaries. `tcp_client_verbs.yaml` fires 34 `tcp.openStream` calls in ~0.4s to closed ports; the rate-limit window saturates; subsequent tcp tests in the same process fail with "Connection rate limit exceeded" for ~1 second until timestamps age out.

**Fix**: new `tcp_reset_rate_limit_window()` in `Common/source/tcpverbs.c` that under `TCP_LOCK` zeros the sliding-window state (`connection_timestamps_us[]`, `timestamp_write_pos`) and the per-window telemetry counter (`rate_limited_count`). Called from `frontier-cli/op_handler.c::handle_clear_context` — the natural per-test-boundary reset site.

**Does NOT reset**: `connections_per_sec` (user-set policy), structural resources (`streams[]`, `listeners[]`, `active_count`), or lifetime telemetry (`total_connections`, `failed_connections`). Audit pass confirmed only 3 fields in `g_tcp_context` need reset semantics.

PR 3 of 3 in the #120 (tcp.* burndown) chain.

## Verification

**Pre-implementation audit** (read-only, separate agent before implementation): confirmed only `connection_timestamps_us[]`, `timestamp_write_pos`, and `rate_limited_count` need reset on clearContext. No other `g_tcp_context` fields leak. Documented inline in the new function's comment block.

**TDD behavioral tests** added to `tests/integration/test_cases/tcp_phase2_verbs.yaml`:

1. **Regression**: protocol_ops with 3 ops (saturate / clearContext / probe). Pre-fix: probe sees "rate_limited" error. Post-fix: probe sees "connection_failed" (the actual closed-port error).
2. **Positive control**: rate limit still fires within a single eval (15 rapid attempts).
3. **Positive control**: rate limit accumulates across statements in the same eval (6+9 split, 11th trips).

**Suite-level result**: 52 → 18 failures (-34). All -34 are tcp tests previously masked by the poisoned rate-limit window. **Zero new regressions in non-tcp/non-html files.** The 18 remaining are 12 pre-existing html.* baseline + 6 tcp echo/callback failures unrelated to rate-limit batch contamination (separately tracked as #666 follow-up surface).

## /gate review (full reviewers per critical-path policy — no trivial-threshold skip)

- **bar-raiser** ✓ PASS, 1 P2 polish (applied inline before push — comment clarification)
- **security** ✓ CLEAN — verified `tcp_reset_rate_limit_window` is not UserTalk-reachable; WebSocket transport is `INADDR_LOOPBACK`-bound with documented "(localhost only, no auth)" threat model; no DoS amplification vector
- **concurrency** ✓ CLEAN — `TCP_LOCK` held for entire reset; lock ordering matches every other TCP verb (GIL → TCP_LOCK at `op_dispatch:881` invariant); no new yield points; no allocation under lock

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 498/498
- [x] Integration tests: `cd tests && make test-integration` — 18 failures (52 → 18 = -34 visible drop; zero new regressions)
- [x] 3 new TDD behavioral tests pass at HEAD
- [x] Build clean: `make -C frontier-cli`
- [x] Canonical Virgin.root md5 unchanged throughout: `8a79a18b192a0d0c776e87180a81511e`

Closes #130. Closes #120 (tcp.* burndown chain — 3 of 3 PRs done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
