### PR TITLE
feat(menu): compose REPL menubar via legacy system.menus.buildMenubar

### DIFF
--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -3628,7 +3628,7 @@ void repl_uninstall_verb_host(void) {
 
 /*
  * Boot the REPL menubar by invoking the UserTalk install script, then
- * run the legacy dynamic-composition verb system.menus.buildMenubar to
+ * run the legacy dynamic-composition verb system.menus.buildMenuBar to
  * fold in any additional menus (user.menus.*, system.menus.helpMenu,
  * the frontmost-keyed modal menu, etc.) the way the legacy GUI did.
  *
@@ -3640,12 +3640,13 @@ void repl_uninstall_verb_host(void) {
  * idempotent — guarded by menu.isInstalled — so re-invocation across
  * sessions is safe and cheap.
  *
- * system.menus.buildMenubar is the legacy UserTalk composer. Its
- * headless effect is currently a no-op for the bar projection (the
- * menu.install / menu.clearMenuBar / menu.buildMenuBar kernel verbs are
- * GUI-only no-ops in headless, and the composer's menu.install calls
- * land on addresses outside system.menus.data so the projection's
- * .installed flags are unchanged). Wiring it in now is a
+ * system.menus.buildMenuBar is the legacy UserTalk composer. Its
+ * headless effect is currently a no-op for the bar projection: the
+ * composer's menu.install calls target addresses outside
+ * system.menus.data (e.g. @user.menus.menubar, @system.menus.helpMenu),
+ * which menudata_resolve_bar_path treats as depth=0 and does not flip
+ * the .installed flag for. menu.clearMenuBar and kernel menu.buildMenuBar
+ * are also headless no-ops. Wiring the composer in now is a
  * mechanism-fidelity step: as soon as editor windows exist and the
  * frontmost-keyed modal menu has somewhere to land, the same code path
  * will produce the dynamic per-window behavior. The empty-frontmost
@@ -3664,8 +3665,8 @@ static void install_repl_menubar(void) {
 	const char *expr =
 	    "if defined (@system.menus.installReplMenubar) "
 	    "{system.menus.installReplMenubar ()}; "
-	    "if defined (@system.menus.buildMenubar) "
-	    "{system.menus.buildMenubar ()}";
+	    "if defined (@system.menus.buildMenuBar) "
+	    "{system.menus.buildMenuBar ()}";
 	size_t expr_len = strlen(expr);
 	Handle htext = nil;
 

--- a/frontier-cli/repl.c
+++ b/frontier-cli/repl.c
@@ -3627,7 +3627,10 @@ void repl_uninstall_verb_host(void) {
 
 
 /*
- * Boot the REPL menubar by invoking the UserTalk install script.
+ * Boot the REPL menubar by invoking the UserTalk install script, then
+ * run the legacy dynamic-composition verb system.menus.buildMenubar to
+ * fold in any additional menus (user.menus.*, system.menus.helpMenu,
+ * the frontmost-keyed modal menu, etc.) the way the legacy GUI did.
  *
  * Design note: the menubar lives in the ODB (system.menus.data.repl), and
  * its install logic + handler scripts live in UserTalk (under
@@ -3637,10 +3640,22 @@ void repl_uninstall_verb_host(void) {
  * idempotent — guarded by menu.isInstalled — so re-invocation across
  * sessions is safe and cheap.
  *
+ * system.menus.buildMenubar is the legacy UserTalk composer. Its
+ * headless effect is currently a no-op for the bar projection (the
+ * menu.install / menu.clearMenuBar / menu.buildMenuBar kernel verbs are
+ * GUI-only no-ops in headless, and the composer's menu.install calls
+ * land on addresses outside system.menus.data so the projection's
+ * .installed flags are unchanged). Wiring it in now is a
+ * mechanism-fidelity step: as soon as editor windows exist and the
+ * frontmost-keyed modal menu has somewhere to land, the same code path
+ * will produce the dynamic per-window behavior. The empty-frontmost
+ * path is handled gracefully by the composer itself (try/else around
+ * the modal install).
+ *
  * Boot failure mode (per ADR-016 / planning doc): a missing or broken
- * install script must NOT take down the REPL. Log a prominent warning
- * and continue. The user can still operate via legacy /commands and the
- * palette will simply show no items if it's opened.
+ * install or composer script must NOT take down the REPL. Log a
+ * prominent warning and continue. The user can still operate via legacy
+ * /commands and the palette will simply show no items if it's opened.
  *
  * GIL: must be called with the GIL held. Called once from repl_main
  * before either loop runs.
@@ -3648,7 +3663,9 @@ void repl_uninstall_verb_host(void) {
 static void install_repl_menubar(void) {
 	const char *expr =
 	    "if defined (@system.menus.installReplMenubar) "
-	    "{system.menus.installReplMenubar ()}";
+	    "{system.menus.installReplMenubar ()}; "
+	    "if defined (@system.menus.buildMenubar) "
+	    "{system.menus.buildMenubar ()}";
 	size_t expr_len = strlen(expr);
 	Handle htext = nil;
 

--- a/tests/integration/test_cases/menu_buildmenubar_repl.yaml
+++ b/tests/integration/test_cases/menu_buildmenubar_repl.yaml
@@ -1,0 +1,80 @@
+# Integration tests for system.menus.buildMenubar running alongside
+# system.menus.installReplMenubar — the legacy UserTalk composer must
+# leave the REPL bar in system.menus.data intact so the palette can
+# still render it.
+#
+# Background
+# ----------
+# The legacy Frontier app composed its menubar via a UserTalk verb,
+# system.menus.buildMenubar, which clears the bar, folds in user.menus
+# tables, helpMenu, and a frontmost-keyed modal menu, then calls the
+# kernel menu.buildMenuBar(). The headless REPL today populates its
+# bar by direct writes from system.menus.installReplMenubar.
+#
+# This file pins the contract that the composer can run *after*
+# installReplMenubar without disturbing the REPL bar that the palette
+# (frontier-cli/repl_palette_source.c, walking system.menus.data.repl)
+# depends on. Required because the composer calls menu.clearMenuBar()
+# (currently a headless no-op — these tests fail fast if that ever
+# changes to a real wipe) and a chain of menu.install() calls on
+# addresses outside system.menus.data (also currently silent no-ops —
+# the tests catch any regression where those start writing somewhere
+# that clobbers system.menus.data.repl).
+#
+# sequential: true because system.menus.data.repl is a singleton path;
+# parallel tests can't isolate via unique bar names like
+# menu_data_write_projection.yaml does.
+
+needs_guest_dbs: false
+sequential: true
+
+tests:
+  - name: "buildMenubar runs cleanly on a hydrated DB"
+    description: |
+      The legacy composer must evaluate end-to-end without erroring on
+      the empty-frontmost path (no editor windows, window.frontmost()
+      returns ""). All called verbs (menu.clearMenuBar, menu.install,
+      html.menu.install, window.getType, menu.buildMenuBar) must
+      resolve and complete. RED today only if the composer is broken;
+      the contract is that it stays runnable.
+    script: |
+      local(ok = false);
+      try {
+        system.menus.buildMenubar();
+        ok = true
+      };
+      return ok
+    expected_success: true
+    expected_result: "true"
+
+  - name: "buildMenubar preserves the REPL bar after installReplMenubar"
+    description: |
+      Running the composer after installReplMenubar must leave
+      system.menus.data.repl installed. This is the load-bearing
+      assertion for the REPL bootstrap: if menu.clearMenuBar ever
+      becomes a real wipe, or if some menu.install side effect clears
+      .installed, this test catches the regression before the palette
+      goes blank in production.
+    script: |
+      system.menus.installReplMenubar();
+      system.menus.buildMenubar();
+      return menu.isInstalled(@system.menus.data.repl)
+    expected_success: true
+    expected_result: "true"
+
+  - name: "buildMenubar leaves REPL menu items intact"
+    description: |
+      After the composer runs, the REPL menu items written by
+      installReplMenubar must still exist and still carry the script
+      bodies installReplMenubar set. Reads through the same field
+      path the palette renderer uses (system.menus.data.<bar>.<menu>.
+      <item>.script). Behavioral, not source-inspection: this would
+      fail if the composer wiped or rewrote the projection.
+    script: |
+      system.menus.installReplMenubar();
+      system.menus.buildMenubar();
+      local(helpDefined = defined(@system.menus.data.repl.REPL.Help));
+      local(helpScript = system.menus.data.repl.REPL.Help.script);
+      return helpDefined and (string.patternMatch("repl.help", helpScript) > 0)
+    expected_success: true
+    expected_result: "true"

--- a/usertalk_scripts/Frontier.root/system/menus/buildMenuBar.ut
+++ b/usertalk_scripts/Frontier.root/system/menus/buildMenuBar.ut
@@ -1,0 +1,39 @@
+on add (adrmenu) {
+	try {
+		menu.install (adrmenu)}};
+
+menu.clearMenuBar ();
+
+bundle { //install menus
+	if defined (user.menus.menubar) {
+		add (@user.menus.menubar)}
+	else {
+		add (@system.menus.menubar)};
+	html.menu.install ();
+	add (@user.menus.bookmarkMenu);
+	add (@user.menus.customMenu);
+	local (i);
+	for i = 1 to sizeOf (user.menus) { //PBS 8/13/98: add additional user menus
+		local (adrMenu = @user.menus [i]);
+		if typeOf (adrMenu^) == addressType { //menus can be address
+			if not defined (adrMenu^^) {
+				continue};
+			adrMenu = adrMenu^};
+		if typeOf (adrMenu^) == menuBarType {
+			case string.lower (nameOf (user.menus [i])) {
+				"bookmarkmenu";
+				"custommenu";
+				"menubar" {
+					continue}};
+			add (adrMenu)}};
+	add (@system.menus.helpMenu)};
+
+bundle { //add the modal menu, based on the type of the frontmost window
+	local (winType = window.getType (window.frontmost ()));
+	try {
+		menu.install (@system.menus.modals.[winType])}
+	else {
+		winType = 0};
+	system.menus.data.currentMenuType = winType}; //see system.menus.agent
+
+menu.buildMenuBar () //force update


### PR DESCRIPTION
## Summary

- Wire the legacy UserTalk composer `system.menus.buildMenubar` into the REPL bootstrap, so the REPL menu is composed via the same dynamic-composition code path the legacy GUI used.
- Export `usertalk_scripts/Frontier.root/system/menus/buildMenuBar.ut` into the corpus so the composer is source-controlled and reviewable (mirrors the script that has always existed in `databases/Virgin.root` -- the binary is unchanged).
- Add 3 behavioral integration tests that pin the composer's interaction with the existing REPL bar.

## Why it matters

This is a **mechanism-fidelity** step, not a behavior change in headless today. The composer's `menu.install` / `menu.clearMenuBar` / `menu.buildMenuBar` calls are no-ops in the current headless verb impls, and its `menu.install(@user.menus.*)` calls land outside `system.menus.data` so the palette projection is unaffected. The composer's empty-frontmost path (no editor windows) is handled gracefully by the script itself (`try/else` around the modal install).

Wiring it in now means: the moment editor windows exist and the frontmost-keyed modal menu has somewhere to land, the same code path will produce the dynamic per-window behavior without further wiring changes. The legacy Frontier app's menubar dynamism is restored to the REPL.

## What changed

- `frontier-cli/repl.c` -- `install_repl_menubar()` now chains `system.menus.buildMenubar()` after `system.menus.installReplMenubar()`. Both calls are guarded by `defined()` and the bootstrap continues on either's failure (per ADR-016).
- `usertalk_scripts/Frontier.root/system/menus/buildMenuBar.ut` -- NEW. Exported via `--ut-sync-dir` after dirtying the in-memory script with `setTimeModified` (no source change to the ODB script). `verify_virgin_root_sync.sh --paths ...` confirms byte-equality with the kernel canonical form.
- `tests/integration/test_cases/menu_buildmenubar_repl.yaml` -- NEW. Three behavioral tests using `menu.isInstalled` and field-path reads (the same paths `repl_palette_source.c` walks):
  1. composer runs cleanly on a hydrated DB
  2. composer preserves the REPL bar after `installReplMenubar`
  3. composer leaves REPL menu items intact (`@system.menus.data.repl.REPL.Help.script` still contains `"repl.help"`)

## Virgin.root status

`databases/Virgin.root` is **unchanged**. The composer was already present in the binary; only its `.ut` text mirror was missing from the corpus. The bootstrap edit is in C, not the ODB. No live-test pause was required.

## Test plan

- [x] **Unit (required):** `./tools/run_headless_tests.sh` -- 580/580 pass
- [x] **Integration (required):** `cd tests && make test-integration` -- 32 pre-existing batch-mode flakiness failures (`html.*`, `tcp.*`, `startup_*`, `guest_db_*`), all unrelated; verified identical fail set with/without this change. New tests in `menu_buildmenubar_repl.yaml` all pass; full menu+palette suite (78 tests) green.
- [x] ODB sync drift check: `./tools/verify_virgin_root_sync.sh --paths usertalk_scripts/Frontier.root/system/menus/buildMenuBar.ut` -> `OK: all 1 file(s) match Virgin.root`
- [x] Smoke: REPL boots cleanly with new bootstrap, accepts commands, exits cleanly

## Audit findings worth keeping

The Plan agent's audit captured two important semantics worth recording for future readers:

1. **`menu.install(adrmenu)` writes ONLY when `adrmenu` is already under `system.menus.data`.** It uses `menudata_resolve_bar_path` with `depth >= 1`; addresses outside that subtree -> silent no-op. This is why the composer's `menu.install(@user.menus.*)` and `menu.install(@system.menus.helpMenu)` calls don't populate the palette projection in headless today.
2. **`menu.clearMenuBar()` and kernel `menu.buildMenuBar()` are pure no-ops headless.** Safe to call from the composer; safe to run during boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
