### PR TITLE
feat(strings_compiler): accept multiple positional input files (#681)

### DIFF
--- a/frontier-cli/Makefile
+++ b/frontier-cli/Makefile
@@ -254,13 +254,7 @@ $(GENERATED_STRINGS): $(STRINGS_COMPILER) $(STRINGS_INPUTS)
 		echo "No YAML string tables found under resources/strings." >&2; \
 		exit 1; \
 	fi
-	# Pipe-via-cat workaround: strings_compiler currently accepts only one
-	# positional input file (strings_compiler_main.c rejects a second arg).
-	# Concatenating to stdin works because the YAML loader handles a root
-	# mapping with multiple table keys, but parse errors report "stdin"
-	# rather than the source filename. Follow-up: teach the compiler to
-	# loop over multiple positional args and revert this to a direct call.
-	cat $(STRINGS_INPUTS) | $(STRINGS_COMPILER) --c-output $(STRINGS_C) --h-output $(STRINGS_H) --manifest $(STRINGS_MANIFEST) -
+	$(STRINGS_COMPILER) --c-output $(STRINGS_C) --h-output $(STRINGS_H) --manifest $(STRINGS_MANIFEST) $(STRINGS_INPUTS)
 
 strings_generated: $(GENERATED_STRINGS)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -671,6 +671,8 @@ test-integration: check-python-deps check-license
 	@./verify_odb_sync_test.sh
 	@echo "Running ODB<->.ut sync lifecycle tests..."
 	@./ut_sync_lifecycle_test.sh
+	@echo "Running strings_compiler multi-input tests..."
+	@./strings_compiler_multi_input_test.sh
 
 test-integration-verbose: check-python-deps check-license
 	@echo "Running integration tests (verbose)..."
@@ -735,13 +737,7 @@ $(GENERATED_STRINGS): $(STRINGS_COMPILER) $(STRINGS_INPUTS)
 		echo "No YAML string tables found under resources/strings." >&2; \
 		exit 1; \
 	fi
-	# Pipe-via-cat workaround: strings_compiler currently accepts only one
-	# positional input file (strings_compiler_main.c rejects a second arg).
-	# Concatenating to stdin works because the YAML loader handles a root
-	# mapping with multiple table keys, but parse errors report "stdin"
-	# rather than the source filename. Follow-up: teach the compiler to
-	# loop over multiple positional args and revert this to a direct call.
-	cat $(STRINGS_INPUTS) | $(STRINGS_COMPILER) --c-output $(STRINGS_C) --h-output $(STRINGS_H) --manifest $(STRINGS_MANIFEST) -
+	$(STRINGS_COMPILER) --c-output $(STRINGS_C) --h-output $(STRINGS_H) --manifest $(STRINGS_MANIFEST) $(STRINGS_INPUTS)
 
 strings_generated: $(GENERATED_STRINGS)
 

--- a/tests/strings_compiler_multi_input_test.sh
+++ b/tests/strings_compiler_multi_input_test.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# Test for tools/strings_compiler multi-input support (issue #681).
+#
+# Before the fix: strings_compiler accepted only ONE positional input
+# file. A second positional argument printed "unexpected argument" and
+# exited 1. Both Makefiles worked around this by piping concatenated
+# YAML to stdin via `cat <inputs> | compiler ... -`, which loses source
+# filenames on parse errors.
+#
+# After the fix: argv-loop multi-input. The compiler accepts multiple
+# positional inputs, processes them in order, and reports parse errors
+# with the real filename.
+#
+# Strategy: build the compiler, invoke it with both real corpus inputs
+# (idsystemtablescripts.yaml + langerrorlist.yaml) as separate args,
+# assert exit 0 and that the produced .c and .h outputs contain symbols
+# from BOTH inputs. Then re-run with a deliberately-broken second file
+# and confirm the error message names the right file.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPILER="$PROJECT_ROOT/tools/strings_compiler/strings_compiler"
+INPUTS_DIR="$PROJECT_ROOT/resources/strings"
+
+if [ ! -x "$COMPILER" ]; then
+    echo "Error: strings_compiler not found or not executable: $COMPILER" >&2
+    echo "Build it first: make -C tools/strings_compiler" >&2
+    exit 1
+fi
+
+# The two real inputs in the corpus today; the issue exists precisely
+# because there are >=2 inputs. If the corpus drops back to a single
+# YAML in the future, this test becomes trivial and should still pass.
+INPUT_A="$INPUTS_DIR/idsystemtablescripts.yaml"
+INPUT_B="$INPUTS_DIR/langerrorlist.yaml"
+for f in "$INPUT_A" "$INPUT_B"; do
+    if [ ! -f "$f" ]; then
+        echo "Error: fixture missing: $f" >&2
+        exit 1
+    fi
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+TMPDIR_BASE=$(mktemp -d -t strings_compiler_multi_input_test.XXXXXX)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# ----------------------------------------------------------------
+# Test 1: two positional inputs are accepted; both contribute symbols
+# ----------------------------------------------------------------
+
+echo "Test 1: positive - two positional inputs both contribute symbols"
+
+C_OUT="$TMPDIR_BASE/test1.c"
+H_OUT="$TMPDIR_BASE/test1.h"
+MANIFEST="$TMPDIR_BASE/test1.manifest"
+
+if "$COMPILER" --c-output "$C_OUT" --h-output "$H_OUT" --manifest "$MANIFEST" "$INPUT_A" "$INPUT_B" 2>"$TMPDIR_BASE/test1.err"; then
+    # Confirm both sources contributed to the manifest. Each input
+    # declares a top-level table name; the manifest enumerates them.
+    # idsystemtablescripts.yaml contributes idsystemtablescripts (plus
+    # several embedded sub-tables); langerrorlist.yaml contributes
+    # langerrorlist. Both names must appear.
+    if grep -q "idsystemtablescripts" "$MANIFEST" && grep -q "langerrorlist" "$MANIFEST"; then
+        echo -e "  ${GREEN}PASS${NC}"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "  ${RED}FAIL${NC}: output produced but manifest missing expected symbols"
+        echo "  Manifest contents:"
+        sed 's/^/    /' "$MANIFEST"
+        FAILED=$((FAILED + 1))
+    fi
+else
+    echo -e "  ${RED}FAIL${NC}: compiler rejected two positional inputs"
+    echo "  stderr:"
+    sed 's/^/    /' "$TMPDIR_BASE/test1.err"
+    FAILED=$((FAILED + 1))
+fi
+
+# ----------------------------------------------------------------
+# Test 2: parse error names the source file (not "stdin")
+# ----------------------------------------------------------------
+#
+# Create a sandboxed bad-syntax YAML and invoke with the good input first
+# then the bad one. The error message must name the bad file, not "stdin"
+# (which was the pre-fix behavior via the cat-pipe workaround).
+
+echo "Test 2: parse error names the source file"
+
+BAD_YAML="$TMPDIR_BASE/bad.yaml"
+printf 'table: this_is_not_valid_strings_yaml\n: : :\n' > "$BAD_YAML"
+
+C_OUT2="$TMPDIR_BASE/test2.c"
+H_OUT2="$TMPDIR_BASE/test2.h"
+MANIFEST2="$TMPDIR_BASE/test2.manifest"
+
+if "$COMPILER" --c-output "$C_OUT2" --h-output "$H_OUT2" --manifest "$MANIFEST2" "$INPUT_A" "$BAD_YAML" >/dev/null 2>"$TMPDIR_BASE/test2.err"; then
+    echo -e "  ${RED}FAIL${NC}: compiler should have rejected the bad YAML"
+    FAILED=$((FAILED + 1))
+else
+    # Expect the error to mention the bad file's basename, not "stdin".
+    if grep -q "bad.yaml" "$TMPDIR_BASE/test2.err"; then
+        echo -e "  ${GREEN}PASS${NC}"
+        PASSED=$((PASSED + 1))
+    elif grep -q "stdin" "$TMPDIR_BASE/test2.err"; then
+        echo -e "  ${RED}FAIL${NC}: error reported 'stdin' instead of source filename"
+        echo "  stderr:"
+        sed 's/^/    /' "$TMPDIR_BASE/test2.err"
+        FAILED=$((FAILED + 1))
+    else
+        echo -e "  ${RED}FAIL${NC}: error message did not name a source file"
+        echo "  stderr:"
+        sed 's/^/    /' "$TMPDIR_BASE/test2.err"
+        FAILED=$((FAILED + 1))
+    fi
+fi
+
+# ----------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------
+
+echo ""
+echo "============================================================"
+echo "strings_compiler_multi_input_test.sh: $PASSED passed, $FAILED failed"
+echo "============================================================"
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tools/strings_compiler/strings_compiler_main.c
+++ b/tools/strings_compiler/strings_compiler_main.c
@@ -88,14 +88,14 @@ int main(int argc, char **argv) {
 
 	/* No inputs => read stdin once, same backwards-compatible behavior
 	 * as before. Callers can still pipe via `cat foo.yaml bar.yaml |
-	 * strings_compiler`, though they lose source filenames in errors. */
+	 * strings_compiler`, though they lose source filenames in errors.
+	 * Invariant: input_cap grows only when input_count grows, so
+	 * input_count == 0 implies input_cap == 0 and inputs == NULL. */
 	if (input_count == 0) {
-		if (input_cap == 0) {
-			inputs = malloc(sizeof(*inputs));
-			if (!inputs) {
-				fprintf(stderr, "strings_compiler: out of memory\n");
-				return EXIT_FAILURE;
-			}
+		inputs = malloc(sizeof(*inputs));
+		if (!inputs) {
+			fprintf(stderr, "strings_compiler: out of memory\n");
+			return EXIT_FAILURE;
 		}
 		inputs[0] = "-";
 		input_count = 1;

--- a/tools/strings_compiler/strings_compiler_main.c
+++ b/tools/strings_compiler/strings_compiler_main.c
@@ -17,12 +17,23 @@ static const char *path_basename(const char *path) {
 
 static void print_usage(const char *prog) {
 	fprintf(stderr,
-			"Usage: %s [--c-output <file>] [--h-output <file>] [--manifest <file>] [input.yaml]\n",
+			"Usage: %s [--c-output <file>] [--h-output <file>] [--manifest <file>] [input.yaml ...]\n",
 			prog);
 }
 
 int main(int argc, char **argv) {
-	const char *input_path = NULL;
+	/*
+	 * Positional inputs are collected into a small heap-allocated array
+	 * and processed in argv order. strings_compiler_runtime accumulates
+	 * tables across calls within a single strings_begin_document /
+	 * strings_finish_document bracket (issue #681). Per-file invocations
+	 * preserve source filenames for parse-error reporting -- the prior
+	 * single-arg-or-stdin design forced callers to pipe `cat *.yaml` and
+	 * lost filenames in the merged stream.
+	 */
+	const char **inputs = NULL;
+	int input_count = 0;
+	int input_cap = 0;
 	const char *c_output = NULL;
 	const char *h_output = NULL;
 	const char *manifest = NULL;
@@ -32,61 +43,99 @@ int main(int argc, char **argv) {
 		if (strcmp(arg, "--c-output") == 0) {
 			if (i + 1 >= argc) {
 				fprintf(stderr, "strings_compiler: missing argument for --c-output\n");
+				free(inputs);
 				return EXIT_FAILURE;
 			}
 			c_output = argv[++i];
 		} else if (strcmp(arg, "--h-output") == 0) {
 			if (i + 1 >= argc) {
 				fprintf(stderr, "strings_compiler: missing argument for --h-output\n");
+				free(inputs);
 				return EXIT_FAILURE;
 			}
 			h_output = argv[++i];
 		} else if (strcmp(arg, "--manifest") == 0) {
 			if (i + 1 >= argc) {
 				fprintf(stderr, "strings_compiler: missing argument for --manifest\n");
+				free(inputs);
 				return EXIT_FAILURE;
 			}
 			manifest = argv[++i];
 		} else if (strcmp(arg, "--help") == 0) {
 			print_usage(argv[0]);
+			free(inputs);
 			return EXIT_SUCCESS;
 		} else if (strcmp(arg, "--version") == 0) {
 			printf("strings_compiler 0.1\n");
+			free(inputs);
 			return EXIT_SUCCESS;
-		} else if (!input_path) {
-			input_path = arg;
 		} else {
-			fprintf(stderr, "strings_compiler: unexpected argument '%s'\n", arg);
-			return EXIT_FAILURE;
+			/* Treat any non-option arg as a positional input file. */
+			if (input_count == input_cap) {
+				int new_cap = input_cap ? input_cap * 2 : 4;
+				const char **resized = realloc(inputs, (size_t)new_cap * sizeof(*inputs));
+				if (!resized) {
+					fprintf(stderr, "strings_compiler: out of memory collecting inputs\n");
+					free(inputs);
+					return EXIT_FAILURE;
+				}
+				inputs = resized;
+				input_cap = new_cap;
+			}
+			inputs[input_count++] = arg;
 		}
 	}
 
-	if (!input_path)
-		input_path = "-";
-
-	FILE *input = NULL;
-	if (strcmp(input_path, "-") == 0) {
-		input = stdin;
-	} else {
-		input = fopen(input_path, "rb");
-		if (!input) {
-			fprintf(stderr, "strings_compiler: failed to open '%s'\n", input_path);
-			return EXIT_FAILURE;
+	/* No inputs => read stdin once, same backwards-compatible behavior
+	 * as before. Callers can still pipe via `cat foo.yaml bar.yaml |
+	 * strings_compiler`, though they lose source filenames in errors. */
+	if (input_count == 0) {
+		if (input_cap == 0) {
+			inputs = malloc(sizeof(*inputs));
+			if (!inputs) {
+				fprintf(stderr, "strings_compiler: out of memory\n");
+				return EXIT_FAILURE;
+			}
 		}
+		inputs[0] = "-";
+		input_count = 1;
 	}
 
 	strings_begin_document();
 
-	int parse_result;
-	if (input == stdin)
-		parse_result = strings_load_yaml_stream(input, "stdin");
-	else
-		parse_result = strings_load_yaml_stream(input, input_path);
+	int saw_error = 0;
+	for (int i = 0; i < input_count; ++i) {
+		const char *input_path = inputs[i];
+		FILE *input = NULL;
+		if (strcmp(input_path, "-") == 0) {
+			input = stdin;
+		} else {
+			input = fopen(input_path, "rb");
+			if (!input) {
+				fprintf(stderr, "strings_compiler: failed to open '%s'\n", input_path);
+				saw_error = 1;
+				break;
+			}
+		}
 
-	if (input && input != stdin)
-		fclose(input);
+		int parse_result;
+		if (input == stdin)
+			parse_result = strings_load_yaml_stream(input, "stdin");
+		else
+			parse_result = strings_load_yaml_stream(input, input_path);
 
-	if (parse_result != 0 || strings_has_errors()) {
+		if (input != stdin)
+			fclose(input);
+
+		if (parse_result != 0 || strings_has_errors()) {
+			saw_error = 1;
+			break;
+		}
+	}
+
+	free(inputs);
+
+	if (saw_error) {
 		strings_document_free(&g_document);
 		return EXIT_FAILURE;
 	}

--- a/tools/strings_compiler/strings_yaml_loader.c
+++ b/tools/strings_compiler/strings_yaml_loader.c
@@ -57,7 +57,17 @@ int strings_load_yaml_stream(FILE *stream, const char *source_name) {
 	yaml_parser_set_input_file(&parser, stream);
 
 	if (!yaml_parser_load(&parser, &document)) {
-		strings_report_error("libyaml parser error: %s", parser.problem ? parser.problem : "unknown");
+		/*
+		 * Issue #681: include source_name + libyaml's reported line/col
+		 * so multi-input runs can point the operator at the right file.
+		 * problem_mark.line is 0-based; bump to 1-based for human-style
+		 * "filename:line:col" output.
+		 */
+		strings_report_error("%s:%lu:%lu: libyaml parser error: %s",
+				source_name ? source_name : "input",
+				(unsigned long)(parser.problem_mark.line + 1),
+				(unsigned long)(parser.problem_mark.column + 1),
+				parser.problem ? parser.problem : "unknown");
 		yaml_parser_delete(&parser);
 		return -1;
 	}


### PR DESCRIPTION
Closes #681.

## Summary

`strings_compiler` previously rejected a second positional argument, forcing both `frontier-cli/Makefile` and `tests/Makefile` to work around it with `cat *.yaml | compiler ... -`. The pipe-via-cat workaround compiled correctly (the runtime accumulates tables across `begin_table` calls in one stream) but parse errors lost their source filename and reported `"stdin"` with a line number that was the offset into the concatenated stream.

This PR teaches the compiler to argv-loop multi-input, reverts both Makefiles to direct invocation, and tightens the libyaml-parser error path to prepend source name + line/col so multi-file runs can pin parse errors to the right file.

## What changed

- **`tools/strings_compiler/strings_compiler_main.c`** — Collect positional inputs into a heap array (initial cap 4, grows by doubling). Loop after argparse, one `strings_load_yaml_stream` per file. `strings_begin/finish_document` still brackets the whole multi-file load so cross-file dedup works unchanged. Zero-input case still reads stdin (backward compat). Every exit path frees the inputs array.
- **`tools/strings_compiler/strings_yaml_loader.c`** — The libyaml-parser-level error branch now formats as `<source_name>:<line>:<col>: libyaml parser error: <problem>`. The structural-error branches already prepended source_name; this brings the parser branch in line.
- **`frontier-cli/Makefile` + `tests/Makefile`** — Reverted from `cat $(STRINGS_INPUTS) | $(STRINGS_COMPILER) ... -` to direct `$(STRINGS_COMPILER) ... $(STRINGS_INPUTS)`. Workaround explanation comments removed.
- **`tests/strings_compiler_multi_input_test.sh`** (new) — Test 1 (positive): invoke with both real corpus inputs, assert exit 0 + manifest contains both. Test 2 (negative): sandbox a bad-syntax YAML as the second positional, assert the error message names the file (not "stdin"). Wired into `tests/Makefile test-integration`.

## /gate review

**Verdict: PASS** (0 P0, 0 P1, 2 P2; 1 fixed inline, 1 deferred as separate-issue FYI).

| Reviewer | Findings | Status |
|---|---|---|
| bar-raiser | 1 P2 (dead defensive branch in stdin fallback) + 1 P2-FYI (pre-existing `tests/Makefile` chain short-circuits on Python runner failure; my test inherits this but works directly) | P2 #1 fixed in `eb75ec042`. P2 FYI deferred — separate concern, can file as a follow-up issue if desired |
| security | 0 findings | ship-ready |
| concurrency | skipped (no triggers) | n/a |
| swiftui | excluded | n/a |

## Test plan

- [x] `./tests/strings_compiler_multi_input_test.sh` — 2/2 pass
- [x] `make -C tools/strings_compiler` builds clean (`-Wall -Wextra -std=c99`)
- [x] `make -C frontier-cli clean && make -C frontier-cli` rebuilds from scratch via new direct multi-input invocation
- [x] `./tools/run_headless_tests.sh` — 580/580 pass
- [x] `cd tests && make test-integration` — 2186 pass, 20 baseline failures preserved
- [x] stdin backward-compat: `cat *.yaml | strings_compiler` still works (verified directly)
