### PR TITLE
feat(menu): Phase C - window-event callback bridge (#682)

### DIFF
--- a/docs/MENU_PORT_PLAN.md
+++ b/docs/MENU_PORT_PLAN.md
@@ -122,20 +122,20 @@ Both sub-tracks block Phase C.
 
 ### Phase C — Window-Event Callback Bridge
 
-**Refined 2026-05-31 (post-B1 #680 merge + windowTypes audit)**: list 139 entries are inline UserTalk script templates with `^0`/`^1` parameter substitution markers, NOT bare ODB verb paths. Phase C dispatch is `getsystemtablescript → parsedialogstring (with escaped params) → processrunstring`, NOT `→ langfindvalue → meuserselected_headless`. See PR #680 and issues #681, #682.
+**Phase C shipped** (2026-05-31, worktree-menu-port-phase-c-bridge). Dispatch implementation: `getsystemtablescript → langdeparsestring(bs_path, '"') → parsedialogstring → langrunstringnoerror`. Key correction vs. original spec: the script templates use straight ASCII double-quotes `"` as string delimiters, so the escaping uses `'"'` (not `chclosecurlyquote`/0xD3) to prevent injection of embedded `"` characters. All 5 behavioral unit tests in `tests/test_window_bridge.c` pass (green).
 
-**Audit findings** (see also `/tmp/phase-c-windowtypes-audit.md` if present, or re-derive from `usertalk_scripts/.../windowTypes/`):
-- Framework calls `window.frontMost()`, `window.attributes.getOne("type", ...)`, `window.attributes.setOne`, `window.setTitle(adr, title)` — Phase C must implement these in headless, OR verify existing implementations
-- Framework calls `thread.callScript(adr, params)` for menu-item dispatch — **already implemented** in `frontier-cli/headless_thread_verbs.c` (`headless_thread_callscript`). Async dispatch for menu items is therefore handled at the framework layer, NOT in Phase C's bridge — see Decision Point 2 resolution
-- Framework looks up windowType definitions in `user.tools.windowTypes.[type]` and `Frontier.tools.data.windowTypes.[type]` (in that order); Phase C must install a `ReplWindow` entry in the latter
+**What was delivered**:
+- `frontier-cli/window_registry.c` + `window_registry.h`: `window_registry_init()` creates `system.temp.windowTypes.windows.repl` with `type="ReplWindow"`, `title="REPL"`. `on_frontmost_changed(old, new)` fires `idclosewindowscript`/`idopenwindowscript` using the corrected dispatch chain with `'"'` escaping.
+- `frontier-cli/repl.c`: wired `window_registry_init()` + `on_frontmost_changed(nil, WINDOW_BRIDGE_REPL_PATH)` into boot sequence after `install_repl_menubar()` (step 3.3).
+- `usertalk_scripts/.../Frontier/tools/data/windowTypes/ReplWindow/openWindow.ut`: installed in `databases/Virgin.root` via protocol; returns true as a Phase D placeholder.
+- `tests/test_window_bridge.c`: 5 behavioral tests using C-side `langcompiletext`+`hashtableassign` stubs (avoids `script.newScriptObject` dependency on full Frontier.root). Confirmed RED → GREEN.
 
-**Phase C tasks**:
-- Implement `on_frontmost_changed(old, new)` in `repl.c`: fires `getsystemtablescript(idclosewindowscript)` for old, `getsystemtablescript(idopenwindowscript)` for new. For each fired script, substitute `^0` = `langdeparsestring(adr.path, chclosecurlyquote)` via `parsedialogstring`, then `processrunstring` synchronously. (Sync is fine here — this runs once at boot, before REPL accepts input.)
-- Implement the static "REPL window" sentinel: a `tyhdlwindow repl_window` global with `type="ReplWindow"`, `title="REPL"`, wired as initial `frontmost_window` at boot
-- Install a `Frontier.tools.data.windowTypes.ReplWindow` entry (via UserTalk boot script under `databases/usertalk_scripts/` or via C-side ODB API at boot) — contains the menubar manifest pointing at the `repl` bar that Phase A enumeration finds
-- At boot: fire `on_frontmost_changed(nil, &repl_window)` to trigger `idopenwindowscript`
-- **Per-dispatch-site escaping checklist** (from issue #682): document trust assumption for each `^0`/`^1` source; window paths are user-controllable → MUST escape via `langdeparsestring`
-- **Size**: ~150-250 LOC in `repl.c` + small new `window_registry.c` + UserTalk boot script for the `ReplWindow` entry
+**Phase D pre-work signal**: `window.attributes.getOne("type", adr)` is NOT implemented in headless. The framework's `callbacks/openWindow.ut` gracefully returns true when this fails (`if window.attributes.getOne(...) {...}` skips the if-body). Full ReplWindow menu composition is blocked until Phase D implements `window.attributes.*`.
+
+**Escaping correction** (issue #682): original spec said use `chclosecurlyquote` (0xD3). Actual template strings use straight ASCII `"`. `langdeparsestring(bs, 0xD3)` does NOT escape `"` (0x22) — it only escapes the curly-quote (0xD3). Fixed to `langdeparsestring(bs_path, '"')`.
+
+**Refined 2026-05-31 (post-B1 #680 merge + windowTypes audit)**: list 139 entries are inline UserTalk script templates with `^0`/`^1` parameter substitution markers, NOT bare ODB verb paths.
+
 - **Dependencies**: Phase A (#678, merged), Phase B1 (#680, merged)
 - **Blocks**: Phase D
 

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -96,7 +96,8 @@ CLI_SOURCES = \
     pane.c \
     palette.c \
     palette_arg_inject.c \
-    scrollback_pane.c
+    scrollback_pane.c \
+    window_registry.c
 
 # cJSON (vendored JSON parser)
 CJSON_SOURCES = $(THIRDPARTYDIR)/cJSON/cJSON.c

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -57,6 +57,7 @@
 #include "repl_palette_source.h"
 #include "scrollback_pane.h"
 #include "repl_output_async.h"
+#include "window_registry.h"	/* window_registry_init, on_frontmost_changed */
 #include "../Common/headers/menudata_headless.h" /* meuserselected_headless */
 #include "../Common/headers/oplist.h"		/* opcountlistitems */
 #include "../Common/headers/langsystem7.h"	/* getnthlistval */
@@ -3749,10 +3750,31 @@ int repl_main(cli_options_t *options, ws_server_t *ws_server) {
 	g_repl_exit_requested = 0;
 	install_repl_verbs_host();
 
-	// 3.2 Boot the REPL menubar via UserTalk. Idempotent — the install
+	// 3.2 Boot the REPL menubar via UserTalk. Idempotent -- the install
 	//     script guards with menu.isInstalled. Failure logs a warning and
 	//     continues; the legacy /commands still work.
 	install_repl_menubar();
+
+	// 3.3 Phase C: initialize the static REPL window sentinel in the ODB
+	//     and fire the initial "window opened" event.
+	//
+	//     window_registry_init() creates system.temp.windowTypes.windows.repl
+	//     with type = "ReplWindow" so the windowTypes framework can resolve
+	//     this window's type entry.
+	//
+	//     on_frontmost_changed(nil, REPL_PATH) fires idopenwindowscript, which
+	//     calls system.callbacks.openWindow(repl_path).  The windowTypes
+	//     framework (Frontier.tools.windowTypes.callbacks.openWindow) handles
+	//     this call and composes the menu for the REPL window type.
+	//
+	//     Both calls are boot-failure-safe (ADR-016): they log and continue
+	//     on error rather than aborting the REPL.
+	if (!window_registry_init()) {
+		log_warn(LOG_COMP_GENERAL,
+		         "repl_main: window_registry_init failed -- "
+		         "REPL window sentinel not created; windowTypes bridge is no-op");
+	}
+	on_frontmost_changed(nil, WINDOW_BRIDGE_REPL_PATH);
 
 	// 4. Display welcome message and mark REPL as active
 	repl_output_welcome();

--- a/frontier-cli/window_registry.c
+++ b/frontier-cli/window_registry.c
@@ -1,0 +1,244 @@
+/*
+ * window_registry.c - Static REPL window sentinel and window-event bridge
+ *
+ * Phase C of docs/MENU_PORT_PLAN.md.
+ *
+ * See window_registry.h for full design documentation.
+ *
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Frontier contributors
+ */
+
+#include <string.h>
+
+#include "window_registry.h"
+
+#include "../Common/headers/frontier.h"
+#include "../Common/headers/lang.h"
+#include "../Common/headers/langinternal.h"
+#include "../Common/headers/strings.h"
+#include "../Common/headers/tablestructure.h"
+#include "../Common/headers/tableverbs.h"
+#include "../Common/headers/langexternal.h"
+#include "../Common/headers/logging.h"
+
+/*
+ * getsystemtablescript is a 1-line wrapper in tablestructure.c:
+ *   return getstringlist(idsystemtablescripts, idscript, bsscript);
+ * It fills bsscript with the Pascal-string template for the given hook ID.
+ */
+extern boolean getsystemtablescript(short idscript, bigstring bsscript);
+
+/*
+ * parsedialogstring substitutes ^0..^3 parameters into a template.
+ * Signature (from strings.c):
+ *   void parsedialogstring(const bigstring bssource,
+ *                          ptrstring bs0, ptrstring bs1,
+ *                          ptrstring bs2, ptrstring bs3,
+ *                          bigstring bsresult);
+ */
+extern void parsedialogstring(const bigstring bssource,
+                              ptrstring bs0, ptrstring bs1,
+                              ptrstring bs2, ptrstring bs3,
+                              bigstring bsresult);
+
+/*
+ * langdeparsestring escapes a bigstring for safe embedding as a string
+ * literal inside a UserTalk expression.  The second parameter is the
+ * quote character (chclosecurlyquote = '"' in the UserTalk lexer).
+ * Returns true if any escaping was done.
+ */
+extern boolean langdeparsestring(bigstring bs, byte ch);
+
+/*
+ * chclosecurlyquote is the UserTalk string-literal quote character.
+ * Defined in lang.c; also visible via lang.h or langinternal.h.
+ */
+#ifndef chclosecurlyquote
+#define chclosecurlyquote '"'
+#endif
+
+/*
+ * langrunstringnoerror: compile and run a UserTalk bigstring expression.
+ * Suppresses error output (like shellrunwindowconfirmationscript uses).
+ * Returns true if the script compiled and ran without error.
+ */
+extern boolean langrunstringnoerror(const bigstring bsprogram, bigstring bsresult);
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Copy a C string into a Pascal bigstring.  Truncates silently at 255 bytes.
+ */
+static void cstr_to_bigstring(const char *cstr, bigstring bs) {
+	size_t len = strlen(cstr);
+	if (len > 255) len = 255;
+	bs[0] = (unsigned char)len;
+	memcpy(bs + 1, cstr, len);
+}
+
+/*
+ * fire_window_script -- internal workhorse.
+ *
+ * Looks up the script template for idscript, substitutes the escaped window
+ * path as ^0, and runs it synchronously via langrunstringnoerror.
+ *
+ * Logs a warning and returns (does NOT abort) on any failure, per the
+ * "boot-failure-safe" contract in docs/MENU_PORT_PLAN.md and ADR-016.
+ *
+ * ESCAPING CONTRACT (issue #682)
+ * The window_path string is passed through langdeparsestring before
+ * parsedialogstring substitution.  langdeparsestring(bs, '"') inserts a
+ * backslash before any embedded ASCII '"' (0x22) so it cannot break out
+ * of the surrounding UserTalk string literal and inject additional statements.
+ * We pass '"' (not chclosecurlyquote/0xD3) because the script templates use
+ * straight ASCII double-quotes as string delimiters.
+ *
+ * In Phase C, window_path is always WINDOW_BRIDGE_REPL_PATH, which is a
+ * compile-time constant with no user-controlled content.  The escaping is
+ * present regardless to enforce the contract for Phase E callers that will
+ * supply user-derived window paths (editor window ODB addresses).
+ */
+static void fire_window_script(short idscript, const char *window_path) {
+	bigstring bs_template;
+	bigstring bs_path;
+	bigstring bs_substituted;
+	bigstring bs_result;
+
+	/* Step 1: get the script template from the system table script registry */
+	if (!getsystemtablescript(idscript, bs_template)) {
+		log_warn(LOG_COMP_GENERAL,
+		         "window_registry: getsystemtablescript(%d) returned false -- "
+		         "script hook not configured (normal if windowTypes not loaded)",
+		         (int)idscript);
+		return;
+	}
+
+	/* Step 2: copy the window path into a Pascal bigstring */
+	cstr_to_bigstring(window_path, bs_path);
+
+	/*
+	 * Step 3: escape the path for safe embedding as a string literal.
+	 *
+	 * The idsystemtablescripts templates use straight ASCII double-quotes
+	 * to delimit the ^0 parameter (e.g. openWindow("^0")).  We must escape
+	 * any embedded '"' (0x22) in the path so it cannot break out of the
+	 * surrounding string literal.
+	 *
+	 * langdeparsestring(bs, chendquote) inserts a backslash before every
+	 * occurrence of chendquote in bs.  Passing '"' (0x22) ensures that an
+	 * embedded double-quote becomes '\"', which the UserTalk scanner reads
+	 * as an escaped quote inside the string literal rather than as the
+	 * string terminator.
+	 *
+	 * We do NOT pass chclosecurlyquote (0xD3) here because the templates
+	 * use straight ASCII quotes, not curly quotes.  Using 0xD3 would leave
+	 * embedded ASCII '"' unescaped and allow injection.
+	 *
+	 * Example: if window_path were 'a");evil("b', after escaping it becomes
+	 * 'a\");evil(\"b', which is the string content a");evil("b to UserTalk,
+	 * NOT two statements.
+	 */
+	langdeparsestring(bs_path, '"');
+
+	/* Step 4: substitute the escaped path as ^0 in the template */
+	parsedialogstring(bs_template, bs_path, nil, nil, nil, bs_substituted);
+
+	/* Step 5: run the substituted script synchronously */
+	if (!langrunstringnoerror(bs_substituted, bs_result)) {
+		/*
+		 * Log but do not fail: the windowTypes framework may not be loaded
+		 * (e.g. a minimal headless build without Frontier.root), or the
+		 * script may reference a path that doesn't exist yet.  In all cases
+		 * the REPL should continue.
+		 */
+		log_warn(LOG_COMP_GENERAL,
+		         "window_registry: script for hook %d failed or returned error "
+		         "(window path: %s) -- REPL continues",
+		         (int)idscript, window_path);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public API                                                         */
+/* ------------------------------------------------------------------ */
+
+boolean window_registry_init(void) {
+	/*
+	 * Create system.temp.windowTypes.windows.repl as a table with a "type"
+	 * attribute of "ReplWindow".  This lets the windowTypes framework resolve
+	 * the window's type entry in Frontier.tools.data.windowTypes.ReplWindow.
+	 *
+	 * We do this via a short inline UserTalk script rather than raw ODB API
+	 * calls because:
+	 *   1. The path is multi-level; ODB API calls would need multiple
+	 *      hashtablelookupnode + hashtablesetnodevalue calls.
+	 *   2. The UserTalk path matches what the framework expects, so if the
+	 *      path convention changes we only change it in one place.
+	 *   3. The script is idempotent ("if not defined" guards).
+	 *
+	 * If any part of this fails (e.g. system.temp doesn't exist yet), we log
+	 * a warning and return false.  The caller (repl.c) continues -- the REPL
+	 * runs without the window sentinel, but the bridge will be a no-op.
+	 */
+	static const char *init_script =
+		"if not defined (system.temp.windowTypes) {"
+		"  new (tableType, @system.temp.windowTypes)};"
+		"if not defined (system.temp.windowTypes.windows) {"
+		"  new (tableType, @system.temp.windowTypes.windows)};"
+		"if not defined (system.temp.windowTypes.windows.repl) {"
+		"  new (tableType, @system.temp.windowTypes.windows.repl)};"
+		/* Store "type" directly as a string value in the window table.
+		 * window.attributes.getOne reads from the /atts sibling of the
+		 * window node; we also store directly for simpler Phase C testing. */
+		"system.temp.windowTypes.windows.repl.type = \"ReplWindow\";"
+		"system.temp.windowTypes.windows.repl.title = \"REPL\"";
+
+	bigstring bsprog;
+	bigstring bsresult;
+	cstr_to_bigstring(init_script, bsprog);
+
+	if (!langrunstringnoerror(bsprog, bsresult)) {
+		log_warn(LOG_COMP_GENERAL,
+		         "window_registry_init: init script failed -- "
+		         "REPL window sentinel not created");
+		return false;
+	}
+
+	log_debug(LOG_COMP_GENERAL,
+	          "window_registry_init: REPL window sentinel created at "
+	          WINDOW_BRIDGE_REPL_PATH);
+	return true;
+}
+
+void on_frontmost_changed(const char *old_path, const char *new_path) {
+	/*
+	 * Edge case 1: both nil -- no window transitions, nothing to fire.
+	 */
+	if (old_path == nil && new_path == nil)
+		return;
+
+	/*
+	 * Edge case 2: same window -- the conceptual "frontmost" did not change
+	 * (e.g. a spurious call from the boot sequence when the REPL is already
+	 * front and a re-init is triggered).  Do not re-fire open/close.
+	 */
+	if (old_path != nil && new_path != nil &&
+	    strcmp(old_path, new_path) == 0)
+		return;
+
+	/*
+	 * Close the old window first (matches legacy Frontier ordering in
+	 * shellwindow.c: close fires before open on a window-switch event).
+	 */
+	if (old_path != nil)
+		fire_window_script(idclosewindowscript, old_path);
+
+	/*
+	 * Open the new window.
+	 */
+	if (new_path != nil)
+		fire_window_script(idopenwindowscript, new_path);
+}

--- a/frontier-cli/window_registry.c
+++ b/frontier-cli/window_registry.c
@@ -171,40 +171,59 @@ boolean window_registry_init(void) {
 	 * attribute of "ReplWindow".  This lets the windowTypes framework resolve
 	 * the window's type entry in Frontier.tools.data.windowTypes.ReplWindow.
 	 *
-	 * We do this via a short inline UserTalk script rather than raw ODB API
-	 * calls because:
+	 * We do this via a sequence of short inline UserTalk statements rather than
+	 * raw ODB API calls because:
 	 *   1. The path is multi-level; ODB API calls would need multiple
 	 *      hashtablelookupnode + hashtablesetnodevalue calls.
 	 *   2. The UserTalk path matches what the framework expects, so if the
 	 *      path convention changes we only change it in one place.
 	 *   3. The script is idempotent ("if not defined" guards).
 	 *
-	 * If any part of this fails (e.g. system.temp doesn't exist yet), we log
+	 * Each statement is kept under 255 bytes (the bigstring limit -- see
+	 * lenbigstring / Str255) so no statement is truncated mid-token.
+	 * The original single-script form was 411 bytes and was silently truncated
+	 * to 255, producing a syntax error on "line 1" at startup (PR #683 bug 1).
+	 *
+	 * If any statement fails (e.g. system.temp doesn't exist yet), we log
 	 * a warning and return false.  The caller (repl.c) continues -- the REPL
 	 * runs without the window sentinel, but the bridge will be a no-op.
 	 */
-	static const char *init_script =
-		"if not defined (system.temp.windowTypes) {"
-		"  new (tableType, @system.temp.windowTypes)};"
-		"if not defined (system.temp.windowTypes.windows) {"
-		"  new (tableType, @system.temp.windowTypes.windows)};"
-		"if not defined (system.temp.windowTypes.windows.repl) {"
-		"  new (tableType, @system.temp.windowTypes.windows.repl)};"
-		/* Store "type" directly as a string value in the window table.
-		 * window.attributes.getOne reads from the /atts sibling of the
-		 * window node; we also store directly for simpler Phase C testing. */
-		"system.temp.windowTypes.windows.repl.type = \"ReplWindow\";"
-		"system.temp.windowTypes.windows.repl.title = \"REPL\"";
+
+	/*
+	 * Five idempotent statements, each well under 255 bytes:
+	 *   s1: ensure system.temp.windowTypes table exists
+	 *   s2: ensure system.temp.windowTypes.windows table exists
+	 *   s3: ensure system.temp.windowTypes.windows.repl table exists
+	 *   s4: set .type = "ReplWindow"  (read by windowTypes framework)
+	 *   s5: set .title = "REPL"       (display name)
+	 */
+	static const char *stmts[] = {
+		"if not defined (system.temp.windowTypes) "
+		"{new (tableType, @system.temp.windowTypes)}",
+
+		"if not defined (system.temp.windowTypes.windows) "
+		"{new (tableType, @system.temp.windowTypes.windows)}",
+
+		"if not defined (system.temp.windowTypes.windows.repl) "
+		"{new (tableType, @system.temp.windowTypes.windows.repl)}",
+
+		"system.temp.windowTypes.windows.repl.type = \"ReplWindow\"",
+
+		"system.temp.windowTypes.windows.repl.title = \"REPL\"",
+	};
+	static const int nstmts = (int)(sizeof(stmts) / sizeof(stmts[0]));
 
 	bigstring bsprog;
 	bigstring bsresult;
-	cstr_to_bigstring(init_script, bsprog);
 
-	if (!langrunstringnoerror(bsprog, bsresult)) {
-		log_warn(LOG_COMP_GENERAL,
-		         "window_registry_init: init script failed -- "
-		         "REPL window sentinel not created");
-		return false;
+	for (int i = 0; i < nstmts; i++) {
+		cstr_to_bigstring(stmts[i], bsprog);
+		if (!langrunstringnoerror(bsprog, bsresult)) {
+			log_warn(LOG_COMP_GENERAL,
+			         "window_registry_init: statement %d failed -- "
+			         "REPL window sentinel not created", i);
+			return false;
+		}
 	}
 
 	log_debug(LOG_COMP_GENERAL,

--- a/frontier-cli/window_registry.h
+++ b/frontier-cli/window_registry.h
@@ -1,0 +1,107 @@
+/*
+ * window_registry.h - Static REPL window sentinel and window-event bridge
+ *
+ * Phase C of docs/MENU_PORT_PLAN.md: the C-side bridge that fires
+ * idopenwindowscript / idclosewindowscript when the REPL "frontmost window"
+ * changes.  This is the headless equivalent of the legacy Carbon window
+ * manager's focus-change events.
+ *
+ * DESIGN
+ * ------
+ * Legacy Frontier maintained a z-ordered window list; the OS called
+ * shellwindow.c:shellrunwindowconfirmationscript() on focus changes.  In
+ * headless mode there is no OS window manager.  Instead:
+ *
+ *   - A static "REPL window" sentinel is the only window that exists at
+ *     boot.  It lives at the ODB path WINDOW_BRIDGE_REPL_PATH.
+ *   - on_frontmost_changed(old_path, new_path) is called by repl.c whenever
+ *     the conceptual "frontmost window" changes.  Each non-nil argument
+ *     triggers the corresponding kernel-fired UserTalk hook:
+ *       old != nil  ->  idclosewindowscript
+ *       new != nil  ->  idopenwindowscript
+ *   - The window path string is escaped with langdeparsestring(bs, '"') before
+ *     substitution into the script template (issue #682 escaping contract).
+ *     ASCII '"' is the delimiter used by the script templates; backslash-escaping
+ *     embedded '"' prevents injection.
+ *
+ * DISPATCH PATH (per docs/MENU_PORT_PLAN.md Phase C)
+ * --------------------------------------------------
+ *   getsystemtablescript(idopenwindowscript)
+ *     -> template: "if defined(system.callbacks){system.callbacks.openWindow(\"^0\");}"
+ *   langdeparsestring(path, '"')  -- escape embedded ASCII double-quotes
+ *   parsedialogstring(template, escaped_path, ...) -- substitute ^0
+ *   langrunstringnoerror(substituted)           -- run synchronously
+ *
+ * TRUST ASSUMPTION
+ * ----------------
+ * In Phase C the only window path is the static REPL sentinel below
+ * (WINDOW_BRIDGE_REPL_PATH), which is a compile-time constant with no
+ * user-controllable content.  Future phases (Phase E editor windows) will
+ * populate paths from ODB keys; those callers MUST pass the path through
+ * langdeparsestring before calling on_frontmost_changed, or call this
+ * function which does it internally.
+ *
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Frontier contributors
+ */
+
+#ifndef WINDOW_REGISTRY_H
+#define WINDOW_REGISTRY_H
+
+#include "../Common/headers/frontier.h"
+
+/*
+ * ODB path for the static REPL window sentinel.
+ *
+ * Lives under system.temp.windowTypes.windows so that
+ * Frontier.tools.windowTypes.init() (which creates the parent tables) does
+ * not conflict.  "repl" is a fixed key -- the REPL is the only headless
+ * window until Phase E editor windows arrive.
+ *
+ * This path is passed as ^0 to idopenwindowscript / idclosewindowscript.
+ * The callbacks/openWindow.ut framework checks defined(adr^) and looks up
+ * window.attributes.getOne("type", ...) on this address.
+ */
+#define WINDOW_BRIDGE_REPL_PATH "@system.temp.windowTypes.windows.repl"
+
+/*
+ * Initialize the REPL window sentinel in the ODB.
+ *
+ * Creates system.temp.windowTypes.windows.repl as a table and writes the
+ * "type" = "ReplWindow" attribute into it so the windowTypes framework can
+ * look up the window's type entry in Frontier.tools.data.windowTypes.
+ *
+ * Must be called after the system root is loaded (db_format_prepare_runtime)
+ * and before on_frontmost_changed is first called.  Safe to call multiple
+ * times (idempotent).
+ *
+ * Returns true on success, false on ODB error (REPL continues without the
+ * sentinel -- the bridge will be a no-op for the open event).
+ */
+boolean window_registry_init(void);
+
+/*
+ * Fire the window-focus-change bridge scripts.
+ *
+ * old_path: C string ODB address of the window losing focus, or nil.
+ *           If non-nil, fires idclosewindowscript with old_path as ^0.
+ *
+ * new_path: C string ODB address of the window gaining focus, or nil.
+ *           If non-nil, fires idopenwindowscript with new_path as ^0.
+ *
+ * Edge cases:
+ *   - Both nil: no-op (nothing fires).
+ *   - old_path == new_path (strcmp equal): no-op -- same window is still
+ *     frontmost; do not re-fire open/close for it.
+ *   - Each path is independently escaped via langdeparsestring(path, '"') before
+ *     parsedialogstring substitution (issue #682 contract).
+ *
+ * Errors: if getsystemtablescript or langrunstringnoerror fails, a warning
+ * is logged and the function continues (boot-failure-safe per ADR-016 / the
+ * REPL boot sequence contract).
+ *
+ * GIL: must be called with the GIL held.
+ */
+void on_frontmost_changed(const char *old_path, const char *new_path);
+
+#endif /* WINDOW_REGISTRY_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -222,7 +222,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -526,6 +526,14 @@ test_stringerrorlist: test_stringerrorlist.c $(TEST_FRAMEWORK) ../frontier-cli/s
 test_getsystemtablescript: test_getsystemtablescript.c $(TEST_FRAMEWORK) ../frontier-cli/stubs/headless_lang_runtime_more_stubs.c $(STRINGS_C) ../Common/source/logging.c ../portable/classic_handle.c ../Common/source/portable_handles.c
 	$(CC) $(CFLAGS) -I../Common/headers -I../Common/SystemHeaders -I../portable -I../generated \
 		test_getsystemtablescript.c framework/test_framework.c ../frontier-cli/stubs/headless_lang_runtime_more_stubs.c $(STRINGS_C) ../Common/source/logging.c ../portable/classic_handle.c ../Common/source/portable_handles.c -o $@ $(LDFLAGS)
+
+# Phase C: window-event callback bridge tests (window_registry.c).
+# Links the full lang runtime (langrunstringnoerror, parsedialogstring,
+# langdeparsestring, getsystemtablescript) plus the frontier-cli runtime
+# sources needed for headless operation.
+test_window_bridge: test_window_bridge.c $(TEST_FRAMEWORK) $(LANG_RUNTIME_SOURCES) ../frontier-cli/window_registry.c ../frontier-cli/stubs/headless_shell.c
+	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -I../Common/headers -I../Common/SystemHeaders -I../portable -I../frontier-cli \
+		test_window_bridge.c $(TEST_FRAMEWORK) $(LANG_RUNTIME_SOURCES) ../frontier-cli/window_registry.c ../frontier-cli/stubs/headless_shell.c -o $@ $(LINK_LIBS)
 
 # UserTalk object test executables
 test_usertalk_runner: components/usertalk_objects/test_usertalk_objects.c components/usertalk_objects/test_runner.c $(TEST_FRAMEWORK) $(FRONTIER_SOURCES) $(CLI_SOURCES)

--- a/tests/test_window_bridge.c
+++ b/tests/test_window_bridge.c
@@ -337,8 +337,9 @@ static bool test_injection_attempt_is_safe(void) {
 	 * Without langdeparsestring escaping, this path would produce the script:
 	 *   system.callbacks.openWindow("evil");system.temp.phasec_inject_marker=true;(")
 	 *
-	 * With proper escaping, the embedded quote is doubled so the injected code
-	 * is never parsed as a separate statement.
+	 * With proper escaping (langdeparsestring inserts a backslash before each
+	 * `"` and `\`), the embedded quote is backslash-escaped to `\"` so the
+	 * injected code is never parsed as a separate statement.
 	 */
 	const char *evil_path =
 		"evil\");system.temp.phasec_inject_marker=true;(\"";

--- a/tests/test_window_bridge.c
+++ b/tests/test_window_bridge.c
@@ -1,0 +1,433 @@
+/*
+ * test_window_bridge.c - Behavioral tests for Phase C window-event callback bridge
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2026 Frontier contributors
+ *
+ * Phase C of docs/MENU_PORT_PLAN.md: the C-side bridge that fires
+ * idopenwindowscript / idclosewindowscript when the REPL "frontmost window"
+ * changes.
+ *
+ * These tests are BEHAVIORAL: they invoke the real function and assert on
+ * observable ODB side-effects. No source-inspection.
+ *
+ * Test plan (per task prompt):
+ *   1. Bridge fires idopenwindowscript at the right time (openWindow marker set)
+ *   2. Bridge fires idclosewindowscript at the right time (closeWindow marker set)
+ *   3. nil + nil is a no-op (no markers set)
+ *   4. Same window to same window: no double-fire
+ *   5. Escaping: malicious path with embedded "); does not inject code
+ *
+ * Hook installation strategy
+ * --------------------------
+ * The bridge fires system.callbacks.openWindow/closeWindow via UserTalk.
+ * The test installs lightweight stubs into system.callbacks.openWindow and
+ * system.callbacks.closeWindow using the C-side langcompiletext + hashtableassign
+ * API (same pattern as test_callback_infrastructure.c).  This avoids the
+ * dependency on script.newScriptObject (which requires a full Frontier.root DB),
+ * making the test run cleanly against the standalone headless runtime initialized
+ * by db_format_prepare_runtime().
+ *
+ * Stub body design: the stub bodies are pure expressions
+ * (no "on handler(...)" wrappers) that set a marker in system.temp:
+ *
+ *   system.temp.phasec_open_marker = true; return(true)
+ *   system.temp.phasec_close_marker = true; return(true)
+ *
+ * When the bridge fires system.callbacks.openWindow("path"), the UserTalk
+ * evaluator calls the CodeValue stored at that key and executes the stub body.
+ * Parameters passed by the caller are accessible via "name" (first param) if
+ * the body references them, but for marker-setting we only need side effects.
+ */
+
+#include "framework/test_framework.h"
+#include "test_report.h"
+
+#include <string.h>
+
+#include "../Common/headers/frontier.h"
+#include "../Common/headers/lang.h"
+#include "../Common/headers/langinternal.h"
+#include "../Common/headers/langsystem7.h"
+#include "../Common/headers/tablestructure.h"
+#include "../Common/headers/strings.h"
+#include "../Common/headers/logging.h"
+#include "../Common/headers/langexternal.h"
+#include "../Common/headers/tableverbs.h"
+#include "../Common/headers/db_format.h"
+
+/*
+ * The bridge functions we are testing.  These are declared in
+ * frontier-cli/window_registry.h but we include the header directly from
+ * the CLI tree.
+ */
+#include "../frontier-cli/window_registry.h"
+
+/* ------------------------------------------------------------------ */
+/*  Helper: run a UserTalk expression and return the bigstring result. */
+/* ------------------------------------------------------------------ */
+
+static boolean run_expr(const char *expr, bigstring bsresult) {
+	bigstring bsprog;
+	size_t len = strlen(expr);
+	if (len > 255) len = 255;
+	bsprog[0] = (unsigned char)len;
+	memcpy(bsprog + 1, expr, len);
+	return langrunstringnoerror(bsprog, bsresult);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: check that a bigstring equals a C literal.                 */
+/* ------------------------------------------------------------------ */
+
+static boolean bs_equals(bigstring bs, const char *expected) {
+	size_t elen = strlen(expected);
+	size_t blen = (size_t)(unsigned char)bs[0];
+	if (blen != elen) return false;
+	return memcmp(bs + 1, expected, elen) == 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: compile a script body and assign it to a name in a table. */
+/*                                                                      */
+/*  Mirrors the add_test_script() pattern in test_callback_infra.      */
+/*  ht:   target hash table (e.g. the system.callbacks sub-table)      */
+/*  name: key name as a Pascal bigstring                               */
+/*  body: C string script body (no "on handler" wrapper needed)        */
+/* ------------------------------------------------------------------ */
+
+static boolean assign_compiled_stub(hdlhashtable ht, bigstring name, const char *body) {
+	Handle htext;
+	hdltreenode hcode;
+	tyvaluerecord val;
+	bigstring bsbody;
+
+	copyctopstring(body, bsbody);
+
+	if (!newtexthandle(bsbody, &htext)) {
+		printf("[test] assign_compiled_stub: newtexthandle failed\n");
+		return false;
+	}
+
+	if (!langcompiletext(htext, false, &hcode)) {
+		printf("[test] assign_compiled_stub: langcompiletext failed for: %s\n", body);
+		return false;
+	}
+
+	val.valuetype = codevaluetype;
+	val.data.codevalue = hcode;
+
+	return hashtableassign(ht, name, val);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: clear marker ODB values from prior test runs.             */
+/*                                                                     */
+/*  Uses the C-side hashdelete API because the bare UserTalk "delete" */
+/*  verb is registered under "lang.delete" and bare-name lookup       */
+/*  doesn't find it in the minimal headless runtime.                  */
+/* ------------------------------------------------------------------ */
+
+static boolean clear_markers(void) {
+	bigstring bssystem, bstemp;
+	bigstring bsopen, bsclose, bsinject;
+	hdlhashtable hsystem, htemp;
+
+	copyctopstring("system", bssystem);
+	copyctopstring("temp", bstemp);
+	copyctopstring("phasec_open_marker", bsopen);
+	copyctopstring("phasec_close_marker", bsclose);
+	copyctopstring("phasec_inject_marker", bsinject);
+
+	if (!findnamedtable(roottable, bssystem, &hsystem))
+		return false;
+	if (!findnamedtable(hsystem, bstemp, &htemp))
+		return false;
+
+	/* Silently ignore errors -- marker may not exist on first run */
+	pushhashtable(htemp);
+	hashdelete(bsopen, false, false);
+	hashdelete(bsclose, false, false);
+	hashdelete(bsinject, false, false);
+	pophashtable();
+
+	return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Install test hooks into system.callbacks.                         */
+/*                                                                     */
+/*  Compiles simple stub bodies and assigns them directly into the     */
+/*  system.callbacks table using the C hash table API.  This avoids   */
+/*  the script.newScriptObject dependency.                             */
+/* ------------------------------------------------------------------ */
+
+static hdlhashtable g_hcallbacks = nil;
+
+static boolean install_test_hooks(void) {
+	bigstring bsopen, bsclose;
+
+	if (g_hcallbacks == nil) {
+		printf("[test] install_test_hooks: g_hcallbacks is nil -- setup failed\n");
+		return false;
+	}
+
+	copyctopstring("openWindow", bsopen);
+	copyctopstring("closeWindow", bsclose);
+
+	/*
+	 * The bridge calls system.callbacks.openWindow("path") and
+	 * system.callbacks.closeWindow("path") passing the window path as
+	 * a string argument.  The stubs must declare a parameter to accept it;
+	 * otherwise the runtime raises "too many parameters".
+	 */
+	if (!assign_compiled_stub(g_hcallbacks, bsopen,
+	        "on openWindow(name) {system.temp.phasec_open_marker = true; return(true)}"))
+		return false;
+
+	if (!assign_compiled_stub(g_hcallbacks, bsclose,
+	        "on closeWindow(title) {system.temp.phasec_close_marker = true; return(true)}"))
+		return false;
+
+	return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Remove test hooks so subsequent tests see a clean callbacks table. */
+/*  Uses C-side hashdelete for same reason as clear_markers.          */
+/* ------------------------------------------------------------------ */
+
+static boolean remove_test_hooks(void) {
+	bigstring bsopen, bsclose;
+
+	if (g_hcallbacks == nil)
+		return true;
+
+	copyctopstring("openWindow", bsopen);
+	copyctopstring("closeWindow", bsclose);
+
+	pushhashtable(g_hcallbacks);
+	hashdelete(bsopen, false, false);
+	hashdelete(bsclose, false, false);
+	pophashtable();
+
+	return true;
+}
+
+/* ================================================================== */
+/*  Test 1: firing idopenwindowscript sets the open marker            */
+/* ================================================================== */
+
+static bool test_openwindow_fires_script(void) {
+	g_test_stats.current_test_name = "on_frontmost_changed(nil, window) fires idopenwindowscript";
+
+	clear_markers();
+	install_test_hooks();
+
+	/* Fire the bridge: nil -> test window (simulates REPL boot) */
+	on_frontmost_changed(nil, WINDOW_BRIDGE_REPL_PATH);
+
+	/* Check that the open marker was set by the stub */
+	bigstring bsresult;
+	run_expr(
+		"if defined(system.temp.phasec_open_marker) {\"set\"} else {\"(not set)\"}",
+		bsresult);
+	TEST_ASSERT(!bs_equals(bsresult, "(not set)"),
+		"system.temp.phasec_open_marker must have been set by idopenwindowscript");
+
+	remove_test_hooks();
+	clear_markers();
+	TEST_PASS("on_frontmost_changed(nil, window) fires idopenwindowscript");
+}
+
+/* ================================================================== */
+/*  Test 2: firing idclosewindowscript sets the close marker          */
+/* ================================================================== */
+
+static bool test_closewindow_fires_script(void) {
+	g_test_stats.current_test_name = "on_frontmost_changed(window, nil) fires idclosewindowscript";
+
+	clear_markers();
+	install_test_hooks();
+
+	/* Fire the bridge: test window -> nil (window closing) */
+	on_frontmost_changed(WINDOW_BRIDGE_REPL_PATH, nil);
+
+	bigstring bsresult;
+	run_expr(
+		"if defined(system.temp.phasec_close_marker) {\"set\"} else {\"(not set)\"}",
+		bsresult);
+	TEST_ASSERT(!bs_equals(bsresult, "(not set)"),
+		"system.temp.phasec_close_marker must have been set by idclosewindowscript");
+
+	remove_test_hooks();
+	clear_markers();
+	TEST_PASS("on_frontmost_changed(window, nil) fires idclosewindowscript");
+}
+
+/* ================================================================== */
+/*  Test 3: nil -> nil is a no-op (no markers set)                   */
+/* ================================================================== */
+
+static bool test_nil_to_nil_noop(void) {
+	g_test_stats.current_test_name = "on_frontmost_changed(nil, nil) is a no-op";
+
+	clear_markers();
+	install_test_hooks();
+
+	on_frontmost_changed(nil, nil);
+
+	bigstring bsresult;
+	run_expr(
+		"if defined(system.temp.phasec_open_marker) {\"set\"} else {\"(not set)\"}",
+		bsresult);
+	TEST_ASSERT(bs_equals(bsresult, "(not set)"),
+		"nil->nil must NOT set open marker");
+
+	run_expr(
+		"if defined(system.temp.phasec_close_marker) {\"set\"} else {\"(not set)\"}",
+		bsresult);
+	TEST_ASSERT(bs_equals(bsresult, "(not set)"),
+		"nil->nil must NOT set close marker");
+
+	remove_test_hooks();
+	TEST_PASS("on_frontmost_changed(nil, nil) is a no-op");
+}
+
+/* ================================================================== */
+/*  Test 4: same window -> same window does not double-fire           */
+/* ================================================================== */
+
+static bool test_same_window_no_double_fire(void) {
+	g_test_stats.current_test_name = "on_frontmost_changed(same, same) does not double-fire";
+
+	clear_markers();
+	install_test_hooks();
+
+	/* fire same -> same */
+	on_frontmost_changed(WINDOW_BRIDGE_REPL_PATH, WINDOW_BRIDGE_REPL_PATH);
+
+	bigstring bsresult;
+	run_expr(
+		"if defined(system.temp.phasec_open_marker) {\"set\"} else {\"(not set)\"}",
+		bsresult);
+	TEST_ASSERT(bs_equals(bsresult, "(not set)"),
+		"same->same must fire openWindow ZERO times (open marker must be not set)");
+
+	remove_test_hooks();
+	clear_markers();
+	TEST_PASS("on_frontmost_changed(same, same) does not double-fire");
+}
+
+/* ================================================================== */
+/*  Test 5: injection-attempt path does not execute injected code     */
+/* ================================================================== */
+
+static bool test_injection_attempt_is_safe(void) {
+	g_test_stats.current_test_name = "Injection-attempt window path is safely escaped";
+
+	clear_markers();
+	install_test_hooks();
+
+	/*
+	 * A window path designed to break out of the string parameter and inject
+	 * a second UserTalk statement.
+	 *
+	 * Without langdeparsestring escaping, this path would produce the script:
+	 *   system.callbacks.openWindow("evil");system.temp.phasec_inject_marker=true;(")
+	 *
+	 * With proper escaping, the embedded quote is doubled so the injected code
+	 * is never parsed as a separate statement.
+	 */
+	const char *evil_path =
+		"evil\");system.temp.phasec_inject_marker=true;(\"";
+
+	on_frontmost_changed(nil, evil_path);
+
+	bigstring bsresult;
+	run_expr(
+		"if defined(system.temp.phasec_inject_marker) {\"INJECTED\"} else {\"safe\"}",
+		bsresult);
+	TEST_ASSERT(bs_equals(bsresult, "safe"),
+		"Injected code must NOT execute; langdeparsestring must double the embedded quote");
+
+	remove_test_hooks();
+	clear_markers();
+	TEST_PASS("Injection-attempt window path is safely escaped");
+}
+
+/* ================================================================== */
+/*  Suite registration                                                 */
+/* ================================================================== */
+
+static test_case_t test_cases[] = {
+	{"openwindow fires script",       test_openwindow_fires_script},
+	{"closewindow fires script",      test_closewindow_fires_script},
+	{"nil to nil is noop",            test_nil_to_nil_noop},
+	{"same window no double fire",    test_same_window_no_double_fire},
+	{"injection attempt is safe",     test_injection_attempt_is_safe},
+};
+
+int main(void) {
+	TR_INIT("test_window_bridge");
+	printf("=== Phase C Window-Event Callback Bridge Tests ===\n");
+	log_init();
+
+	/*
+	 * Full runtime init: db_format_prepare_runtime() handles the complete
+	 * sequence (initmemory, initstrings, initlang, inittablestructure,
+	 * langinitresources_headless, langinitverbs, linksystemtablestructure).
+	 * After this call, roottable has system.temp available and all verb
+	 * handlers are registered.
+	 */
+	if (!db_format_prepare_runtime()) {
+		printf("FATAL: db_format_prepare_runtime() failed -- cannot run bridge tests\n");
+		return 1;
+	}
+
+	/*
+	 * Create system.callbacks table using the C-side API.
+	 *
+	 * system.temp is already created by linksystemtablestructure inside
+	 * db_format_prepare_runtime (it calls checktable on the system branch).
+	 * system.callbacks is NOT created by that path, so we create it here
+	 * using tablenewsystemtable (which marks it as not-saved, matching the
+	 * ephemeral semantics of a headless-only callbacks table).
+	 *
+	 * Path: roottable -> "system" -> create "callbacks"
+	 */
+	{
+		bigstring bssystem, bscallbacks;
+		hdlhashtable hsystem;
+
+		copyctopstring("system", bssystem);
+		copyctopstring("callbacks", bscallbacks);
+
+		/* Navigate to system sub-table (created by inittablestructure path) */
+		if (!findnamedtable(roottable, bssystem, &hsystem)) {
+			printf("FATAL: system table not found in roottable -- cannot run bridge tests\n");
+			return 1;
+		}
+
+		/* Create system.callbacks if it doesn't already exist */
+		if (!findnamedtable(hsystem, bscallbacks, &g_hcallbacks)) {
+			if (!tablenewsystemtable(hsystem, bscallbacks, &g_hcallbacks)) {
+				printf("FATAL: tablenewsystemtable(system.callbacks) failed -- cannot run bridge tests\n");
+				return 1;
+			}
+		}
+	}
+
+	test_init();
+	bool all_passed = run_test_suite(test_cases, sizeof(test_cases) / sizeof(test_cases[0]));
+	test_summary();
+	if (tr_count < TR_MAX_TESTS) {
+		tr_results[tr_count].name = "run_test_suite";
+		tr_results[tr_count].passed = (all_passed ? 1 : 0);
+		tr_count++;
+		if (all_passed) tr_pass_count++; else tr_fail_count++;
+	}
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}

--- a/tests/test_window_bridge.c
+++ b/tests/test_window_bridge.c
@@ -351,7 +351,7 @@ static bool test_injection_attempt_is_safe(void) {
 		"if defined(system.temp.phasec_inject_marker) {\"INJECTED\"} else {\"safe\"}",
 		bsresult);
 	TEST_ASSERT(bs_equals(bsresult, "safe"),
-		"Injected code must NOT execute; langdeparsestring must double the embedded quote");
+		"Injected code must NOT execute; langdeparsestring must backslash-escape the embedded quote");
 
 	remove_test_hooks();
 	clear_markers();

--- a/usertalk_scripts/Frontier.root/system/verbs/builtins/Frontier/tools/data/windowTypes/ReplWindow/openWindow.ut
+++ b/usertalk_scripts/Frontier.root/system/verbs/builtins/Frontier/tools/data/windowTypes/ReplWindow/openWindow.ut
@@ -1,0 +1,8 @@
+on openWindow (adr) {
+	//Phase C: REPL window opened event.
+	//The windowTypes framework calls this after finding "ReplWindow" as the
+	//window type. In Phase D, window.attributes.getOne will be implemented
+	//and this handler will configure the REPL window (set title, compose
+	//menus via the menuTypes framework).
+	//For now, return true to signal successful handling.
+	return (true)}


### PR DESCRIPTION
## Summary

Phase C of `docs/MENU_PORT_PLAN.md`: the C-side bridge that fires `idopenwindowscript` / `idclosewindowscript` when the REPL "frontmost window" changes, so the existing UserTalk windowTypes framework at `system.verbs.builtins.Frontier.tools.windowTypes/` receives window-focus-change events at REPL boot.

- **`frontier-cli/window_registry.c` + `window_registry.h`**: `window_registry_init()` creates `system.temp.windowTypes.windows.repl` with `type="ReplWindow"`. `on_frontmost_changed(old, new)` fires `idclosewindowscript` / `idopenwindowscript` via `getsystemtablescript -> langdeparsestring(bs, ASCII-DQ) -> parsedialogstring -> langrunstringnoerror`.
- **`frontier-cli/repl.c`**: boot step 3.3 calls `window_registry_init()` then `on_frontmost_changed(nil, WINDOW_BRIDGE_REPL_PATH)` after `install_repl_menubar()`.
- **`databases/Virgin.root` + `usertalk_scripts/.../ReplWindow/openWindow.ut`**: installs `Frontier.tools.data.windowTypes.ReplWindow` so `findWindowType("ReplWindow")` returns true.
- **`tests/test_window_bridge.c`**: 5 behavioral tests (open fires, close fires, nil+nil noop, same-path no double-fire, injection attempt safe). Uses C-side `langcompiletext+hashtableassign` stubs - no `script.newScriptObject` dependency on full Frontier.root.

**Escaping correction** (issue #682): original spec said use `chclosecurlyquote` (0xD3). The script templates use straight ASCII `"` as string delimiters. `langdeparsestring(bs, 0xD3)` does NOT escape ASCII `"` (0x22) - it only escapes the Mac curly-quote (0xD3). Fixed to `langdeparsestring(bs_path, '"')`. Without this fix, test 5 (injection attempt) fails because embedded `"` breaks out of the string literal.

**Phase D pre-work signal**: `window.attributes.getOne("type", adr)` is NOT implemented in headless. The windowTypes framework's `callbacks/openWindow.ut` gracefully returns true when this fails (skips the if-body). Full ReplWindow menu composition via the framework is blocked until Phase D implements `window.attributes.*`.

## Test plan

- [x] `tests/test_window_bridge.c` - 5 behavioral tests, all GREEN
- [x] Unit suite: 491 -> 492 tests (1 new suite, 5 new tests), 492/492 pass
- [x] Integration suite: html/tcp failures are pre-existing (same on develop base, confirmed before this PR); repl_sessions and repl_commands are cleaner on this branch than on develop
- [x] CLI builds clean: `make -C frontier-cli`
- [x] `tools/verify_virgin_root_sync.sh` confirms ReplWindow/openWindow.ut syncs with Virgin.root

🤖 Generated with [Claude Code](https://claude.com/claude-code)
