### PR TITLE
fix(palette): cursor-anchored horizontal scroll for overflowing dropdowns

### DIFF
--- a/frontier-cli/palette.c
+++ b/frontier-cli/palette.c
@@ -229,6 +229,15 @@ static void ensure_cursor_visible(palette_level_t *lvl, int strip_w) {
 		lvl->hscroll = item_right - (strip_w - right_margin);
 	}
 
+	/* Reconcile when the item is wider than the visible window: the
+	 * right-edge branch above may have scrolled far enough to reveal the
+	 * item's tail while pushing its head (and hotkey letter) off-screen.
+	 * An over-wide item cannot fit either way, so prefer showing its head
+	 * -- anchor the left edge -- rather than a headless middle slice. */
+	if (item_lx - lvl->hscroll < left_margin) {
+		lvl->hscroll = item_lx - left_margin;
+	}
+
 	/* Clamp: never scroll past the content's end, never below zero. */
 	int max_scroll = content_w - strip_w;
 	if (max_scroll < 0) max_scroll = 0;
@@ -856,6 +865,23 @@ palette_done_t palette_feed_mouse(palette_state_t *st, const mouse_event_t *ev) 
 		palette_level_t *lvl = &st->levels[d];
 		pane_t *p = &lvl->pane;
 		if (my != p->y) continue;
+		/* Edge indicators are scroll affordances, not items.  render_level
+		 * draws '<' at col 0 when scrolled off the left and '>' at the last
+		 * col when content extends past the right.  A click there must NOT
+		 * fall through to the item hit-test below: the cell under the
+		 * indicator maps (via content-x = screen-x + hscroll) to a real but
+		 * visually-occluded item, so without this guard clicking '<' would
+		 * silently fire a hidden command.  Instead, step the cursor toward
+		 * the off-screen side, which scrolls the strip in that direction. */
+		int content_w = level_content_width(lvl);
+		if (mx == 0 && lvl->hscroll > 0) {
+			cursor_step(st, -1);
+			return PALETTE_DONE_NONE;
+		}
+		if (mx == p->w - 1 && content_w - lvl->hscroll > p->w) {
+			cursor_step(st, +1);
+			return PALETTE_DONE_NONE;
+		}
 		/* Convert the screen click to content space: the strip is shifted
 		 * left by hscroll, so content-x = screen-x + hscroll. */
 		int cx = mx + lvl->hscroll;

--- a/frontier-cli/palette.c
+++ b/frontier-cli/palette.c
@@ -190,6 +190,52 @@ static int item_screen_x(const palette_level_t *lvl, int i) {
 	return x;
 }
 
+/* Total laid-out width of a level's strip in cells (lead-in + all items +
+ * inter-item separators), before any horizontal scroll is applied. */
+static int level_content_width(const palette_level_t *lvl) {
+	if (lvl->item_count <= 0) return 0;
+	int last = lvl->item_count - 1;
+	return item_screen_x(lvl, last) + item_cell_width(&lvl->items[last]);
+}
+
+/* Adjust lvl->hscroll so the cursor item is fully visible within a strip
+ * `strip_w` cells wide.  Reserves one cell on each overflowing edge for the
+ * '<' / '>' indicators so the indicator never hides part of the item.  Also
+ * clamps hscroll so the strip never scrolls past its content. */
+static void ensure_cursor_visible(palette_level_t *lvl, int strip_w) {
+	if (lvl->item_count <= 0 || strip_w <= 0) {
+		lvl->hscroll = 0;
+		return;
+	}
+	int c = lvl->cursor;
+	if (c < 0 || c >= lvl->item_count) return;
+
+	int item_lx = item_screen_x(lvl, c);
+	int item_w = item_cell_width(&lvl->items[c]);
+	int content_w = level_content_width(lvl);
+
+	/* Left edge: if the item starts before the visible window, scroll left.
+	 * Reserve a cell for the '<' indicator when not at the very start. */
+	int left_margin = (item_lx > 0) ? 1 : 0;
+	if (item_lx - lvl->hscroll < left_margin) {
+		lvl->hscroll = item_lx - left_margin;
+	}
+
+	/* Right edge: if the item ends past the visible window, scroll right.
+	 * Reserve a cell for the '>' indicator when content extends past it. */
+	int right_margin = ((item_lx + item_w) < content_w) ? 1 : 0;
+	int item_right = item_lx + item_w;
+	if (item_right - lvl->hscroll > strip_w - right_margin) {
+		lvl->hscroll = item_right - (strip_w - right_margin);
+	}
+
+	/* Clamp: never scroll past the content's end, never below zero. */
+	int max_scroll = content_w - strip_w;
+	if (max_scroll < 0) max_scroll = 0;
+	if (lvl->hscroll > max_scroll) lvl->hscroll = max_scroll;
+	if (lvl->hscroll < 0) lvl->hscroll = 0;
+}
+
 /* Render the menubar pane.  Menubar entries do not use the
  * bracket-reservation scheme -- they only render " Label " around each
  * label.  The selected entry is INVERSE; the hotkey letter inside each
@@ -233,11 +279,29 @@ static void render_menubar(palette_state_t *st) {
 
 /* Render one cascade level as a single-row horizontal strip.  Pane is
  * full-width, height 1.  Items are stamped left-to-right with bracket
- * reservation so neighbour cells stay put as selection moves. */
+ * reservation so neighbour cells stay put as selection moves.  The whole
+ * strip is shifted left by lvl->hscroll cells so the cursor item stays
+ * visible when the content overflows the terminal width; '<' / '>' edge
+ * indicators are drawn when items remain off-screen in either direction. */
+
+/* Place a glyph at content-x `cx` shifted by hscroll, clipped to the pane.
+ * Cells that scroll off either edge are simply dropped. */
+static void strip_putc(pane_t *p, int cx, int hscroll, uint32_t ch,
+                       uint8_t fg, uint8_t bg, uint8_t attr) {
+	int sx = cx - hscroll;
+	if (sx < 0 || sx >= p->w) return;
+	pane_putc_color(p, sx, 0, ch, fg, bg, attr);
+}
+
 static void render_level(palette_state_t *st, int depth) {
 	palette_level_t *lvl = &st->levels[depth];
 	pane_t *p = &lvl->pane;
 	pane_clear(p);
+
+	/* Keep hscroll in sync with the current cursor/pane width even when this
+	 * render was not triggered by a cursor_step (e.g. resize, first open). */
+	ensure_cursor_visible(lvl, p->w);
+	int hs = lvl->hscroll;
 
 	/* Background fill for the whole strip. */
 	for (int x = 0; x < p->w; ++x) {
@@ -254,18 +318,18 @@ static void render_level(palette_state_t *st, int depth) {
 		if (!it->enabled) base |= PALETTE_ATTR_DIM;
 
 		int lx = item_screen_x(lvl, i);
-		if (lx >= p->w) break;       /* overflow: stop, no pagination yet */
 		int total_w = item_cell_width(it);
-		/* Truncation: if this item would run past the strip's right edge
-		 * just stop here.  Pagination is a follow-up. */
-		if (lx + total_w > p->w) break;
+		/* Skip items entirely off either edge of the visible window; partial
+		 * items are clipped per-cell by strip_putc. */
+		if (lx + total_w - hs <= 0) continue;
+		if (lx - hs >= p->w) break;
 
 		/* Separator: a single dim divider glyph, never selected, never the
 		 * cursor (cursor_step skips it). It is always disabled, so it draws
 		 * dim regardless of the `selected` math above. */
 		if (it->is_separator) {
-			pane_putc_color(p, lx, 0, PALETTE_SEP_GLYPH,
-			                PT_FG_DISABLED, PT_BG_MENUBAR, PALETTE_ATTR_DIM);
+			strip_putc(p, lx, hs, PALETTE_SEP_GLYPH,
+			           PT_FG_DISABLED, PT_BG_MENUBAR, PALETTE_ATTR_DIM);
 			continue;
 		}
 
@@ -275,13 +339,13 @@ static void render_level(palette_state_t *st, int depth) {
 		int label_x = lx + 2 + (it->checked ? PALETTE_CHECK_CELLS : 0);
 
 		/* Cell 0: opening bracket (space when not selected). */
-		pane_putc_color(p, lx, 0, selected ? '[' : ' ', fg, bg, base);
+		strip_putc(p, lx, hs, selected ? '[' : ' ', fg, bg, base);
 		/* Cell 1: leading space. */
-		pane_putc_color(p, lx + 1, 0, ' ', fg, bg, base);
+		strip_putc(p, lx + 1, hs, ' ', fg, bg, base);
 		/* Checkmark glyph + trailing space (only when checked). */
 		if (it->checked) {
-			pane_putc_color(p, lx + 2, 0, PALETTE_CHECK_GLYPH, fg, bg, base);
-			pane_putc_color(p, lx + 3, 0, ' ', fg, bg, base);
+			strip_putc(p, lx + 2, hs, PALETTE_CHECK_GLYPH, fg, bg, base);
+			strip_putc(p, lx + 3, hs, ' ', fg, bg, base);
 		}
 		/* Label, with hotkey letter styling. */
 		char hk = it->shortcut;
@@ -295,14 +359,27 @@ static void render_level(palette_state_t *st, int depth) {
 				if (!selected && it->enabled) cell_fg = PT_FG_HOTKEY;
 				hk_seen = true;
 			}
-			pane_putc_color(p, label_x + k, 0,
-			                (uint32_t)(unsigned char)ch, cell_fg, bg, a);
+			strip_putc(p, label_x + k, hs,
+			           (uint32_t)(unsigned char)ch, cell_fg, bg, a);
 		}
 		/* Trailing space. */
-		pane_putc_color(p, label_x + label_len, 0, ' ', fg, bg, base);
+		strip_putc(p, label_x + label_len, hs, ' ', fg, bg, base);
 		/* Closing bracket (space when not selected). */
-		pane_putc_color(p, label_x + label_len + 1, 0,
-		                selected ? ']' : ' ', fg, bg, base);
+		strip_putc(p, label_x + label_len + 1, hs,
+		           selected ? ']' : ' ', fg, bg, base);
+	}
+
+	/* Edge indicators: '<' when content is scrolled off the left, '>' when
+	 * content extends past the right edge.  Drawn last so they sit on top of
+	 * any partially clipped item cell. */
+	int content_w = level_content_width(lvl);
+	if (hs > 0) {
+		pane_putc_color(p, 0, 0, '<', PT_FG_HOTKEY, PT_BG_MENUBAR,
+		                PALETTE_ATTR_BOLD);
+	}
+	if (content_w - hs > p->w) {
+		pane_putc_color(p, p->w - 1, 0, '>', PT_FG_HOTKEY, PT_BG_MENUBAR,
+		                PALETTE_ATTR_BOLD);
 	}
 }
 
@@ -585,6 +662,7 @@ static void cursor_step(palette_state_t *st, int delta) {
 		c = next;
 	}
 	lvl->cursor = c;
+	ensure_cursor_visible(lvl, lvl->pane.w);
 }
 
 /* Process a CSI terminator.  csi_buf holds the bytes between '[' and
@@ -778,6 +856,9 @@ palette_done_t palette_feed_mouse(palette_state_t *st, const mouse_event_t *ev) 
 		palette_level_t *lvl = &st->levels[d];
 		pane_t *p = &lvl->pane;
 		if (my != p->y) continue;
+		/* Convert the screen click to content space: the strip is shifted
+		 * left by hscroll, so content-x = screen-x + hscroll. */
+		int cx = mx + lvl->hscroll;
 		/* Find which item the click landed on. */
 		for (int i = 0; i < lvl->item_count; ++i) {
 			int lx = item_screen_x(lvl, i);
@@ -786,10 +867,11 @@ palette_done_t palette_feed_mouse(palette_state_t *st, const mouse_event_t *ev) 
 			 * nothing rather than selecting a phantom item. */
 			if (lvl->items[i].is_separator)
 				continue;
-			if (mx >= lx && mx < lx + total_w) {
+			if (cx >= lx && cx < lx + total_w) {
 				/* Collapse any deeper levels first. */
 				while (st->open_depth - 1 > d) close_deepest_level(st);
 				lvl->cursor = i;
+				ensure_cursor_visible(lvl, p->w);
 				return activate_cursor_item(st);
 			}
 		}

--- a/frontier-cli/palette.h
+++ b/frontier-cli/palette.h
@@ -283,6 +283,11 @@ typedef struct palette_level {
 	 * visible[scroll_top]. Adjusted automatically when cursor moves
 	 * outside the visible window or by explicit page/wheel scrolls. */
 	int scroll_top;
+	/* Horizontal scroll offset in cells for the single-row cascade strip.
+	 * The strip is drawn shifted left by `hscroll` columns so an item that
+	 * would otherwise overflow the right edge stays visible. Adjusted
+	 * automatically when the cursor moves outside the visible window. */
+	int hscroll;
 } palette_level_t;
 
 /* Palette state. The whole struct is value-typed (no internal mallocs

--- a/tests/fixtures/palette/dropdown_wide_scrolled.txt
+++ b/tests/fixtures/palette/dropdown_wide_scrolled.txt
@@ -1,0 +1,22 @@
+Type /help for commands, /exit to quit
+
+[root]> menu.addMenuCommand(@system.menus.data.aaedit, "Edit", "Find", "noop()")
+
+true
+[root]> menu.addMenuCommand(@system.menus.data.aaedit, "Edit", "Find Next", "noo
+p()")
+true
+[root]> menu.addMenuCommand(@system.menus.data.aaedit, "Edit", "Replace", "noop(
+)")
+true
+[root]> menu.addMenuCommand(@system.menus.data.aaedit, "Edit", "Replace and Find
+ Next", "noop()")
+true
+[root]> menu.addMenuCommand(@system.menus.data.aaedit, "Edit", "Insert Date/Time
+", "noop()")
+true
+[root]> menu.install(@system.menus.data.aaedit)
+true
+ Edit  File  Edit  View  REPL
+<      Find Next      Replace      Replace and Find Next    [ Insert Date/Time ]
+[root]> /

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -802,6 +802,17 @@ class FrontierCLI:
                         screenshot_failures.append(err or 'screenshot mismatch')
                     continue
 
+                # {'delay': <seconds>} -- pause between steps. Used to space
+                # out palette keystrokes so each escape sequence is fully
+                # processed (and rendered) before the next arrives. The
+                # palette modal's ESC parser uses a 1ms fast-timer under
+                # FRONTIER_PALETTE_FAST_TIMERS=1, so back-to-back arrow
+                # sequences can race the parser; a small inter-keystroke
+                # delay lets the modal's poll loop drain + redraw between
+                # them. May be combined with a send_raw in the same step
+                # (delay runs AFTER the send).
+                delay = step.get('delay')
+
                 expect_pattern = step.get('expect')
                 send_text = step.get('send')
                 send_raw = step.get('send_raw')
@@ -824,6 +835,27 @@ class FrontierCLI:
                     child.send(send_raw)
                 elif send_text is not None:
                     child.sendline(send_text)
+
+                # Honor an explicit inter-step delay (after any send): SLEEP
+                # first so the palette modal's poll loop (10ms period) has
+                # time to consume the keystroke and emit its redraw, THEN
+                # drain the pty so that redraw reaches pyte. Order matters --
+                # draining before the modal has rendered would capture a stale
+                # frame and the post-keystroke redraw would back up unread
+                # until the next screenshot_match. The harness otherwise only
+                # reads the pty at screenshot_match steps, so without this the
+                # final captured frame shows the menubar but not the
+                # drilled-in dropdown (the navigation redraws were never read).
+                # Draining here keeps the pyte framebuffer current
+                # step-by-step, mirroring a real terminal that paints
+                # continuously.
+                if delay is not None:
+                    import time as _time
+                    _time.sleep(float(delay))
+                    pending = drain_pty(child)
+                    if pending:
+                        collected_output.append(pending)
+                        stream.feed(pending)
 
             # Drain any final output.
             try:

--- a/tests/integration/test_cases/repl_palette_wide_dropdown.yaml
+++ b/tests/integration/test_cases/repl_palette_wide_dropdown.yaml
@@ -1,0 +1,142 @@
+# L4 integration test: wide-dropdown horizontal scroll (Issue #677 follow-up)
+#
+# What this file proves
+# ---------------------
+# When an opened dropdown's items overflow the terminal width, arrowing the
+# cursor to an item that would otherwise be clipped past the right edge
+# scrolls the strip horizontally so the cursor item stays visible, and a
+# '<' edge indicator appears once the strip has scrolled off its left edge.
+#
+# This is the end-to-end guard for the cursor-anchored horizontal scroll in
+# render_level (palette.c). Before the fix, render_level truncated any item
+# whose laid-out cells ran past p->w with `if (lx + total_w > p->w) break;`
+# and the last item ("Insert Date/Time") was silently dropped -- the live
+# dist menu rendered incomplete. The unit test
+# (palette_render_snapshot_tests.c::test_wide_menu_keeps_cursor_item_visible)
+# covers the synthetic-source render math; this file proves it holds through
+# the full ODB -> repl_palette_source -> palette modal stack driven over a
+# real PTY.
+#
+# Setup
+# -----
+# 1. Build a bar "aaedit" (sorts before the boot "repl" bar, so it is the
+#    leftmost menubar entry -> menu index 0) with one menu "Edit" holding
+#    five wide items whose combined cell widths overflow an 80-col strip:
+#      Find | Find Next | Replace | Replace and Find Next | Insert Date/Time
+# 2. Install it, open the palette with the '//' fast-path.
+# 3. DOWN opens the leftmost (Edit) dropdown; RIGHT x4 walks the cursor to
+#    the last item, forcing a horizontal scroll.
+# 4. screenshot_match against a golden that shows the scrolled strip: the
+#    cursor item "Insert Date/Time" is fully visible and a '<' indicator
+#    sits at the left edge.
+# 5. Cleanup: delete the transient bar so other tests see a clean ODB.
+#
+# pyte note: the captured frame is plain text (SGR attrs are dropped), so
+# the golden locks in the *text* layout -- the presence of "Insert
+# Date/Time" and the '<' indicator, and the absence of the now-scrolled-off
+# leftmost items -- which is exactly what the truncation bug got wrong.
+#
+# Sequential because we mutate system.menus.data (process-global ODB state).
+
+needs_guest_dbs: false
+sequential: true
+
+tests:
+  - name: "palette wide dropdown: overflow scrolls to keep cursor item visible"
+    palette_mode: true
+    timeout: 20
+    environment:
+      FRONTIER_PALETTE_PROMPT_ROW: "20"
+      # Disable the 1ms ESC fast-timer for this test. The harness sets
+      # FRONTIER_PALETTE_FAST_TIMERS=1 globally, which collapses the
+      # bare-ESC-vs-CSI disambiguation window to 1ms. When pexpect delivers
+      # an arrow sequence ("\x1b[B") with the ESC byte and the "[B" in
+      # separate PTY reads, a 1ms window can expire between them -- the modal
+      # then treats the ESC as a lone-ESC DISMISS, closing the palette and
+      # leaking the "[B" to the REPL. An empty value falls through
+      # palette_esc_timeout_ms() to the 10ms default, wide enough for the
+      # rest of the CSI sequence to arrive. The "//" double-slash fast-path
+      # opens the menu immediately regardless of the (now 350ms) slash
+      # disambiguation timer, so navigation timing is unaffected.
+      FRONTIER_PALETTE_FAST_TIMERS: ""
+    interactive_steps:
+      # Step 1: Wait for the REPL prompt after boot.
+      - expect: "\\[root\\]> "
+
+      # Step 2: Build the wide Edit menu on bar "aaedit".
+      - send_raw: "menu.addMenuCommand(@system.menus.data.aaedit, \"Edit\", \"Find\", \"noop()\")\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+      - send_raw: "menu.addMenuCommand(@system.menus.data.aaedit, \"Edit\", \"Find Next\", \"noop()\")\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+      - send_raw: "menu.addMenuCommand(@system.menus.data.aaedit, \"Edit\", \"Replace\", \"noop()\")\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+      - send_raw: "menu.addMenuCommand(@system.menus.data.aaedit, \"Edit\", \"Replace and Find Next\", \"noop()\")\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+      - send_raw: "menu.addMenuCommand(@system.menus.data.aaedit, \"Edit\", \"Insert Date/Time\", \"noop()\")\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+
+      # Step 3: Install the bar and confirm.
+      - send_raw: "menu.install(@system.menus.data.aaedit)\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+      - send_raw: "menu.isInstalled(@system.menus.data.aaedit)\r"
+      - expect: "true"
+      - expect: "\\[root\\]> "
+
+      # Step 4: Open the palette (fast-path). "aaedit" sorts before "repl",
+      # so menubar entry 0 is Edit. The trailing delay lets the modal's read
+      # loop fully take over linenoise before we start arrowing.
+      - send_raw: "//"
+        delay: 0.3
+
+      # Step 5: DOWN opens the Edit dropdown; RIGHT x4 walks to the last item.
+      # Each arrow is its own step with a delay AFTER it: the palette modal's
+      # ESC parser runs a 1ms fast-timer (FRONTIER_PALETTE_FAST_TIMERS=1), so
+      # the bytes of one escape sequence must arrive together (they do, in a
+      # single send) but consecutive sequences must be spaced out -- otherwise
+      # the modal's poll loop hasn't finished parsing + redrawing the previous
+      # arrow before the next arrives, and the navigation desyncs. 80ms per
+      # keystroke is comfortably above the 10ms poll period.
+      - send_raw: "\x1b[B"
+        delay: 0.3
+      - send_raw: "\x1b[C"
+        delay: 0.3
+      - send_raw: "\x1b[C"
+        delay: 0.3
+      - send_raw: "\x1b[C"
+        delay: 0.3
+      - send_raw: "\x1b[C"
+        delay: 0.3
+
+      # Step 6: Capture the scrolled strip. Golden must show "Insert
+      # Date/Time" (the cursor item, previously clipped) and the '<'
+      # left-edge indicator.
+      - screenshot_match: "fixtures/palette/dropdown_wide_scrolled.txt"
+
+      # Step 7: Dismiss the palette. ESC collapses ONE cascade level at a
+      # time (palette.c: bare ESC with open_depth>0 calls
+      # close_deepest_level; only open_depth==0 returns PALETTE_DONE_CANCEL).
+      # The dropdown is open (open_depth==1), so the first ESC collapses it
+      # back to the menubar and the second ESC dismisses the menubar and
+      # returns control to the REPL. A delay between them lets the modal's
+      # poll loop process each ESC (and clear esc_pending) before the next
+      # arrives. Without the second ESC the palette stays open at the
+      # menubar level, the following delete() leaks into the modal as
+      # keystrokes, no prompt returns, and the child is SIGHUP-killed at
+      # teardown (exit -1).
+      - send_raw: "\x1b"
+      - send_raw: "\x1b"
+      - expect: "\\[root\\]> "
+
+      # Step 8: Clean up the transient bar.
+      - send_raw: "delete(@system.menus.data.aaedit)\r"
+      - expect: "\\[root\\]> "
+
+      # Step 9: Exit.
+      - send_raw: "\x04"
+    expected_success: true

--- a/tests/palette_render_snapshot_tests.c
+++ b/tests/palette_render_snapshot_tests.c
@@ -502,6 +502,61 @@ static void test_cursor_skips_separator(void) {
 	palette_close(&st);
 }
 
+/* Fixture mirroring the real "Edit" menu that overflows an 80-col strip.
+ * Five wide items whose combined cell widths run past column 80, so the
+ * last item ("Insert Date/Time") is clipped by the pre-scroll renderer. */
+static snap_item_t g_wide_items[] = {
+	{ "Find",                  'F', true, false, false, false, "edit.find()",   NULL, 0 },
+	{ "Find Next",             'N', true, false, false, false, "edit.findn()",  NULL, 0 },
+	{ "Replace",               'R', true, false, false, false, "edit.repl()",   NULL, 0 },
+	{ "Replace and Find Next", 'a', true, false, false, false, "edit.replfn()", NULL, 0 },
+	{ "Insert Date/Time",      'I', true, false, false, false, "edit.date()",   NULL, 0 },
+};
+
+static snap_menu_t g_wide_menus[] = {
+	{ "Edit", 'E', g_wide_items, 5 },
+};
+
+static snap_source_t g_wide_src = { g_wide_menus, 1 };
+
+static void test_wide_menu_keeps_cursor_item_visible(void) {
+	/* When the cascade strip overflows the terminal width, arrowing the
+	 * cursor to the last (off-screen) item must scroll the row so that
+	 * item's label becomes visible.  Pre-scroll renderer clips anything
+	 * past p->w and silently drops it -- this test is RED until the
+	 * cursor-anchored horizontal scroll lands. */
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+	palette_state_t st;
+	palette_menu_source_t src = snap_source(&g_wide_src);
+	palette_open(&st, 24, 80, 0, &src);
+	palette_feed_byte(&st, '\r');           /* open Edit menu */
+
+	/* Step RIGHT to the last item (index 4). */
+	for (int i = 0; i < 4; ++i) {
+		palette_feed_byte(&st, 0x1b);
+		palette_feed_byte(&st, '[');
+		palette_feed_byte(&st, 'C');
+	}
+	assert(st.levels[0].cursor == 4);
+	render_all(&st);
+
+	int y = st.levels[0].pane.y;
+	cell_t row[80];
+	int n = snapshot_row(y, row, 80);
+	assert(n > 0);
+
+	/* The 'I' of "Insert Date/Time" (the cursor item) must be present on
+	 * the visible strip row. */
+	int col_i = -1;
+	for (int x = 0; x < n; ++x) {
+		if (row[x].ch == 'I') { col_i = x; break; }
+	}
+	assert(col_i >= 0 && "cursor item must be visible after horizontal scroll");
+
+	palette_close(&st);
+}
+
 static void test_menubar_hotkey_styling(void) {
 	/* On the menubar itself, the hotkey letter of a non-selected entry
 	 * is bright yellow on blue. */
@@ -541,6 +596,7 @@ int main(void) {
 	TR_RUN(test_checked_item_draws_check_glyph);
 	TR_RUN(test_separator_draws_dim_divider);
 	TR_RUN(test_cursor_skips_separator);
+	TR_RUN(test_wide_menu_keeps_cursor_item_visible);
 	TR_SUMMARY();
 	return TR_EXIT_CODE();
 }

--- a/tests/palette_render_snapshot_tests.c
+++ b/tests/palette_render_snapshot_tests.c
@@ -546,13 +546,42 @@ static void test_wide_menu_keeps_cursor_item_visible(void) {
 	int n = snapshot_row(y, row, 80);
 	assert(n > 0);
 
-	/* The 'I' of "Insert Date/Time" (the cursor item) must be present on
-	 * the visible strip row. */
-	int col_i = -1;
-	for (int x = 0; x < n; ++x) {
-		if (row[x].ch == 'I') { col_i = x; break; }
+	/* Flatten the row to ASCII so we can assert on substrings.  Non-ASCII
+	 * glyphs (the '<' indicator is ASCII; any wide glyphs are not present
+	 * here) collapse to '?', which never matches the labels we search for. */
+	char text[81];
+	for (int x = 0; x < n && x < 80; ++x) {
+		uint32_t ch = row[x].ch;
+		text[x] = (ch >= 0x20 && ch < 0x7f) ? (char)ch : '?';
 	}
-	assert(col_i >= 0 && "cursor item must be visible after horizontal scroll");
+	text[n < 80 ? n : 80] = '\0';
+
+	/* (a) The cursor item's full label must be contiguous on the strip --
+	 * not just an 'I' somewhere (the pre-fix bug dropped the whole item, and
+	 * a lone-glyph check is too weak to catch a partial render). */
+	assert(strstr(text, "Insert Date/Time") != NULL &&
+	       "cursor item must be fully visible after horizontal scroll");
+
+	/* (b) The '<' left-edge indicator must be present at column 0, proving
+	 * the strip actually scrolled (and signalling off-screen items left). */
+	assert(row[0].ch == (uint32_t)'<' &&
+	       "left-edge '<' indicator must mark the scrolled-off content");
+
+	/* (c) The leftmost item must have scrolled off.  With the cursor on the
+	 * rightmost item, the strip shifts left just far enough to reveal the
+	 * cursor item; item 0 ("Find") is the first to leave the window, so the
+	 * first label still visible is "Find Next".  The bare "Find" item label
+	 * is the prefix of "Find Next", so we cannot search for it directly;
+	 * instead assert the first non-blank glyph after the '<' indicator
+	 * begins the "Find Next" label, proving item 0 is gone. */
+	{
+		const char *first_label = text + 1;
+		while (*first_label == ' ')
+			first_label++;
+		assert(strncmp(first_label, "Find Next", 9) == 0 &&
+		       "after scroll the first visible item must be 'Find Next', "
+		       "with item 0 'Find' scrolled off");
+	}
 
 	palette_close(&st);
 }


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in the REPL palette dropdown renderer: wide
menus dropped their rightmost items. `render_level` truncated any dropdown
item whose laid-out cells ran past the strip width (`if (lx + total_w >
p->w) break;`), so the live dist Edit menu rendered incomplete.

Replaces truncation with a **cursor-anchored horizontal scroll**:
- The strip shifts left by `lvl->hscroll` so the cursor item stays fully visible.
- Partial items are clipped per-cell via `strip_putc`.
- `<` / `>` edge indicators are drawn when content remains off either edge.
- `ensure_cursor_visible` reserves a cell for each indicator and clamps so the strip never scrolls past its content.
- Mouse hit-testing maps screen-x to content-x via `hscroll`.

## Gate findings addressed (follow-up commit)

- **P1** -- edge-indicator clicks fired hidden commands. Clicking `<` / `>` mapped to an occluded item via `content-x = screen-x + hscroll` and silently dispatched it. Now a click on an indicator steps the cursor toward that side (scrolls), instead of firing a command.
- **P2** -- over-wide cursor item rendered headless. When an item is wider than the visible strip, the right-edge scroll could push the item's head and hotkey off-screen. Added a reconcile pass that anchors the item's left edge so it shows its head.
- **P2** -- strengthened the unit test from a lone-glyph check to a full-label + indicator + scrolled-off-neighbor assertion.

## Tests

- Unit: `palette_render_snapshot_tests` 11/11; full headless suite 509/509.
- Integration: `repl_palette_wide_dropdown.yaml` builds a 5-item wide Edit menu over a real PTY, arrows to the last item, and screenshot-matches the scrolled strip (`<` indicator + `Insert Date/Time` visible). Deterministic.
- `runner.py`: added a `delay` step (sleep-then-drain) so the harness reads the modal's per-keystroke redraws between navigation steps.

## Test plan

- [x] `cd tests && make palette_render_snapshot_tests && ./palette_render_snapshot_tests` -> 11/11
- [x] `./tools/run_headless_tests.sh` -> 509/509
- [x] `./tools/run_integration_tests.sh tests/integration/test_cases/repl_palette_wide_dropdown.yaml` -> pass
- [ ] live dist verification: Edit menu shows all 5 items, scroll + indicators behave

Note: the (#677) reference in commits is the originating issue thread; that issue tracks the broader host-menubar work and is closed.

Generated with Claude Code
