### PR TITLE
feat(palette): multi-menubar enumeration with union composition (Phase A, #677)

### DIFF
--- a/docs/MENU_PORT_PLAN.md
+++ b/docs/MENU_PORT_PLAN.md
@@ -111,6 +111,8 @@ Supersedes the 8-PR plan's Phases 6-8. Recasts the deep-dive's 5-step sequence w
 - **Open decisions to resolve here**: Decision Point 4 (storage path reconciliation) — either fix or defer explicitly
 - **Blocks**: all subsequent phases
 
+**Phase A shipped** (2026-05-31, worktree-menu-port-phase-a-enumerate). `repl_palette_source.c` now enumerates all children of `@system.menus.data` filtered by `.installed = true` and composes their top-level menus into a single horizontal strip, sorted alphabetically by bar name for deterministic output. The existing `_init_for` (single-bar, bypasses installed filter) is preserved for test compatibility. The L4 PTY regression test (`repl_palette_multi_bar.yaml`) installs a second bar dynamically and verifies the union strip renders "File REPL" (alphabetical: aux < repl). When the union of all installed bars' menus exceeds terminal width, `palette.c` truncates at the right edge; overflow UX (ellipsization, horizontal scroll) is deferred as a follow-up per issue #677.
+
 ### Phase B — Script Hook Infrastructure (two parallel sub-tracks)
 
 **B1 — `getsystemtablescript` headless support**

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -2966,12 +2966,11 @@ static Handle run_palette_modal(struct linenoiseState *ls,
 	 * the terminal is still in raw mode. */
 	terminal_hide_cursor();
 
-	/* 3. Build the ODB-backed palette source. */
+	/* 3. Build the ODB-backed palette source (all installed bars). */
 	palette_menu_source_t src;
-	bool src_ok = repl_palette_source_init(&src);
+	bool src_ok = repl_palette_source_init_all(&src);
 	if (!src_ok) {
-		printf("(no menubar installed: system.menus.data.%s)\n",
-		       REPL_PALETTE_DEFAULT_MENUBAR);
+		printf("(no menubar installed: system.menus.data.*)\n");
 		fflush(stdout);
 		goto cleanup_terminal;
 	}

--- a/frontier-cli/repl_palette_source.c
+++ b/frontier-cli/repl_palette_source.c
@@ -225,7 +225,12 @@ static hdlhashtable resolve_bar_by_name(const bigstring bsname) {
 	if (hdata == nil)
 		return nil;
 
-	if (!findnamedtable(hdata, bsname, &hbar))
+	/* Cast away const: findnamedtable's bigstring param is non-const in
+	 * the legacy header but does not mutate. Our caller declares bsname
+	 * const to advertise its own non-mutation. Cast via (unsigned char *)
+	 * because bigstring is an array type and cannot be the target of a
+	 * direct cast. */
+	if (!findnamedtable(hdata, (unsigned char *)bsname, &hbar))
 		return nil;
 	return hbar;
 }

--- a/frontier-cli/repl_palette_source.c
+++ b/frontier-cli/repl_palette_source.c
@@ -111,6 +111,8 @@
 #include "palette.h"
 #include "repl_palette_source.h"
 
+#include "../Common/headers/logging.h"
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -236,21 +238,40 @@ static hdlhashtable resolve_bar_by_name(const bigstring bsname) {
 }
 
 
-/* hashinversesearch callback shared by count-children and pick-Nth. */
-typedef struct ty_walk_state {
-	int seen;             /* how many subtable entries we've visited */
-	int target_index;     /* index we want, -1 to just count */
-	hdlhashtable hresult; /* set when target_index reached */
-	bigstring bsresult;   /* name of the picked entry */
-} ty_walk_state;
+/*
+ * Collect-then-sort helpers for deterministic menu ordering within a bar.
+ *
+ * hashinversesearch visits nodes in hash-bucket order, which is not
+ * alphabetical and may change if the table is resized on insert. In the
+ * headless runtime langcallbacks.comparenodescallback is cb_noop_compare
+ * (always returns 0), so hashsortedinversesearch also produces insertion
+ * order rather than alphabetical order. We therefore collect all subtable
+ * children into a local array and qsort them by name before indexing.
+ *
+ * The cap of 256 children is generous -- typical menus have fewer than
+ * 16 entries. It matches the bigstring size limit so no slot can be
+ * constructively larger than the name encoding allows.
+ */
+#define SUBTABLE_CHILDREN_CAP 256
+
+typedef struct ty_child_slot {
+	bigstring bsname;
+	hdlhashtable htable;
+} ty_child_slot;
+
+typedef struct ty_collect_state {
+	ty_child_slot *slots;
+	int count;
+	int cap;
+} ty_collect_state;
 
 
 /* Returns true to STOP per hashinversesearch. */
-static boolean walk_cb(bigstring bsname, hdlhashnode hnode,
-                       tyvaluerecord val, ptrvoid refcon) {
+static boolean collect_cb(bigstring bsname, hdlhashnode hnode,
+                          tyvaluerecord val, ptrvoid refcon) {
 	(void) hnode;
 
-	ty_walk_state *st = (ty_walk_state *) refcon;
+	ty_collect_state *st = (ty_collect_state *) refcon;
 	hdlhashtable hchild = nil;
 
 	if (val.valuetype != externalvaluetype)
@@ -259,37 +280,66 @@ static boolean walk_cb(bigstring bsname, hdlhashnode hnode,
 		return false;
 	if (hchild == nil)
 		return false;
+	if (st->count >= st->cap)
+		return false; /* cap reached -- keep walking to count all */
 
-	if (st->target_index >= 0 && st->seen == st->target_index) {
-		st->hresult = hchild;
-		copystring(bsname, st->bsresult);
-		return true; /* found -- stop */
-	}
-	st->seen++;
-	return false; /* keep walking */
+	copystring(bsname, st->slots[st->count].bsname);
+	st->slots[st->count].htable = hchild;
+	st->count++;
+	return false; /* always continue */
+}
+
+
+/* qsort comparator for ty_child_slot -- alphabetical by Pascal bigstring. */
+static int child_slot_cmp(const void *a, const void *b) {
+	const ty_child_slot *sa = (const ty_child_slot *) a;
+	const ty_child_slot *sb = (const ty_child_slot *) b;
+	int la = stringlength(sa->bsname);
+	int lb = stringlength(sb->bsname);
+	int minlen = la < lb ? la : lb;
+	int cmp = memcmp(&sa->bsname[1], &sb->bsname[1], (size_t) minlen);
+	if (cmp != 0)
+		return cmp;
+	return la - lb;
+}
+
+
+/*
+ * Collect and sort direct subtable children of ht into caller-supplied
+ * slots[cap]. Returns the count of children found (<= cap).
+ * Children are sorted alphabetically by name.
+ */
+static int collect_sorted_children(hdlhashtable ht,
+                                   ty_child_slot *slots, int cap) {
+	ty_collect_state st;
+	bigstring bsfound;
+
+	if (ht == nil || slots == nil || cap <= 0)
+		return 0;
+
+	st.slots = slots;
+	st.count = 0;
+	st.cap = cap;
+	(void) hashinversesearch(ht, &collect_cb, &st, bsfound);
+
+	if (st.count > 1)
+		qsort(slots, (size_t) st.count, sizeof(slots[0]), child_slot_cmp);
+	return st.count;
 }
 
 
 /* Count direct subtable children of ht. */
 static int count_subtable_children(hdlhashtable ht) {
-	ty_walk_state st;
-	bigstring bsfound;
-
-	if (ht == nil)
-		return 0;
-
-	memset(&st, 0, sizeof(st));
-	st.target_index = -1; /* count-only mode */
-	(void) hashinversesearch(ht, &walk_cb, &st, bsfound);
-	return st.seen;
+	ty_child_slot slots[SUBTABLE_CHILDREN_CAP];
+	return collect_sorted_children(ht, slots, SUBTABLE_CHILDREN_CAP);
 }
 
 
 /* Get the Nth subtable child of ht (0-based). Returns nil if out of range. */
 static hdlhashtable nth_subtable_child(hdlhashtable ht, int idx,
                                        bigstring bsout_name) {
-	ty_walk_state st;
-	bigstring bsfound;
+	ty_child_slot slots[SUBTABLE_CHILDREN_CAP];
+	int n;
 
 	if (bsout_name != nil)
 		setemptystring(bsout_name);
@@ -297,14 +347,13 @@ static hdlhashtable nth_subtable_child(hdlhashtable ht, int idx,
 	if (ht == nil || idx < 0)
 		return nil;
 
-	memset(&st, 0, sizeof(st));
-	st.target_index = idx;
-	(void) hashinversesearch(ht, &walk_cb, &st, bsfound);
+	n = collect_sorted_children(ht, slots, SUBTABLE_CHILDREN_CAP);
+	if (idx >= n)
+		return nil;
 
-	if (st.hresult != nil && bsout_name != nil)
-		copystring(st.bsresult, bsout_name);
-
-	return st.hresult;
+	if (bsout_name != nil)
+		copystring(slots[idx].bsname, bsout_name);
+	return slots[idx].htable;
 }
 
 
@@ -367,8 +416,12 @@ static Handle cache_script_handle(ty_repl_multi_source_ctx *ctx,
 	}
 
 	/* Miss: insert a new entry. */
-	if (ctx->cached_scripts_count >= REPL_PS_MAX_CACHED_SCRIPTS)
+	if (ctx->cached_scripts_count >= REPL_PS_MAX_CACHED_SCRIPTS) {
+		log_warn(LOG_COMP_GENERAL,
+		         "REPL palette: script cache full (%d unique items),"
+		         " cannot cache additional scripts", REPL_PS_MAX_CACHED_SCRIPTS);
 		return nil;
+	}
 	if (!copyhandle(horig, &hcopy))
 		return nil;
 
@@ -728,8 +781,16 @@ static boolean bar_enum_cb(bigstring bsname, hdlhashnode hnode,
 	boolean installed = false;
 	int mc;
 
-	if (*st->count >= st->max)
-		return false; /* capacity reached -- stop */
+	if (*st->count >= st->max) {
+		/*
+		 * Capacity reached. Return true so hashinversesearch stops traversal
+		 * (see Common/source/langhash.c:2474 -- the early-out triggers on
+		 * true, not false). Log once; the caller is responsible for emitting
+		 * the overflow warning before invoking hashinversesearch so that the
+		 * message fires at most once per init, not once per dropped bar.
+		 */
+		return true;
+	}
 
 	if (val.valuetype != externalvaluetype)
 		return false; /* skip scalars (currentmenu, currentsuite, etc.) */
@@ -818,6 +879,12 @@ bool repl_palette_source_init_all(palette_menu_source_t *out) {
 
 	(void) hashinversesearch(hdata, &bar_enum_cb, &est, bsfound);
 
+	/* Warn once if the traversal stopped early due to capacity. */
+	if (ctx->bar_count >= REPL_PS_MAX_BARS)
+		log_warn(LOG_COMP_GENERAL,
+		         "REPL palette: bar count exceeded REPL_PS_MAX_BARS (%d),"
+		         " dropping additional bars", REPL_PS_MAX_BARS);
+
 	if (ctx->bar_count == 0) {
 		free(ctx);
 		return false; /* no installed bars */
@@ -853,6 +920,14 @@ bool repl_palette_source_init_for(palette_menu_source_t *out,
 
 	ctx = (ty_repl_multi_source_ctx *) calloc(1, sizeof(*ctx));
 	if (ctx == nil)
+		return false;
+
+	/*
+	 * bigstring is unsigned char[256]: byte 0 is the Pascal length, bytes
+	 * 1..255 hold content. A name of 256+ characters cannot be represented
+	 * without overflow. Fail loudly rather than truncating silently.
+	 */
+	if (strlen(menubar_name) > 255)
 		return false;
 
 	copyctopstring((char *)menubar_name, bsname);

--- a/frontier-cli/repl_palette_source.c
+++ b/frontier-cli/repl_palette_source.c
@@ -193,6 +193,12 @@ typedef struct ty_repl_multi_source_ctx {
 	ty_script_cache_entry cached_scripts[REPL_PS_MAX_CACHED_SCRIPTS];
 	int cached_scripts_count;
 
+	/* Latch so the script-cache overflow warning fires once per init,
+	 * not once per miss-after-full. Without this, a long session that
+	 * arrows through many unique items after the cache fills would
+	 * emit a log line per describe. */
+	boolean cache_overflow_warned;
+
 	boolean initialised;
 } ty_repl_multi_source_ctx;
 
@@ -417,9 +423,13 @@ static Handle cache_script_handle(ty_repl_multi_source_ctx *ctx,
 
 	/* Miss: insert a new entry. */
 	if (ctx->cached_scripts_count >= REPL_PS_MAX_CACHED_SCRIPTS) {
-		log_warn(LOG_COMP_GENERAL,
-		         "REPL palette: script cache full (%d unique items),"
-		         " cannot cache additional scripts", REPL_PS_MAX_CACHED_SCRIPTS);
+		if (!ctx->cache_overflow_warned) {
+			log_warn(LOG_COMP_GENERAL,
+			         "REPL palette: script cache full (%d unique items),"
+			         " cannot cache additional scripts",
+			         REPL_PS_MAX_CACHED_SCRIPTS);
+			ctx->cache_overflow_warned = true;
+		}
 		return nil;
 	}
 	if (!copyhandle(horig, &hcopy))

--- a/frontier-cli/repl_palette_source.c
+++ b/frontier-cli/repl_palette_source.c
@@ -31,18 +31,33 @@
  * Tree shape (per ADR-016):
  *
  *   system.menus.data
- *      └─ <menubar>             (e.g. "repl")
- *          └─ <menu>             (e.g. "REPL", "Help")
- *              └─ <item>         (e.g. "Help", "Exit")
- *                  ├─ label      (string scalar)
- *                  ├─ script     (string scalar — UserTalk source)
- *                  ├─ cmdkey     (char)
- *                  └─ ...        (other documented fields, see
- *                                 menudata_describe_leaf in
- *                                 Common/source/menudata_headless.c)
+ *      +-- <menubar>             (e.g. "repl")
+ *          +-- <menu>             (e.g. "REPL", "Help")
+ *              +-- <item>         (e.g. "Help", "Exit")
+ *                  +-- label      (string scalar)
+ *                  +-- script     (string scalar -- UserTalk source)
+ *                  +-- cmdkey     (char)
+ *                  +-- ...        (other documented fields, see
+ *                                  menudata_describe_leaf in
+ *                                  Common/source/menudata_headless.c)
  *
  * Top-level menus and their items are sub-tables. The lowest rung's children
- * are all scalars — that's what makes it a "leaf" (per menudata_list_leaves).
+ * are all scalars -- that's what makes it a "leaf" (per menudata_list_leaves).
+ *
+ * Multi-bar adapter
+ * -----------------
+ * ty_repl_multi_source_ctx holds a sorted array of ty_bar_slot entries, one
+ * per installed bar. Global menu indices are decomposed into (bar_idx,
+ * local_menu_idx) by decompose_menu_index, which walks the slot array summing
+ * menu_count values until the target is reached. This allows the vtable
+ * callbacks to remain O(B) in the number of bars (typically <= 16) rather
+ * than walking ODB on every index operation.
+ *
+ * Overflow UX
+ * -----------
+ * When the union of all installed bars' menus exceeds term_cols, palette.c
+ * truncates at the right edge. Overflow UX (ellipsization, horizontal scroll)
+ * is deferred per issue #677.
  *
  * Handle privacy contract
  * -----------------------
@@ -54,25 +69,25 @@
  * adapter-private storage, keyed by the item's hashtable handle so re-
  * describes of the same item reuse the existing copy instead of growing
  * the cache. Free wholesale in repl_palette_source_dispose. The adapter
- * never aliases the underlying ODB handle into the palette — every
+ * never aliases the underlying ODB handle into the palette -- every
  * palette_item_t.script_handle returned is an independently-allocated handle
  * owned by this adapter.
  *
  * Why route (a) and not (b)? While menudata_describe_leaf returns a
  * deeply-copied record (so the script field's handle is independently
  * allocated relative to the ODB hashtable), the record itself must be
- * disposed promptly — otherwise we leak record envelopes for every
+ * disposed promptly -- otherwise we leak record envelopes for every
  * keystroke that re-fetches an item. Route (a) gives us symmetric ownership:
  * one copy in, one disposehandle out.
  *
  * Cache shape: the keyed-by-item-handle design (see ty_script_cache_entry)
- * bounds growth by the number of UNIQUE items in the menubar — typically
- * <50 — rather than by the number of describe calls (which can easily
+ * bounds growth by the number of UNIQUE items in the menubar -- typically
+ * <50 -- rather than by the number of describe calls (which can easily
  * exceed 256 in a single session of arrow-key navigation).
  *
  * Threading
  * ---------
- * All entry points hold the GIL — they read roottable / hashtable globals
+ * All entry points hold the GIL -- they read roottable / hashtable globals
  * and allocate lang values. The vtable is documented as GIL-required (see
  * palette.h's per-function annotations).
  */
@@ -101,28 +116,40 @@
 
 
 /* ------------------------------------------------------------ */
-/*  adapter context                                              */
+/*  constants                                                    */
 /* ------------------------------------------------------------ */
+
+/*
+ * Maximum number of distinct installed menubars the adapter will enumerate.
+ * Practically, a terminal session rarely has more than a handful. 16 is
+ * generous headroom without imposing measurable stack cost.
+ */
+#define REPL_PS_MAX_BARS 16
 
 /*
  * Cap matches the maximum number of distinct leaf items the headless menu
  * tree can practically host: bar/menu/item is 3-deep, and the palette renders
  * (and thus describes) at most one item-list at a time. 256 unique leaves
- * across a session is enormous headroom — typical menubars have fewer than
+ * across a session is enormous headroom -- typical menubars have fewer than
  * 50 leaves total. This is a defensive ceiling, not a performance budget.
  */
 #define REPL_PS_MAX_CACHED_SCRIPTS 256
 
+
+/* ------------------------------------------------------------ */
+/*  adapter context                                              */
+/* ------------------------------------------------------------ */
+
 /*
  * Per-item cache slot: keyed by the item's hashtable handle (which is stable
- * for the menubar's lifetime — repl_palette_source_init validates the bar and
+ * for the menubar's lifetime -- repl_palette_source_init validates the bar and
  * the underlying ODB handles do not move while the palette is open). Keying
  * on the handle pointer lets re-describes of the same item re-use the
  * existing copy instead of allocating a new one.
  *
  * Why keyed cache (option b) rather than "only cache the pick" (option a):
  * palette_item_t::script_handle has a strict lifetime contract (palette.h
- * L109-128) — it MUST remain valid for the entire palette session AND
+ * L109-128) -- it MUST remain valid for the entire palette session AND
  * across GIL yields. The palette aliases the pointer into exec_script
  * the moment a leaf is highlighted (palette.c:454), and the user might
  * navigate away and back before pressing Enter. Lazy-on-DONE_EXECUTE
@@ -131,28 +158,50 @@
  * entirely while still capping growth.
  */
 typedef struct ty_script_cache_entry {
-	hdlhashtable hitem;                 /* key — item subtable handle */
-	Handle hscript;                     /* value — copy of script body */
+	hdlhashtable hitem;                 /* key -- item subtable handle */
+	Handle hscript;                     /* value -- copy of script body */
 } ty_script_cache_entry;
 
-typedef struct ty_repl_palette_source_ctx {
-	bigstring bsmenubar_name;          /* e.g. "\x04" "repl" */
+
+/*
+ * One slot per installed menubar in the composed strip. bar_count entries
+ * are populated in init_all / init_for, sorted alphabetically by bsname
+ * so the composition is deterministic across runs.
+ */
+typedef struct ty_bar_slot {
+	bigstring bsname;     /* bar name under system.menus.data */
+	int menu_count;       /* number of top-level menus in this bar */
+} ty_bar_slot;
+
+
+/*
+ * The multi-source adapter context. Replaces the old single-bar
+ * ty_repl_palette_source_ctx. Supports up to REPL_PS_MAX_BARS bars.
+ *
+ * Both repl_palette_source_init_all (multi-bar) and
+ * repl_palette_source_init_for (single-bar, test compat) fill this
+ * struct -- init_for just sets bar_count=1 and skips the installed filter.
+ */
+typedef struct ty_repl_multi_source_ctx {
+	ty_bar_slot bars[REPL_PS_MAX_BARS];
+	int bar_count;
+
 	/* Adapter-owned copies of script handles, keyed by item handle.
 	   Freed wholesale in dispose so the caller never has to. */
 	ty_script_cache_entry cached_scripts[REPL_PS_MAX_CACHED_SCRIPTS];
 	int cached_scripts_count;
-	boolean initialised;                /* trips false in dispose so a second
-	                                       dispose is a no-op */
-} ty_repl_palette_source_ctx;
+
+	boolean initialised;
+} ty_repl_multi_source_ctx;
 
 
 /* ------------------------------------------------------------ */
 /*  helpers                                                      */
 /* ------------------------------------------------------------ */
 
-/* Find system.menus.data.<bar>; returns nil if missing. */
-static hdlhashtable resolve_menubar(const ty_repl_palette_source_ctx *ctx) {
-	hdlhashtable hsystem = nil, hmenus = nil, hdata = nil, hbar = nil;
+/* Find system.menus.data; returns nil if missing. */
+static hdlhashtable resolve_data_table(void) {
+	hdlhashtable hsystem = nil, hmenus = nil, hdata = nil;
 
 	if (roottable == nil)
 		return nil;
@@ -163,7 +212,20 @@ static hdlhashtable resolve_menubar(const ty_repl_palette_source_ctx *ctx) {
 		return nil;
 	if (!findnamedtable(hmenus, STR_data, &hdata))
 		return nil;
-	if (!findnamedtable(hdata, ctx->bsmenubar_name, &hbar))
+	return hdata;
+}
+
+
+/* Find system.menus.data.<bsname>; returns nil if missing. */
+static hdlhashtable resolve_bar_by_name(const bigstring bsname) {
+	hdlhashtable hdata = nil;
+	hdlhashtable hbar = nil;
+
+	hdata = resolve_data_table();
+	if (hdata == nil)
+		return nil;
+
+	if (!findnamedtable(hdata, bsname, &hbar))
 		return nil;
 	return hbar;
 }
@@ -196,7 +258,7 @@ static boolean walk_cb(bigstring bsname, hdlhashnode hnode,
 	if (st->target_index >= 0 && st->seen == st->target_index) {
 		st->hresult = hchild;
 		copystring(bsname, st->bsresult);
-		return true; /* found — stop */
+		return true; /* found -- stop */
 	}
 	st->seen++;
 	return false; /* keep walking */
@@ -242,17 +304,49 @@ static hdlhashtable nth_subtable_child(hdlhashtable ht, int idx,
 
 
 /*
+ * Decompose a global menu index into (bar_idx, local_menu_idx).
+ * Walks bars[] summing menu_count until the target is reached.
+ *
+ * Returns true and fills *out_bar_idx, *out_local_idx on success.
+ * Returns false if global_idx is out of range.
+ *
+ * Pure helper: reads only ctx->bars[] and ctx->bar_count, no ODB access.
+ */
+static bool decompose_menu_index(const ty_repl_multi_source_ctx *ctx,
+                                 int global_idx,
+                                 int *out_bar_idx,
+                                 int *out_local_idx) {
+	int offset = 0;
+	int i;
+
+	if (global_idx < 0)
+		return false;
+
+	for (i = 0; i < ctx->bar_count; i++) {
+		int mc = ctx->bars[i].menu_count;
+		if (global_idx < offset + mc) {
+			*out_bar_idx = i;
+			*out_local_idx = global_idx - offset;
+			return true;
+		}
+		offset += mc;
+	}
+	return false;
+}
+
+
+/*
  * Look up or insert a per-item script handle copy. Keyed by the item
  * subtable handle so re-describes of the same item return the already-
  * cached copy rather than allocating a new one. This bounds the cache
  * by the number of UNIQUE items in the menubar, not by the number of
- * describe calls — the latter can easily exceed 256 in a single
+ * describe calls -- the latter can easily exceed 256 in a single
  * session as the user arrows through menus.
  *
  * Returns the cached handle, or nil on failure (true cache exhaustion
- * — more unique items than the slot count — or copy failure).
+ * -- more unique items than the slot count -- or copy failure).
  */
-static Handle cache_script_handle(ty_repl_palette_source_ctx *ctx,
+static Handle cache_script_handle(ty_repl_multi_source_ctx *ctx,
                                   hdlhashtable hitem,
                                   Handle horig) {
 	Handle hcopy = nil;
@@ -261,7 +355,7 @@ static Handle cache_script_handle(ty_repl_palette_source_ctx *ctx,
 	if (horig == nil || hitem == nil)
 		return nil;
 
-	/* Hit: same item already cached — reuse the copy. */
+	/* Hit: same item already cached -- reuse the copy. */
 	for (i = 0; i < ctx->cached_scripts_count; i++) {
 		if (ctx->cached_scripts[i].hitem == hitem)
 			return ctx->cached_scripts[i].hscript;
@@ -298,20 +392,24 @@ static void bs_to_cstr(const bigstring bs, char *outbuf, size_t cap) {
 /* ------------------------------------------------------------ */
 
 static int cb_count_menus(void *vctx) {
-	ty_repl_palette_source_ctx *ctx = (ty_repl_palette_source_ctx *) vctx;
-	hdlhashtable hbar;
+	ty_repl_multi_source_ctx *ctx = (ty_repl_multi_source_ctx *) vctx;
+	int total = 0;
+	int i;
 
 	if (ctx == nil)
 		return 0;
-	hbar = resolve_menubar(ctx);
-	return count_subtable_children(hbar);
+
+	for (i = 0; i < ctx->bar_count; i++)
+		total += ctx->bars[i].menu_count;
+	return total;
 }
 
 
 static bool cb_menu_describe(void *vctx, int menu_index,
                              char *out_label, size_t label_cap,
                              char *out_hotkey) {
-	ty_repl_palette_source_ctx *ctx = (ty_repl_palette_source_ctx *) vctx;
+	ty_repl_multi_source_ctx *ctx = (ty_repl_multi_source_ctx *) vctx;
+	int bar_idx = 0, local_idx = 0;
 	hdlhashtable hbar = nil;
 	hdlhashtable hmenu = nil;
 	bigstring bsname;
@@ -324,11 +422,14 @@ static bool cb_menu_describe(void *vctx, int menu_index,
 	if (ctx == nil)
 		return false;
 
-	hbar = resolve_menubar(ctx);
+	if (!decompose_menu_index(ctx, menu_index, &bar_idx, &local_idx))
+		return false;
+
+	hbar = resolve_bar_by_name(ctx->bars[bar_idx].bsname);
 	if (hbar == nil)
 		return false;
 
-	hmenu = nth_subtable_child(hbar, menu_index, bsname);
+	hmenu = nth_subtable_child(hbar, local_idx, bsname);
 	if (hmenu == nil)
 		return false;
 
@@ -337,7 +438,7 @@ static bool cb_menu_describe(void *vctx, int menu_index,
 
 	/*
 	 * Future: read a "hotkey" or "cmdkey" field from the menu sub-table
-	 * itself. For PR 6 we leave hotkey unset — palette.c falls back to
+	 * itself. For PR 6 we leave hotkey unset -- palette.c falls back to
 	 * first-letter matching and the menubar still navigates fine.
 	 */
 	return true;
@@ -349,27 +450,31 @@ static bool cb_menu_describe(void *vctx, int menu_index,
  * and menu_index selects which one. For deeper levels parent_opaque is the
  * void* token we returned in palette_item_t.opaque. We never set
  * is_submenu=true for any leaf in PR 6 (the headless tree is always
- * 3-deep — bar/menu/leaf — and the palette only walks leaves), so
+ * 3-deep -- bar/menu/leaf -- and the palette only walks leaves), so
  * parent_opaque should always be NULL coming back. Defensive: if a caller
  * does pass parent_opaque, treat it as the menu hashtable handle.
  */
-static hdlhashtable resolve_menu_for_items(ty_repl_palette_source_ctx *ctx,
+static hdlhashtable resolve_menu_for_items(ty_repl_multi_source_ctx *ctx,
                                            int menu_index,
                                            void *parent_opaque) {
+	int bar_idx = 0, local_idx = 0;
 	hdlhashtable hbar;
 
 	if (parent_opaque != nil)
 		return (hdlhashtable) parent_opaque;
 
-	hbar = resolve_menubar(ctx);
+	if (!decompose_menu_index(ctx, menu_index, &bar_idx, &local_idx))
+		return nil;
+
+	hbar = resolve_bar_by_name(ctx->bars[bar_idx].bsname);
 	if (hbar == nil)
 		return nil;
-	return nth_subtable_child(hbar, menu_index, nil);
+	return nth_subtable_child(hbar, local_idx, nil);
 }
 
 
 static int cb_item_count(void *vctx, int menu_index, void *parent_opaque) {
-	ty_repl_palette_source_ctx *ctx = (ty_repl_palette_source_ctx *) vctx;
+	ty_repl_multi_source_ctx *ctx = (ty_repl_multi_source_ctx *) vctx;
 	hdlhashtable hmenu;
 
 	if (ctx == nil)
@@ -381,7 +486,7 @@ static int cb_item_count(void *vctx, int menu_index, void *parent_opaque) {
 
 /* Locate the "script" field inside a record-typed value and return its
    underlying string handle (which is an independently-allocated copy from
-   menudata_describe_leaf). Caller must NOT dispose this handle directly —
+   menudata_describe_leaf). Caller must NOT dispose this handle directly --
    it lives inside the record envelope which the caller will dispose. */
 static Handle script_handle_from_record(tyvaluerecord rec) {
 	hdllistrecord hlist;
@@ -495,7 +600,7 @@ static void string_field_to_cstr(tyvaluerecord rec, const char *key,
 
 static bool cb_item_describe(void *vctx, int menu_index, void *parent_opaque,
                              int item_index, palette_item_t *out) {
-	ty_repl_palette_source_ctx *ctx = (ty_repl_palette_source_ctx *) vctx;
+	ty_repl_multi_source_ctx *ctx = (ty_repl_multi_source_ctx *) vctx;
 	hdlhashtable hmenu;
 	hdlhashtable hitem;
 	bigstring bsitem_name;
@@ -558,7 +663,7 @@ static bool cb_item_describe(void *vctx, int menu_index, void *parent_opaque,
 
 	disposevaluerecord(rec, false);
 
-	/* If we couldn't cache the script handle, fail the describe — the
+	/* If we couldn't cache the script handle, fail the describe -- the
 	   palette would otherwise PALETTE_DONE_EXECUTE with a NULL handle and
 	   the caller would silently drop the dispatch. */
 	if (hscript_in_record != nil && hcached == nil)
@@ -569,65 +674,229 @@ static bool cb_item_describe(void *vctx, int menu_index, void *parent_opaque,
 
 
 /* ------------------------------------------------------------ */
-/*  public API                                                   */
+/*  bar slot sort (qsort comparator)                             */
 /* ------------------------------------------------------------ */
 
-bool repl_palette_source_init(palette_menu_source_t *out) {
-	return repl_palette_source_init_for(out, REPL_PALETTE_DEFAULT_MENUBAR);
+/*
+ * Compare two ty_bar_slot entries by their Pascal bigstring names.
+ * Used by qsort in init_all to produce deterministic alphabetical ordering.
+ *
+ * Pascal bigstrings: byte 0 is the length, bytes 1..n are the chars.
+ * We compare as NUL-terminated C strings by using the length to bound
+ * the comparison -- equalish to strncmp but on Pascal data.
+ */
+static int bar_slot_cmp(const void *a, const void *b) {
+	const ty_bar_slot *sa = (const ty_bar_slot *) a;
+	const ty_bar_slot *sb = (const ty_bar_slot *) b;
+	int la = stringlength(sa->bsname);
+	int lb = stringlength(sb->bsname);
+	int minlen = la < lb ? la : lb;
+	int cmp = memcmp(&sa->bsname[1], &sb->bsname[1], (size_t) minlen);
+	if (cmp != 0)
+		return cmp;
+	return la - lb;
 }
 
 
+/* ------------------------------------------------------------ */
+/*  hashinversesearch callback for enumerating data children     */
+/* ------------------------------------------------------------ */
+
+typedef struct ty_bar_enum_state {
+	ty_bar_slot *slots;    /* output array to fill */
+	int *count;            /* number of slots filled so far */
+	int max;               /* slots capacity */
+} ty_bar_enum_state;
+
+
+/*
+ * Called by hashinversesearch for each child of system.menus.data.
+ * Populates one ty_bar_slot per installed child subtable.
+ * Returns false to always continue (we want to visit every child).
+ */
+static boolean bar_enum_cb(bigstring bsname, hdlhashnode hnode,
+                           tyvaluerecord val, ptrvoid refcon) {
+	(void) hnode;
+
+	ty_bar_enum_state *st = (ty_bar_enum_state *) refcon;
+	hdlhashtable hbar = nil;
+	boolean installed = false;
+	int mc;
+
+	if (*st->count >= st->max)
+		return false; /* capacity reached -- stop */
+
+	if (val.valuetype != externalvaluetype)
+		return false; /* skip scalars (currentmenu, currentsuite, etc.) */
+
+	if (!langexternalvaltotable(val, &hbar, HNoNode))
+		return false;
+	if (hbar == nil)
+		return false;
+
+	/* Only include bars marked .installed = true. */
+	if (!menudata_get_installed(bsname, &installed))
+		return false;
+	if (!installed)
+		return false; /* not installed -- skip */
+
+	/* Skip empty bars: no top-level menus means nothing to render. */
+	mc = count_subtable_children(hbar);
+	if (mc <= 0)
+		return false;
+
+	copystring(bsname, st->slots[*st->count].bsname);
+	st->slots[*st->count].menu_count = mc;
+	(*st->count)++;
+
+	return false; /* always false -- continue visiting all children */
+}
+
+
+/* ------------------------------------------------------------ */
+/*  context allocation helpers                                   */
+/* ------------------------------------------------------------ */
+
+static void wire_vtable(palette_menu_source_t *out,
+                        ty_repl_multi_source_ctx *ctx) {
+	out->ctx = ctx;
+	out->count_menus = cb_count_menus;
+	out->menu_describe = cb_menu_describe;
+	out->item_count = cb_item_count;
+	out->item_describe = cb_item_describe;
+}
+
+
+/* ------------------------------------------------------------ */
+/*  public API                                                   */
+/* ------------------------------------------------------------ */
+
+/*
+ * Enumerate ALL installed menubars and compose their menus into a single
+ * strip. Bars are sorted alphabetically by name for deterministic output.
+ *
+ * Does NOT check the .installed field of the hardcoded "repl" bar -- it
+ * applies the filter uniformly to all children of system.menus.data.
+ * Use repl_palette_source_init_for for direct-name access (e.g. tests).
+ */
+bool repl_palette_source_init_all(palette_menu_source_t *out) {
+	ty_repl_multi_source_ctx *ctx = nil;
+	hdlhashtable hdata = nil;
+	ty_bar_enum_state est;
+	bigstring bsfound;
+
+	if (out == nil)
+		return false;
+
+	memset(out, 0, sizeof(*out));
+
+	ctx = (ty_repl_multi_source_ctx *) calloc(1, sizeof(*ctx));
+	if (ctx == nil)
+		return false;
+
+	if (!menudata_ensure_root()) {
+		free(ctx);
+		return false;
+	}
+
+	hdata = resolve_data_table();
+	if (hdata == nil) {
+		free(ctx);
+		return false;
+	}
+
+	/* Enumerate installed children of system.menus.data. */
+	est.slots = ctx->bars;
+	est.count = &ctx->bar_count;
+	est.max = REPL_PS_MAX_BARS;
+	ctx->bar_count = 0;
+
+	(void) hashinversesearch(hdata, &bar_enum_cb, &est, bsfound);
+
+	if (ctx->bar_count == 0) {
+		free(ctx);
+		return false; /* no installed bars */
+	}
+
+	/* Sort alphabetically so the strip is deterministic. */
+	qsort(ctx->bars, (size_t) ctx->bar_count, sizeof(ctx->bars[0]),
+	      bar_slot_cmp);
+
+	ctx->initialised = true;
+	wire_vtable(out, ctx);
+	return true;
+}
+
+
+/*
+ * Initialise for a specific menubar name (e.g. "test_menubar" in unit tests).
+ * Does NOT check .installed -- bypasses installed-filter for direct test
+ * access. Use repl_palette_source_init_all for production enumeration.
+ *
+ * Stores the name internally; caller need not retain the string.
+ */
 bool repl_palette_source_init_for(palette_menu_source_t *out,
                                   const char *menubar_name) {
-	ty_repl_palette_source_ctx *ctx = nil;
+	ty_repl_multi_source_ctx *ctx = nil;
 	hdlhashtable hbar = nil;
+	bigstring bsname;
 
 	if (out == nil || menubar_name == nil)
 		return false;
 
 	memset(out, 0, sizeof(*out));
 
-	ctx = (ty_repl_palette_source_ctx *) calloc(1, sizeof(*ctx));
+	ctx = (ty_repl_multi_source_ctx *) calloc(1, sizeof(*ctx));
 	if (ctx == nil)
 		return false;
 
-	copyctopstring((char *)menubar_name, ctx->bsmenubar_name);
-	ctx->initialised = true;
+	copyctopstring((char *)menubar_name, bsname);
 
 	/*
 	 * Validate the menubar exists. Returning false here lets the caller
 	 * decide whether to install a stub source (no slash menu) versus erroring
 	 * out. Lazy-create system.menus.data so this works on a freshly-migrated
-	 * v7 root, but DO NOT lazy-create the menubar itself — its absence is
+	 * v7 root, but DO NOT lazy-create the menubar itself -- its absence is
 	 * the host's signal that no menubar was installed.
 	 */
 	if (!menudata_ensure_root()) {
 		free(ctx);
 		return false;
 	}
-	hbar = resolve_menubar(ctx);
+	hbar = resolve_bar_by_name(bsname);
 	if (hbar == nil) {
 		free(ctx);
 		return false;
 	}
 
-	out->ctx = ctx;
-	out->count_menus = cb_count_menus;
-	out->menu_describe = cb_menu_describe;
-	out->item_count = cb_item_count;
-	out->item_describe = cb_item_describe;
+	/* Single-slot context: one bar, menu_count populated from ODB. */
+	copystring(bsname, ctx->bars[0].bsname);
+	ctx->bars[0].menu_count = count_subtable_children(hbar);
+	ctx->bar_count = 1;
+	ctx->initialised = true;
 
+	wire_vtable(out, ctx);
 	return true;
 }
 
 
+/*
+ * Deprecated: use repl_palette_source_init_all. Preserved for compat.
+ * Initialise a palette_menu_source_t pointing at the default menubar
+ * (system.menus.data.repl).
+ */
+bool repl_palette_source_init(palette_menu_source_t *out) {
+	return repl_palette_source_init_for(out, REPL_PALETTE_DEFAULT_MENUBAR);
+}
+
+
 void repl_palette_source_dispose(palette_menu_source_t *src) {
-	ty_repl_palette_source_ctx *ctx;
+	ty_repl_multi_source_ctx *ctx;
 	int i;
 
 	if (src == nil)
 		return;
-	ctx = (ty_repl_palette_source_ctx *) src->ctx;
+	ctx = (ty_repl_multi_source_ctx *) src->ctx;
 	if (ctx == nil)
 		return;
 	if (!ctx->initialised) {

--- a/frontier-cli/repl_palette_source.h
+++ b/frontier-cli/repl_palette_source.h
@@ -55,28 +55,49 @@ extern "C" {
 #define REPL_PALETTE_DEFAULT_MENUBAR "repl"
 
 /*
+ * Deprecated: use repl_palette_source_init_all. Preserved for compat.
+ *
  * Initialise a palette_menu_source_t pointing at the default menubar
- * (system.menus.data.repl). The adapter holds its own private context
- * referenced by out->ctx; the caller does not need to allocate or free
- * anything between repl_palette_source_init() and the corresponding
- * repl_palette_source_dispose() — the adapter manages its cache lifecycle.
+ * (system.menus.data.repl). Does NOT check .installed -- bypasses the
+ * installed filter. Use repl_palette_source_init_all for production
+ * enumeration that respects the installed flag.
  *
- * Returns true on success, false on allocation failure.
+ * Returns true on success, false if the default menubar is absent or on
+ * allocation failure.
  *
- * GIL: must be called while holding the GIL. Touches roottable to validate
- * the menubar exists; on first call lazy-creates system.menus.data via
- * menudata_ensure_root().
+ * GIL: must be called while holding the GIL.
  */
 bool repl_palette_source_init(palette_menu_source_t *out);
 
 /*
- * Same, but for a specific menubar name (e.g. "test_menubar" in unit tests).
+ * Initialise for a specific menubar name (e.g. "test_bar" in unit tests).
+ * Does NOT check .installed -- bypasses installed-filter for direct test
+ * access. Use repl_palette_source_init_all for production enumeration.
+ *
  * Stores the name internally; caller need not retain the string.
  *
  * GIL: must be held.
  */
 bool repl_palette_source_init_for(palette_menu_source_t *out,
                                   const char *menubar_name);
+
+/*
+ * Enumerate ALL installed menubars under system.menus.data and compose their
+ * top-level menus into a single horizontal strip (union semantics, matching
+ * legacy OS menubar behavior). Only bars whose .installed field is true are
+ * included. Bars are ordered alphabetically by name for deterministic output.
+ *
+ * Use this in production code (e.g. repl.c's run_palette_modal) instead of
+ * repl_palette_source_init / repl_palette_source_init_for.
+ *
+ * Returns true if at least one installed bar was found; false if none are
+ * installed (caller should suppress the palette in that case) or on
+ * allocation failure.
+ *
+ * GIL: must be held. Calls menudata_ensure_root() and walks the full
+ * system.menus.data subtree.
+ */
+bool repl_palette_source_init_all(palette_menu_source_t *out);
 
 /*
  * Tear down the adapter. Releases any handles the adapter copied into its

--- a/tests/fixtures/palette/menubar_two_bars.txt
+++ b/tests/fixtures/palette/menubar_two_bars.txt
@@ -1,0 +1,20 @@
+Frontier REPL - Interactive UserTalk Environment
+Type /help for commands, /exit to quit
+
+[root]> menu.addMenuCommand(@system.menus.data.aux, "File", "Open", "fileOpen()"
+)
+true
+[root]> menu.install(@system.menus.data.aux)
+true
+[root]> menu.isInstalled(@system.menus.data.aux)
+true
+[root]> /
+
+
+
+
+
+
+
+
+ File  REPL

--- a/tests/integration/test_cases/repl_palette_multi_bar.yaml
+++ b/tests/integration/test_cases/repl_palette_multi_bar.yaml
@@ -1,0 +1,114 @@
+# L4 integration test: multi-menubar union composition (Phase A, Issue #677)
+#
+# What this file proves
+# ---------------------
+# When two menubars are installed (the boot-default "repl" bar plus a
+# dynamically-added "aux" bar), repl_palette_source_init_all composes their
+# top-level menus into a single horizontal strip. The palette renders both
+# bars' menus left-to-right, sorted alphabetically by bar name:
+#
+#   "aux" sorts before "repl", so the strip is: File | REPL | Help
+#                                                ^^^^   ^^^^   ^^^^
+#                                                aux    repl   repl
+#
+# The screenshot golden locks in the union semantics as a regression guard.
+# Any future change that breaks the enumeration, filter, or ordering will
+# produce a golden diff and surface here.
+#
+# Setup
+# -----
+# 1. The "repl" bar is installed at REPL boot (installReplMenubar hook).
+# 2. Before opening the palette we send a REPL command that installs a
+#    second bar named "aux" with a single "File" menu containing one item.
+#    UserTalk: menu.addMenuCommand(@system.menus.data.aux, "File", "Open",
+#              "fileOpen()"); menu.install(@system.menus.data.aux)
+# 3. The palette is opened with '/' and screenshot-matched.
+# 4. Cleanup: 'delete(@system.menus.data.aux)' removes the transient bar
+#    so subsequent tests start from the same clean state.
+#
+# Why "aux" and not an arbitrary name
+# ------------------------------------
+# "aux" sorts lexicographically before "repl", so alphabetical ordering
+# produces a deterministic strip: File (from aux) + REPL + Help (from repl).
+# If we used "zzz" the strip would be REPL | Help | FileZ -- still valid but
+# harder to reason about in the golden.
+#
+# Screenshot match
+# ----------------
+# Golden: tests/fixtures/palette/menubar_two_bars.txt
+# Regenerate only when Phase A UX intentionally changes:
+#   cd tests && FRONTIER_UPDATE_GOLDENS=1 make test-integration
+#
+# Sequential because we mutate system.menus.data (shared process-global ODB
+# state). A parallel runner sharing the same staged DB would race.
+#
+# Note on sizeof(system.menus.data)
+# ----------------------------------
+# system.menus.data contains non-bar scalar entries (currentmenu,
+# currentMenuType, currentsuite) in addition to bar subtables, so
+# sizeof() returns more than just the number of bars. We use
+# menu.isInstalled to verify bar setup instead.
+
+needs_guest_dbs: false
+sequential: true
+
+tests:
+  - name: "palette multi-bar: union of two installed bars renders as single strip"
+    palette_mode: true
+    timeout: 20
+    environment:
+      # Pin prompt row so we skip the 50ms DSR poll that the test harness
+      # cannot answer (harness redirects stderr away from the PTY, so the
+      # DSR query eats the answer). Without this pin, the DSR timeout is
+      # enough to exhaust drain_pty's consecutive-empty-reads budget before
+      # the palette has finished rendering, producing a stale golden frame.
+      FRONTIER_PALETTE_PROMPT_ROW: "20"
+    interactive_steps:
+      # Step 1: Wait for the REPL prompt after boot (installReplMenubar ran).
+      - expect: "\\[root\\]> "
+
+      # Step 2a: Add a "File" menu to a new bar "aux".
+      # Expect "true" first so pexpect consumes the verb's return value before
+      # matching the prompt -- otherwise the prompt from the PREVIOUS step's
+      # output could be matched prematurely, leaving this command's completion
+      # unconfirmed and the "install" step racing with its own execution.
+      - send_raw: "menu.addMenuCommand(@system.menus.data.aux, \"File\", \"Open\", \"fileOpen()\")\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+
+      # Step 2b: Mark the aux bar installed.
+      - send_raw: "menu.install(@system.menus.data.aux)\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+
+      # Step 2c: Verify the aux bar is installed.
+      # Note: sizeof(system.menus.data) is intentionally not checked here --
+      # system.menus.data contains non-bar scalar entries (currentmenu,
+      # currentMenuType, currentsuite) in addition to the bar subtables, so
+      # the count is environment-dependent. menu.isInstalled is the right
+      # predicate: it checks the .installed flag set by menu.install.
+      - send_raw: "menu.isInstalled(@system.menus.data.aux)\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+
+      # Step 3: Open the palette using the double-slash fast-path which
+      # bypasses the disambiguation timer. repl_palette_source_init_all
+      # now finds two installed bars ("aux" + "repl") and composes a strip:
+      # File | REPL | Help  (alphabetical: aux < repl).
+      - send_raw: "//"
+
+      # Step 4: Capture the composed strip. Golden must show "File" before
+      # "REPL" (alphabetical: aux < repl).
+      - screenshot_match: "fixtures/palette/menubar_two_bars.txt"
+
+      # Step 5: Dismiss the palette.
+      - send_raw: "\x1b"
+      - expect: "\\[root\\]> "
+
+      # Step 6: Clean up the transient bar so other tests see a clean ODB.
+      - send_raw: "delete(@system.menus.data.aux)\r"
+      - expect: "\\[root\\]> "
+
+      # Step 7: Exit.
+      - send_raw: "\x04"
+    expected_success: true

--- a/tests/repl_palette_source_tests.c
+++ b/tests/repl_palette_source_tests.c
@@ -450,6 +450,94 @@ static void test_describe_handle_stable_under_repeated_calls(void) {
 	fflush(stdout);
 }
 
+/*
+ * P1 #1 guard: init_for with a name longer than 255 bytes must return false
+ * rather than silently overflowing the bigstring buffer. bigstring is
+ * unsigned char[256] with byte 0 as the Pascal length, so max content is
+ * 255 characters.
+ */
+static void test_init_for_too_long_name_returns_false(void) {
+	printf("[adapter] Test: init_for rejects name longer than 255 bytes... ");
+	fflush(stdout);
+
+	/* 300-byte name -- well beyond the 255-char bigstring limit. */
+	char long_name[301];
+	memset(long_name, 'x', 300);
+	long_name[300] = '\0';
+
+	palette_menu_source_t src;
+	memset(&src, 0xAA, sizeof(src)); /* poison */
+
+	bool ok = repl_palette_source_init_for(&src, long_name);
+	assert(!ok);
+
+	/* dispose must be safe on a rejected init */
+	repl_palette_source_dispose(&src);
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
+/*
+ * P2 #3 guard: menus within a bar must be enumerated in deterministic
+ * alphabetical order regardless of insertion order.
+ *
+ * We install three menus in non-alphabetical order ("Zoo", "Apple", "Mango")
+ * and verify menu_describe returns them sorted ("Apple", "Mango", "Zoo").
+ */
+static void test_menus_within_bar_are_alphabetically_ordered(void) {
+	printf("[adapter] Test: menus within a bar are alphabetically ordered... ");
+	fflush(stdout);
+
+	hdlhashtable hdata = nil;
+	assert(menudata_ensure_root());
+	clear_data_children();
+	assert(find_data(&hdata));
+
+	/* Insert menus in non-alphabetical order: Zoo, Apple, Mango. */
+	hdlhashtable hbar = mk_subtable(hdata, "sort_test_bar");
+
+	hdlhashtable hzoo  = mk_subtable(hbar, "Zoo");
+	hdlhashtable hzi   = mk_subtable(hzoo, "Item1");
+	set_string(hzi, "label", "Zoo");
+	set_string(hzi, "script", "-- zoo script");
+
+	hdlhashtable happle = mk_subtable(hbar, "Apple");
+	hdlhashtable hai    = mk_subtable(happle, "Item2");
+	set_string(hai, "label", "Apple");
+	set_string(hai, "script", "-- apple script");
+
+	hdlhashtable hmango = mk_subtable(hbar, "Mango");
+	hdlhashtable hmi    = mk_subtable(hmango, "Item3");
+	set_string(hmi, "label", "Mango");
+	set_string(hmi, "script", "-- mango script");
+
+	palette_menu_source_t src;
+	assert(repl_palette_source_init_for(&src, "sort_test_bar"));
+
+	int n = src.count_menus(src.ctx);
+	assert(n == 3);
+
+	char label0[64] = {0}, label1[64] = {0}, label2[64] = {0};
+	char hk = '\0';
+	assert(src.menu_describe(src.ctx, 0, label0, sizeof(label0), &hk));
+	assert(src.menu_describe(src.ctx, 1, label1, sizeof(label1), &hk));
+	assert(src.menu_describe(src.ctx, 2, label2, sizeof(label2), &hk));
+
+	/* Alphabetical: Apple < Mango < Zoo */
+	assert(strcmp(label0, "Apple") == 0);
+	assert(strcmp(label1, "Mango") == 0);
+	assert(strcmp(label2, "Zoo")   == 0);
+
+	repl_palette_source_dispose(&src);
+	clear_data_children();
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
 static void test_dispose_idempotent(void) {
 	printf("[adapter] Test: dispose is idempotent... ");
 	fflush(stdout);
@@ -690,6 +778,7 @@ int main(void) {
 	assert(wp_portable_init());
 
 	TR_RUN(test_init_for_missing_menubar_returns_false);
+	TR_RUN(test_init_for_too_long_name_returns_false);
 	TR_RUN(test_count_menus_reflects_menubar);
 	TR_RUN(test_menu_describe_returns_label);
 	TR_RUN(test_item_count_for_top_menu);
@@ -697,6 +786,7 @@ int main(void) {
 	TR_RUN(test_script_handle_survives_copy_cycle);
 	TR_RUN(test_describe_handle_stable_under_repeated_calls);
 	TR_RUN(test_dispose_idempotent);
+	TR_RUN(test_menus_within_bar_are_alphabetically_ordered);
 
 	/* Phase A: multi-bar init_all tests */
 	TR_RUN(test_multi_bar_union_count);

--- a/tests/repl_palette_source_tests.c
+++ b/tests/repl_palette_source_tests.c
@@ -468,6 +468,209 @@ static void test_dispose_idempotent(void) {
 	fflush(stdout);
 }
 
+/* ---------- multi-bar helpers ---------- */
+
+/*
+ * Set the .installed boolean on a bar that already has its subtable
+ * created (build_test_menubar calls menudata_ensure_root so the system
+ * path exists; we then call menudata_set_installed to stamp the flag).
+ */
+static void install_bar(const char *bar_name) {
+	bigstring bs;
+	cstr_to_bs(bar_name, bs);
+	assert(menudata_set_installed(bs, true));
+}
+
+/*
+ * Build a minimal menubar at system.menus.data.<bar_name> WITHOUT clearing
+ * existing data children first (unlike build_test_menubar which calls
+ * clear_data_children). Used so multi-bar tests can build two bars
+ * side-by-side.
+ *
+ * Shape: <bar_name>/<menu_a>/Item1, <bar_name>/<menu_b>/Item2
+ */
+static hdlhashtable build_bar_additive(const char *bar_name,
+                                       const char *menu1, const char *menu2) {
+	hdlhashtable hdata = nil;
+
+	assert(menudata_ensure_root());
+	assert(find_data(&hdata));
+
+	hdlhashtable hbar = mk_subtable(hdata, bar_name);
+
+	hdlhashtable hm1 = mk_subtable(hbar, menu1);
+	hdlhashtable hi1 = mk_subtable(hm1, "Item1");
+	set_string(hi1, "label", menu1);
+	set_string(hi1, "script", "-- item1 script");
+	set_char(hi1, "cmdkey", '1');
+
+	if (menu2 != nil) {
+		hdlhashtable hm2 = mk_subtable(hbar, menu2);
+		hdlhashtable hi2 = mk_subtable(hm2, "Item2");
+		set_string(hi2, "label", menu2);
+		set_string(hi2, "script", "-- item2 script");
+		set_char(hi2, "cmdkey", '2');
+	}
+
+	return hbar;
+}
+
+
+/* ---------- multi-bar init_all tests ---------- */
+
+/*
+ * Two installed bars: bar_a (2 menus), bar_b (1 menu).
+ * init_all should union them -> count_menus == 3.
+ */
+static void test_multi_bar_union_count(void) {
+	printf("[adapter] Test: init_all unions menus from multiple bars... ");
+	fflush(stdout);
+
+	clear_data_children();
+	build_bar_additive("bar_a", "Alpha", "Beta");
+	install_bar("bar_a");
+	build_bar_additive("bar_b", "Gamma", nil);
+	install_bar("bar_b");
+
+	palette_menu_source_t src;
+	bool ok = repl_palette_source_init_all(&src);
+	assert(ok);
+
+	int n = src.count_menus(src.ctx);
+	assert(n == 3); /* bar_a: Alpha, Beta; bar_b: Gamma */
+
+	repl_palette_source_dispose(&src);
+	clear_data_children();
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
+/*
+ * Alphabetical ordering: bar "zzz" vs bar "aaa".
+ * menu_describe(0) must return the first menu from "aaa".
+ */
+static void test_multi_bar_ordering_is_alphabetical(void) {
+	printf("[adapter] Test: init_all orders bars alphabetically... ");
+	fflush(stdout);
+
+	clear_data_children();
+	build_bar_additive("zzz", "ZMenu", nil);
+	install_bar("zzz");
+	build_bar_additive("aaa", "AMenu", nil);
+	install_bar("aaa");
+
+	palette_menu_source_t src;
+	bool ok = repl_palette_source_init_all(&src);
+	assert(ok);
+
+	char label[64] = {0};
+	char hk = '\0';
+	bool described = src.menu_describe(src.ctx, 0, label, sizeof(label), &hk);
+	assert(described);
+	/* "aaa" sorts before "zzz", so index 0 must be from "aaa" -> "AMenu" */
+	assert(strcmp(label, "AMenu") == 0);
+
+	repl_palette_source_dispose(&src);
+	clear_data_children();
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
+/*
+ * Cross-bar describe: two bars (2+1 menus), menu_describe(2) returns
+ * the label from the second bar's first menu.
+ */
+static void test_multi_bar_item_describe_crosses_bars(void) {
+	printf("[adapter] Test: init_all menu_describe crosses bar boundary... ");
+	fflush(stdout);
+
+	clear_data_children();
+	build_bar_additive("aaa", "Menu1", "Menu2");
+	install_bar("aaa");
+	build_bar_additive("zzz", "Menu3", nil);
+	install_bar("zzz");
+
+	palette_menu_source_t src;
+	bool ok = repl_palette_source_init_all(&src);
+	assert(ok);
+
+	int n = src.count_menus(src.ctx);
+	assert(n == 3);
+
+	char label[64] = {0};
+	char hk = '\0';
+	bool described = src.menu_describe(src.ctx, 2, label, sizeof(label), &hk);
+	assert(described);
+	/* index 2 is the 3rd menu across the union: aaa[0]=Menu1 aaa[1]=Menu2 zzz[0]=Menu3 */
+	assert(strcmp(label, "Menu3") == 0);
+
+	repl_palette_source_dispose(&src);
+	clear_data_children();
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
+/*
+ * Installed filter: two bars, only one marked installed.
+ * init_all must exclude the uninstalled bar.
+ */
+static void test_installed_filter_excludes_uninstalled(void) {
+	printf("[adapter] Test: init_all excludes bars not marked installed... ");
+	fflush(stdout);
+
+	clear_data_children();
+	build_bar_additive("installed_bar", "VisibleMenu", nil);
+	install_bar("installed_bar");
+	build_bar_additive("hidden_bar", "HiddenMenu", nil);
+	/* hidden_bar: do NOT call install_bar — .installed defaults to false */
+
+	palette_menu_source_t src;
+	bool ok = repl_palette_source_init_all(&src);
+	assert(ok);
+
+	int n = src.count_menus(src.ctx);
+	assert(n == 1); /* only installed_bar's VisibleMenu */
+
+	repl_palette_source_dispose(&src);
+	clear_data_children();
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
+/*
+ * Single installed bar named "repl" still works through init_all.
+ */
+static void test_single_installed_bar_still_works_via_init_all(void) {
+	printf("[adapter] Test: init_all works with single installed bar... ");
+	fflush(stdout);
+
+	clear_data_children();
+	build_bar_additive("repl", "REPL", "Help");
+	install_bar("repl");
+
+	palette_menu_source_t src;
+	bool ok = repl_palette_source_init_all(&src);
+	assert(ok);
+
+	int n = src.count_menus(src.ctx);
+	assert(n == 2); /* REPL + Help */
+
+	repl_palette_source_dispose(&src);
+	clear_data_children();
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
 /* ---------- main ---------- */
 
 int main(void) {
@@ -494,6 +697,13 @@ int main(void) {
 	TR_RUN(test_script_handle_survives_copy_cycle);
 	TR_RUN(test_describe_handle_stable_under_repeated_calls);
 	TR_RUN(test_dispose_idempotent);
+
+	/* Phase A: multi-bar init_all tests */
+	TR_RUN(test_multi_bar_union_count);
+	TR_RUN(test_multi_bar_ordering_is_alphabetical);
+	TR_RUN(test_multi_bar_item_describe_crosses_bars);
+	TR_RUN(test_installed_filter_excludes_uninstalled);
+	TR_RUN(test_single_installed_bar_still_works_via_init_all);
 
 	printf("\n========================================\n");
 	printf("[adapter] ALL TESTS PASSED\n");


### PR DESCRIPTION
## Summary

Phase A of `docs/MENU_PORT_PLAN.md`: multi-menubar enumeration in `repl_palette_source.c`. Closes #677.

Previously hardcoded to a single menubar named `"repl"`; replaced with a multi-source adapter that enumerates all children of `@system.menus.data` filtered by `.installed=true` and composes their top-level menus into a single horizontal strip (union semantics, matching legacy OS menubar behavior — not tabs, not stacked rows).

Internal: new `ty_repl_multi_source_ctx` holds a sorted array of bar slots; `decompose_menu_index` maps global menu index → (bar, local). The `palette_menu_source_t` vtable contract is unchanged — the palette sees one source as before; the N-source routing is entirely internal.

API:
- New `repl_palette_source_init_all(out)` — enumerates and applies the `.installed` filter
- `repl_palette_source_init_for(out, name)` — direct-name init, **bypasses** the installed filter (preserved for unit tests)
- `repl_palette_source_init(out)` — deprecated wrapper around `_init_for("repl")` for callsite-stable compat

`run_palette_modal` switches from `_init` to `_init_all` — single-line behavioral change at the call site.

Ordering: alphabetical by menubar name. Deterministic across runs. Legacy used menubarlist insertion order; that's not faithful in headless without timestamp tracking, so alphabetical is the closest deterministic approximant. Documented inline.

## Test plan

- [x] Unit: 488/488 pass (added 5 new multi-bar tests for the union/ordering/filter/cross-bar paths)
- [x] Integration: 2155 pass / 207 skip / 18 fail (+5 net new tests; 18 failures pre-existing in html.*/tcp.*, unchanged)
- [x] New L4 integration test `repl_palette_multi_bar.yaml` installs a second menubar dynamically during the test (via `menu.addMenuCommand` + `menu.install` over the REPL) and screenshot-asserts the cascade strip shows `File  REPL` — the union composition
- [x] Const-qualifier warning at `repl_palette_source.c:228` cleaned up (was caused by `findnamedtable`'s legacy non-const bigstring param; fixed with documented cast)
- [x] Build clean (`make -C frontier-cli`)
- [x] No Virgin.root changes — Phase A is pure C in `frontier-cli/` plus tests

## Out of scope (deferred per `docs/MENU_PORT_PLAN.md`)

- Phase B1: `getsystemtablescript` headless support — next PR
- Phase B2: async menu script dispatch — blocked on task #25 (sync vs async decision)
- Phase C: window-event callback bridge — depends on Phase A + B1
- Phase D: windowTypes framework port — UserTalk framework already exists in Virgin.root at `system.verbs.builtins.Frontier.tools.windowTypes/`; Phase D becomes "verify kernel primitives (`window.frontMost`, `window.attributes.*`, callback registry) work in headless." Task #24 closed accordingly.
- Phase E: actual menu content (File / Edit / View etc.) — Phase 6 from the original 8-PR plan
- Terminal-width overflow behavior — documented current behavior is left-to-right truncation; deferred per task #26 and the rescoped issue #677 comment

## Chain context

First PR in the menu-port chain. Plan + deep-dive lives in `docs/MENU_PORT_PLAN.md` + `docs/LEGACY_MENU_SYSTEM.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
