### PR TITLE
fix(tcp): gate variant verbs on stream state (#666)

### DIFF
--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -2262,8 +2262,16 @@ static boolean tcp_read_until_condition(
 
     /* Acquire stream reference (TOCTOU protection) */
     stream = tcp_stream_acquire(stream_id);
-    if (!stream) {
-        tcp_set_error(TCP_ERR_INVALID_STREAM, "Invalid stream");
+
+    /* Issue #666: gate on stream state in addition to !stream. Accept
+     * STREAM_CONNECTED (client-initiated connect) and STREAM_ACCEPTED
+     * (server-side accept inside a listener callback); reject everything
+     * else (notably STREAM_LISTENING and STREAM_CONNECTING). Mirrors the
+     * post-#667 gate in tcp_read_stream (~line 889) and tcp_write_stream. */
+    if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
+        if (stream)
+            tcp_stream_release(stream);
+        tcp_set_error(TCP_ERR_INVALID_STREAM, "Stream not connected");
         return false;
     }
 
@@ -2551,8 +2559,15 @@ boolean tcp_read_stream_inetd(long stream_id, Handle hbuffer, long timeout_secs)
 
     /* Acquire stream reference (TOCTOU protection) */
     stream = tcp_stream_acquire(stream_id);
-    if (!stream) {
-        tcp_set_error(TCP_ERR_INVALID_STREAM, "Invalid stream");
+
+    /* Issue #666: gate on stream state. Accept STREAM_CONNECTED /
+     * STREAM_ACCEPTED only; reject STREAM_LISTENING / STREAM_CONNECTING
+     * up-front rather than surfacing a kernel error from recv() on a
+     * non-readable socket. Mirrors tcp_read_stream (~line 889). */
+    if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
+        if (stream)
+            tcp_stream_release(stream);
+        tcp_set_error(TCP_ERR_INVALID_STREAM, "Stream not connected");
         return false;
     }
 
@@ -2732,8 +2747,15 @@ boolean tcp_write_string_to_stream(long stream_id, Handle hdata, long chunk_size
 
     /* Acquire stream reference (TOCTOU protection) */
     stream = tcp_stream_acquire(stream_id);
-    if (!stream) {
-        tcp_set_error(TCP_ERR_INVALID_STREAM, "Invalid stream");
+
+    /* Issue #666: gate on stream state. Accept STREAM_CONNECTED /
+     * STREAM_ACCEPTED only; reject STREAM_LISTENING / STREAM_CONNECTING
+     * up-front rather than surfacing a kernel error from send() on a
+     * non-writable socket. Mirrors tcp_write_stream (~line 961). */
+    if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
+        if (stream)
+            tcp_stream_release(stream);
+        tcp_set_error(TCP_ERR_INVALID_STREAM, "Stream not connected");
         return false;
     }
 
@@ -2844,8 +2866,15 @@ boolean tcp_write_file_to_stream(long stream_id, Handle hprefix, Handle hsuffix,
 
     /* Acquire stream reference (TOCTOU protection) */
     stream = tcp_stream_acquire(stream_id);
-    if (!stream) {
-        tcp_set_error(TCP_ERR_INVALID_STREAM, "Invalid stream");
+
+    /* Issue #666: gate on stream state. Accept STREAM_CONNECTED /
+     * STREAM_ACCEPTED only; reject STREAM_LISTENING / STREAM_CONNECTING
+     * up-front so we don't attempt file I/O whose bytes can never flow
+     * through this socket. Mirrors tcp_write_stream (~line 961). */
+    if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
+        if (stream)
+            tcp_stream_release(stream);
+        tcp_set_error(TCP_ERR_INVALID_STREAM, "Stream not connected");
         return false;
     }
 

--- a/tests/integration/test_cases/tcp_phase2_verbs.yaml
+++ b/tests/integration/test_cases/tcp_phase2_verbs.yaml
@@ -792,3 +792,164 @@ tests:
           result:
             value: "true"
             type: "boolean"
+
+  # ===========================================================================
+  # CATEGORY 10: Regression tests for #666 (variant verbs reject non-CONNECTED
+  # stream states)
+  # ===========================================================================
+  #
+  # Issue #666: The TCP variant verbs (tcp.readStreamUntil / .readStreamBytes
+  # / .readStreamUntilClosed / .writeStringToStream / .writeFileToStream and
+  # the C-only tcp_read_stream_inetd) historically gated only on `!stream`;
+  # they inherited tcp_get_stream's filter for STREAM_INVALID / STREAM_CLOSING
+  # / sockfd<0 but silently accepted STREAM_CONNECTING (in-flight client
+  # connect) and STREAM_LISTENING (listener socket), surfacing kernel-level
+  # errors (EBADF/ENOTCONN) instead of the documented "Stream not connected"
+  # rejection. PR #667 closed the same gap on the main tcp.readStream /
+  # tcp.writeStream verbs (state != CONNECTED && state != ACCEPTED); this set
+  # extends that gate to the variants.
+  #
+  # Test shape: open a listener on a fresh port to obtain an id in
+  # STREAM_LISTENING state, call each variant verb on the listener id wrapped
+  # in try/else, and assert the verb errors with "Stream not connected".
+  # Pre-fix the verb proceeds into the kernel (recv/send on a listen socket)
+  # and either succeeds with bogus semantics or fails with a kernel error
+  # message; post-fix it rejects at the state gate with the documented
+  # message. STREAM_CONNECTING uses the same `state != CONNECTED && state !=
+  # ACCEPTED` check and is not separately tested (the in-flight handshake
+  # window is milliseconds wide and would race; LISTENING coverage is
+  # sufficient to prove the gate is in place).
+  #
+  # tcp.readStreamInetd is NOT exposed via the headless verb processor (used
+  # only by webserver.inetd via langhtml.c), so no integration test is
+  # written for it; the C fix is symmetric and covered by code review.
+
+  - name: "tcp.readStreamUntil - rejects listener-state stream (#666)"
+    description: "Regression for #666. tcp.readStreamUntil must reject a stream id in STREAM_LISTENING state with 'Stream not connected', not proceed into a kernel recv() on a listen socket. The test obtains a listener id from tcp.listenStream, wraps the variant call in try/else, and asserts the verb errors AND the message matches the documented gate. Pre-fix the verb dispatches into tcp_read_until_condition which only checked !stream, then issued recv() on a listen socket, surfacing a kernel error or a select() timeout. Post-fix the state-gate rejects with TCP_ERR_INVALID_STREAM."
+    timeout: 10
+    script: |
+      local(listenID = tcp.listenStream(9216, 5, ""));
+      local(rejected = false);
+      local(msgMatched = false);
+
+      local(buffer = "");
+      local(pattern = "X");
+      try {
+        tcp.readStreamUntil(listenID, pattern, 1, @buffer)
+      }
+      else {
+        rejected = true;
+        if string.patternMatch("Stream not connected", tryError) > 0 {
+          msgMatched = true
+        }
+      };
+
+      tcp.closeListen(listenID);
+
+      return rejected and msgMatched
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #666 - state gate rejects STREAM_LISTENING with documented error"
+
+  - name: "tcp.readStreamBytes - rejects listener-state stream (#666)"
+    description: "Regression for #666. tcp.readStreamBytes must reject STREAM_LISTENING with 'Stream not connected'. Same shape as the readStreamUntil test: open a listener, call the variant on the listener id, assert verb-level rejection plus error-message match. Pre-fix the verb proceeded into kernel recv() on the listen socket; post-fix the state-gate rejects up front."
+    timeout: 10
+    script: |
+      local(listenID = tcp.listenStream(9217, 5, ""));
+      local(rejected = false);
+      local(msgMatched = false);
+
+      local(buffer = "");
+      try {
+        tcp.readStreamBytes(listenID, 1, 1, @buffer)
+      }
+      else {
+        rejected = true;
+        if string.patternMatch("Stream not connected", tryError) > 0 {
+          msgMatched = true
+        }
+      };
+
+      tcp.closeListen(listenID);
+
+      return rejected and msgMatched
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #666 - state gate rejects STREAM_LISTENING with documented error"
+
+  - name: "tcp.readStreamUntilClosed - rejects listener-state stream (#666)"
+    description: "Regression for #666. tcp.readStreamUntilClosed must reject STREAM_LISTENING with 'Stream not connected'. Same shape as the other variant tests; the underlying tcp_read_until_condition path is shared, but each public variant gets its own regression test so a future refactor that splits the gating per-variant cannot silently regress one."
+    timeout: 10
+    script: |
+      local(listenID = tcp.listenStream(9218, 5, ""));
+      local(rejected = false);
+      local(msgMatched = false);
+
+      local(buffer = "");
+      try {
+        tcp.readStreamUntilClosed(listenID, 1, @buffer)
+      }
+      else {
+        rejected = true;
+        if string.patternMatch("Stream not connected", tryError) > 0 {
+          msgMatched = true
+        }
+      };
+
+      tcp.closeListen(listenID);
+
+      return rejected and msgMatched
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #666 - state gate rejects STREAM_LISTENING with documented error"
+
+  - name: "tcp.writeStringToStream - rejects listener-state stream (#666)"
+    description: "Regression for #666. tcp.writeStringToStream must reject STREAM_LISTENING with 'Stream not connected'. Pre-fix the verb proceeded into kernel send() on a listen socket; post-fix the state-gate rejects up front. Same try/else + patternMatch shape as the read variants."
+    timeout: 10
+    script: |
+      local(listenID = tcp.listenStream(9219, 5, ""));
+      local(rejected = false);
+      local(msgMatched = false);
+
+      try {
+        tcp.writeStringToStream(listenID, "hello", 0, 1)
+      }
+      else {
+        rejected = true;
+        if string.patternMatch("Stream not connected", tryError) > 0 {
+          msgMatched = true
+        }
+      };
+
+      tcp.closeListen(listenID);
+
+      return rejected and msgMatched
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #666 - state gate rejects STREAM_LISTENING with documented error"
+
+  - name: "tcp.writeFileToStream - rejects listener-state stream (#666)"
+    description: "Regression for #666. tcp.writeFileToStream must reject STREAM_LISTENING with 'Stream not connected' at the state-gate (before attempting to open the file). The state-check runs immediately after tcp_stream_acquire, so the filespec contents are irrelevant -- the test passes a synthesized lang.filespec path without creating the file. Pre-fix the verb proceeded past the !stream check and would attempt I/O on a listen socket; post-fix the state-gate rejects up front."
+    timeout: 10
+    script: |
+      local(listenID = tcp.listenStream(9220, 5, ""));
+      local(rejected = false);
+      local(msgMatched = false);
+
+      local(fspec = lang.filespec("/tmp/tcp666_does_not_need_to_exist.bin"));
+      try {
+        tcp.writeFileToStream(listenID, fspec)
+      }
+      else {
+        rejected = true;
+        if string.patternMatch("Stream not connected", tryError) > 0 {
+          msgMatched = true
+        }
+      };
+
+      tcp.closeListen(listenID);
+
+      return rejected and msgMatched
+    expected_success: true
+    expected_result: "true"
+    notes: "Issue #666 - state gate rejects STREAM_LISTENING before file I/O is attempted"


### PR DESCRIPTION
## Summary

Gates 4 TCP variant verbs in `Common/source/tcpverbs.c` on stream state, matching the post-PR-#667 main-verb pattern. Pre-existing inconsistency surfaced as PR #667 bar-raiser P2-01.

**Variants gated**:
- `tcp_read_until_condition` (line 2271) — backs `tcp.readStreamUntil` / `.readStreamBytes` / `.readStreamUntilClosed`
- `tcp_read_stream_inetd` (line 2567) — used by `webserver.inetd` via `langhtml.c:6878`
- `tcp_write_string_to_stream` (line 2755) — backs `tcp.writeStringToStream`
- `tcp_write_file_to_stream` (line 2874) — backs `tcp.writeFileToStream`

**Gate shape** (identical across all 4, mirrors main verbs at `tcpverbs.c:889` and `:1004`):
```c
stream = tcp_stream_acquire(stream_id);
if (!stream || (stream->state != STREAM_CONNECTED && stream->state != STREAM_ACCEPTED)) {
    if (stream) tcp_stream_release(stream);
    tcp_set_error(TCP_ERR_INVALID_STREAM, "Stream not connected");
    return false;
}
```

**The gap pre-fix**: `tcp_get_stream` (at line 428) already filtered STREAM_INVALID, STREAM_CLOSING, and sockfd<0. The variants silently accepted STREAM_CONNECTING (handshake in flight) and STREAM_LISTENING (listen socket), surfacing kernel-level errors (EBADF/ENOTCONN) instead of the documented "Stream not connected" rejection.

## Tests added

5 new behavioral tests in `tests/integration/test_cases/tcp_phase2_verbs.yaml` Category 10:
1-3. `tcp.readStreamUntil/Bytes/UntilClosed - rejects listener-state stream (#666)` — each variant rejects when called on a listener ID (STREAM_LISTENING state).
4. `tcp.writeStringToStream - rejects listener-state stream (#666)`
5. `tcp.writeFileToStream - rejects listener-state stream (#666)` — gate fires before file I/O, so a non-existent filespec proves the gate runs first.

**No STREAM_CONNECTING test**: the state is in-flight for milliseconds; targeting it would be flaky. The single `state != CONNECTED && state != ACCEPTED` predicate covers both LISTENING and CONNECTING by construction; the LISTENING tests prove the predicate fires.

**No integration test for `tcp_read_stream_inetd`**: not exposed via headless verb processor (used only by `webserver.inetd` via `langhtml.c`). C-level gate is symmetric with the other 3; security review verified the inetd call site delivers streams in STREAM_ACCEPTED (the gate accepts it).

## /gate review (all 3 reviewers, critical-path TCP code, no trivial-threshold skip)

- **bar-raiser** ✓ PASS — gate placement verified before resource acquisition (no fd/lock/heap leak on rejection)
- **security** ✓ CLEAN — strictly defensive hardening, no widened attack surface. Verified the `tcp_read_stream_inetd` call site at `langhtml.c:6878` traces back to `tcp_accept_thread:1487` which sets `STREAM_ACCEPTED` (gate accepts it; no spurious rejection of legitimate inetd traffic).
- **concurrency** ✓ CLEAN — state-read-after-unlock window is benign (refcount pin prevents free; single-word enum, no torn reads; any concurrent state transition leads to either correct rejection or clean downstream error path).

Zero P0/P1/P2 findings across all reviewers.

## Test plan

- [x] Unit tests: `./tools/run_headless_tests.sh` — 498/498
- [x] Integration tests: `cd tests && make test-integration` — 18 baseline failures preserved + 5 new tests pass; zero regressions
- [x] Build clean: `make -C frontier-cli`
- [x] Canonical Virgin.root md5 unchanged: `8a79a18b192a0d0c776e87180a81511e`

Closes #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
