### PR TITLE
fix(ut-sync): lossless path encoding + import-discovery scan + security hardening (#699)

### DIFF
--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -94,6 +94,7 @@ _Static_assert(sizeof(tydisksymbolrecord_v7) == 16, "tydisksymbolrecord_v7 must 
 _Static_assert(offsetof(tydisksymbolrecord_v7, data) == 8, "tydisksymbolrecord_v7.data offset must be 8");
 #endif
 #if defined(FRONTIER_HEADLESS)
+#include "../../frontier-cli/ut_sync.h" /* ut_pct_encode_segment for ODB path encoding */
 #include "../portable/wptext_portable.h"
 #include <stdio.h>
 #include <errno.h>
@@ -259,24 +260,48 @@ static boolean langhash_materialize_table_internal(hdlhashtable htable, const ch
 		const char *prior_path = langhash_materialize_current_path;
 
 		gethashkey(nomad, bsname);
-			size_t need = (size_t) bsname[0] + 1; /* name + dot/null */
+			/*
+			 * Percent-encode the raw segment name. Worst case: each byte of
+			 * a max-length Pascal string (255 bytes) encodes to 3 chars, plus
+			 * the NUL. 255*3 + 1 = 766. nodepath is 512, so a single very long
+			 * encoded segment may legitimately overflow -- that is a safe fail.
+			 */
+			{
+			char encoded_seg[766]; /* 255 * 3 + 1 -- max encoded Pascal name */
+			size_t encoded_len;
+			size_t need;
+
+			if (!ut_pct_encode_segment((const char *)&bsname[1], (size_t)bsname[0],
+			                           encoded_seg, sizeof(encoded_seg))) {
+#if defined(FRONTIER_HEADLESS)
+				if (log_enabled(LOG_LEVEL_TRACE, LOG_COMP_HASH)) {
+					log_trace(LOG_COMP_HASH,
+					          "materialize encode overflow path=%s name=%.*s",
+					          path ? path : "<nil>", (int)bsname[0], (char *)&bsname[1]);
+				}
+#endif
+				return false;
+			}
+			encoded_len = strlen(encoded_seg);
+			need = encoded_len + 1; /* name + null (or dot joins below) */
 			if (path != NULL && path[0] != '\0')
-				need += strlen(path) + 1; /* dot + existing path */
+				need += strlen(path) + 1; /* path + dot separator */
 			if (need >= sizeof(nodepath)) {
 #if defined(FRONTIER_HEADLESS)
 				if (log_enabled(LOG_LEVEL_TRACE, LOG_COMP_HASH)) {
-					log_trace(LOG_COMP_HASH, "materialize path overflow path=%s name=%.*s need=%zu limit=%zu",
-		        path ? path : "<nil>", (int) bsname[0], (char *) &bsname[1],
-		        need, sizeof(nodepath));
+					log_trace(LOG_COMP_HASH,
+					          "materialize path overflow path=%s encoded=%s need=%zu limit=%zu",
+					          path ? path : "<nil>", encoded_seg, need, sizeof(nodepath));
 				}
 #endif
 				return false; /* avoid overflow on deep nesting */
 			}
 
 			if (path != NULL && path[0] != '\0')
-				snprintf(nodepath, sizeof(nodepath), "%s.%.*s", path, (int) bsname[0], (char *) &bsname[1]);
+				snprintf(nodepath, sizeof(nodepath), "%s.%s", path, encoded_seg);
 			else
-				snprintf(nodepath, sizeof(nodepath), "%.*s", (int) bsname[0], (char *) &bsname[1]);
+				snprintf(nodepath, sizeof(nodepath), "%s", encoded_seg);
+			} /* end encoding block */
 
 		strncpy(langhash_materialize_path_buf, nodepath, sizeof(langhash_materialize_path_buf) - 1);
 		langhash_materialize_path_buf[sizeof(langhash_materialize_path_buf) - 1] = '\0';

--- a/Common/source/langhash.c
+++ b/Common/source/langhash.c
@@ -387,7 +387,7 @@ static boolean langhash_materialize_external(tyvaluerecord *val, const char *pat
 		return true;
 
 	const char *prior_path = langhash_materialize_current_path;
-	char local_path_buf[256];
+	char local_path_buf[512]; /* matches nodepath[512] in the caller */
 
 	if (path != NULL) {
 		strncpy(local_path_buf, path, sizeof(local_path_buf) - 1);

--- a/Common/source/opverbs.c
+++ b/Common/source/opverbs.c
@@ -583,6 +583,11 @@ static boolean opverbpackoutline (hdloutlinerecord houtline, Handle *hpacked) {
 
 #if defined(FRONTIER_HEADLESS)
 #include <time.h> /* time() for the .ut hot-path import throttle */
+/* ut_pct_encode_segment lives in frontier-cli/ut_sync.c; declare here so
+ * ut_find_dotted_path_topdown can encode raw bsname segments without
+ * pulling in the full ut_sync.h include chain from Common/source. */
+extern int ut_pct_encode_segment(const char *raw, size_t rawlen,
+                                 char *out, size_t outsz);
 /*
  * ut_find_dotted_path_topdown - recursively search a hashtable subtree for the
  * external variable `target`, building the dotted path top-down (root-first).
@@ -613,13 +618,24 @@ static int ut_find_dotted_path_topdown(hdlhashtable htable, hdlexternalvariable 
 			continue;
 
 		gethashkey(nomad, bsname);
-		if (prefix != NULL && prefix[0] != '\0')
-			snprintf(nodepath, sizeof(nodepath), "%s.%.*s",
-			         prefix, (int)bsname[0], (char *)&bsname[1]);
-		else
-			snprintf(nodepath, sizeof(nodepath), "%.*s",
-			         (int)bsname[0], (char *)&bsname[1]);
-		nodepath[sizeof(nodepath) - 1] = '\0';
+		{
+			/* Encode the raw segment before joining into the dotted path. */
+			char encoded_seg[766]; /* 255 * 3 + 1 -- max encoded Pascal name */
+			int enc_ok;
+			int n;
+			enc_ok = ut_pct_encode_segment((const char *)&bsname[1],
+			                               (size_t)bsname[0],
+			                               encoded_seg, sizeof(encoded_seg));
+			if (!enc_ok)
+				continue; /* segment un-encodable: skip (for loop advances nomad) */
+			if (prefix != NULL && prefix[0] != '\0')
+				n = snprintf(nodepath, sizeof(nodepath), "%s.%s", prefix, encoded_seg);
+			else
+				n = snprintf(nodepath, sizeof(nodepath), "%s", encoded_seg);
+			if (n < 0 || n >= (int)sizeof(nodepath))
+				continue; /* path overflow: skip */
+		}
+		nodepath[sizeof(nodepath) - 1] = '\0'; /* belt-and-suspenders NUL */
 
 		{
 			hdlexternalvariable hv = (hdlexternalvariable) val->data.externalvalue;

--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -98,7 +98,8 @@ CLI_SOURCES = \
     palette_arg_inject.c \
     scrollback_pane.c \
     window_registry.c \
-    ut_sync.c
+    ut_sync.c \
+    ut_scan.c
 
 # cJSON (vendored JSON parser)
 CJSON_SOURCES = $(THIRDPARTYDIR)/cJSON/cJSON.c

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -1750,7 +1750,8 @@ static boolean hydrate_system_root_database(const char* path, boolean read_only)
 	 * so the cli_redirty_ut_imported_paths call below re-dirtied them for save. */
 	if (cli_get_ut_sync_dir() != NULL) {
 		int scan_count = ut_sync_scan_and_create(cli_get_ut_sync_dir(),
-		                                         cli_get_system_root_basename());
+		                                         cli_get_system_root_basename(),
+		                                         1 /* record_for_redirty: boot path */);
 		if (scan_count > 0) {
 			log_info(LOG_COMP_STARTUP,
 			         "ut-scan: %d orphan node(s) created from sync tree", scan_count);

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -83,6 +83,7 @@
 
 // CLI-specific headers
 #include "ut_sync.h"
+#include "ut_scan.h"
 #include "cli_parser.h"
 #include "cli_executor.h"
 #include "cli_utils.h"
@@ -1730,6 +1731,24 @@ static boolean hydrate_system_root_database(const char* path, boolean read_only)
 	 * this, save_system_root_on_exit() rewrites the entire file on every
 	 * shutdown even when no user mutation occurred (~1.2 MB drift). */
 	clear_post_hydration_dirty_flags(hroot);
+
+	/* ut-sync boot-discovery scan: walk the sync tree and auto-create any .ut
+	 * leaves that have no corresponding in-memory ODB node (orphans dropped
+	 * into the sync dir while the runtime was not running). Must run AFTER the
+	 * full-materialization pass above (so hashtable misses are genuine absences)
+	 * and AFTER clear_post_hydration_dirty_flags (so only the newly-created
+	 * nodes end up dirty). Each created path is recorded via cli_record_ut_import
+	 * so the cli_redirty_ut_imported_paths call below re-dirtied them for save. */
+	if (cli_get_ut_sync_dir() != NULL) {
+		int scan_count = ut_sync_scan_and_create(cli_get_ut_sync_dir(),
+		                                         cli_get_system_root_basename());
+		if (scan_count > 0) {
+			log_info(LOG_COMP_STARTUP,
+			         "ut-scan: %d orphan node(s) created from sync tree", scan_count);
+		} else if (scan_count < 0) {
+			cli_log_warn("ut-scan: boot scan encountered an error");
+		}
+	}
 
 	/* ut-sync Direction B: re-dirty any scripts imported from .ut files during
 	 * the bulk hydrate walk. The clear pass above wiped the dirty flags that

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -253,13 +253,19 @@ static int redirty_one_path(const char *dotted_path) {
 		if (dot != NULL)
 			*dot = '\0';
 
-		/* Build Pascal string for this segment. */
+		/* Decode the percent-encoded segment back to its raw ODB key name
+		 * before building the Pascal string for hashtablelookup. */
+		char decoded_seg[256]; /* max raw Pascal name: 255 bytes + NUL */
+		if (!ut_pct_decode_segment(seg, decoded_seg, sizeof(decoded_seg)))
+			break; /* malformed %XX in a path we emitted -- treat as miss */
+
+		/* Build Pascal string for this (now raw) segment. */
 		bigstring bsseg;
-		size_t seglen = strlen(seg);
+		size_t seglen = strlen(decoded_seg);
 		if (seglen > 255)
 			break;
 		bsseg[0] = (unsigned char) seglen;
-		memcpy(&bsseg[1], seg, seglen);
+		memcpy(&bsseg[1], decoded_seg, seglen);
 
 		tyvaluerecord val;
 		hdlhashnode hnode = nil;
@@ -2036,14 +2042,27 @@ static void ut_export_walk_table(hdlhashtable htable, const char *path,
 
 		gethashkey(nomad, bsname);
 
-		/* Build the dotted path for this node. */
-		if (path != NULL && path[0] != '\0')
-			snprintf(nodepath, sizeof(nodepath), "%s.%.*s",
-			         path, (int)bsname[0], (char *)&bsname[1]);
-		else
-			snprintf(nodepath, sizeof(nodepath), "%.*s",
-			         (int)bsname[0], (char *)&bsname[1]);
-		nodepath[sizeof(nodepath) - 1] = '\0';
+		/* Build the dotted path for this node, percent-encoding the raw segment
+		 * so ODB keys with '.' '/' ':' '"' '\' or control bytes are lossless. */
+		{
+			char encoded_seg[766]; /* 255 * 3 + 1 -- max encoded Pascal name */
+			int n;
+			if (!ut_pct_encode_segment((const char *)&bsname[1], (size_t)bsname[0],
+			                           encoded_seg, sizeof(encoded_seg))) {
+				cli_log_warn("ut-sync: segment encode overflow for node under %s",
+				             path ? path : "<root>");
+				continue;
+			}
+			if (path != NULL && path[0] != '\0')
+				n = snprintf(nodepath, sizeof(nodepath), "%s.%s", path, encoded_seg);
+			else
+				n = snprintf(nodepath, sizeof(nodepath), "%s", encoded_seg);
+			if (n < 0 || n >= (int)sizeof(nodepath)) {
+				cli_log_warn("ut-sync: nodepath overflow under %s", path ? path : "<root>");
+				continue;
+			}
+		}
+		nodepath[sizeof(nodepath) - 1] = '\0'; /* belt-and-suspenders NUL */
 
 		if (val->valuetype != externalvaluetype)
 			continue;

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -257,6 +257,16 @@ static int redirty_one_path(const char *dotted_path) {
 		/* Decode the percent-encoded segment back to its raw ODB key name
 		 * before building the Pascal string for hashtablelookup. */
 		char decoded_seg[256]; /* max raw Pascal name: 255 bytes + NUL */
+		/*
+		 * Defense-in-depth NUL guard: reject any segment that contains %00.
+		 * ut_pct_decode_segment would decode it to an embedded NUL byte,
+		 * causing strlen(decoded_seg) to silently truncate the key and diverge
+		 * from the codec contract (ut_sync.h line ~219). This matches the
+		 * equivalent rawlen==0 guard in ut_scan.c. %00 has no hex-case variant
+		 * (both digits are '0'), so a literal strstr suffices.
+		 */
+		if (strstr(seg, "%00") != NULL)
+			break;
 		if (!ut_pct_decode_segment(seg, decoded_seg, sizeof(decoded_seg)))
 			break; /* malformed %XX in a path we emitted -- treat as miss */
 

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -288,6 +288,15 @@ static int redirty_one_path(const char *dotted_path) {
 			/* Intermediate: descend into the table if it is already in memory. */
 			if (val.valuetype == externalvaluetype && val.data.externalvalue != NULL) {
 				hdlexternalvariable hv_seg = (hdlexternalvariable) val.data.externalvalue;
+				/*
+				 * P1 #1 defense-in-depth: verify the intermediate node is a table
+				 * (idtableprocessor) before casting variabledata to hdlhashtable.
+				 * A non-table external (script, outline, menu) has variabledata
+				 * pointing to its own record type, not an hdlhashtable. Casting
+				 * it would produce wrong-typed memory access.
+				 */
+				if ((**hv_seg).id != idtableprocessor)
+					break;
 				/* variabledata is a long; when flinmemory it holds an hdlhashtable cast. */
 				if ((**hv_seg).flinmemory && (**hv_seg).variabledata != 0)
 					cur = (hdlhashtable)(Handle)(uintptr_t)(**hv_seg).variabledata;

--- a/frontier-cli/protocol_handler.c
+++ b/frontier-cli/protocol_handler.c
@@ -38,6 +38,7 @@
 #include "protocol_handler.h"
 #include "op_handler.h"
 #include "ws_server.h"
+#include "repl.h"
 
 #include "../Common/headers/logging.h"
 #include "headless_threading.h"
@@ -142,14 +143,20 @@ int protocol_main(cli_options_t *options, ws_server_t *ws_server) {
 
 	int stdin_flags = -1;  /* saved stdin fcntl flags; restored before return */
 
+	/* Install the repl.* verb host adapter so verbs like repl.syncScan()
+	 * work in --protocol mode, just as they do in --repl mode. */
+	repl_install_verb_host();
+
 	char *line_buf = malloc(PROTOCOL_LINE_MAX);
 	if (line_buf == NULL) {
 		fprintf(stderr, "protocol: failed to allocate line buffer\n");
+		repl_uninstall_verb_host();
 		return 1;
 	}
 
 	if (setup_protocol_output() < 0) {
 		free(line_buf);
+		repl_uninstall_verb_host();
 		return 1;
 	}
 
@@ -337,6 +344,7 @@ int protocol_main(cli_options_t *options, ws_server_t *ws_server) {
 
 	free(line_buf);
 	teardown_protocol_output();
+	repl_uninstall_verb_host();
 
 	log_info(LOG_COMP_GENERAL, "Protocol mode: shutting down");
 	return 0;

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -73,6 +73,13 @@
 #include "../Common/headers/langinternal.h" /* flreplmode */
 #include "../Common/headers/threadregistry.h" /* headless_backgroundtask */
 #include "ws_server.h"						 /* ws_server_t, ws_server_* */
+#include "ut_scan.h"						 /* ut_sync_scan_and_create */
+
+/* cli_get_ut_sync_dir and cli_get_system_root_basename are defined in main.c.
+ * Forward-declared here to avoid a circular header dependency -- same pattern
+ * as ut_scan.c::cli_record_ut_import. */
+extern const char *cli_get_ut_sync_dir(void);
+extern const char *cli_get_system_root_basename(void);
 
 // History configuration
 #define HISTORY_FILE ".frontier_history"
@@ -3559,6 +3566,23 @@ static void replverbhost_list(const char *path) {
 }
 
 /*
+ * Walk the ut-sync tree and create any ODB nodes whose .ut file exists on
+ * disk but is absent from the in-memory hashtable.  Delegates to
+ * ut_sync_scan_and_create().  Backs repl.syncScan().
+ *
+ * Returns the count of newly created nodes (>= 0), or 0 when ut-sync mode
+ * is not active (--ut-sync-dir was not supplied) so the verb is a safe
+ * no-op in non-sync sessions.
+ */
+static int replverbhost_sync_scan(void) {
+	const char *sync_dir = cli_get_ut_sync_dir();
+	if (sync_dir == NULL)
+		return 0;
+	int n = ut_sync_scan_and_create(sync_dir, cli_get_system_root_basename());
+	return (n < 0) ? 0 : n;
+}
+
+/*
  * Build and install the host adapter struct. Called once from repl_main
  * before either loop runs. Pairs with repl_verbs_set_host(NULL) on
  * cleanup so a follow-on call to a repl.* verb after the REPL exits
@@ -3575,6 +3599,7 @@ static void install_repl_verbs_host(void) {
 	host.help = replverbhost_help;
 	host.from_slash = replverbhost_from_slash;
 	host.is_active = replverbhost_is_active;
+	host.sync_scan = replverbhost_sync_scan;
 	repl_verbs_set_host(&host);
 }
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -3570,6 +3570,10 @@ static void replverbhost_list(const char *path) {
  * disk but is absent from the in-memory hashtable.  Delegates to
  * ut_sync_scan_and_create().  Backs repl.syncScan().
  *
+ * GIL: called on the UserTalk thread that evaluates repl.syncScan(), which
+ * holds the GIL at the point of call (all UserTalk evaluation is GIL-held).
+ * ut_sync_scan_and_create and all kernel primitives it calls are safe.
+ *
  * Returns the count of newly created nodes (>= 0), or 0 when ut-sync mode
  * is not active (--ut-sync-dir was not supplied) so the verb is a safe
  * no-op in non-sync sessions.
@@ -3578,7 +3582,8 @@ static int replverbhost_sync_scan(void) {
 	const char *sync_dir = cli_get_ut_sync_dir();
 	if (sync_dir == NULL)
 		return 0;
-	int n = ut_sync_scan_and_create(sync_dir, cli_get_system_root_basename());
+	int n = ut_sync_scan_and_create(sync_dir, cli_get_system_root_basename(),
+	                                0 /* record_for_redirty: post-boot, dirty bits persist naturally */);
 	return (n < 0) ? 0 : n;
 }
 
@@ -3605,6 +3610,19 @@ static void install_repl_verbs_host(void) {
 
 static void uninstall_repl_verbs_host(void) {
 	repl_verbs_set_host(NULL);
+}
+
+/*
+ * repl_install_verb_host / repl_uninstall_verb_host - public wrappers so
+ * protocol_main (protocol_handler.c) can install the same host adapter that
+ * repl_main installs.  This ensures that repl.* verbs (including
+ * repl.syncScan()) work in both --repl and --protocol modes.
+ */
+void repl_install_verb_host(void) {
+	install_repl_verbs_host();
+}
+void repl_uninstall_verb_host(void) {
+	uninstall_repl_verbs_host();
 }
 
 

--- a/frontier-cli/repl.h
+++ b/frontier-cli/repl.h
@@ -43,6 +43,12 @@
 // Returns: exit code (0 for success, 1 for error)
 int repl_main(cli_options_t *options, ws_server_t *ws_server);
 
+/* Install/uninstall the repl.* verb host adapter (backs repl.syncScan etc.).
+ * Called by repl_main; also called by protocol_main so that repl.* verbs
+ * work in --protocol mode.  Safe to call without the GIL. */
+void repl_install_verb_host(void);
+void repl_uninstall_verb_host(void);
+
 /* Result from index-aware path navigation (repl_navigate_path_ex).
  * Can represent either a table or a scalar value at the end of a path. */
 typedef struct {

--- a/frontier-cli/repl_output.c
+++ b/frontier-cli/repl_output.c
@@ -293,6 +293,9 @@ void repl_output_help(void) {
 	fputs("    workspace.x = 42         (saved to database)\n", stdout);
 	fputs("\n", stdout);
 	fputs("Multi-line input: Coming in Phase 2\n", stdout);
+	fputs("\n", stdout);
+	fputs("Kernel verbs (call from any UserTalk expression):\n", stdout);
+	fputs("  repl.syncScan()    scan the ut-sync dir and create ODB nodes for any orphan .ut files\n", stdout);
 	fflush(stdout);
 }
 

--- a/frontier-cli/repl_verbs.c
+++ b/frontier-cli/repl_verbs.c
@@ -99,7 +99,8 @@ enum {
 	rplv_list = 4,
 	rplv_help = 5,
 	rplv_fromslash = 6,
-	rplv_isactive = 7
+	rplv_isactive = 7,
+	rplv_syncscan = 8
 };
 
 
@@ -236,6 +237,12 @@ static boolean repl_valueproc(short token, hdltreenode hparam1,
 			return setbooleanvalue(false, vreturned);
 		return setbooleanvalue(g_host.is_active(), vreturned);
 
+	case rplv_syncscan:
+		(void) hparam1;
+		if (!g_host_installed || g_host.sync_scan == NULL)
+			return setlongvalue(0, vreturned);
+		return setlongvalue((long) g_host.sync_scan(), vreturned);
+
 	default:
 		return false;
 	}
@@ -274,6 +281,7 @@ boolean replinitverbs(void) {
 	ADD_VERB(PSTRING("\004", "help"), rplv_help);
 	ADD_VERB(PSTRING("\x09", "fromslash"), rplv_fromslash);
 	ADD_VERB(PSTRING("\x08", "isactive"), rplv_isactive);
+	ADD_VERB(PSTRING("\x08", "syncscan"), rplv_syncscan);
 
 	#undef ADD_VERB
 

--- a/frontier-cli/repl_verbs.h
+++ b/frontier-cli/repl_verbs.h
@@ -200,11 +200,11 @@ extern boolean replinitverbs(void);
  * at the script level rather than crash). The adapter struct is COPIED
  * by value internally, so the caller may free or stack-allocate `host`.
  *
- * Thread-safety note: host installation is protected by no mutex. The
- * intended pattern is "install once at REPL startup, never change" —
- * the host pointer is read by the verb dispatcher on the main thread,
- * and it is the caller's responsibility to install before any user
- * script can run.
+ * Thread-safety note: the host is installed at the start of whichever
+ * mode runs (repl_main or protocol_main) and uninstalled on that mode's
+ * exit. The two modes are mutually exclusive (main.c dispatches to one
+ * or the other), so there is never concurrent or overlapping installation.
+ * All install/uninstall calls happen on the main thread under the GIL.
  */
 extern void repl_verbs_set_host(const repl_verbs_host_t *host);
 

--- a/frontier-cli/repl_verbs.h
+++ b/frontier-cli/repl_verbs.h
@@ -161,6 +161,21 @@ typedef struct ty_repl_verbs_host {
 	 * Returns false when no host is installed.
 	 */
 	boolean (*is_active)(void);
+	/*
+	 * sync_scan: walk the ut-sync tree and auto-create any ODB nodes whose
+	 * .ut file exists on disk but is absent from the in-memory hashtable.
+	 * Delegates to ut_sync_scan_and_create(). Backs repl.syncScan().
+	 *
+	 * Returns the count of newly created ODB nodes (>= 0), or 0 when
+	 * ut-sync mode is not active (--ut-sync-dir was not supplied) so the
+	 * verb is a safe no-op in non-sync sessions.
+	 *
+	 * Return contract: the verb returns the count as a UserTalk number
+	 * (longvalue). A return of 0 means "no orphans found" OR "not in
+	 * ut-sync mode"; a return >= 1 means that many nodes were created.
+	 * Returns 0 (not a crash) when no host is installed.
+	 */
+	int (*sync_scan)(void);
 } repl_verbs_host_t;
 
 

--- a/frontier-cli/ut_scan.c
+++ b/frontier-cli/ut_scan.c
@@ -1,0 +1,553 @@
+/*
+ * ut_scan.c - Boot-time import-discovery scan for ODB<->.ut sync.
+ *
+ * Implements ut_sync_scan_and_create(): walk the .ut sync tree, find .ut
+ * leaves that have no corresponding in-memory ODB node, and auto-create the
+ * missing intermediate table chain + leaf script. Each created path is
+ * recorded via cli_record_ut_import() so the existing redirty pass persists
+ * the new nodes on the next tablesavesystemtable call.
+ *
+ * This file is compiled ONLY into the production CLI. It must NOT be linked
+ * into any kernel-free test binary.
+ *
+ * License
+ * -------
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Frontier contributors.
+ */
+
+#include "ut_scan.h"
+#include "ut_sync.h"
+
+/* POSIX / libc */
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* Kernel headers -- this file is CLI-only, so these links are fine. */
+#include "../Common/headers/frontier.h"
+#include "../Common/headers/logging.h"
+#include "../Common/headers/lang.h"
+#include "../Common/headers/memory.h"
+#include "../Common/headers/strings.h"
+#include "../Common/headers/tablestructure.h"
+#include "../Common/headers/langexternal.h"
+#include "../Common/headers/opinternal.h"
+#include "../Common/headers/opverbs.h"
+
+/* cli_record_ut_import is defined in main.c; forward-declared here to avoid
+ * a circular include (main.c already includes ut_scan.h). */
+extern void cli_record_ut_import(const char *dotted_path);
+
+
+/* -------------------------------------------------------------------------
+ * Internal: maximum depth for recursive directory walk (guards against
+ * pathological symlink loops that O_NOFOLLOW at the open level can't catch
+ * for the opendir path).
+ * ------------------------------------------------------------------------- */
+#define UT_SCAN_MAX_DEPTH 32
+
+/*
+ * Maximum segments in a dotted ODB path. A reasonable corpus ceiling; paths
+ * deeper than this are silently skipped with a warning (don't abort the scan).
+ */
+#define UT_SCAN_MAX_SEGMENTS 64
+
+/*
+ * Maximum size of a .ut file we will attempt to import during the scan.
+ * Matches UT_IMPORT_SIZE_CAP in ut_sync.c (1 MB).
+ */
+#define UT_SCAN_SIZE_CAP ((size_t)(1u << 20))
+
+
+/* -------------------------------------------------------------------------
+ * Internal: split a NUL-terminated dotted string into its segments.
+ *
+ * Writes up to max_segs pointers into segs[] (pointing into buf, which is
+ * modified in place by NUL-termination). Returns the number of segments, or
+ * -1 if there are more than max_segs.
+ * ------------------------------------------------------------------------- */
+static int split_dotted(char *buf, const char **segs, int max_segs) {
+	int n = 0;
+	char *p = buf;
+	segs[n++] = p;
+	while (*p != '\0') {
+		if (*p == '.') {
+			*p = '\0';
+			if (n >= max_segs)
+				return -1;
+			segs[n++] = p + 1;
+		}
+		p++;
+	}
+	return n;
+}
+
+
+/* -------------------------------------------------------------------------
+ * Internal: read an entire .ut file into a malloc'd buffer.
+ *
+ * Returns 1 on success (*out is malloc'd, *outlen is the byte count).
+ * Returns 0 on any error (*out is NULL, *outlen is 0).
+ * Uses O_NOFOLLOW to refuse symlinks (matches the import hook's posture).
+ * ------------------------------------------------------------------------- */
+static int read_ut_file(const char *fspath, unsigned char **out, size_t *outlen) {
+	*out = NULL;
+	*outlen = 0;
+
+	int fd = open(fspath, O_RDONLY | O_NOFOLLOW);
+	if (fd < 0)
+		return 0;
+
+	struct stat st;
+	if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 0) {
+		close(fd);
+		return 0;
+	}
+	size_t sz = (size_t)st.st_size;
+	if (sz > UT_SCAN_SIZE_CAP) {
+		log_warn(LOG_COMP_STARTUP,
+		         "ut-scan: skipping oversized .ut (%zu bytes): %s", sz, fspath);
+		close(fd);
+		return 0;
+	}
+
+	/* Empty file is valid (empty script body). */
+	unsigned char *buf = (unsigned char *) malloc(sz + 1);
+	if (buf == NULL) {
+		close(fd);
+		return 0;
+	}
+
+	size_t total = 0;
+	while (total < sz) {
+		ssize_t n = read(fd, buf + total, sz - total);
+		if (n < 0) {
+			free(buf);
+			close(fd);
+			return 0;
+		}
+		if (n == 0)
+			break;
+		total += (size_t)n;
+	}
+	close(fd);
+
+	buf[total] = '\0';
+	*out = buf;
+	*outlen = total;
+	return 1;
+}
+
+
+/* -------------------------------------------------------------------------
+ * Internal: check whether a .ut leaf already has a live in-memory ODB node.
+ *
+ * Takes the ENCODED dotted path (e.g. "system.verbs.builtins.foo%2Ebar"),
+ * decodes each segment, and walks the hashtable chain from roottable.
+ *
+ * Returns:
+ *   1  - node exists in memory (skip creation)
+ *   0  - node is absent from memory (genuine orphan - create it)
+ *
+ * CRITICAL: This MUST use direct hashtable descent (hashtablelookupnode),
+ * NOT any verb-resolution or defined()-style call. The EFP search path
+ * causes defined()/@address lookups on DIRECT children of
+ * system.verbs.builtins to return a phantom true even for nodes that do
+ * not exist. Structural hashtable descent is the only EFP-immune existence
+ * check. See docs/ARCHITECTURAL_ANTIPATTERNS.md "Name resolution vs verb
+ * dispatch" and the test comment in ut_sync_lifecycle_test.sh Test 6.
+ *
+ * POST-FULL-MATERIALIZATION SEMANTICS:
+ * At the boot seam where this function is called, langhash_materialize_disk_values
+ * has already walked the entire tree and loaded every external table into memory.
+ * Therefore a miss in the hashtable at any depth is a genuine structural absence
+ * (the node does not exist in the ODB), NOT a lazy-load deferral. We do not need
+ * a separate lazy-registry check: the full materialization pass guarantees that
+ * any real ODB node will be present in the in-memory hashtable chain.
+ * ------------------------------------------------------------------------- */
+static int node_exists_in_memory(const char *encoded_dotted) {
+	/* Work on a copy so split_dotted can NUL-terminate in place. */
+	char *buf = strdup(encoded_dotted);
+	if (buf == NULL)
+		return 1; /* conservatively treat as exists on OOM to avoid creating garbage */
+
+	const char *segs[UT_SCAN_MAX_SEGMENTS];
+	int nseg = split_dotted(buf, segs, UT_SCAN_MAX_SEGMENTS);
+	if (nseg <= 0) {
+		free(buf);
+		return 1; /* malformed or too deep -- skip */
+	}
+
+	/*
+	 * Walk the hashtable chain segment by segment. After each intermediate
+	 * segment we descend into its table. At the final (leaf) segment, if we
+	 * find a node the leaf exists; otherwise it does not.
+	 *
+	 * GIL assumption: called on the main thread during boot while the GIL is
+	 * held. No locking required.
+	 */
+	hdlhashtable curtable = roottable;
+	int found = 0;
+
+	for (int i = 0; i < nseg && curtable != nil; i++) {
+		/* Decode the percent-encoded segment to its raw ODB key. */
+		char decoded[256]; /* max Pascal name: 255 bytes + NUL */
+		if (!ut_pct_decode_segment(segs[i], decoded, sizeof(decoded))) {
+			/* Malformed encoding -- treat as absent (orphan candidate). */
+			found = 0;
+			goto done;
+		}
+
+		size_t rawlen = strlen(decoded);
+		if (rawlen > 255) {
+			found = 0; /* too long for a Pascal string */
+			goto done;
+		}
+
+		/* Build Pascal string: length byte + raw bytes. */
+		bigstring bsseg;
+		bsseg[0] = (unsigned char)rawlen;
+		memcpy(&bsseg[1], decoded, rawlen);
+
+		hdlhashnode hnode = nil;
+		if (!hashtablelookupnode(curtable, bsseg, &hnode) || hnode == nil) {
+			/* Not found at this level -- genuine orphan. */
+			found = 0;
+			goto done;
+		}
+
+		if (i == nseg - 1) {
+			/* Reached the leaf and found a node -- node exists. */
+			found = 1;
+			goto done;
+		}
+
+		/*
+		 * Intermediate segment: descend into the table. The node must be an
+		 * in-memory table external variable. If it isn't (e.g. it's some other
+		 * type), we can't descend and treat the leaf as absent.
+		 */
+		tyvaluerecord val = (**hnode).val;
+		if (val.valuetype != externalvaluetype || val.data.externalvalue == NULL) {
+			found = 0;
+			goto done;
+		}
+		hdlexternalvariable hv = (hdlexternalvariable) val.data.externalvalue;
+		if (!(**hv).flinmemory || (**hv).variabledata == 0) {
+			/*
+			 * Intermediate table is not in memory. Post-full-materialization
+			 * this should not happen for a real ODB node, but if it does we
+			 * conservatively treat the leaf as present (don't shadow a real
+			 * lazy node we couldn't descend into).
+			 */
+			found = 1;
+			goto done;
+		}
+		curtable = (hdlhashtable)(Handle)(uintptr_t)(**hv).variabledata;
+	}
+
+done:
+	free(buf);
+	return found;
+}
+
+
+/* -------------------------------------------------------------------------
+ * Internal: create the intermediate table chain and leaf script for one orphan.
+ *
+ * encoded_dotted - ENCODED dotted path (the form stored by cli_record_ut_import
+ *                  and consumed by cli_redirty_ut_imported_paths / redirty_one_path).
+ * fspath         - absolute filesystem path to the .ut file.
+ *
+ * Returns 1 on success, 0 on failure.
+ * ------------------------------------------------------------------------- */
+static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
+	/* Split on dots to get segment list. */
+	char *buf = strdup(encoded_dotted);
+	if (buf == NULL)
+		return 0;
+
+	const char *segs[UT_SCAN_MAX_SEGMENTS];
+	int nseg = split_dotted(buf, segs, UT_SCAN_MAX_SEGMENTS);
+	if (nseg <= 0) {
+		free(buf);
+		return 0;
+	}
+
+	/*
+	 * Walk from roottable, creating missing intermediate tables, until we
+	 * reach the parent of the leaf (nseg-1 segments). The leaf itself is
+	 * created as a script external.
+	 */
+	hdlhashtable curtable = roottable;
+	int ok = 0;
+
+	for (int i = 0; i < nseg - 1 && curtable != nil; i++) {
+		char decoded[256];
+		if (!ut_pct_decode_segment(segs[i], decoded, sizeof(decoded)))
+			goto done;
+		size_t rawlen = strlen(decoded);
+		if (rawlen > 255)
+			goto done;
+
+		bigstring bsseg;
+		bsseg[0] = (unsigned char)rawlen;
+		memcpy(&bsseg[1], decoded, rawlen);
+
+		hdlhashtable nexttable = nil;
+		/*
+		 * langsuretablevalue: if the table already exists, return it; if not,
+		 * create a new empty table and assign it. Safe to call when the node
+		 * is already present (idempotent for the already-exists case).
+		 */
+		if (!langsuretablevalue(curtable, bsseg, &nexttable) || nexttable == nil)
+			goto done;
+		curtable = nexttable;
+	}
+
+	/* Now curtable is the parent table for the leaf. */
+	{
+		const char *leaf_enc = segs[nseg - 1];
+		char leaf_raw[256];
+		if (!ut_pct_decode_segment(leaf_enc, leaf_raw, sizeof(leaf_raw)))
+			goto done;
+		size_t leaflen = strlen(leaf_raw);
+		if (leaflen > 255)
+			goto done;
+
+		bigstring bsleaf;
+		bsleaf[0] = (unsigned char)leaflen;
+		memcpy(&bsleaf[1], leaf_raw, leaflen);
+
+		/* Read the .ut file bytes. */
+		unsigned char *ut_bytes = NULL;
+		size_t ut_len = 0;
+		if (!read_ut_file(fspath, &ut_bytes, &ut_len)) {
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: could not read .ut file: %s", fspath);
+			goto done;
+		}
+
+		/*
+		 * Decanonicalize the .ut bytes (UTF-8/LF/"//") back to the kernel's
+		 * in-memory form (MacRoman/CR/0xC7) so optexttooutline can parse them.
+		 */
+		unsigned char *decan_bytes = NULL;
+		size_t decan_len = 0;
+		if (!ut_decanonicalize_outline_text(ut_bytes, ut_len, &decan_bytes, &decan_len)) {
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: decanonicalization failed for: %s", fspath);
+			free(ut_bytes);
+			goto done;
+		}
+		free(ut_bytes);
+
+		/*
+		 * Build a kernel Handle from the decanonicalized bytes so
+		 * optexttooutline can consume them. optexttooutline copies internally;
+		 * we dispose the handle after the call.
+		 */
+		Handle htext = nil;
+		if (!newhandle((long)decan_len, &htext)) {
+			free(decan_bytes);
+			goto done;
+		}
+		moveleft(decan_bytes, *htext, (long)decan_len);
+		free(decan_bytes);
+
+		/*
+		 * Create a new script external value, convert to outline, install the
+		 * source text, then assign to the parent table.
+		 *
+		 * Mirrors opgetsourceverb (opverbs.c ~2688-2708) and the import hook
+		 * (opverbs.c ut_import_hook ~846-852).
+		 */
+		tyvaluerecord vscript;
+		if (!langexternalnewvalue(idscriptprocessor, nil, &vscript)) {
+			disposehandle(htext);
+			goto done;
+		}
+
+		hdloutlinerecord ho = nil;
+		opvaltoscript(vscript, &ho);
+		if (ho == nil) {
+			disposevaluerecord(vscript, true);
+			disposehandle(htext);
+			goto done;
+		}
+
+		hdlheadrecord hsummit = nil;
+		if (!optexttooutline(ho, htext, &hsummit)) {
+			disposehandle(htext);
+			disposevaluerecord(vscript, true);
+			goto done;
+		}
+		disposehandle(htext);
+
+		opsetsummit(ho, hsummit);
+		opsetctexpanded(ho);
+
+		if (!hashtableassign(curtable, bsleaf, vscript)) {
+			disposevaluerecord(vscript, true);
+			goto done;
+		}
+
+		ok = 1;
+	}
+
+done:
+	free(buf);
+	return ok;
+}
+
+
+/* -------------------------------------------------------------------------
+ * Internal: recursive directory walk.
+ *
+ * For each regular .ut file found:
+ *   1. Reverse-map its fs path to the ENCODED dotted ODB path.
+ *   2. Check existence via structural hashtable walk (EFP-immune).
+ *   3. If absent, create the intermediate table chain + leaf script.
+ *   4. Record the created path so the redirty pass persists it.
+ *
+ * count_out is incremented for each node successfully created.
+ * depth guards against runaway recursion.
+ * ------------------------------------------------------------------------- */
+static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
+                                int depth, int *count_out) {
+	if (depth > UT_SCAN_MAX_DEPTH) {
+		log_warn(LOG_COMP_STARTUP,
+		         "ut-scan: max depth %d exceeded at: %s", UT_SCAN_MAX_DEPTH, dirpath);
+		return;
+	}
+
+	DIR *d = opendir(dirpath);
+	if (d == NULL)
+		return;
+
+	struct dirent *ent;
+	while ((ent = readdir(d)) != NULL) {
+		const char *name = ent->d_name;
+
+		/* Skip "." and "..". */
+		if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
+			continue;
+
+		/* Build full child path. */
+		char childpath[4096];
+		int n = snprintf(childpath, sizeof(childpath), "%s/%s", dirpath, name);
+		if (n < 0 || n >= (int)sizeof(childpath)) {
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: path too long, skipping: %s/%s", dirpath, name);
+			continue;
+		}
+
+		/* lstat to classify without following symlinks. */
+		struct stat st;
+		if (lstat(childpath, &st) != 0)
+			continue;
+
+		/* Skip symlinks -- defense against symlink escape. */
+		if (S_ISLNK(st.st_mode))
+			continue;
+
+		if (S_ISDIR(st.st_mode)) {
+			scan_dir_recursive(childpath, sync_dir, depth + 1, count_out);
+		} else if (S_ISREG(st.st_mode)) {
+			size_t namelen = strlen(name);
+			if (namelen < 3 || strcmp(name + namelen - 3, ".ut") != 0)
+				continue;
+
+			/*
+			 * Reverse-map this .ut fs path to its ENCODED dotted ODB path.
+			 * sync_dir here is the effective sync base (sync_dir/root_basename),
+			 * which was pre-computed by the caller.
+			 */
+			char encoded_dotted[2048];
+			if (!ut_fs_path_to_odb(childpath, sync_dir, encoded_dotted,
+			                       sizeof(encoded_dotted))) {
+				log_warn(LOG_COMP_STARTUP,
+				         "ut-scan: could not map to ODB path (skipping): %s", childpath);
+				continue;
+			}
+
+			/* Structural EFP-immune existence check. */
+			if (node_exists_in_memory(encoded_dotted))
+				continue;
+
+			/* Genuine orphan: create the table chain + leaf. */
+			log_info(LOG_COMP_STARTUP,
+			         "ut-scan: creating orphan node: %s", encoded_dotted);
+			if (create_orphan_node(encoded_dotted, childpath)) {
+				/*
+				 * Record with the ENCODED dotted form. cli_record_ut_import feeds
+				 * cli_redirty_ut_imported_paths which calls redirty_one_path. That
+				 * function (main.c ~237) splits on '.' and decodes each segment with
+				 * ut_pct_decode_segment before building the Pascal key for
+				 * hashtablelookup. So the ENCODED form is the correct contract for
+				 * cli_record_ut_import. Passing the raw form would break the decode
+				 * step for paths that contain '%' or other encoded characters.
+				 */
+				cli_record_ut_import(encoded_dotted);
+				(*count_out)++;
+			} else {
+				log_warn(LOG_COMP_STARTUP,
+				         "ut-scan: failed to create node for: %s", childpath);
+			}
+		}
+	}
+
+	closedir(d);
+}
+
+
+/* -------------------------------------------------------------------------
+ * Public entry point.
+ * ------------------------------------------------------------------------- */
+int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename) {
+	if (sync_dir == NULL || root_basename == NULL)
+		return -1;
+
+	/*
+	 * Build the effective sync base = sync_dir + "/" + root_basename.
+	 * This mirrors what the import hook (opverbs.c ut_import_hook) builds as
+	 * sync_base and passes as sync_dir to ut_odb_path_to_fs/ut_fs_path_to_odb.
+	 */
+	char scan_base[4096];
+	int nb;
+	if (root_basename[0] != '\0')
+		nb = snprintf(scan_base, sizeof(scan_base), "%s/%s", sync_dir, root_basename);
+	else
+		nb = snprintf(scan_base, sizeof(scan_base), "%s", sync_dir);
+	if (nb < 0 || nb >= (int)sizeof(scan_base)) {
+		log_warn(LOG_COMP_STARTUP,
+		         "ut-scan: sync base path too long (sync_dir=%s root=%s), aborting scan",
+		         sync_dir, root_basename);
+		return -1;
+	}
+
+	/* Check the scan base exists; if not, nothing to do (not an error). */
+	struct stat st;
+	if (stat(scan_base, &st) != 0 || !S_ISDIR(st.st_mode)) {
+		/* No sync tree yet -- not an error, just nothing to import. */
+		return 0;
+	}
+
+	int count = 0;
+	scan_dir_recursive(scan_base, scan_base, 0, &count);
+
+	if (count > 0) {
+		log_info(LOG_COMP_STARTUP,
+		         "ut-scan: boot scan complete, created %d orphan node(s)", count);
+	}
+
+	return count;
+}

--- a/frontier-cli/ut_scan.c
+++ b/frontier-cli/ut_scan.c
@@ -133,29 +133,36 @@ static int split_dotted(char *buf, const char **segs, int max_segs) {
 
 
 /* -------------------------------------------------------------------------
- * Internal: read an entire .ut file into a malloc'd buffer.
+ * Internal: read an entire .ut file from an already-opened fd.
+ *
+ * Takes ownership of fd (closes it on both success and failure).
+ * The fd must have been opened with O_NOFOLLOW and O_NONBLOCK; this
+ * function verifies S_ISREG via fstat, clears O_NONBLOCK, and reads.
+ * fspath_for_log is used only for warning messages -- it does not
+ * re-open the file, so no TOCTOU window is introduced.
  *
  * Returns 1 on success (*out is malloc'd, *outlen is the byte count).
  * Returns 0 on any error (*out is NULL, *outlen is 0).
- * Uses O_NOFOLLOW to refuse symlinks (matches the import hook's posture).
  * ------------------------------------------------------------------------- */
-static int read_ut_file(const char *fspath, unsigned char **out, size_t *outlen) {
+static int read_ut_file_fd(int fd, const char *fspath_for_log,
+                            unsigned char **out, size_t *outlen) {
 	*out = NULL;
 	*outlen = 0;
-
-	int fd = open(fspath, O_RDONLY | O_NOFOLLOW);
-	if (fd < 0)
-		return 0;
 
 	struct stat st;
 	if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 0) {
 		close(fd);
 		return 0;
 	}
+	/* Confirmed regular file: clear O_NONBLOCK so read() blocks normally. */
+	int fl = fcntl(fd, F_GETFL);
+	if (fl != -1)
+		(void) fcntl(fd, F_SETFL, fl & ~O_NONBLOCK);
+
 	size_t sz = (size_t)st.st_size;
 	if (sz > UT_SCAN_SIZE_CAP) {
 		log_warn(LOG_COMP_STARTUP,
-		         "ut-scan: skipping oversized .ut (%zu bytes): %s", sz, fspath);
+		         "ut-scan: skipping oversized .ut (%zu bytes): %s", sz, fspath_for_log);
 		close(fd);
 		return 0;
 	}
@@ -185,6 +192,26 @@ static int read_ut_file(const char *fspath, unsigned char **out, size_t *outlen)
 	*out = buf;
 	*outlen = total;
 	return 1;
+}
+
+/* -------------------------------------------------------------------------
+ * Internal: read an entire .ut file into a malloc'd buffer (path-based).
+ *
+ * Opens with O_NOFOLLOW|O_NONBLOCK to refuse symlinks and avoid blocking
+ * on a FIFO before the S_ISREG fstat guard in read_ut_file_fd runs.
+ * Delegates to read_ut_file_fd after the open.
+ *
+ * Returns 1 on success (*out is malloc'd, *outlen is the byte count).
+ * Returns 0 on any error (*out is NULL, *outlen is 0).
+ * ------------------------------------------------------------------------- */
+static int read_ut_file(const char *fspath, unsigned char **out, size_t *outlen) {
+	int fd = open(fspath, O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
+	if (fd < 0) {
+		*out = NULL;
+		*outlen = 0;
+		return 0;
+	}
+	return read_ut_file_fd(fd, fspath, out, outlen);
 }
 
 
@@ -368,7 +395,11 @@ done:
  *
  * encoded_dotted - ENCODED dotted path (the form stored by cli_record_ut_import
  *                  and consumed by cli_redirty_ut_imported_paths / redirty_one_path).
- * fspath         - absolute filesystem path to the .ut file.
+ * fspath         - absolute filesystem path to the .ut file (for logging only
+ *                  when prefd >= 0; used to open the file when prefd == -1).
+ * prefd          - if >= 0, a pre-opened fd for the .ut file (opened via openat
+ *                  on the pinned parent dir fd; ownership is transferred to this
+ *                  function). If -1, the file is opened by path via read_ut_file.
  *
  * GIL: must be called with the GIL held. All kernel primitives used here
  * (langsuretablevalue, hashtableassign, langexternalnewvalue, etc.) require
@@ -376,17 +407,26 @@ done:
  *
  * Returns 1 on success, 0 on failure.
  * ------------------------------------------------------------------------- */
-static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
+static int create_orphan_node(const char *encoded_dotted, const char *fspath, int prefd) {
+	/*
+	 * prefd (when >= 0) is owned by this function: it must be closed on EVERY
+	 * exit path. read_ut_file_fd consumes it (closes it) on the success path;
+	 * for all earlier bails we close it here. Centralize via the close_prefd
+	 * label so no early return leaks the fd. ut_bytes (if allocated) is freed
+	 * before reaching close_prefd on every path, so this label only owns prefd.
+	 */
+	int ok = 0; /* declared before any goto so close_prefd can return it */
+
 	/* Split on dots to get segment list. */
 	char *buf = strdup(encoded_dotted);
 	if (buf == NULL)
-		return 0;
+		goto close_prefd;
 
 	const char *segs[UT_SCAN_MAX_SEGMENTS];
 	int nseg = split_dotted(buf, segs, UT_SCAN_MAX_SEGMENTS);
 	if (nseg <= 0) {
 		free(buf);
-		return 0;
+		goto close_prefd;
 	}
 
 	/*
@@ -425,7 +465,6 @@ static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
 	 * above, so we only need the type-guard check here.
 	 */
 	hdlhashtable curtable = roottable;
-	int ok = 0;
 
 	for (int i = 0; i < nseg - 1 && curtable != nil; i++) {
 		char decoded[256];
@@ -503,10 +542,19 @@ static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
 		bsleaf[0] = (unsigned char)leaflen;
 		memcpy(&bsleaf[1], leaf_raw, leaflen);
 
-		/* Read the .ut file bytes. */
+		/* Read the .ut file bytes.  Use the pre-opened fd when available
+		 * (openat path from scan_dir_fd); fall back to open-by-path when
+		 * prefd == -1 (legacy callers that have no pinned parent fd). */
 		unsigned char *ut_bytes = NULL;
 		size_t ut_len = 0;
-		if (!read_ut_file(fspath, &ut_bytes, &ut_len)) {
+		int read_ok;
+		if (prefd >= 0) {
+			read_ok = read_ut_file_fd(prefd, fspath, &ut_bytes, &ut_len);
+			prefd = -1; /* read_ut_file_fd took ownership and closed it */
+		} else {
+			read_ok = read_ut_file(fspath, &ut_bytes, &ut_len);
+		}
+		if (!read_ok) {
 			log_warn(LOG_COMP_STARTUP,
 			         "ut-scan: could not read .ut file: %s", fspath);
 			goto done;
@@ -581,6 +629,11 @@ static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
 
 done:
 	free(buf);
+close_prefd:
+	/* Close prefd if it was not consumed by read_ut_file_fd (every early
+	 * bail before the read reaches here with prefd still owned). */
+	if (prefd >= 0)
+		close(prefd);
 	return ok;
 }
 
@@ -601,24 +654,33 @@ done:
  * count_out is incremented for each node successfully created.
  * depth guards against runaway recursion.
  *
- * P1 #3 -- TOCTOU fix for directory descent: directory children are opened
- * with O_RDONLY|O_NOFOLLOW|O_DIRECTORY|O_NONBLOCK and classified via fstat()
- * on the pinned fd (fdopendir).  This eliminates the window between lstat()
- * and opendir() where an attacker could swap a directory entry for a symlink
- * pointing out of the sync tree.  Regular files are still handled by the
- * existing O_NOFOLLOW path inside read_ut_file().
+ * P1 #3 / P2 -- TOCTOU-free descent: every child is resolved via openat()
+ * on the pinned parent dir fd (dirfd(d)), so no absolute path re-walk can
+ * race with a directory entry swap.  Directory children are recursed with
+ * the pinned DIR* passed directly into scan_dir_fd -- the caller never
+ * closes the dir before recursing.  Regular .ut files are opened via
+ * openat() and the pre-opened fd is passed into create_orphan_node (prefd
+ * argument), so read_ut_file_fd is used instead of open-by-path.
  * ------------------------------------------------------------------------- */
-static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
-                                int depth, int *count_out, int record_for_redirty) {
+
+/* Forward declaration: scan_dir_fd is mutually recursive with itself. */
+static void scan_dir_fd(DIR *d, const char *dirpath, const char *sync_dir,
+                         int depth, int *count_out, int record_for_redirty);
+
+static void scan_dir_fd(DIR *d, const char *dirpath, const char *sync_dir,
+                         int depth, int *count_out, int record_for_redirty) {
+	/*
+	 * d is owned by this frame; closedir(d) at exit (also closes dirfd(d)).
+	 * dirpath is used only for path-string construction (logging + ODB mapping).
+	 */
 	if (depth > UT_SCAN_MAX_DEPTH) {
 		log_warn(LOG_COMP_STARTUP,
 		         "ut-scan: max depth %d exceeded at: %s", UT_SCAN_MAX_DEPTH, dirpath);
+		closedir(d);
 		return;
 	}
 
-	DIR *d = opendir(dirpath);
-	if (d == NULL)
-		return;
+	int parent_fd = dirfd(d);
 
 	struct dirent *ent;
 	while ((ent = readdir(d)) != NULL) {
@@ -628,7 +690,8 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 		if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
 			continue;
 
-		/* Build full child path. */
+		/* Build full child path string (for logging and ODB path mapping only --
+		 * actual file opens use openat on parent_fd, not this path string). */
 		char childpath[4096];
 		int n = snprintf(childpath, sizeof(childpath), "%s/%s", dirpath, name);
 		if (n < 0 || n >= (int)sizeof(childpath)) {
@@ -638,22 +701,27 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 		}
 
 		/*
-		 * Classify the child by opening it with O_NOFOLLOW so symlinks are
-		 * never followed at any point.  Use O_DIRECTORY to detect directories
-		 * without a separate lstat(): if open() succeeds, the child is a
-		 * directory and the fd is pinned to that inode.  O_NONBLOCK avoids
-		 * blocking on a FIFO masquerading as a directory (macOS requirement).
+		 * Classify the child by opening it relative to the pinned parent fd
+		 * via openat().  O_NOFOLLOW refuses symlinks; O_DIRECTORY succeeds
+		 * only for directories; O_NONBLOCK avoids blocking on a FIFO
+		 * masquerading as a directory (macOS requirement).  This resolves the
+		 * name relative to the kernel-pinned parent inode, not via the path
+		 * string -- no TOCTOU window.
 		 */
-		int cfd = open(childpath, O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_NONBLOCK);
+		int cfd = openat(parent_fd, name,
+		                 O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_NONBLOCK);
 		if (cfd >= 0) {
 			/* Verify via fstat -- confirms S_ISDIR on the pinned inode. */
 			struct stat st;
 			if (fstat(cfd, &st) == 0 && S_ISDIR(st.st_mode)) {
 				DIR *cd = fdopendir(cfd); /* takes ownership of cfd */
 				if (cd != NULL) {
-					closedir(cd); /* also closes cfd */
-					scan_dir_recursive(childpath, sync_dir, depth + 1,
-					                   count_out, record_for_redirty);
+					/* Pass the pinned DIR* directly into the recursive frame.
+					 * Do NOT closedir(cd) here: scan_dir_fd owns it and will
+					 * close it on exit.  This eliminates the TOCTOU window
+					 * between closedir and a re-resolving opendir(childpath). */
+					scan_dir_fd(cd, childpath, sync_dir, depth + 1,
+					            count_out, record_for_redirty);
 					continue;
 				}
 			}
@@ -662,11 +730,11 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 		}
 
 		/*
-		 * open() failed with O_DIRECTORY -- child is not a directory.
+		 * openat() with O_DIRECTORY failed -- child is not a directory.
 		 * It may be a regular file, a symlink, or another special type.
-		 * Symlinks are silently skipped: open() with O_NOFOLLOW returns
-		 * ELOOP for symlinks, and read_ut_file() also uses O_NOFOLLOW, so
-		 * any symlink attempt is refused at both layers.
+		 * Symlinks are silently skipped: openat() with O_NOFOLLOW returns
+		 * ELOOP for symlinks, and read_ut_file_fd also received the fd from
+		 * an O_NOFOLLOW openat, so symlink pivot is refused at both layers.
 		 * Only process potential .ut regular files below.
 		 */
 		size_t namelen = strlen(name);
@@ -675,8 +743,9 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 
 		/*
 		 * Reverse-map this .ut fs path to its ENCODED dotted ODB path.
-		 * sync_dir here is the effective sync base (sync_dir/root_basename),
-		 * which was pre-computed by the caller.
+		 * sync_dir is the effective sync base (sync_dir/root_basename),
+		 * pre-computed by the caller.  childpath is the path string used
+		 * for mapping; the actual file read uses a pre-opened fd below.
 		 */
 		char encoded_dotted[2048];
 		if (!ut_fs_path_to_odb(childpath, sync_dir, encoded_dotted,
@@ -690,10 +759,18 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 		if (node_exists_in_memory(encoded_dotted))
 			continue;
 
-		/* Genuine orphan: create the table chain + leaf. */
+		/* Open the .ut file relative to the pinned parent fd via openat --
+		 * no re-resolution of the absolute path string. */
+		int ffd = openat(parent_fd, name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
+		if (ffd < 0)
+			continue; /* vanished or became a symlink after readdir -- skip */
+
+		/* Genuine orphan: create the table chain + leaf.
+		 * Pass ffd as prefd so create_orphan_node uses read_ut_file_fd
+		 * (ffd ownership transferred; create_orphan_node closes it). */
 		log_info(LOG_COMP_STARTUP,
 		         "ut-scan: creating orphan node: %s", encoded_dotted);
-		if (create_orphan_node(encoded_dotted, childpath)) {
+		if (create_orphan_node(encoded_dotted, childpath, ffd)) {
 			if (record_for_redirty) {
 				/*
 				 * Boot path: record with the ENCODED dotted form so
@@ -713,6 +790,41 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 	}
 
 	closedir(d);
+}
+
+static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
+                                int depth, int *count_out, int record_for_redirty) {
+	if (depth > UT_SCAN_MAX_DEPTH) {
+		log_warn(LOG_COMP_STARTUP,
+		         "ut-scan: max depth %d exceeded at: %s", UT_SCAN_MAX_DEPTH, dirpath);
+		return;
+	}
+
+	/*
+	 * Open the directory with O_NOFOLLOW|O_DIRECTORY|O_NONBLOCK so the root
+	 * of the recursion is also pinned to a kernel inode.  The top-level
+	 * dirpath is operator-supplied (--ut-sync-dir), not an attacker-controlled
+	 * subtree path, so it does not strictly need openat hardening -- but
+	 * pinning it here is cheap and gives consistent posture throughout.
+	 */
+	int fd = open(dirpath, O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_NONBLOCK);
+	if (fd < 0)
+		return;
+
+	struct stat st;
+	if (fstat(fd, &st) != 0 || !S_ISDIR(st.st_mode)) {
+		close(fd);
+		return;
+	}
+
+	DIR *d = fdopendir(fd); /* takes ownership of fd */
+	if (d == NULL) {
+		close(fd);
+		return;
+	}
+
+	/* Delegate to the fd-pinned recursive worker.  scan_dir_fd owns d. */
+	scan_dir_fd(d, dirpath, sync_dir, depth, count_out, record_for_redirty);
 }
 
 

--- a/frontier-cli/ut_scan.c
+++ b/frontier-cli/ut_scan.c
@@ -48,6 +48,44 @@ extern void cli_record_ut_import(const char *dotted_path);
 
 
 /* -------------------------------------------------------------------------
+ * Internal: count the number of decoded bytes that ut_pct_decode_segment
+ * would produce for the given encoded segment, WITHOUT actually decoding.
+ *
+ * Each non-'%' character contributes 1 byte. Each valid '%XX' escape
+ * contributes 1 byte. Returns -1 if the encoding is malformed (lone '%'
+ * or '%X' without two hex digits). The caller can compare this against
+ * strlen(decoded) to detect an embedded NUL: if they differ, at least one
+ * decoded byte was 0x00 (which strlen stops at, giving a smaller count).
+ * ------------------------------------------------------------------------- */
+static int hex_digit_val(unsigned char c) {
+	if (c >= '0' && c <= '9') return c - '0';
+	if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+	if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+	return -1;
+}
+
+static int pct_decoded_byte_count(const char *enc) {
+	int count = 0;
+	const char *p = enc;
+	while (*p != '\0') {
+		if (*p == '%') {
+			if (p[1] == '\0' || p[2] == '\0')
+				return -1; /* malformed */
+			if (hex_digit_val((unsigned char)p[1]) < 0 ||
+			    hex_digit_val((unsigned char)p[2]) < 0)
+				return -1; /* malformed */
+			count++;
+			p += 3;
+		} else {
+			count++;
+			p++;
+		}
+	}
+	return count;
+}
+
+
+/* -------------------------------------------------------------------------
  * Internal: maximum depth for recursive directory walk (guards against
  * pathological symlink loops that O_NOFOLLOW at the open level can't catch
  * for the opendir path).
@@ -207,6 +245,44 @@ static int node_exists_in_memory(const char *encoded_dotted) {
 		}
 
 		size_t rawlen = strlen(decoded);
+
+		/*
+		 * P1 #2 -- post-decode NUL guard: a crafted %00 sequence in an encoded
+		 * filename decodes to a NUL byte. strlen() stops at the first NUL, so
+		 * rawlen (= strlen(decoded)) would be shorter than the actual decoded
+		 * byte count. This silently truncates the Pascal string we build from
+		 * decoded[0..rawlen], potentially corrupting a hashtable key.
+		 *
+		 * Detection: pct_decoded_byte_count() counts the bytes the decoder
+		 * WOULD produce (one per char or per %XX) without actually decoding.
+		 * If that count exceeds strlen(decoded), at least one decoded byte was
+		 * 0x00 and strlen stopped early. In that case, reject this orphan.
+		 *
+		 * Note: segment_is_safe() is NOT called here. segment_is_safe() is a
+		 * forward-direction (ODB->fs) validator that rejects "/" and control
+		 * bytes to prevent unsafe filesystem path components. On the reverse
+		 * path (fs->ODB), "/" and control bytes are valid ODB key characters
+		 * (e.g. URL-keyed tables like "http://webns.net/mvcb/") and must be
+		 * allowed through. NUL is the only byte dangerous in this direction.
+		 */
+		{
+			int expected_len = pct_decoded_byte_count(segs[i]);
+			if (expected_len < 0 || (size_t)expected_len != rawlen) {
+				/* Malformed encoding or embedded NUL: reject. */
+				log_warn(LOG_COMP_STARTUP,
+				         "ut-scan: embedded NUL or malformed encoding in segment (encoded: '%.64s'), skipping",
+				         segs[i]);
+				found = 0;
+				goto done;
+			}
+		}
+
+		if (rawlen == 0) {
+			/* Empty decoded segment is not a valid ODB key. */
+			found = 0;
+			goto done;
+		}
+
 		if (rawlen > 255) {
 			found = 0; /* too long for a Pascal string */
 			goto done;
@@ -232,8 +308,16 @@ static int node_exists_in_memory(const char *encoded_dotted) {
 
 		/*
 		 * Intermediate segment: descend into the table. The node must be an
-		 * in-memory table external variable. If it isn't (e.g. it's some other
-		 * type), we can't descend and treat the leaf as absent.
+		 * in-memory EXTERNAL TABLE variable (id == idtableprocessor).
+		 *
+		 * P1 #1 -- type guard: if the existing node is an external but is NOT
+		 * a table (e.g. it is a script, outline, menu, or picture), the path
+		 * component collides with a real non-table object. We must NOT treat
+		 * the leaf as an orphan and attempt to create it -- doing so would
+		 * cause create_orphan_node to call langsuretablevalue on this slot,
+		 * which silently overwrites the existing script/outline with an empty
+		 * table (data loss). Treat the path as "present" (found=1) so the
+		 * entire orphan is skipped.
 		 */
 		tyvaluerecord val = (**hnode).val;
 		if (val.valuetype != externalvaluetype || val.data.externalvalue == NULL) {
@@ -241,9 +325,10 @@ static int node_exists_in_memory(const char *encoded_dotted) {
 			goto done;
 		}
 		hdlexternalvariable hv = (hdlexternalvariable) val.data.externalvalue;
+
 		if (!(**hv).flinmemory || (**hv).variabledata == 0) {
 			/*
-			 * Intermediate table is not in memory. Post-full-materialization
+			 * Intermediate node is not in memory. Post-full-materialization
 			 * this should not happen for a real ODB node, but if it does we
 			 * conservatively treat the leaf as present (don't shadow a real
 			 * lazy node we couldn't descend into).
@@ -251,6 +336,21 @@ static int node_exists_in_memory(const char *encoded_dotted) {
 			found = 1;
 			goto done;
 		}
+
+		if ((**hv).id != idtableprocessor) {
+			/*
+			 * The intermediate slot exists but is a non-table external (script,
+			 * outline, menu, picture, etc.). A .ut path cannot thread through a
+			 * non-table node. Treat as present so create_orphan_node is not
+			 * called -- calling it would clobber the existing non-table object.
+			 */
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: intermediate segment '%.64s' is a non-table external (id=%u), skipping orphan",
+			         decoded, (unsigned)(**hv).id);
+			found = 1;
+			goto done;
+		}
+
 		curtable = (hdlhashtable)(Handle)(uintptr_t)(**hv).variabledata;
 	}
 
@@ -283,9 +383,39 @@ static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
 	}
 
 	/*
+	 * P1 #2 -- pre-flight segment validation: decode and validate ALL
+	 * segments before making any ODB mutation. This ensures we never create
+	 * partial intermediate tables that would be orphaned if a later segment
+	 * (e.g. the leaf) fails validation. A crafted %00 in any segment would
+	 * cause strlen to stop early, producing a wrong-length Pascal key or a
+	 * collision with an existing node.
+	 */
+	for (int i = 0; i < nseg; i++) {
+		char decoded_check[256];
+		if (!ut_pct_decode_segment(segs[i], decoded_check, sizeof(decoded_check))) {
+			free(buf);
+			return 0; /* malformed %XX */
+		}
+		size_t rawlen_check = strlen(decoded_check);
+		int expected_check = pct_decoded_byte_count(segs[i]);
+		if (expected_check < 0 || (size_t)expected_check != rawlen_check || rawlen_check == 0) {
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: create: pre-flight rejected segment (encoded: '%.64s'), aborting orphan",
+			         segs[i]);
+			free(buf);
+			return 0;
+		}
+		if (rawlen_check > 255) {
+			free(buf);
+			return 0;
+		}
+	}
+
+	/*
 	 * Walk from roottable, creating missing intermediate tables, until we
 	 * reach the parent of the leaf (nseg-1 segments). The leaf itself is
-	 * created as a script external.
+	 * created as a script external. All segment encodings were validated
+	 * above, so we only need the type-guard check here.
 	 */
 	hdlhashtable curtable = roottable;
 	int ok = 0;
@@ -295,18 +425,55 @@ static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
 		if (!ut_pct_decode_segment(segs[i], decoded, sizeof(decoded)))
 			goto done;
 		size_t rawlen = strlen(decoded);
-		if (rawlen > 255)
-			goto done;
+		/* rawlen is validated safe by the pre-flight pass above. */
 
 		bigstring bsseg;
 		bsseg[0] = (unsigned char)rawlen;
 		memcpy(&bsseg[1], decoded, rawlen);
 
+		/*
+		 * P1 #1 -- pre-langsuretablevalue type guard: if a node already exists
+		 * at this intermediate slot and it is a non-table external (script,
+		 * outline, menu, picture), langsuretablevalue would silently overwrite
+		 * it with a new empty table (data loss). Guard by checking the existing
+		 * node's type before calling langsuretablevalue.
+		 *
+		 * langsuretablevalue is only safe to call when:
+		 *   (a) the slot is empty (no existing node), OR
+		 *   (b) the existing node is already a table (idtableprocessor).
+		 * In all other cases, abort this orphan creation.
+		 */
+		{
+			tyvaluerecord existing_val;
+			hdlhashnode existing_hnode = nil;
+			if (hashtablelookup(curtable, bsseg, &existing_val, &existing_hnode)) {
+				/* Slot occupied: verify it is a table before proceeding. */
+				if (existing_val.valuetype == externalvaluetype &&
+				    existing_val.data.externalvalue != NULL) {
+					hdlexternalvariable hv_exist =
+					    (hdlexternalvariable) existing_val.data.externalvalue;
+					if ((**hv_exist).id != idtableprocessor) {
+						/* Non-table external occupies an intermediate slot -- do NOT clobber. */
+						log_warn(LOG_COMP_STARTUP,
+						         "ut-scan: create: intermediate '%.64s' is non-table (id=%u), aborting orphan",
+						         decoded, (unsigned)(**hv_exist).id);
+						goto done;
+					}
+				} else if (existing_val.valuetype != externalvaluetype) {
+					/* Slot holds a non-external value (scalar, etc.) -- cannot descend. */
+					log_warn(LOG_COMP_STARTUP,
+					         "ut-scan: create: intermediate '%.64s' is a non-external value, aborting orphan",
+					         decoded);
+					goto done;
+				}
+			}
+		}
+
 		hdlhashtable nexttable = nil;
 		/*
 		 * langsuretablevalue: if the table already exists, return it; if not,
-		 * create a new empty table and assign it. Safe to call when the node
-		 * is already present (idempotent for the already-exists case).
+		 * create a new empty table and assign it. The pre-guard above ensures
+		 * we only reach this call when the slot is empty or already a table.
 		 */
 		if (!langsuretablevalue(curtable, bsseg, &nexttable) || nexttable == nil)
 			goto done;
@@ -320,6 +487,8 @@ static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
 		if (!ut_pct_decode_segment(leaf_enc, leaf_raw, sizeof(leaf_raw)))
 			goto done;
 		size_t leaflen = strlen(leaf_raw);
+		/* leaflen is validated safe (non-zero, no embedded NUL, <= 255) by the
+		 * pre-flight pass above. No additional check needed here. */
 		if (leaflen > 255)
 			goto done;
 

--- a/frontier-cli/ut_scan.c
+++ b/frontier-cli/ut_scan.c
@@ -100,7 +100,10 @@ static int pct_decoded_byte_count(const char *enc) {
 
 /*
  * Maximum size of a .ut file we will attempt to import during the scan.
- * Matches UT_IMPORT_SIZE_CAP in ut_sync.c (1 MB).
+ * ut_sync.c uses UT_MAX_FILE_BYTES (8 MB) as the import-hook cap; this
+ * scan-side cap is intentionally tighter (1 MB) -- boot-scan files should
+ * be small scripts, and a larger cap just widens the attack surface for
+ * resource exhaustion via a planted oversized file in the sync dir.
  */
 #define UT_SCAN_SIZE_CAP ((size_t)(1u << 20))
 
@@ -367,6 +370,10 @@ done:
  *                  and consumed by cli_redirty_ut_imported_paths / redirty_one_path).
  * fspath         - absolute filesystem path to the .ut file.
  *
+ * GIL: must be called with the GIL held. All kernel primitives used here
+ * (langsuretablevalue, hashtableassign, langexternalnewvalue, etc.) require
+ * exclusive GIL ownership, matching the boot-scan and repl.syncScan contexts.
+ *
  * Returns 1 on success, 0 on failure.
  * ------------------------------------------------------------------------- */
 static int create_orphan_node(const char *encoded_dotted, const char *fspath) {
@@ -585,13 +592,24 @@ done:
  *   1. Reverse-map its fs path to the ENCODED dotted ODB path.
  *   2. Check existence via structural hashtable walk (EFP-immune).
  *   3. If absent, create the intermediate table chain + leaf script.
- *   4. Record the created path so the redirty pass persists it.
+ *   4. Record the created path (only when record_for_redirty is non-zero,
+ *      i.e. the boot path) so the redirty pass persists it on save.
+ *      Post-boot (repl.syncScan) callers pass 0: the dirty bits set by
+ *      hashtableassign/langsuretablevalue survive naturally to the next
+ *      save without the record/redirty mechanism.
  *
  * count_out is incremented for each node successfully created.
  * depth guards against runaway recursion.
+ *
+ * P1 #3 -- TOCTOU fix for directory descent: directory children are opened
+ * with O_RDONLY|O_NOFOLLOW|O_DIRECTORY|O_NONBLOCK and classified via fstat()
+ * on the pinned fd (fdopendir).  This eliminates the window between lstat()
+ * and opendir() where an attacker could swap a directory entry for a symlink
+ * pointing out of the sync tree.  Regular files are still handled by the
+ * existing O_NOFOLLOW path inside read_ut_file().
  * ------------------------------------------------------------------------- */
 static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
-                                int depth, int *count_out) {
+                                int depth, int *count_out, int record_for_redirty) {
 	if (depth > UT_SCAN_MAX_DEPTH) {
 		log_warn(LOG_COMP_STARTUP,
 		         "ut-scan: max depth %d exceeded at: %s", UT_SCAN_MAX_DEPTH, dirpath);
@@ -619,58 +637,78 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 			continue;
 		}
 
-		/* lstat to classify without following symlinks. */
-		struct stat st;
-		if (lstat(childpath, &st) != 0)
-			continue;
-
-		/* Skip symlinks -- defense against symlink escape. */
-		if (S_ISLNK(st.st_mode))
-			continue;
-
-		if (S_ISDIR(st.st_mode)) {
-			scan_dir_recursive(childpath, sync_dir, depth + 1, count_out);
-		} else if (S_ISREG(st.st_mode)) {
-			size_t namelen = strlen(name);
-			if (namelen < 3 || strcmp(name + namelen - 3, ".ut") != 0)
-				continue;
-
-			/*
-			 * Reverse-map this .ut fs path to its ENCODED dotted ODB path.
-			 * sync_dir here is the effective sync base (sync_dir/root_basename),
-			 * which was pre-computed by the caller.
-			 */
-			char encoded_dotted[2048];
-			if (!ut_fs_path_to_odb(childpath, sync_dir, encoded_dotted,
-			                       sizeof(encoded_dotted))) {
-				log_warn(LOG_COMP_STARTUP,
-				         "ut-scan: could not map to ODB path (skipping): %s", childpath);
-				continue;
+		/*
+		 * Classify the child by opening it with O_NOFOLLOW so symlinks are
+		 * never followed at any point.  Use O_DIRECTORY to detect directories
+		 * without a separate lstat(): if open() succeeds, the child is a
+		 * directory and the fd is pinned to that inode.  O_NONBLOCK avoids
+		 * blocking on a FIFO masquerading as a directory (macOS requirement).
+		 */
+		int cfd = open(childpath, O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_NONBLOCK);
+		if (cfd >= 0) {
+			/* Verify via fstat -- confirms S_ISDIR on the pinned inode. */
+			struct stat st;
+			if (fstat(cfd, &st) == 0 && S_ISDIR(st.st_mode)) {
+				DIR *cd = fdopendir(cfd); /* takes ownership of cfd */
+				if (cd != NULL) {
+					closedir(cd); /* also closes cfd */
+					scan_dir_recursive(childpath, sync_dir, depth + 1,
+					                   count_out, record_for_redirty);
+					continue;
+				}
 			}
+			close(cfd);
+			continue;
+		}
 
-			/* Structural EFP-immune existence check. */
-			if (node_exists_in_memory(encoded_dotted))
-				continue;
+		/*
+		 * open() failed with O_DIRECTORY -- child is not a directory.
+		 * It may be a regular file, a symlink, or another special type.
+		 * Symlinks are silently skipped: open() with O_NOFOLLOW returns
+		 * ELOOP for symlinks, and read_ut_file() also uses O_NOFOLLOW, so
+		 * any symlink attempt is refused at both layers.
+		 * Only process potential .ut regular files below.
+		 */
+		size_t namelen = strlen(name);
+		if (namelen < 3 || strcmp(name + namelen - 3, ".ut") != 0)
+			continue;
 
-			/* Genuine orphan: create the table chain + leaf. */
-			log_info(LOG_COMP_STARTUP,
-			         "ut-scan: creating orphan node: %s", encoded_dotted);
-			if (create_orphan_node(encoded_dotted, childpath)) {
+		/*
+		 * Reverse-map this .ut fs path to its ENCODED dotted ODB path.
+		 * sync_dir here is the effective sync base (sync_dir/root_basename),
+		 * which was pre-computed by the caller.
+		 */
+		char encoded_dotted[2048];
+		if (!ut_fs_path_to_odb(childpath, sync_dir, encoded_dotted,
+		                       sizeof(encoded_dotted))) {
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: could not map to ODB path (skipping): %s", childpath);
+			continue;
+		}
+
+		/* Structural EFP-immune existence check. */
+		if (node_exists_in_memory(encoded_dotted))
+			continue;
+
+		/* Genuine orphan: create the table chain + leaf. */
+		log_info(LOG_COMP_STARTUP,
+		         "ut-scan: creating orphan node: %s", encoded_dotted);
+		if (create_orphan_node(encoded_dotted, childpath)) {
+			if (record_for_redirty) {
 				/*
-				 * Record with the ENCODED dotted form. cli_record_ut_import feeds
-				 * cli_redirty_ut_imported_paths which calls redirty_one_path. That
-				 * function (main.c ~237) splits on '.' and decodes each segment with
-				 * ut_pct_decode_segment before building the Pascal key for
-				 * hashtablelookup. So the ENCODED form is the correct contract for
-				 * cli_record_ut_import. Passing the raw form would break the decode
-				 * step for paths that contain '%' or other encoded characters.
+				 * Boot path: record with the ENCODED dotted form so
+				 * cli_redirty_ut_imported_paths can re-dirty the node
+				 * after clear_post_hydration_dirty_flags wiped it.
+				 * cli_record_ut_import/redirty_one_path split on '.'
+				 * and call ut_pct_decode_segment per segment, so the
+				 * ENCODED form is the correct contract here.
 				 */
 				cli_record_ut_import(encoded_dotted);
-				(*count_out)++;
-			} else {
-				log_warn(LOG_COMP_STARTUP,
-				         "ut-scan: failed to create node for: %s", childpath);
 			}
+			(*count_out)++;
+		} else {
+			log_warn(LOG_COMP_STARTUP,
+			         "ut-scan: failed to create node for: %s", childpath);
 		}
 	}
 
@@ -680,8 +718,22 @@ static void scan_dir_recursive(const char *dirpath, const char *sync_dir,
 
 /* -------------------------------------------------------------------------
  * Public entry point.
+ *
+ * record_for_redirty controls whether newly created nodes are recorded via
+ * cli_record_ut_import() for the post-boot redirty pass:
+ *
+ *   1 (boot path, main.c): boot scan runs AFTER clear_post_hydration_dirty_flags
+ *     wipes all dirty bits, so created nodes must be re-dirtied explicitly via
+ *     cli_record_ut_import + cli_redirty_ut_imported_paths to survive to save.
+ *
+ *   0 (post-boot, repl.syncScan): no clear pass runs between the scan and the
+ *     next save, so the dirty bits set by hashtableassign/langsuretablevalue
+ *     inside create_orphan_node survive naturally.  Recording the paths is both
+ *     unnecessary and a memory leak (the recorded list is consumed only once, at
+ *     boot, and post-boot accumulations are never freed).
  * ------------------------------------------------------------------------- */
-int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename) {
+int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename,
+                             int record_for_redirty) {
 	if (sync_dir == NULL || root_basename == NULL)
 		return -1;
 
@@ -711,11 +763,12 @@ int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename) {
 	}
 
 	int count = 0;
-	scan_dir_recursive(scan_base, scan_base, 0, &count);
+	scan_dir_recursive(scan_base, scan_base, 0, &count, record_for_redirty);
 
 	if (count > 0) {
 		log_info(LOG_COMP_STARTUP,
-		         "ut-scan: boot scan complete, created %d orphan node(s)", count);
+		         "ut-scan: %s scan complete, created %d orphan node(s)",
+		         record_for_redirty ? "boot" : "on-demand", count);
 	}
 
 	return count;

--- a/frontier-cli/ut_scan.h
+++ b/frontier-cli/ut_scan.h
@@ -1,0 +1,60 @@
+/*
+ * ut_scan.h - Boot-time import-discovery scan for ODB<->.ut sync.
+ *
+ * Walks the .ut sync tree at boot (after full ODB materialization) and
+ * auto-creates any ODB node whose .ut file exists on disk but is absent
+ * from the in-memory hashtable chain. Intermediate tables are created as
+ * needed; leaf script objects are built from the raw .ut body bytes using
+ * the same kernel primitives the normal import hook uses.
+ *
+ * This module is compiled ONLY into the production CLI binary. It must NOT
+ * be linked into any kernel-free test binary (e.g. tests/runtime_tests).
+ *
+ * See docs/ODB_UT_SYNC_DESIGN.md for the full sync contract.
+ *
+ * License
+ * -------
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Frontier contributors.
+ */
+
+#ifndef UT_SCAN_INCLUDE
+#define UT_SCAN_INCLUDE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * ut_sync_scan_and_create - walk sync_dir/<root_basename>/ and create any
+ * orphan ODB nodes found there.
+ *
+ * Must be called after langhash_materialize_disk_values() has fully loaded
+ * the tree into memory (so a hashtable miss genuinely means absent, not
+ * lazy-unloaded) and after clear_post_hydration_dirty_flags() has cleared
+ * all dirty bits (so the caller can re-dirty only the nodes it creates).
+ * Each newly created path is recorded via cli_record_ut_import() so the
+ * existing cli_redirty_ut_imported_paths() pass persists them on save.
+ *
+ * Runs on the main thread holding the GIL -- the same execution context as
+ * the bulk hydrate walk, so all kernel hashtable/op/lang primitives are safe
+ * to call directly.
+ *
+ * Parameters:
+ *   sync_dir     - value of --ut-sync-dir (e.g. "usertalk_scripts"). Not NULL.
+ *   root_basename - filename of the loaded .root (e.g. "Frontier.root"). Not NULL.
+ *
+ * Returns the number of ODB nodes created (>= 0), or -1 on a hard error
+ * (e.g. sync directory not accessible).
+ *
+ * Designed as a clean reusable routine: the future repl.syncScan REPL verb
+ * will call this after boot to pick up .ut drops that arrive while the
+ * runtime is running.
+ */
+int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UT_SCAN_INCLUDE */

--- a/frontier-cli/ut_scan.h
+++ b/frontier-cli/ut_scan.h
@@ -31,27 +31,30 @@ extern "C" {
  *
  * Must be called after langhash_materialize_disk_values() has fully loaded
  * the tree into memory (so a hashtable miss genuinely means absent, not
- * lazy-unloaded) and after clear_post_hydration_dirty_flags() has cleared
- * all dirty bits (so the caller can re-dirty only the nodes it creates).
- * Each newly created path is recorded via cli_record_ut_import() so the
- * existing cli_redirty_ut_imported_paths() pass persists them on save.
+ * lazy-unloaded).
  *
  * Runs on the main thread holding the GIL -- the same execution context as
  * the bulk hydrate walk, so all kernel hashtable/op/lang primitives are safe
  * to call directly.
  *
  * Parameters:
- *   sync_dir     - value of --ut-sync-dir (e.g. "usertalk_scripts"). Not NULL.
- *   root_basename - filename of the loaded .root (e.g. "Frontier.root"). Not NULL.
+ *   sync_dir          - value of --ut-sync-dir (e.g. "usertalk_scripts"). Not NULL.
+ *   root_basename     - filename of the loaded .root (e.g. "Frontier.root"). Not NULL.
+ *   record_for_redirty - non-zero: record each created path via cli_record_ut_import()
+ *                        so cli_redirty_ut_imported_paths() can re-dirty them after
+ *                        clear_post_hydration_dirty_flags() wiped the bits (boot path).
+ *                        Zero: skip recording -- dirty bits from hashtableassign/
+ *                        langsuretablevalue survive naturally to the next save
+ *                        (post-boot / repl.syncScan path). Passing 0 post-boot also
+ *                        prevents an unbounded memory leak: the recorded list is only
+ *                        consumed once (at boot) and post-boot accumulations are
+ *                        never freed.
  *
  * Returns the number of ODB nodes created (>= 0), or -1 on a hard error
  * (e.g. sync directory not accessible).
- *
- * Designed as a clean reusable routine: the future repl.syncScan REPL verb
- * will call this after boot to pick up .ut drops that arrive while the
- * runtime is running.
  */
-int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename);
+int ut_sync_scan_and_create(const char *sync_dir, const char *root_basename,
+                             int record_for_redirty);
 
 #ifdef __cplusplus
 }

--- a/frontier-cli/ut_sync.c
+++ b/frontier-cli/ut_sync.c
@@ -816,8 +816,9 @@ int ut_pct_decode_segment(const char *enc, char *out, size_t outsz) {
 /* ------------------------------------------------------------------------- */
 
 /* Reject a single ODB-path segment that cannot safely become an fs component:
- * empty, ".", "..", or containing "/" or a control byte. Returns 1 if safe. */
-static int segment_is_safe(const char *seg, size_t len) {
+ * empty, ".", "..", or containing "/" or a control byte. Returns 1 if safe.
+ * Exported (non-static) for use by ut_scan.c post-decode validation. */
+int segment_is_safe(const char *seg, size_t len) {
 	size_t i;
 	if (len == 0)
 		return 0;

--- a/frontier-cli/ut_sync.c
+++ b/frontier-cli/ut_sync.c
@@ -680,6 +680,138 @@ fail:
 }
 
 /* ------------------------------------------------------------------------- */
+/* Percent-codec                                                             */
+/* ------------------------------------------------------------------------- */
+
+/*
+ * Hex digit emit helper. Returns the ASCII hex char for the low nibble of v,
+ * uppercase (0-9, A-F).
+ */
+static char hex_upper(unsigned int v) {
+	v &= 0x0f;
+	return (v < 10) ? (char)('0' + v) : (char)('A' + v - 10);
+}
+
+/*
+ * Hex digit parse helper. Returns the value of a single hex digit c (0..15),
+ * or -1 if c is not a valid hex digit.
+ */
+static int hex_val(unsigned char c) {
+	if (c >= '0' && c <= '9') return (int)(c - '0');
+	if (c >= 'A' && c <= 'F') return (int)(c - 'A' + 10);
+	if (c >= 'a' && c <= 'f') return (int)(c - 'a' + 10);
+	return -1;
+}
+
+int ut_pct_encode_segment(const char *raw, size_t rawlen,
+                          char *out, size_t outsz) {
+	size_t i;
+	size_t pos = 0;
+
+	if (out == NULL || outsz == 0)
+		return 0;
+	out[0] = '\0';
+
+	for (i = 0; i < rawlen; i++) {
+		unsigned char b = (unsigned char)raw[i];
+		int escape = 0;
+		unsigned int hex_byte = (unsigned int)b;
+
+		/*
+		 * Decide whether this byte must be percent-escaped and, if so, which
+		 * hex value to emit. The order of checks matters: '%' is tested first
+		 * so the escape-the-escape invariant holds.
+		 */
+		if (b == '%') {
+			escape = 1; hex_byte = 0x25;
+		} else if (b == '.') {
+			escape = 1; hex_byte = 0x2E;
+		} else if (b == '/') {
+			escape = 1; hex_byte = 0x2F;
+		} else if (b == ':') {
+			escape = 1; hex_byte = 0x3A;
+		} else if (b == '"') {
+			escape = 1; hex_byte = 0x22;
+		} else if (b == '\\') {
+			escape = 1; hex_byte = 0x5C;
+		} else if (b < 0x20 || b == 0x7F) {
+			/* Control bytes and DEL */
+			escape = 1; hex_byte = (unsigned int)b;
+		} else if (i == 0 && b == '-') {
+			/* Leading dash only */
+			escape = 1; hex_byte = 0x2D;
+		}
+
+		if (escape) {
+			/* Need 3 bytes (%XX) + the final NUL sentinel */
+			if (pos + 3 + 1 > outsz) {
+				out[0] = '\0';
+				return 0;
+			}
+			out[pos++] = '%';
+			out[pos++] = hex_upper(hex_byte >> 4);
+			out[pos++] = hex_upper(hex_byte);
+		} else {
+			/* Need 1 byte + the final NUL sentinel */
+			if (pos + 1 + 1 > outsz) {
+				out[0] = '\0';
+				return 0;
+			}
+			out[pos++] = (char)b;
+		}
+	}
+
+	out[pos] = '\0';
+	return 1;
+}
+
+int ut_pct_decode_segment(const char *enc, char *out, size_t outsz) {
+	size_t pos = 0;
+	const char *p = enc;
+
+	if (out == NULL || outsz == 0)
+		return 0;
+	out[0] = '\0';
+	if (enc == NULL)
+		return 0;
+
+	while (*p != '\0') {
+		if (*p == '%') {
+			int hi, lo;
+			/* Require exactly two following hex digits. */
+			if (p[1] == '\0' || p[2] == '\0') {
+				out[0] = '\0';
+				return 0;
+			}
+			hi = hex_val((unsigned char)p[1]);
+			lo = hex_val((unsigned char)p[2]);
+			if (hi < 0 || lo < 0) {
+				out[0] = '\0';
+				return 0;
+			}
+			/* Need 1 decoded byte + the final NUL sentinel */
+			if (pos + 1 + 1 > outsz) {
+				out[0] = '\0';
+				return 0;
+			}
+			out[pos++] = (char)((hi << 4) | lo);
+			p += 3;
+		} else {
+			/* Need 1 literal byte + the final NUL sentinel */
+			if (pos + 1 + 1 > outsz) {
+				out[0] = '\0';
+				return 0;
+			}
+			out[pos++] = *p++;
+		}
+	}
+
+	out[pos] = '\0';
+	return 1;
+}
+
+
+/* ------------------------------------------------------------------------- */
 /* Path mapping                                                              */
 /* ------------------------------------------------------------------------- */
 

--- a/frontier-cli/ut_sync.c
+++ b/frontier-cli/ut_sync.c
@@ -816,9 +816,8 @@ int ut_pct_decode_segment(const char *enc, char *out, size_t outsz) {
 /* ------------------------------------------------------------------------- */
 
 /* Reject a single ODB-path segment that cannot safely become an fs component:
- * empty, ".", "..", or containing "/" or a control byte. Returns 1 if safe.
- * Exported (non-static) for use by ut_scan.c post-decode validation. */
-int segment_is_safe(const char *seg, size_t len) {
+ * empty, ".", "..", or containing "/" or a control byte. Returns 1 if safe. */
+static int segment_is_safe(const char *seg, size_t len) {
 	size_t i;
 	if (len == 0)
 		return 0;

--- a/frontier-cli/ut_sync.h
+++ b/frontier-cli/ut_sync.h
@@ -148,24 +148,86 @@ int ut_decanonicalize_outline_text(const unsigned char *in, size_t inlen,
 
 
 /*
- * PATH MAPPING
- * ------------
- * A script at ODB dotted path "a.b.c" maps to the filesystem path
- * "<sync_dir>/a/b/c.ut" and back. The mapping is purely lexical: each dotted
- * segment becomes one filesystem path component, with no escaping. This
- * matches the corpus on disk (segments like "#filters" are stored as literal
- * directory names) and the verifier's documented contract
- * (tools/verify_virgin_root_sync.py: "lexical, no escaping").
+ * PERCENT-CODEC
+ * -------------
+ * Raw ODB segment names may contain characters that are structurally
+ * significant in the dotted-path interchange string ('.' separator) or
+ * unsafe as filesystem path components ('/', ':', '"', '\', control bytes,
+ * leading '-'). The codec escapes these bytes as %XX sequences so each
+ * encoded segment is safe to use as one component of both the dotted path
+ * and the filesystem path. The '%' sigil is always escaped first ("%25"),
+ * ensuring the codec is a lossless bijection.
+ */
+
+/*
+ * ut_pct_encode_segment - percent-encode a raw ODB segment name.
  *
- * The dotted path is the one the kernel builds during hydrate
- * (langhash_materialize_current_path) and pack: it is a "." join of raw key
- * names, NOT bracket-quoted. The lexical mapping is therefore ambiguous only
- * if a key name itself contains "." or "/"; no script in the corpus does, and
- * the functions reject any segment containing "/" (path-separator injection)
- * or control bytes. A key containing "." cannot be distinguished from a
- * segment boundary by these functions -- callers that might handle such keys
- * must walk the hashtable chain instead. (Documented limitation; not present
- * in any real corpus.)
+ * Encodes each byte that would be structurally unsafe or ambiguous:
+ *   '%' -> "%25"  (escape-the-escape FIRST)
+ *   '.' -> "%2E"  '/' -> "%2F"  ':' -> "%3A"  '"' -> "%22"  '\' -> "%5C"
+ *   b < 0x20 OR b == 0x7F  -> "%XX"  (control bytes / DEL; uppercase hex)
+ *   leading '-' (i==0)     -> "%2D"  (interior / trailing '-' passed through)
+ *   all other bytes        -> copied unchanged
+ *
+ * Returns 1 on success (out is NUL-terminated). Returns 0 if the encoded
+ * result plus NUL would not fit in outsz; in that case out[0] is set to '\0'.
+ * Empty input (rawlen 0) writes out="" and returns 1.
+ *
+ * Pure function: no globals, no kernel state, thread-safe.
+ */
+int ut_pct_encode_segment(const char *raw, size_t rawlen,
+                          char *out, size_t outsz);
+
+/*
+ * ut_pct_decode_segment - decode a percent-encoded ODB segment name.
+ *
+ * For each input character:
+ *   '%' -> requires two following hex digits ([0-9A-Fa-f]); decoded to one byte.
+ *          A lone trailing '%' or '%X' (only one hex digit) causes failure.
+ *   other -> copied unchanged.
+ *
+ * Returns 1 on success (out is NUL-terminated). Returns 0 on any malformed %
+ * escape or if the decoded result plus NUL would not fit in outsz; on failure
+ * out[0] is set to '\0'. Empty input writes out="" and returns 1.
+ *
+ * Lenient hex case: both upper and lower case hex digits are accepted (%2E
+ * and %2e both decode to '.').
+ *
+ * Pure function: no globals, no kernel state, thread-safe.
+ */
+int ut_pct_decode_segment(const char *enc, char *out, size_t outsz);
+
+
+/*
+ * PATH MAPPING + PERCENT-CODEC
+ * ----------------------------
+ * A script at ODB dotted path "a.b.c" maps to the filesystem path
+ * "<sync_dir>/a/b/c.ut" and back. Each dotted segment is percent-encoded
+ * before being used as a filesystem path component (see ut_pct_encode_segment
+ * below), so ODB keys that contain '.', '/', ':', '"', '\', '%', control
+ * bytes, or a leading '-' are represented losslessly on disk. The encoded
+ * form uses only characters that are safe as filesystem path components and
+ * does not contain '.' or '/', so the structural separator and the
+ * segment-safety checks in ut_odb_path_to_fs / ut_fs_path_to_odb continue to
+ * work without modification.
+ *
+ * The dotted path that traverses the boundary between the kernel and the
+ * path-mapping layer carries ENCODED segment names joined by '.'. Callers
+ * that build this string (langhash_materialize_table_internal,
+ * ut_export_walk_table, ut_find_dotted_path_topdown) MUST encode each raw
+ * Pascal-string segment with ut_pct_encode_segment before joining. Callers
+ * that split the string back into raw segment names (redirty_one_path,
+ * hashtablelookup) MUST decode each segment with ut_pct_decode_segment before
+ * building the Pascal string.
+ *
+ * Segments like "#filters" that consist entirely of safe characters encode to
+ * themselves, so the corpus on disk is byte-identical for the common case.
+ *
+ * SECURITY: ut_odb_path_to_fs refuses any dotted path that, after mapping,
+ * would escape sync_dir -- empty segments, segments equal to "." or "..", a
+ * leading/trailing/double dot, or any segment containing "/" or a control
+ * byte. This prevents a hostile or corrupt ODB key (e.g. "..") from steering
+ * an export write outside the sync directory.
  *
  * SECURITY: ut_odb_path_to_fs refuses any dotted path that, after mapping,
  * would escape sync_dir -- empty segments, segments equal to "." or "..", a

--- a/frontier-cli/ut_sync.h
+++ b/frontier-cli/ut_sync.h
@@ -160,23 +160,6 @@ int ut_decanonicalize_outline_text(const unsigned char *in, size_t inlen,
  */
 
 /*
- * segment_is_safe - validate a decoded ODB segment for use as a path component.
- *
- * Returns 1 if the segment (byte pointer + length) is safe: non-empty, not "."
- * or "..", and contains no "/" or control bytes (< 0x20 or 0x7F). Returns 0 if
- * the segment is unsafe.
- *
- * Used in the ODB->fs forward direction (ut_odb_path_to_fs) and by ut_scan.c
- * for post-decode validation of segments decoded from percent-encoded filenames.
- * Keeping the check in one function ensures the two directions apply identical
- * rejection criteria.
- *
- * Pure function: no globals, no kernel state, thread-safe.
- */
-int segment_is_safe(const char *seg, size_t len);
-
-
-/*
  * ut_pct_encode_segment - percent-encode a raw ODB segment name.
  *
  * Encodes each byte that would be structurally unsafe or ambiguous:

--- a/frontier-cli/ut_sync.h
+++ b/frontier-cli/ut_sync.h
@@ -160,6 +160,23 @@ int ut_decanonicalize_outline_text(const unsigned char *in, size_t inlen,
  */
 
 /*
+ * segment_is_safe - validate a decoded ODB segment for use as a path component.
+ *
+ * Returns 1 if the segment (byte pointer + length) is safe: non-empty, not "."
+ * or "..", and contains no "/" or control bytes (< 0x20 or 0x7F). Returns 0 if
+ * the segment is unsafe.
+ *
+ * Used in the ODB->fs forward direction (ut_odb_path_to_fs) and by ut_scan.c
+ * for post-decode validation of segments decoded from percent-encoded filenames.
+ * Keeping the check in one function ensures the two directions apply identical
+ * rejection criteria.
+ *
+ * Pure function: no globals, no kernel state, thread-safe.
+ */
+int segment_is_safe(const char *seg, size_t len);
+
+
+/*
  * ut_pct_encode_segment - percent-encode a raw ODB segment name.
  *
  * Encodes each byte that would be structurally unsafe or ambiguous:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -190,7 +190,8 @@ LANG_RUNTIME_SOURCES += \
     ../portable/appleevent_portable.c \
     ../portable/script_portable.c \
     ../portable/wptext_portable.c \
-    ../generated/strings_tables.c
+    ../generated/strings_tables.c \
+    ../frontier-cli/ut_sync.c
 
 # CLI source files
 CLI_SOURCES =
@@ -222,7 +223,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -403,6 +404,12 @@ ut_sync_canonicalize_tests: ut_sync_canonicalize_tests.c ../frontier-cli/ut_sync
 ut_sync_pathmap_tests: ut_sync_pathmap_tests.c ../frontier-cli/ut_sync.c ../frontier-cli/ut_sync.h
 	$(CC) $(CFLAGS) -I../frontier-cli \
 		ut_sync_pathmap_tests.c ../frontier-cli/ut_sync.c -o $@ $(LINK_LIBS)
+
+# ODB-segment percent-codec tests. ut_pct_encode_segment / ut_pct_decode_segment
+# are pure byte transforms with no kernel state -- same kernel-free link.
+ut_sync_pctcodec_tests: ut_sync_pctcodec_tests.c ../frontier-cli/ut_sync.c ../frontier-cli/ut_sync.h
+	$(CC) $(CFLAGS) -I../frontier-cli \
+		ut_sync_pctcodec_tests.c ../frontier-cli/ut_sync.c -o $@ $(LINK_LIBS)
 
 # ODB<->.ut export tests. ut_export_script is a pure file-system function
 # (canonicalize + mkdir -p + write + set mtime) with no kernel state.

--- a/tests/repl_verbs_tests.c
+++ b/tests/repl_verbs_tests.c
@@ -88,6 +88,8 @@ typedef struct ty_test_host {
 	int from_slash_calls;
 	boolean is_active_returns;  /* value the test host's is_active hook reports */
 	int is_active_calls;
+	int sync_scan_returns;      /* count the test host's sync_scan hook reports */
+	int sync_scan_calls;
 } ty_test_host;
 
 static ty_test_host g_host;
@@ -97,6 +99,7 @@ static void host_reset(void) {
 	g_host.jump_should_succeed = true; /* default: jumps succeed */
 	g_host.from_slash_returns = false;  /* default: not a slash dispatch */
 	g_host.is_active_returns  = false;  /* default: no REPL active */
+	g_host.sync_scan_returns  = 0;      /* default: no orphans found */
 }
 
 static void host_exit(void) {
@@ -148,6 +151,11 @@ static boolean host_is_active(void) {
 	return g_host.is_active_returns;
 }
 
+static int host_sync_scan(void) {
+	g_host.sync_scan_calls++;
+	return g_host.sync_scan_returns;
+}
+
 static void install_test_host(void) {
 	repl_verbs_host_t host;
 	memset(&host, 0, sizeof(host));
@@ -158,6 +166,7 @@ static void install_test_host(void) {
 	host.list = &host_list;
 	host.from_slash = &host_from_slash;
 	host.is_active  = &host_is_active;
+	host.sync_scan  = &host_sync_scan;
 	repl_verbs_set_host(&host);
 }
 
@@ -490,6 +499,38 @@ static void test_repl_from_slash_no_host_returns_false(void) {
 
 
 /*
+ * repl.syncScan() invokes the host hook and the return value (count as
+ * UserTalk number) flows back to the caller.  Two cases:
+ *   - hook reports 0  -> verb compiles and runs; hook called once
+ *   - hook reports 7  -> same; we can't inspect the number via run_script
+ *                        but we verify the hook was called with the right
+ *                        count configured (proves the long-value path).
+ */
+static void test_repl_sync_scan_calls_host(void) {
+	printf("[repl_verbs] Test: repl.syncScan() invokes host hook and returns count... ");
+	fflush(stdout);
+
+	host_reset();
+	install_test_host();
+
+	/* Case A: host returns 0 -- verb runs cleanly, hook called once. */
+	g_host.sync_scan_returns = 0;
+	assert(run_script("local (x); x = repl.syncScan()"));
+	assert(g_host.sync_scan_calls == 1);
+
+	/* Case B: host returns 7 -- still runs cleanly, hook called again. */
+	host_reset();
+	install_test_host();
+	g_host.sync_scan_returns = 7;
+	assert(run_script("local (x); x = repl.syncScan()"));
+	assert(g_host.sync_scan_calls == 1);
+
+	printf("PASS\n");
+	fflush(stdout);
+}
+
+
+/*
  * No-host safety: if the test forgets to install a host (or the host is
  * cleared), verbs must NOT crash. They should report failure (return
  * false) so the script gets a recoverable error rather than a SIGSEGV.
@@ -511,6 +552,7 @@ static void test_no_host_does_not_crash(void) {
 	(void)run_script("local (x); x = repl.list()");
 	(void)run_script("local (x); x = repl.fromSlash()");
 	(void)run_script("local (x); x = repl.isActive()");
+	(void)run_script("local (x); x = repl.syncScan()");
 
 	/* Without a host, none of the hook counters should have changed. */
 	assert(g_host.exit_calls == 0);
@@ -520,6 +562,7 @@ static void test_no_host_does_not_crash(void) {
 	assert(g_host.list_calls == 0);
 	assert(g_host.from_slash_calls == 0);
 	assert(g_host.is_active_calls == 0);
+	assert(g_host.sync_scan_calls == 0);
 
 	printf("PASS\n");
 	fflush(stdout);
@@ -561,6 +604,7 @@ int main(void) {
 	TR_RUN(test_repl_from_slash_no_host_returns_false);
 	TR_RUN(test_repl_is_active_returns_host_value);
 	TR_RUN(test_repl_is_active_value_drives_branch);
+	TR_RUN(test_repl_sync_scan_calls_host);
 	TR_RUN(test_no_host_does_not_crash);
 
 	printf("\n========================================\n");

--- a/tests/ut_sync_lifecycle_test.sh
+++ b/tests/ut_sync_lifecycle_test.sh
@@ -213,6 +213,156 @@ else
     fail "boot crashed on malformed .ut (exit $BOOT_RC)"
 fi
 
+# ===========================================================================
+# Issue #699 Part 2: BOOT-TRIGGER import-discovery scan (TDD RED).
+#
+# The scan (to be implemented as ut_sync_scan_and_create, invoked at boot AFTER
+# hydration when --ut-sync-dir is active) walks the sync tree, finds .ut leaves
+# whose ODB node does NOT exist, and AUTO-CREATES the intermediate table chain
+# plus the leaf script, marking them dirty so they persist on save.
+#
+# Cases A and B are RED until the scan exists: the dropped nodes are never
+# created, so defined() returns "false". Case C is a no-damage regression guard,
+# expected GREEN throughout (no scan = no damage; with scan, must not duplicate
+# or shadow an already-existing node).
+#
+# A leaf .ut on disk is simply the script body text (no header lines):
+#   on hello () {<TAB>return (true)}
+# A dotted ODB address a.b.c maps to <sync>/<root>/a/b/c.ut; a node key with
+# collision chars is ONE percent-encoded path component (see ut_sync.c codec):
+#   key "http://webns.net/mvcb/" -> dir "http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F".
+#
+# Assertion mechanism mirrors run_protocol usage above: pipe a heredoc of
+# script/eval probes to run_protocol and grep the JSON result for the id-tagged
+# value we expect. probe_value extracts the "value" for a given response id.
+# ---------------------------------------------------------------------------
+ROOT_SYNC="$SYNC_DIR/Frontier.root"
+
+# probe_value OUTPUT ID -- echo the result "value" string for response "id":ID.
+# Matches the protocol JSON shape: {"id":N,"result":{"value":"X",...},...}.
+probe_value() {
+    local output="$1" id="$2"
+    printf '%s\n' "$output" \
+        | grep -o "\"id\":$id,\"result\":{\"value\":\"[^\"]*\"" \
+        | sed 's/.*"value":"//; s/"$//'
+}
+
+# ---------------------------------------------------------------------------
+# Test 6 (Case A): boot scan auto-creates a dropped .ut under a NEW subdir
+# with a simple identifier path. New table "zzdroptest", new leaf "hello".
+# RED until ut_sync_scan_and_create exists.
+#
+# IMPORTANT discriminator note: defined()/typeof()/sizeof() on a DIRECT child of
+# system.verbs.builtins (e.g. @...builtins.zzdroptest) report a phantom
+# "true"/"addr"/32 even pre-scan -- a verb-search/EFP resolution artifact, NOT a
+# real ODB node. Verified: defined(@...builtins.neverEverDropped12345) -> true,
+# but its grandchild .child -> false. So the ONLY honest signal is the GRANDCHILD
+# leaf: @...builtins.zzdroptest.hello resolves to true iff the scan really built
+# BOTH the zzdroptest table AND the hello leaf. We assert on the leaf, and also
+# on calling the created verb (hello() -> true), which cannot succeed unless a
+# real script object exists.
+# ---------------------------------------------------------------------------
+echo "==> Test 6 (Case A): boot scan creates dropped .ut (simple path)"
+DROP_A_DIR="$ROOT_SYNC/system/verbs/builtins/zzdroptest"
+DROP_A_FILE="$DROP_A_DIR/hello.ut"
+mkdir -p "$DROP_A_DIR"
+# Minimal well-formed leaf script body (no header lines required on disk).
+printf 'on hello () {\n\treturn (true)}\n' > "$DROP_A_FILE"
+
+PROBE_A=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.zzdroptest.hello)"}}' \
+    '{"id":2,"op":"script/eval","params":{"expression":"system.verbs.builtins.zzdroptest.hello()"}}' \
+    '{"id":3,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+
+A_LEAF="$(probe_value "$PROBE_A" 1)"
+A_CALL="$(probe_value "$PROBE_A" 2)"
+if [ "$A_LEAF" = "true" ]; then
+    pass "leaf zzdroptest.hello created by boot scan (table chain built)"
+else
+    fail "leaf zzdroptest.hello NOT created (defined -> '${A_LEAF:-<none>}')"
+fi
+if [ "$A_CALL" = "true" ]; then
+    pass "created verb zzdroptest.hello() is callable (returns true)"
+else
+    fail "created verb zzdroptest.hello() not callable (got '${A_CALL:-<none>}')"
+fi
+
+# Persistence: the previous run saved on shutdown. Re-boot and re-probe; a
+# correctly-dirtied orphan must survive the save/reload.
+PROBE_A2=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.zzdroptest.hello)"}}' \
+    '{"id":2,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+A_LEAF2="$(probe_value "$PROBE_A2" 1)"
+if [ "$A_LEAF2" = "true" ]; then
+    pass "created node persists across save/reload"
+else
+    fail "created node did NOT persist across reload (defined -> '${A_LEAF2:-<none>}')"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7 (Case B): boot scan auto-creates a URL-keyed (percent-encoded) path.
+# New table "zztest" so we never collide with the real xml.rss.moduleDrivers.
+# On disk the URL key is ONE percent-encoded component; the UserTalk address
+# uses the RAW key in brackets -- this exercises reverse-map + decode end to end.
+# RED until ut_sync_scan_and_create exists.
+# ---------------------------------------------------------------------------
+echo "==> Test 7 (Case B): boot scan creates URL-keyed (percent-encoded) path"
+# "http://webns.net/mvcb/" encodes to http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F
+URLKEY_ENC='http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F'
+DROP_B_DIR="$ROOT_SYNC/system/verbs/builtins/zztest/moduleDrivers/$URLKEY_ENC"
+DROP_B_FILE="$DROP_B_DIR/init.ut"
+mkdir -p "$DROP_B_DIR"
+printf 'on init () {\n\treturn (true)}\n' > "$DROP_B_FILE"
+
+PROBE_B=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.zztest.moduleDrivers[\"http://webns.net/mvcb/\"].init)"}}' \
+    '{"id":2,"op":"script/eval","params":{"expression":"typeof(@system.verbs.builtins.zztest.moduleDrivers[\"http://webns.net/mvcb/\"])"}}' \
+    '{"id":3,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+
+B_LEAF="$(probe_value "$PROBE_B" 1)"
+B_TABLE_TYPE="$(probe_value "$PROBE_B" 2)"
+if [ "$B_LEAF" = "true" ]; then
+    pass "URL-keyed leaf init created by boot scan (decode path works)"
+else
+    fail "URL-keyed leaf NOT created (defined -> '${B_LEAF:-<none>}')"
+fi
+if [ "$B_TABLE_TYPE" = "addr" ]; then
+    pass "URL-keyed node is a table (typeof -> addr)"
+else
+    # Pre-scan the chain is absent, so typeof() errors out ("Script evaluation
+    # failed") and probe_value yields <none>; post-scan it must resolve to addr.
+    fail "URL-keyed node not a table (typeof -> '${B_TABLE_TYPE:-<none> (chain absent)}')"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8 (Case C): scan must NOT duplicate / NOT create for an EXISTING node.
+# No new drop. The scan runs over the full existing corpus; a well-known node
+# must remain intact, singular, and callable. NO-DAMAGE GUARD: expected GREEN
+# throughout (pre-implementation no scan = no damage; post-implementation the
+# scan must treat existing/lazy nodes as present and not shadow them).
+# ---------------------------------------------------------------------------
+echo "==> Test 8 (Case C): scan does not damage an existing node (guard)"
+PROBE_C=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.string.upper)"}}' \
+    '{"id":2,"op":"script/eval","params":{"expression":"string.upper(\"ab\")"}}' \
+    '{"id":3,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+C_DEFINED="$(probe_value "$PROBE_C" 1)"
+C_RESULT="$(probe_value "$PROBE_C" 2)"
+if [ "$C_DEFINED" = "true" ]; then
+    pass "existing node string.upper still defined after scan"
+else
+    fail "existing node string.upper missing after scan (defined -> '${C_DEFINED:-<none>}')"
+fi
+if [ "$C_RESULT" = "AB" ]; then
+    pass "existing node string.upper still works (\"ab\" -> AB)"
+else
+    fail "string.upper broken after scan (got '${C_RESULT:-<none>}')"
+fi
+
 # ---------------------------------------------------------------------------
 # Canonical protection: the source Virgin.root must be untouched.
 # ---------------------------------------------------------------------------

--- a/tests/ut_sync_lifecycle_test.sh
+++ b/tests/ut_sync_lifecycle_test.sh
@@ -364,6 +364,57 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 9: repl.syncScan() on-demand verb -- callable and returns a number.
+#
+# The PRIMARY red signal is that repl.syncScan() is an UNDEFINED verb
+# pre-implementation, so the protocol eval returns an error (verb not found),
+# and probe_value yields <none>.  After wiring, the verb must:
+#   (a) evaluate without a "can't find verb" error (probe_value returns a
+#       non-empty string), AND
+#   (b) return a non-negative integer (a number >= 0 cast to string).
+#
+# We also drop a fresh .ut that did NOT exist at the time of the previous
+# boot scan, then call repl.syncScan() in the same invocation to prove it
+# picks up the new file on demand.  The verb return value (count) must be
+# >= 1, and defined(@system.verbs.builtins.zzondemand.ping) must be true.
+# ---------------------------------------------------------------------------
+echo "==> Test 9: repl.syncScan() verb is callable and returns a number"
+
+# Drop a new .ut that the earlier boot scans have never seen.
+ONDEMAND_DIR="$ROOT_SYNC/system/verbs/builtins/zzondemand"
+ONDEMAND_FILE="$ONDEMAND_DIR/ping.ut"
+mkdir -p "$ONDEMAND_DIR"
+printf 'on ping () {\n\treturn (true)}\n' > "$ONDEMAND_FILE"
+
+PROBE_9=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"repl.syncScan()"}}' \
+    '{"id":2,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.zzondemand.ping)"}}' \
+    '{"id":3,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+
+SCAN_RETVAL="$(probe_value "$PROBE_9" 1)"
+ONDEMAND_DEFINED="$(probe_value "$PROBE_9" 2)"
+
+if [ -n "$SCAN_RETVAL" ]; then
+    pass "repl.syncScan() is callable (returned '${SCAN_RETVAL}')"
+else
+    fail "repl.syncScan() is NOT callable -- verb undefined or errored (got '${SCAN_RETVAL:-<none>}')"
+fi
+
+# The return value must be a non-negative integer string.
+if printf '%s' "$SCAN_RETVAL" | grep -qE '^[0-9]+$'; then
+    pass "repl.syncScan() returned a non-negative number (${SCAN_RETVAL})"
+else
+    fail "repl.syncScan() did not return a number (got '${SCAN_RETVAL:-<none>}')"
+fi
+
+if [ "$ONDEMAND_DEFINED" = "true" ]; then
+    pass "zzondemand.ping created by on-demand syncScan"
+else
+    fail "zzondemand.ping NOT created by on-demand syncScan (defined -> '${ONDEMAND_DEFINED:-<none>}')"
+fi
+
+# ---------------------------------------------------------------------------
 # Canonical protection: the source Virgin.root must be untouched.
 # ---------------------------------------------------------------------------
 ACTUAL_CANONICAL="$(md5_of "$SOURCE_DB")"

--- a/tests/ut_sync_lifecycle_test.sh
+++ b/tests/ut_sync_lifecycle_test.sh
@@ -573,6 +573,43 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 12 (P1 O_NONBLOCK -- FIFO boot-hang): a FIFO named foo.ut in the sync
+# tree must not cause open() to block forever.  Without O_NONBLOCK on the
+# read_ut_file open, a plain O_RDONLY open on a FIFO blocks until a writer
+# appears -- hanging startup indefinitely.  With O_NONBLOCK the open returns
+# ENXIO immediately and the FIFO is silently skipped.
+#
+# The CLI is wrapped in `timeout 10` so that if the fix regresses we get a
+# definitive failure (RC 124) rather than a hung test suite.
+# ---------------------------------------------------------------------------
+echo "==> Test 12 (P1 O_NONBLOCK): FIFO named .ut does not block boot scan"
+
+FIFO_DIR="$ROOT_SYNC/system/verbs/builtins/zzfifotest"
+FIFO_FILE="$FIFO_DIR/foo.ut"
+mkdir -p "$FIFO_DIR"
+mkfifo "$FIFO_FILE"
+
+FIFO_DB="$STAGE_DIR/Frontier_fifo.root"
+cp "$SOURCE_DB" "$FIFO_DB"
+
+FIFO_RC=0
+timeout 10 "$CLI" --skip-startup --ut-sync-dir "$SYNC_DIR" \
+    --system-root "$FIFO_DB" -e "1+1" >/dev/null 2>/dev/null
+FIFO_RC=$?
+
+# Remove the FIFO before checking (so subsequent tests are not affected).
+rm -f "$FIFO_FILE"
+rmdir "$FIFO_DIR" 2>/dev/null || true
+
+if [ "$FIFO_RC" -eq 124 ]; then
+    fail "FIFO boot-hang: CLI blocked on foo.ut FIFO (timeout 10s expired, RC=124)"
+elif [ "$FIFO_RC" -eq 0 ] || [ "$FIFO_RC" -eq 1 ]; then
+    pass "FIFO boot-hang: boot returned normally with FIFO in sync tree (RC=$FIFO_RC)"
+else
+    pass "FIFO boot-hang: boot returned (RC=$FIFO_RC, non-zero but not timeout)"
+fi
+
+# ---------------------------------------------------------------------------
 # Canonical protection: the source Virgin.root must be untouched.
 # ---------------------------------------------------------------------------
 ACTUAL_CANONICAL="$(md5_of "$SOURCE_DB")"

--- a/tests/ut_sync_lifecycle_test.sh
+++ b/tests/ut_sync_lifecycle_test.sh
@@ -415,6 +415,114 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 10 (P1 #1 -- node-clobber guard): a .ut whose INTERMEDIATE path
+# component collides with an EXISTING script node must NOT clobber that node.
+#
+# system.verbs.builtins.string.upper is a live script.  Drop a .ut at
+#   <sync>/system/verbs/builtins/string/upper/evil.ut
+# so "upper" is the colliding intermediate -- the scan would need "upper" to be
+# a table to descend into it.  It is a script, so the entire orphan must be
+# rejected without touching the existing "upper" verb.
+#
+# Assert:
+#   (a) string.upper("ab") still returns "AB" -- the verb is intact (not clobbered).
+#   (b) the phantom leaf system.verbs.builtins.string.upper.evil is NOT defined.
+# ---------------------------------------------------------------------------
+echo "==> Test 10 (P1 #1): clobber guard -- collision with existing script node"
+
+# Drop the colliding .ut under the live scan dir.
+CLOBBER_DIR="$ROOT_SYNC/system/verbs/builtins/string/upper"
+CLOBBER_FILE="$CLOBBER_DIR/evil.ut"
+mkdir -p "$CLOBBER_DIR"
+printf 'on evil () {\n\treturn (false)}\n' > "$CLOBBER_FILE"
+
+PROBE_10=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"string.upper(\"ab\")"}}' \
+    '{"id":2,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.string.upper.evil)"}}' \
+    '{"id":3,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+
+T10_UPPER="$(probe_value "$PROBE_10" 1)"
+T10_EVIL="$(probe_value "$PROBE_10" 2)"
+
+if [ "$T10_UPPER" = "AB" ]; then
+    pass "clobber guard: string.upper still works after scan with colliding .ut"
+else
+    fail "clobber guard: string.upper BROKEN after scan (got '${T10_UPPER:-<none>}') -- script was clobbered"
+fi
+
+if [ "$T10_EVIL" != "true" ]; then
+    pass "clobber guard: phantom leaf evil was NOT created (correct rejection)"
+else
+    fail "clobber guard: phantom leaf evil WAS created despite intermediate-node collision"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11 (P1 #2 -- post-decode NUL guard): a .ut filename containing %00
+# (which decodes to a NUL byte) must be silently rejected -- the scan must
+# not crash and must not create any node from the NUL-containing key.
+#
+# The security concern: "%00" in an encoded path component decodes to 0x00,
+# which strlen() silently truncates, causing the Pascal string built from the
+# decoded bytes to be shorter than intended. This could corrupt a hashtable
+# key or cause a lookup in the wrong table.
+#
+# Note: "%2E%2E" -> ".." and "%2F" -> "/" are legitimate ODB key characters
+# (URL-keyed tables use slashes and dots in their keys, e.g., RSS module
+# driver keys like "http://webns.net/mvcb/"). The NUL byte (0x00) is the
+# only decoded byte that is genuinely dangerous for ODB Pascal-string keys.
+#
+# We use %00 in the leaf position (the filename stem before .ut).
+# After decoding, the leaf key would be a zero-length string (since strlen
+# stops at the NUL), which we also reject as empty (rawlen==0 check).
+#
+# We also verify that a NUL in an intermediate directory component is rejected,
+# by dropping a file in a subdirectory whose name encodes a NUL.
+# ---------------------------------------------------------------------------
+echo "==> Test 11 (P1 #2): post-decode NUL guard rejects %00 in encoded filenames"
+
+# Leaf NUL: the filename stem decodes to a NUL-containing key.
+NUL_DIR="$ROOT_SYNC/system/verbs/builtins/zznultest"
+NUL_LEAF_FILE="$NUL_DIR/%00evil.ut"
+mkdir -p "$NUL_DIR"
+printf 'on evil () {\n\treturn (true)}\n' > "$NUL_LEAF_FILE"
+
+# Intermediate NUL: a directory component with an encoded NUL.
+# The intermediate dir decodes to a NUL-containing key, which must be rejected.
+NUL_INTM_DIR="$ROOT_SYNC/system/verbs/builtins/%00intm"
+NUL_INTM_FILE="$NUL_INTM_DIR/leaf.ut"
+mkdir -p "$NUL_INTM_DIR"
+printf 'on leaf () {\n\treturn (true)}\n' > "$NUL_INTM_FILE"
+
+PROBE_11=$(printf '%s\n' \
+    '{"id":1,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.zznultest.evil)"}}' \
+    '{"id":2,"op":"shutdown","params":{}}' \
+    | run_protocol "")
+
+T11_BOOT_RC=$?
+T11_NULTEST="$(probe_value "$PROBE_11" 1)"
+
+# Boot must survive (not crash) even with NUL-encoded filenames present.
+if [ "$T11_BOOT_RC" -eq 0 ] || [ "$T11_BOOT_RC" -eq 1 ]; then
+    pass "post-decode NUL guard: boot survived %00-encoded filenames (exit $T11_BOOT_RC)"
+else
+    fail "post-decode NUL guard: boot CRASHED on %00-encoded filenames (exit $T11_BOOT_RC)"
+fi
+
+# Assert the grandchild leaf (.evil) was NOT created. We probe the grandchild
+# (not the table itself) because defined() on a direct child of
+# system.verbs.builtins returns phantom "true" via the EFP search path even
+# for nodes that do not exist -- the same gotcha documented in Test 6.
+# A phantom grandchild is not possible: EFP only applies one level deep.
+# If the grandchild is "true", the NUL guard failed and the table chain WAS
+# created -- i.e., the pre-flight did not abort before creating zznultest.
+if [ "$T11_NULTEST" != "true" ]; then
+    pass "post-decode NUL guard: NUL-encoded leaf rejected (grandchild evil not created)"
+else
+    fail "post-decode NUL guard: grandchild evil WAS created -- pre-flight NUL guard did not abort early enough"
+fi
+
+# ---------------------------------------------------------------------------
 # Canonical protection: the source Virgin.root must be untouched.
 # ---------------------------------------------------------------------------
 ACTUAL_CANONICAL="$(md5_of "$SOURCE_DB")"

--- a/tests/ut_sync_lifecycle_test.sh
+++ b/tests/ut_sync_lifecycle_test.sh
@@ -378,40 +378,90 @@ fi
 # picks up the new file on demand.  The verb return value (count) must be
 # >= 1, and defined(@system.verbs.builtins.zzondemand.ping) must be true.
 # ---------------------------------------------------------------------------
-echo "==> Test 9: repl.syncScan() verb is callable and returns a number"
+# Test 9: repl.syncScan() genuinely picks up an on-demand .ut drop.
+#
+# Design: ping.ut does NOT exist when the CLI boots, so the boot scan
+# cannot create it. A valid .ut is pre-staged in a temp location and then
+# copied into the sync dir from within the running protocol session via
+# sys.unixShellCommand. repl.syncScan() is then called twice:
+#
+#   Call 1: repl.syncScan() must return >= 1 (created ping -- on-demand).
+#   Call 2: repl.syncScan() must return 0 (idempotent -- node exists now).
+#
+# A no-op verb, or one that always returns 0, cannot satisfy BOTH
+# assertions at once. The double-call also confirms idempotency.
+#
+# Verification uses count only (not defined()), because defined() can
+# return phantom-true via EFP for builtins children even when the node does
+# not exist in the hashtable -- see node_exists_in_memory in ut_scan.c.
+#
+# The .ut content must be non-empty (a valid script). Empty files pass
+# read_ut_file but fail optexttooutline, so create_orphan_node returns 0.
+# ---------------------------------------------------------------------------
+echo "==> Test 9: repl.syncScan() picks up an on-demand .ut drop (>= 1 then 0)"
 
-# Drop a new .ut that the earlier boot scans have never seen.
 ONDEMAND_DIR="$ROOT_SYNC/system/verbs/builtins/zzondemand"
 ONDEMAND_FILE="$ONDEMAND_DIR/ping.ut"
+# Ensure parent directory exists (boot will not create it -- ping.ut absent at boot).
 mkdir -p "$ONDEMAND_DIR"
-printf 'on ping () {\n\treturn (true)}\n' > "$ONDEMAND_FILE"
+# ping.ut must NOT exist when the CLI boots.
+rm -f "$ONDEMAND_FILE"
 
-PROBE_9=$(printf '%s\n' \
-    '{"id":1,"op":"script/eval","params":{"expression":"repl.syncScan()"}}' \
-    '{"id":2,"op":"script/eval","params":{"expression":"defined(@system.verbs.builtins.zzondemand.ping)"}}' \
-    '{"id":3,"op":"shutdown","params":{}}' \
-    | run_protocol "")
+# Build shell command that copies ping.ut from within the session (post-boot).
+#
+# The .ut content is pre-staged in a temp file here in the test harness so
+# we avoid complex quoting inside the JSON expression. The UserTalk
+# sys.unixShellCommand then does a simple "cp SRC DST" with no escaping
+# hazards. The content is a minimal canonicalized .ut (UTF-8/LF) so that
+# create_orphan_node's optexttooutline call succeeds (empty files fail to
+# parse and produce a count of 0 even though read_ut_file accepts them).
+#
+# Verification uses the two-call count pattern only (not defined(), which
+# can return phantom-true via EFP even for nodes that do not exist --
+# see node_exists_in_memory comment in ut_scan.c and ARCHITECTURAL_ANTIPATTERNS.md).
+T9_STAGED="$(mktemp /tmp/ut_test9_staged.XXXXXX)"
+printf 'on ping ()\n\treturn (true)\n' > "${T9_STAGED}"
 
-SCAN_RETVAL="$(probe_value "$PROBE_9" 1)"
-ONDEMAND_DEFINED="$(probe_value "$PROBE_9" 2)"
+# cp command: copy the staged file to the target sync path post-boot.
+WRITE_CMD="cp ${T9_STAGED} ${ONDEMAND_FILE}"
 
-if [ -n "$SCAN_RETVAL" ]; then
-    pass "repl.syncScan() is callable (returned '${SCAN_RETVAL}')"
+# Write the protocol request file. Request id=1 drops the file (post-boot);
+# id=2 is the first syncScan (must return >= 1); id=3 is the second syncScan
+# (must return 0 -- idempotent). The two-count pattern is unforgeable by a
+# no-op verb.
+T9_REQUESTS="$(mktemp /tmp/ut_test9_req.XXXXXX)"
+printf '{"id":1,"op":"script/eval","params":{"expression":"sys.unixShellCommand(\\"%s\\")"}}\n' \
+    "${WRITE_CMD}" > "${T9_REQUESTS}"
+printf '%s\n' \
+    '{"id":2,"op":"script/eval","params":{"expression":"repl.syncScan()"}}' \
+    '{"id":3,"op":"script/eval","params":{"expression":"repl.syncScan()"}}' \
+    '{"id":4,"op":"shutdown","params":{}}' \
+    >> "${T9_REQUESTS}"
+
+PROBE_9=$(run_protocol "" < "${T9_REQUESTS}")
+rm -f "${T9_REQUESTS}" "${T9_STAGED}"
+
+SCAN_CALL1="$(probe_value "$PROBE_9" 2)"
+SCAN_CALL2="$(probe_value "$PROBE_9" 3)"
+
+# First call: must be a non-negative integer >= 1 (created ping on-demand).
+if printf '%s' "$SCAN_CALL1" | grep -qE '^[0-9]+$'; then
+    pass "repl.syncScan() call 1 returned a number (${SCAN_CALL1})"
 else
-    fail "repl.syncScan() is NOT callable -- verb undefined or errored (got '${SCAN_RETVAL:-<none>}')"
+    fail "repl.syncScan() call 1 did not return a number (got '${SCAN_CALL1:-<none>}')"
 fi
 
-# The return value must be a non-negative integer string.
-if printf '%s' "$SCAN_RETVAL" | grep -qE '^[0-9]+$'; then
-    pass "repl.syncScan() returned a non-negative number (${SCAN_RETVAL})"
+if [ -n "$SCAN_CALL1" ] && [ "$SCAN_CALL1" -ge 1 ] 2>/dev/null; then
+    pass "repl.syncScan() call 1 returned >= 1 (on-demand path exercised, count=${SCAN_CALL1})"
 else
-    fail "repl.syncScan() did not return a number (got '${SCAN_RETVAL:-<none>}')"
+    fail "repl.syncScan() call 1 returned < 1 -- on-demand creation did NOT run (got '${SCAN_CALL1:-<none>}')"
 fi
 
-if [ "$ONDEMAND_DEFINED" = "true" ]; then
-    pass "zzondemand.ping created by on-demand syncScan"
+# Second call: must return 0 (idempotent -- node now exists).
+if [ "$SCAN_CALL2" = "0" ]; then
+    pass "repl.syncScan() call 2 returned 0 (idempotent, node already exists)"
 else
-    fail "zzondemand.ping NOT created by on-demand syncScan (defined -> '${ONDEMAND_DEFINED:-<none>}')"
+    fail "repl.syncScan() call 2 expected 0, got '${SCAN_CALL2:-<none>}'"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/ut_sync_pathmap_tests.c
+++ b/tests/ut_sync_pathmap_tests.c
@@ -171,6 +171,104 @@ static void test_reverse_rejects_prefix_lookalike(void) {
 	    buf, sizeof(buf)) == 0);
 }
 
+/*
+ * test_round_trip_pct_encoded_rss_key
+ *
+ * End-to-end Phase 1 round-trip for a URL-keyed ODB segment. The interchange
+ * dotted path carries percent-encoded segments; the path mapper treats each
+ * encoded segment as an opaque filesystem-safe token. We build the encoded
+ * interchange string manually (simulating what langhash_materialize produces
+ * after encoding), pass it through the mapper both ways, and verify:
+ *   1. The forward map produces the expected filesystem path.
+ *   2. The reverse map reconstructs the encoded interchange string exactly.
+ *   3. Splitting on '.' and decoding the 7th segment yields the raw URL.
+ *
+ * We also verify that a plain identifier path round-trips byte-identically
+ * (encoding of a safe identifier is itself, so the common case is unaffected).
+ */
+static void test_round_trip_pct_encoded_rss_key(void) {
+	/*
+	 * Raw RSS key segments (8 total):
+	 *   [0] system  [1] verbs  [2] builtins  [3] xml  [4] rss
+	 *   [5] moduleDrivers  [6] http://webns.net/mvcb/  [7] init
+	 *
+	 * After encoding: segments 0-5 and 7 are plain identifiers (encode to
+	 * themselves); segment 6 encodes as:
+	 *   http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F
+	 *
+	 * The encoded interchange path (joined with '.'):
+	 */
+	const char *enc_path =
+	    "system.verbs.builtins.xml.rss.moduleDrivers"
+	    ".http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F.init";
+	const char *expected_fs_suffix =
+	    "/moduleDrivers/http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F/init.ut";
+	char fs[512];
+	char back[512];
+	int i;
+
+	/* Forward: encoded dotted path -> filesystem path. */
+	assert(ut_odb_path_to_fs(enc_path, SYNC, fs, sizeof(fs)) == 1);
+
+	/* The fs path must end with the expected suffix. */
+	{
+		size_t fslen = strlen(fs);
+		size_t suflen = strlen(expected_fs_suffix);
+		assert(fslen > suflen);
+		assert(strcmp(fs + fslen - suflen, expected_fs_suffix) == 0);
+	}
+
+	/* Reverse: filesystem path -> encoded dotted path (round-trip identity). */
+	assert(ut_fs_path_to_odb(fs, SYNC, back, sizeof(back)) == 1);
+	assert(strcmp(back, enc_path) == 0);
+
+	/* Split `back` on '.' and decode each segment to recover the raw names.
+	 * Segment count must be 8; the 7th (index 6) must decode to the raw URL. */
+	{
+		char split_buf[512];
+		const char *raw_url = "http://webns.net/mvcb/";
+		char decoded[256];
+		char *p;
+		int seg_count = 0;
+		int seg6_ok = 0;
+
+		memcpy(split_buf, back, strlen(back) + 1);
+		p = split_buf;
+		while (p != NULL) {
+			char *dot = strchr(p, '.');
+			if (dot != NULL)
+				*dot = '\0';
+			if (seg_count == 6) {
+				/* Decode the 7th segment and check it equals the raw URL. */
+				assert(ut_pct_decode_segment(p, decoded, sizeof(decoded)) == 1);
+				assert(strcmp(decoded, raw_url) == 0);
+				seg6_ok = 1;
+			}
+			seg_count++;
+			p = (dot != NULL) ? dot + 1 : NULL;
+		}
+		assert(seg_count == 8);
+		assert(seg6_ok);
+	}
+
+	/* Regression: a plain-identifier path is byte-identical after round-trip
+	 * (encoding of a safe identifier is itself, so no spurious escaping). */
+	for (i = 0; i < 3; i++) {
+		const char *plain_paths[] = {
+		    "system.verbs.builtins.string.upper",
+		    "system.verbs.builtins.op",
+		    "loner",
+		};
+		char plain_fs[256];
+		char plain_back[256];
+		assert(ut_odb_path_to_fs(plain_paths[i], SYNC,
+		                         plain_fs, sizeof(plain_fs)) == 1);
+		assert(ut_fs_path_to_odb(plain_fs, SYNC,
+		                         plain_back, sizeof(plain_back)) == 1);
+		assert(strcmp(plain_paths[i], plain_back) == 0);
+	}
+}
+
 int main(void) {
 	TR_INIT("ut_sync_pathmap_tests");
 	TR_RUN(test_forward_basic);
@@ -190,6 +288,7 @@ int main(void) {
 	TR_RUN(test_reverse_rejects_missing_ut);
 	TR_RUN(test_reverse_rejects_dot_in_component);
 	TR_RUN(test_reverse_rejects_prefix_lookalike);
+	TR_RUN(test_round_trip_pct_encoded_rss_key);
 	TR_SUMMARY();
 	return TR_EXIT_CODE();
 }

--- a/tests/ut_sync_pctcodec_tests.c
+++ b/tests/ut_sync_pctcodec_tests.c
@@ -1,0 +1,259 @@
+/*
+ * ut_sync_pctcodec_tests.c - Unit tests for the percent-codec that escapes
+ * ODB path segments for safe use as filesystem path components
+ * (frontier-cli/ut_sync.c ut_pct_encode_segment / ut_pct_decode_segment).
+ *
+ * The codec is a pure, lossless byte transform. A raw ODB segment (which may
+ * contain '.', '/', ':', '"', '\\', '%', control bytes, or a leading '-') is
+ * percent-encoded into an ASCII string safe to use as one filesystem path
+ * component, and decoded back to the exact original bytes. These tests cover:
+ *   - identity pass-through for bare identifiers and "#filters"-style names
+ *   - each collision char escaped individually
+ *   - escape-the-escape-first invariant ('%' handled before '.', '/', etc.)
+ *   - control bytes and DEL escaped as uppercase %XX
+ *   - leading '-' encoded, interior/trailing '-' passed through
+ *   - the RSS-key acceptance string (http://webns.net/mvcb/)
+ *   - decode rejects malformed % escapes
+ *   - decode accepts lowercase hex (lenient decode)
+ *   - encode/decode overflow returns failure and clears the output
+ *   - round-trip fuzz set proving the lossless guarantee
+ *
+ * License
+ * -------
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Frontier contributors.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test_report.h"
+
+#include "../frontier-cli/ut_sync.h"
+
+/* ---- identity pass-through ---- */
+
+static void test_encode_identity_bare_identifier(void) {
+	char buf[64];
+	assert(ut_pct_encode_segment("upper", 5, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "upper") == 0);
+	assert(ut_pct_encode_segment("string", 6, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "string") == 0);
+}
+
+static void test_encode_identity_hashfilters(void) {
+	char buf[64];
+	/* '#' and the rest of an identifier pass through unchanged. */
+	assert(ut_pct_encode_segment("#filters", 8, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "#filters") == 0);
+	/* '_' passes through unchanged. */
+	assert(ut_pct_encode_segment("my_table", 8, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "my_table") == 0);
+}
+
+/* ---- each collision char escaped individually ---- */
+
+static void test_encode_each_collision_char_individually(void) {
+	char buf[64];
+	assert(ut_pct_encode_segment("a.b", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "a%2Eb") == 0);
+	assert(ut_pct_encode_segment("a/b", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "a%2Fb") == 0);
+	assert(ut_pct_encode_segment("a:b", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "a%3Ab") == 0);
+	assert(ut_pct_encode_segment("a\"b", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "a%22b") == 0);
+	assert(ut_pct_encode_segment("a\\b", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "a%5Cb") == 0);
+	assert(ut_pct_encode_segment("a%b", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "a%25b") == 0);
+}
+
+/* ---- escape-the-escape-first invariant ---- */
+
+static void test_encode_escape_first_invariant(void) {
+	char buf[64];
+	/* A bare '%' must become "%25". */
+	assert(ut_pct_encode_segment("%", 1, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "%25") == 0);
+	/* "%25" (3 chars) must encode to "%2525": the leading '%' becomes "%25",
+	 * then the literal "25" passes through. If '%' were not escaped first, this
+	 * would be mis-decodable. */
+	assert(ut_pct_encode_segment("%25", 3, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "%2525") == 0);
+	/* Decode round-trips: "%2525" -> "%25" (3 chars). */
+	assert(ut_pct_decode_segment("%2525", buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "%25") == 0);
+	/* And "%25" -> "%" (1 char). */
+	assert(ut_pct_decode_segment("%25", buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "%") == 0);
+}
+
+/* ---- control bytes and DEL ---- */
+
+static void test_encode_control_and_del(void) {
+	char buf[64];
+	/* 0x01 -> "%01" */
+	{
+		char raw[3];
+		raw[0] = 'a';
+		raw[1] = (char)0x01;
+		raw[2] = 'b';
+		assert(ut_pct_encode_segment(raw, 3, buf, sizeof(buf)) == 1);
+		assert(strcmp(buf, "a%01b") == 0);
+	}
+	/* 0x1f -> "%1F" (uppercase hex) */
+	{
+		char raw[3];
+		raw[0] = 'a';
+		raw[1] = (char)0x1f;
+		raw[2] = 'b';
+		assert(ut_pct_encode_segment(raw, 3, buf, sizeof(buf)) == 1);
+		assert(strcmp(buf, "a%1Fb") == 0);
+	}
+	/* 0x7f (DEL) -> "%7F" */
+	{
+		char raw[3];
+		raw[0] = 'a';
+		raw[1] = (char)0x7f;
+		raw[2] = 'b';
+		assert(ut_pct_encode_segment(raw, 3, buf, sizeof(buf)) == 1);
+		assert(strcmp(buf, "a%7Fb") == 0);
+	}
+}
+
+/* ---- leading dash only ---- */
+
+static void test_encode_leading_dash_only(void) {
+	char buf[64];
+	/* A leading '-' is encoded so the path component cannot be mistaken for an
+	 * option flag by downstream tools. */
+	assert(ut_pct_encode_segment("-foo", 4, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "%2Dfoo") == 0);
+	/* Interior '-' passes through unchanged. */
+	assert(ut_pct_encode_segment("foo-bar", 7, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "foo-bar") == 0);
+	/* Trailing '-' passes through unchanged. */
+	assert(ut_pct_encode_segment("foo-", 4, buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, "foo-") == 0);
+}
+
+/* ---- the RSS-key acceptance string ---- */
+
+static void test_combined_rss_key(void) {
+	/* THE acceptance string: a real RSS namespace key used as an ODB segment.
+	 * raw bytes: h t t p : / / w e b n s . n e t / m v c b / */
+	const char *raw = "http://webns.net/mvcb/";
+	size_t rawlen = strlen(raw); /* 22 */
+	char enc[128];
+	char dec[128];
+	assert(ut_pct_encode_segment(raw, rawlen, enc, sizeof(enc)) == 1);
+	assert(strcmp(enc, "http%3A%2F%2Fwebns%2Enet%2Fmvcb%2F") == 0);
+	/* Decode back to the original raw bytes. */
+	assert(ut_pct_decode_segment(enc, dec, sizeof(dec)) == 1);
+	assert(strlen(dec) == rawlen);
+	assert(memcmp(dec, raw, rawlen) == 0);
+}
+
+/* ---- decode rejects malformed percent escapes ---- */
+
+static void test_decode_rejects_malformed_percent(void) {
+	char buf[64];
+	/* lone trailing '%' */
+	assert(ut_pct_decode_segment("%", buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+	/* '%' followed by only one hex digit */
+	assert(ut_pct_decode_segment("%2", buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+	/* '%' followed by two non-hex chars */
+	assert(ut_pct_decode_segment("%ZZ", buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+	/* '%' with a bad second nibble */
+	assert(ut_pct_decode_segment("%2Z", buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+	/* lone trailing '%' after valid content */
+	assert(ut_pct_decode_segment("abc%", buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+}
+
+/* ---- decode accepts lowercase hex ---- */
+
+static void test_decode_accepts_lowercase_hex_input(void) {
+	char buf[64];
+	/* Encode emits UPPERCASE hex, but decode is lenient and accepts either
+	 * case so hand-edited paths still round-trip. "%2e" -> ".". */
+	assert(ut_pct_decode_segment("%2e", buf, sizeof(buf)) == 1);
+	assert(strcmp(buf, ".") == 0);
+}
+
+/* ---- overflow returns failure and clears output ---- */
+
+static void test_encode_overflow_returns_zero(void) {
+	/* "a.b.c" encodes to "a%2Eb%2Ec" (9 bytes + NUL = 10). A 4-byte buffer
+	 * cannot hold it: return 0, out[0]='\0'. */
+	char buf[4];
+	assert(ut_pct_encode_segment("a.b.c", 5, buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+}
+
+static void test_decode_overflow_returns_zero(void) {
+	/* "%2E%2E%2E%2E" decodes to "...." (4 bytes + NUL = 5). A 2-byte buffer
+	 * cannot hold it: return 0, out[0]='\0'. */
+	char buf[2];
+	assert(ut_pct_decode_segment("%2E%2E%2E%2E", buf, sizeof(buf)) == 0);
+	assert(buf[0] == '\0');
+}
+
+/* ---- round-trip fuzz set: the core lossless guarantee ---- */
+
+static void test_round_trip_fuzz_set(void) {
+	/* Each entry is a raw byte buffer plus its length (some contain bytes that
+	 * cannot be written as a plain NUL-terminated C string, e.g. a control
+	 * byte, so we carry an explicit length and compare with memcmp). */
+	struct {
+		const char *raw;
+		size_t rawlen;
+	} cases[9];
+	static const char ctrl_raw[] = { 'w', 'i', 't', 'h', (char)0x05, 'c', 't', 'l' };
+	int i;
+
+	cases[0].raw = "system";                cases[0].rawlen = 6;
+	cases[1].raw = "verbs";                 cases[1].rawlen = 5;
+	cases[2].raw = "http://webns.net/mvcb/"; cases[2].rawlen = 22;
+	cases[3].raw = "a.b/c:d\"e%f";          cases[3].rawlen = 11;
+	cases[4].raw = "-leading";              cases[4].rawlen = 8;
+	cases[5].raw = "trailing-";             cases[5].rawlen = 9;
+	cases[6].raw = "with space";            cases[6].rawlen = 10;
+	cases[7].raw = ctrl_raw;                cases[7].rawlen = sizeof(ctrl_raw);
+	cases[8].raw = "";                      cases[8].rawlen = 0;
+
+	for (i = 0; i < 9; i++) {
+		char enc[256];
+		char dec[256];
+		assert(ut_pct_encode_segment(cases[i].raw, cases[i].rawlen,
+		                             enc, sizeof(enc)) == 1);
+		assert(ut_pct_decode_segment(enc, dec, sizeof(dec)) == 1);
+		/* Decoded raw here has no embedded NUL, so strlen gives its length. */
+		assert(strlen(dec) == cases[i].rawlen);
+		assert(memcmp(dec, cases[i].raw, cases[i].rawlen) == 0);
+	}
+}
+
+int main(void) {
+	TR_INIT("ut_sync_pctcodec_tests");
+	TR_RUN(test_encode_identity_bare_identifier);
+	TR_RUN(test_encode_identity_hashfilters);
+	TR_RUN(test_encode_each_collision_char_individually);
+	TR_RUN(test_encode_escape_first_invariant);
+	TR_RUN(test_encode_control_and_del);
+	TR_RUN(test_encode_leading_dash_only);
+	TR_RUN(test_combined_rss_key);
+	TR_RUN(test_decode_rejects_malformed_percent);
+	TR_RUN(test_decode_accepts_lowercase_hex_input);
+	TR_RUN(test_encode_overflow_returns_zero);
+	TR_RUN(test_decode_overflow_returns_zero);
+	TR_RUN(test_round_trip_fuzz_set);
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}


### PR DESCRIPTION
Closes #699.

## Summary

- **Lossless ODB<->.ut path encoding** via percent-codec (`ut_pct_encode_segment` / `ut_pct_decode_segment`). Handles all ODB key bytes including `/`, `:`, URL-keyed table paths, and non-ASCII. Encode wired at the three segment-join build sites (`opverbs.c` `ut_find_dotted_path_topdown`, `main.c` `ut_export_walk_table`, `langhash.c` `langhash_materialize_table_internal`); decode at the split site (`main.c` `redirty_one_path`).
- **Boot-scan orphan creation** (`ut_sync_scan_and_create`): walks the sync tree at startup and auto-creates any `.ut` leaves that have no corresponding in-memory ODB node, including full intermediate table chain construction.
- **`repl.syncScan()` verb** for on-demand reconciliation: same scan logic post-boot, callable from UserTalk or protocol sessions.
- **Security hardening** (gate review findings):
  - P1 #1: `langsuretablevalue` type-guard -- rejects intermediate path components that are non-table externals (scripts, outlines) to prevent silent clobber
  - P1 #2: post-decode NUL guard -- detects `%00` sequences that would truncate Pascal string keys
  - P1 #3: TOCTOU fix in `scan_dir_recursive` -- `open(O_NOFOLLOW|O_DIRECTORY)` + `fstat` + `fdopendir` eliminates the lstat+opendir race window where a symlink swap could escape the sync tree
  - P1 #4: `record_for_redirty` parameter -- boot caller records paths for the redirty pass; post-boot caller skips recording to eliminate memory accumulation
- **Cleanup**: `segment_is_safe` re-staticized in `ut_sync.c` (was incorrectly exported; the reverse fs->ODB path must not use it because `/` and `:` are legal ODB key bytes)
- **`repl.syncScan()` in `--protocol` mode**: host adapter now installed in `protocol_main` via `repl_install_verb_host` / `repl_uninstall_verb_host` wrappers
- **P2 batch**: stale size-cap comment corrected, GIL doc comments on `create_orphan_node` and `replverbhost_sync_scan`, `local_path_buf[256]` -> `[512]` in `langhash.c`

## Test plan

- [x] Unit suite: 580/580
- [x] Lifecycle test (`tests/ut_sync_lifecycle_test.sh`): 21/21
  - Test 9 redesigned to genuinely exercise the on-demand path: non-empty `.ut` pre-staged, copied post-boot via `sys.unixShellCommand`, two-call count pattern (>= 1 then 0) is unforgeable by a no-op
- [x] Build clean: no new warnings on touched files (pre-existing `main.c:404` qualifier-discard and `ut_sync.c:952` branch-clone noted and unchanged)
- [x] Virgin.root md5 unchanged (test 11 confirms no DB mutation)
- [x] Integration suite: 2183 passed. The 20 failures (12 `html.*`, 6 `tcp.*`, 2 `startup`) are pre-existing/environmental, reproduce identically on the base commit, and are unrelated to this change (the import hook early-returns and the boot scan is gated on `cli_get_ut_sync_dir()`, so the new code is inert without `--ut-sync-dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

