### PR TITLE
fix(#712): surface copyctopstring truncation at user-facing callsites

### DIFF
--- a/Common/source/db_format.c
+++ b/Common/source/db_format.c
@@ -2147,8 +2147,14 @@ boolean db_format_compact_to_path(hdldatabaserecord source_db, Handle source_roo
         goto cleanup;
     }
 
+    /* Defense-in-depth (#712): dst_path comes from the UserTalk caller of
+     * db.compactDatabase.  Fail loud before pathtofilespec sees a truncated path. */
+    if (!copyctopstring(dst_path, bsdst)) {
+        fail_step = "destination path > 255 bytes (truncated)";
+        log_error(LOG_COMP_DB, "db_format_compact_to_path: destination path exceeds 255 bytes and would be truncated: %s", dst_path);
+        goto cleanup;
+    }
     fail_step = "pathtofilespec(dst)";
-    copyctopstring(dst_path, bsdst);
     if (!pathtofilespec(bsdst, &dst_fs))
         goto cleanup;
 
@@ -2375,7 +2381,15 @@ static boolean migrate_internal(const char *db_path, const char *explicit_output
 
     snprintf(temp_path, sizeof temp_path, "%s.v7.tmp", output_path);
 
-    copyctopstring(db_path, bspath);
+    /* Defense-in-depth (#712): fail loudly before pathtofilespec sees a
+     * truncated path.  The CLI pre-check at MIGRATE_MAX_PATH_BYTES is the
+     * first line of defense; this catches callers that bypass the CLI
+     * (e.g. db.open() auto-migration, direct C API). */
+    if (!copyctopstring(db_path, bspath)) {
+        fail_step = "source path > 255 bytes (truncated)";
+        log_error(LOG_COMP_DB, "migrate_internal: source path exceeds 255 bytes and would be truncated: %s", db_path);
+        goto cleanup;
+    }
     fail_step = "pathtofilespec(src)";
     if (!pathtofilespec(bspath, &src_fs))
         goto cleanup;
@@ -2490,7 +2504,13 @@ static boolean migrate_internal(const char *db_path, const char *explicit_output
             goto cleanup;
     }
 
-    copyctopstring(temp_path, bsdst);
+    /* Defense-in-depth (#712): temp_path = output_path + ".v7.tmp" so it is
+     * always longer than db_path -- doubly important to check here. */
+    if (!copyctopstring(temp_path, bsdst)) {
+        fail_step = "temp path > 255 bytes (truncated)";
+        log_error(LOG_COMP_DB, "migrate_internal: temp path exceeds 255 bytes and would be truncated: %s", temp_path);
+        goto cleanup;
+    }
     fail_step = "pathtofilespec(dst)";
     if (!pathtofilespec(bsdst, &dst_fs))
         goto cleanup;

--- a/Common/source/dbverbs.c
+++ b/Common/source/dbverbs.c
@@ -763,9 +763,17 @@ static boolean dbopenverb (hdltreenode hparam1, tyvaluerecord *vreturned) {
 			}
 
 			if (output_path[0] != '\0' && strcmp(cpath, output_path) != 0) {
-				/* Output path differs from input -- update filespec */
+				/* Output path differs from input -- update filespec.
+				 * output_path is derived from the migrated path; it can be >255 bytes
+				 * if the user opened a database with a long path.  Defense-in-depth
+				 * (#712): fail loud rather than letting pathtofilespec see a truncated
+				 * path.  (The primary guard is the CLI pre-check; this catches callers
+				 * that reach dbopenverb directly, e.g. via db.open() UserTalk verb.) */
 				bigstring bsoutput;
-				copyctopstring(output_path, bsoutput);
+				if (!copyctopstring(output_path, bsoutput)) {
+					log_error(LOG_COMP_DB, "dbopenverb: migrated output path exceeds 255 bytes: %s", output_path);
+					return (false);
+				}
 				if (!pathtofilespec(bsoutput, &odbrec.fs)) {
 					log_error(LOG_COMP_DB, "dbopenverb: pathtofilespec failed for %s", output_path);
 					return (false);
@@ -1464,7 +1472,13 @@ boolean db_migrate_reopen_if_legacy(odbref *podb) {
             if (!db_format_last_migration_output_path(migrated_path, sizeof migrated_path))
                 return false;
             bigstring bsmigrated;
-            copyctopstring(migrated_path, bsmigrated);
+            /* Defense-in-depth (#712): migrated_path comes from the migration
+             * output path which may be >255 bytes if the ODB was opened from a
+             * long path.  Fail loud rather than silently truncating. */
+            if (!copyctopstring(migrated_path, bsmigrated)) {
+                log_error(LOG_COMP_DB, "db_migrate_reopen_if_legacy: migrated path exceeds 255 bytes: %s", migrated_path);
+                return false;
+            }
             if (!pathtofilespec(bsmigrated, &(**hodb).fs))
                 return false;
             /* Reopen the migrated file */

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -108,6 +108,14 @@ extern long releasethreadglobals(void);
 // System root filename (used in search path construction)
 #define SYSTEM_ROOT_FILENAME "Frontier.root"
 
+// Maximum path length accepted by --migrate. The migration stack runs each
+// path through copyctopstring, which clips Pascal strings to 255 bytes (1
+// length byte + 255 payload). Reject earlier paths fast at argv-parse time
+// rather than letting them surface as confusing downstream errors. The
+// deep-stack defense-in-depth checks in db_format.c / dbverbs.c catch
+// callers that bypass the CLI (db.open() auto-migration, direct C API).
+#define MIGRATE_MAX_PATH_BYTES 255
+
 // System root search paths (for auto-discovery)
 #define MAX_SEARCH_PATHS 5
 
@@ -648,11 +656,10 @@ int main(int argc, char* argv[]) {
 			return 1;
 		}
 
-		/* Reject paths > 255 bytes early -- copyctopstring in the migration
-		 * stack clips Pascal strings to 255 bytes.  Fail fast here with a
-		 * clear message rather than letting the truncated path surface as a
-		 * confusing "openfile" or "pathtofilespec" error downstream. */
-#define MIGRATE_MAX_PATH_BYTES 255
+		/* Reject paths > 255 bytes early (see MIGRATE_MAX_PATH_BYTES at top
+		 * of file). Fail fast here with a clear message rather than letting
+		 * the truncated path surface as a confusing "openfile" or
+		 * "pathtofilespec" error downstream. */
 		if (input_len > MIGRATE_MAX_PATH_BYTES) {
 			fprintf(stderr, "Error: --migrate: path exceeds %d bytes (maximum supported by database format)\n",
 			        MIGRATE_MAX_PATH_BYTES);

--- a/frontier-cli/main.c
+++ b/frontier-cli/main.c
@@ -648,6 +648,17 @@ int main(int argc, char* argv[]) {
 			return 1;
 		}
 
+		/* Reject paths > 255 bytes early -- copyctopstring in the migration
+		 * stack clips Pascal strings to 255 bytes.  Fail fast here with a
+		 * clear message rather than letting the truncated path surface as a
+		 * confusing "openfile" or "pathtofilespec" error downstream. */
+#define MIGRATE_MAX_PATH_BYTES 255
+		if (input_len > MIGRATE_MAX_PATH_BYTES) {
+			fprintf(stderr, "Error: --migrate: path exceeds %d bytes (maximum supported by database format)\n",
+			        MIGRATE_MAX_PATH_BYTES);
+			return 1;
+		}
+
 		/* Check --output target BEFORE migration to avoid side effects on failure */
 		if (g_cli_options.output_path != NULL) {
 			if (access(g_cli_options.output_path, F_OK) == 0 && !g_cli_options.force_overwrite) {

--- a/portable/fileverbs_portable.c
+++ b/portable/fileverbs_portable.c
@@ -517,6 +517,12 @@ boolean portable_filefunctionvalue(short token, hdltreenode hparam1,
 				bigstring bserrmsg;
 				char errbuf[512];
 				snprintf(errbuf, sizeof(errbuf), "Can't find a file named \"%s\".", path);
+				/* copyctopstring clips to 255 bytes on very long paths.  This is
+				 * intentional here: we are already on the error path (stat failed),
+				 * and a truncated error message is acceptable -- the caller still
+				 * sees a meaningful "Can't find a file named ..." prefix.  No
+				 * secondary error handling is added to avoid nesting error logic
+				 * inside an error reporter. (#712 audit) */
 				copyctopstring(errbuf, bserrmsg);
 				langerrormessage(bserrmsg);
 				return false;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -689,6 +689,14 @@ test-migrate-flag:
 	@echo "Running CLI migration flag tests..."
 	@./test_migrate_flag.sh
 
+# Run --migrate >255-byte-path truncation test (shell-based, issue #712).
+# Defense-in-depth check for copyctopstring callsites in db_format.c
+# migration paths. Today this fails for the right reason: stderr says
+# "openfile(src)" instead of naming the truncation as the cause.
+test-migrate-long-path:
+	@echo "Running --migrate long-path truncation tests..."
+	@./integration/cli_migrate_long_path_test.sh
+
 # Run custom CLI args tests (shell-based, uses -e mode)
 test-custom-args:
 	@echo "Running custom CLI args tests..."
@@ -720,7 +728,7 @@ check-license:
 	@python3 ../tools/relicense_headers.py --check
 
 # Run all tests (unit + integration + CLI migration + custom args + debug + hooks + license check)
-test-all: test test-integration test-migrate-flag test-custom-args test-debug test-cow-idempotent test-ut-sync-lifecycle test-hooks check-license
+test-all: test test-integration test-migrate-flag test-migrate-long-path test-custom-args test-debug test-cow-idempotent test-ut-sync-lifecycle test-hooks check-license
 	@echo "All test suites completed"
 
 # Verify Virgin.root <-> .ut corpus sync (issue #675).
@@ -812,7 +820,7 @@ verify-errors:
 	@echo "Verifying error message coverage..."
 	@../tools/verify_error_coverage.sh
 
-.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-custom-args test-debug test-hooks test-all verify-odb-sync test-odb-sync clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
+.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-migrate-long-path test-custom-args test-debug test-hooks test-all verify-odb-sync test-odb-sync clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
 
 check_v6_tables: check_v6_tables.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c ../frontier-cli/stubs/headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -DHEADLESS_TEST_PORTABLE_FILE -DHEADLESS_LINKS_REAL_DB -I../Common/headers -I../Common/SystemHeaders -I../portable check_v6_tables.c \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -691,8 +691,8 @@ test-migrate-flag:
 
 # Run --migrate >255-byte-path truncation test (shell-based, issue #712).
 # Defense-in-depth check for copyctopstring callsites in db_format.c
-# migration paths. Today this fails for the right reason: stderr says
-# "openfile(src)" instead of naming the truncation as the cause.
+# migration paths. Asserts the CLI rejects >255-byte --migrate paths with
+# a clear error before any filesystem side effects.
 test-migrate-long-path:
 	@echo "Running --migrate long-path truncation tests..."
 	@./integration/cli_migrate_long_path_test.sh

--- a/tests/integration/cli_migrate_long_path_test.sh
+++ b/tests/integration/cli_migrate_long_path_test.sh
@@ -160,7 +160,7 @@ fi
 # "openfile(src)" which is indistinguishable from permission denied,
 # missing file, or any other downstream failure. Post-fix we expect the
 # error to name the actual cause (path too long / truncated / 255).
-if grep -qiE "path.*too.*long|too.*long.*path|exceeds.*255|truncat|> 255 bytes|exceeded 255" "$STDERR_FILE" "$STDOUT_FILE"; then
+if grep -qiE "path.*too.*long|too.*long.*path|exceeds.*255|truncat(ed|ion|ing)|> 255 bytes|exceeded 255" "$STDERR_FILE" "$STDOUT_FILE"; then
     pass "error message identifies path-length / truncation as the cause"
 else
     fail "stderr does not mention truncation or path length" \

--- a/tests/integration/cli_migrate_long_path_test.sh
+++ b/tests/integration/cli_migrate_long_path_test.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# cli_migrate_long_path_test.sh - issue #712
+#
+# Defense-in-depth test for copyctopstring callsites in the --migrate flow.
+#
+# Background: PR #708 fixed a stack buffer overflow in copyctopstring() by
+# clamping the payload to 255 bytes and returning a boolean (false on
+# truncation). The overflow class is gone, BUT three callsites in
+# Common/source/db_format.c (lines 2151, 2378, 2493) discard the return,
+# meaning a >255-byte path is silently truncated to its 255-byte prefix
+# and then handed to pathtofilespec / openfile / opennewfile.
+#
+# The exit criterion in issue #712:
+#   "Add an integration test that supplies a >255-byte path to --migrate
+#    and confirms the truncation is surfaced as an error rather than
+#    silently using the prefix."
+#
+# What this test asserts (will fail today, pass after the fix):
+#   1. --migrate exits non-zero on a >255-byte path (true today, but for
+#      the WRONG reason -- openfile fails on the truncated prefix).
+#   2. stderr contains a clear truncation message (e.g. "too long",
+#      "truncated", "exceeds 255"). Today the user sees "openfile(src)"
+#      which is the same generic error they would see for permission
+#      denied, missing file, etc. -- it does not tell them the actual
+#      cause is a length-clamp.
+#   3. No leftover .v7.tmp file at the truncated-prefix location -- a
+#      silent truncation could have created garbage at the wrong path.
+#
+# Reference fix-shape pattern: frontier-cli/window_registry.c:116
+#   if (!copyctopstring(window_path, bs_path)) {
+#       log_warn(..., "exceeded 255 bytes and was truncated; skipping");
+#       return;
+#   }
+#
+# Test isolation: all temp state lives under tests/tmp/integration/
+# (per testing_rules / docs/AI_SHARED_GUIDELINES.md). Cleanup via trap.
+
+set -u  # NOT set -e -- we want to inspect failing exit codes manually
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+V6_FIXTURE="$PROJECT_ROOT/tests/fixtures/v6/test.root"
+
+TMP_ROOT="$PROJECT_ROOT/tests/tmp/integration"
+mkdir -p "$TMP_ROOT"
+TMP_DIR="$(mktemp -d "$TMP_ROOT/cli_migrate_long_path.XXXXXX")"
+
+cleanup() {
+    if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+        # Recursive remove of test-only scratch dir under tests/tmp/.
+        # Pre-approved per CLAUDE.md (worktree paths / scratch space).
+        chmod -R u+w "$TMP_DIR" 2>/dev/null || true
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+    FAIL=$((FAIL + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+echo "================================================"
+echo "  --migrate long-path truncation test (issue #712)"
+echo "================================================"
+echo ""
+
+# Preconditions
+if [ ! -x "$CLI" ]; then
+    echo -e "${RED}ERROR${NC}: CLI binary not found at $CLI"
+    echo "Run 'make -C frontier-cli' first."
+    exit 2
+fi
+
+if [ ! -f "$V6_FIXTURE" ]; then
+    echo -e "${RED}ERROR${NC}: v6 fixture not found at $V6_FIXTURE"
+    exit 2
+fi
+
+# Construct a path that exceeds 255 bytes but stays under
+# CLI_MAX_PATH_LENGTH (1024). Each segment is ~60 chars (well under the
+# 255-byte single-component filesystem limit on APFS / ext4). Five
+# segments plus the tmp prefix + filename pushes the total to ~345 bytes.
+SEG=$(printf 'a%.0s' $(seq 1 60))
+LONG_PARENT="$TMP_DIR/$SEG/$SEG/$SEG/$SEG/$SEG"
+mkdir -p "$LONG_PARENT"
+LONG_PATH="$LONG_PARENT/test.root"
+cp "$V6_FIXTURE" "$LONG_PATH"
+
+PATH_LEN=${#LONG_PATH}
+echo "Long path constructed: ${PATH_LEN} bytes (must be > 255 and < 1024)"
+echo ""
+
+# Sanity: path must actually be > 255 bytes for this test to be valid.
+if [ "$PATH_LEN" -le 255 ]; then
+    echo -e "${RED}ERROR${NC}: Constructed path is only $PATH_LEN bytes; need > 255."
+    exit 2
+fi
+if [ "$PATH_LEN" -ge 1024 ]; then
+    echo -e "${RED}ERROR${NC}: Constructed path is $PATH_LEN bytes; would be rejected by CLI_MAX_PATH_LENGTH=1024."
+    exit 2
+fi
+
+# What the truncated prefix looks like (the 255-byte cutoff of the full path).
+# A future fix can choose to use this for stronger assertions, but for the
+# fail-loud expectation we mainly care that no .v7.tmp is created anywhere.
+TRUNCATED_PREFIX="${LONG_PATH:0:255}"
+TRUNCATED_TMP="${TRUNCATED_PREFIX}.v7.tmp"
+
+# Capture pre-state for the no-side-effects assertion.
+PRE_V6_HASH=$(shasum -a 256 "$LONG_PATH" | cut -d' ' -f1)
+
+# Run --migrate. Capture stderr separately so we can grep for a clear
+# truncation message vs the generic "openfile" error we get today.
+STDOUT_FILE="$TMP_DIR/stdout.txt"
+STDERR_FILE="$TMP_DIR/stderr.txt"
+
+set +e
+"$CLI" --migrate "$LONG_PATH" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+ACTUAL_EXIT=$?
+set -e
+
+echo "--- stdout ---"
+cat "$STDOUT_FILE"
+echo "--- stderr ---"
+cat "$STDERR_FILE"
+echo "--- exit code: $ACTUAL_EXIT ---"
+echo ""
+
+# Assertion 1: non-zero exit. (Already true today; will stay true post-fix.)
+if [ "$ACTUAL_EXIT" -ne 0 ]; then
+    pass "exits non-zero on >255-byte --migrate path"
+else
+    fail "expected non-zero exit, got $ACTUAL_EXIT" \
+         "Migration appears to have succeeded with a truncated path -- this is the worst-case silent-corruption scenario."
+fi
+
+# Assertion 2: stderr surfaces a CLEAR truncation cause.
+# This is the headline assertion of issue #712. Pre-fix the user sees
+# "openfile(src)" which is indistinguishable from permission denied,
+# missing file, or any other downstream failure. Post-fix we expect the
+# error to name the actual cause (path too long / truncated / 255).
+if grep -qiE "path.*too.*long|too.*long.*path|exceeds.*255|truncat|> 255 bytes|exceeded 255" "$STDERR_FILE" "$STDOUT_FILE"; then
+    pass "error message identifies path-length / truncation as the cause"
+else
+    fail "stderr does not mention truncation or path length" \
+         "Expected one of: 'path too long' / 'truncated' / 'exceeds 255' / 'exceeded 255'. Got the generic downstream error instead -- which is the issue #712 bug."
+fi
+
+# Assertion 3: no stray .v7.tmp file was created at the truncated-prefix
+# location (or anywhere else that isn't under TMP_DIR). A defense-in-depth
+# fix should fail before opennewfile() is invoked with a truncated dst.
+if [ -e "$TRUNCATED_TMP" ]; then
+    fail "stray .v7.tmp file created at truncated prefix" \
+         "Found: $TRUNCATED_TMP -- a silent truncation wrote a file at the wrong path."
+else
+    pass "no .v7.tmp file leaked at the truncated-prefix location"
+fi
+
+# Assertion 4: original v6 fixture is unchanged.
+POST_V6_HASH=$(shasum -a 256 "$LONG_PATH" | cut -d' ' -f1)
+if [ "$PRE_V6_HASH" = "$POST_V6_HASH" ]; then
+    pass "original v6 file untouched by the failed migration"
+else
+    fail "original v6 file was modified despite migration failure" \
+         "pre: $PRE_V6_HASH  post: $POST_V6_HASH"
+fi
+
+echo ""
+echo "================================================"
+echo "  Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -293,6 +293,21 @@ if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$EDIT_VIRGIN_TESTS" ]; then
     fi
 fi
 
+# Shell-based test for --migrate with a >255-byte path (issue #712,
+# copyctopstring callsite defense-in-depth). Exercises the v6->v7
+# migration path with a path that exceeds the bigstring 255-byte limit
+# and asserts the failure surfaces as a clear truncation error rather
+# than a confusing downstream openfile/pathtofilespec failure.
+LONG_PATH_MIGRATE_TEST="$PROJECT_ROOT/tests/integration/cli_migrate_long_path_test.sh"
+if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$LONG_PATH_MIGRATE_TEST" ]; then
+    echo
+    "$LONG_PATH_MIGRATE_TEST"
+    LONG_PATH_RC=$?
+    if [ $LONG_PATH_RC -ne 0 ]; then
+        EXIT_CODE=$LONG_PATH_RC
+    fi
+fi
+
 # Verify integrity of every staged database after tests.
 #
 # Drift is reported as a warning only and does NOT fail EXIT_CODE. This


### PR DESCRIPTION
## Summary

Closes #712. Defense-in-depth follow-up to PR #708 (the canonical `copyctopstring` buffer-overflow fix).

PR #708 made `copyctopstring` return `boolean` (false on truncation). This PR adds explicit checks at the user/filesystem-derived callsites so >255-byte input surfaces as a clear, actionable error instead of silently truncating.

### Callsites fixed

- `Common/source/db_format.c:2151` (`db_format_compact_to_path` dst path)
- `Common/source/db_format.c:2378` (`migrate_internal` source path)
- `Common/source/db_format.c:2493` (`migrate_internal` temp .v7.tmp path)
- `Common/source/dbverbs.c:768` (`dbopenverb` post-migration reopen path)
- `Common/source/dbverbs.c:1467` (`db_migrate_reopen_if_legacy`)
- `portable/fileverbs_portable.c:520` (comment-only -- the truncation is in an error-message formatter already on the error path; documented as intentional)

### CLI fast-fail

`frontier-cli/main.c` -- new `MIGRATE_MAX_PATH_BYTES` (255) check at argv-parse time rejects oversized `--migrate` paths before any resource allocation, with:

```
Error: --migrate: path exceeds 255 bytes (maximum supported by database format)
```

The deep-stack checks in `db_format.c` / `dbverbs.c` are defense-in-depth: they catch paths that arrive through `db.open()` auto-migration or the direct C API, not just the CLI.

## Test plan

- [x] New integration test `tests/integration/cli_migrate_long_path_test.sh` -- constructs a 449-byte path, asserts non-zero exit, asserts stderr identifies path-length as the cause, asserts no `.v7.tmp` leaks at the truncated prefix, asserts the v6 source file is untouched. Was RED before fix (test went red on the "stderr identifies path-length" assertion because the user saw a generic `migrate fail at openfile(src)` instead); now 4/4 GREEN.
- [x] Unit suite: 586/586 pass (no regressions).
- [x] Integration suite: 2186 pass, 21 baseline failures preserved (matches develop -- 12 html, 1 #690 known-baseline, 2 startup, 6 tcp).

## Deferred (out of scope -- noted by Plan agent for follow-up)

The Plan agent's audit surfaced several additional `copyctopstring` callsites that warrant separate issues, intentionally NOT addressed here to keep this PR scoped:

- REPL/completion callsites (`repl.c`, `completion.c`) -- defensive only.
- `langsqlite.c` errmsg sites (cosmetic truncation of SQL error messages).
- `tcpverbs.c`, `WinSockNetEvents.c`, `shellsysverbs.c` INDIRECT callsites.
- `langerror.c:167` -- casts a bigstring (Pascal-encoded) to `const char *` and passes it to `copyctopstring`. The length byte is read as the first character; likely UB. Separate defect class.
- `Common/source/strings.c:1315, 1319` -- push-after-copyctopstring sites where the PUSH (not the initial copy) is the truncation surface. Different bug class.
- `shellsysverbs.c:594` (getenv) -- unbounded env-var input.
- `db.compactDatabase` UserTalk verb -- behavioral analog of the `--migrate` test would be a YAML integration test calling `db.compactDatabase("<long path>")`.

A separate issue can be filed to track the audit-tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
