### PR TITLE
test(#715): behavioral coverage for copyctopstring deep-stack defenses

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -697,6 +697,25 @@ test-migrate-long-path:
 	@echo "Running --migrate long-path truncation tests..."
 	@./integration/cli_migrate_long_path_test.sh
 
+# Run --system-root >255-byte-path truncation test (shell-based, issue #715).
+# Behavioral coverage for db_format.c:2390 (migrate_internal source-path
+# copyctopstring guard, callsite #2). The CLI does not fast-fail on
+# --system-root the way it does on --migrate, so a long v6 path flows
+# through auto-migration and reaches the deep-stack defense.
+test-system-root-long-path:
+	@echo "Running --system-root long-path truncation tests..."
+	@./integration/cli_system_root_long_path_test.sh
+
+# Run --system-root temp-path boundary test (shell-based, issue #715).
+# Behavioral coverage for db_format.c:2511 (migrate_internal temp-path
+# copyctopstring guard, callsite #3). Exercises the [249..255]-byte
+# db_path window where callsite #2 passes but db_path + ".v7.tmp"
+# overflows at callsite #3. Self-skips on worktree paths too long to
+# satisfy the boundary construction.
+test-system-root-temp-path-boundary:
+	@echo "Running --system-root temp-path boundary tests..."
+	@./integration/cli_system_root_temp_path_boundary_test.sh
+
 # Run custom CLI args tests (shell-based, uses -e mode)
 test-custom-args:
 	@echo "Running custom CLI args tests..."
@@ -728,7 +747,7 @@ check-license:
 	@python3 ../tools/relicense_headers.py --check
 
 # Run all tests (unit + integration + CLI migration + custom args + debug + hooks + license check)
-test-all: test test-integration test-migrate-flag test-migrate-long-path test-custom-args test-debug test-cow-idempotent test-ut-sync-lifecycle test-hooks check-license
+test-all: test test-integration test-migrate-flag test-migrate-long-path test-system-root-long-path test-system-root-temp-path-boundary test-custom-args test-debug test-cow-idempotent test-ut-sync-lifecycle test-hooks check-license
 	@echo "All test suites completed"
 
 # Verify Virgin.root <-> .ut corpus sync (issue #675).
@@ -820,7 +839,7 @@ verify-errors:
 	@echo "Verifying error message coverage..."
 	@../tools/verify_error_coverage.sh
 
-.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-migrate-long-path test-custom-args test-debug test-hooks test-all verify-odb-sync test-odb-sync clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
+.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-migrate-long-path test-system-root-long-path test-system-root-temp-path-boundary test-custom-args test-debug test-hooks test-all verify-odb-sync test-odb-sync clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
 
 check_v6_tables: check_v6_tables.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c ../frontier-cli/stubs/headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -DHEADLESS_TEST_PORTABLE_FILE -DHEADLESS_LINKS_REAL_DB -I../Common/headers -I../Common/SystemHeaders -I../portable check_v6_tables.c \

--- a/tests/integration/cli_system_root_long_path_test.sh
+++ b/tests/integration/cli_system_root_long_path_test.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# cli_system_root_long_path_test.sh - issue #715
+#
+# Behavioral coverage for the deep-stack copyctopstring defenses added by
+# PR #714 (#712) in Common/source/db_format.c. PR #714 added five
+# defense-in-depth checks where copyctopstring's return value was
+# previously discarded. The pre-existing integration test
+# cli_migrate_long_path_test.sh only exercises the CLI fast-fail at
+# frontier-cli/main.c:660 (MIGRATE_MAX_PATH_BYTES). The deep-stack
+# callsites needed live-caller coverage; this test provides it for
+# callsite #2.
+#
+# Callsite coverage matrix (issue #715 audit):
+#
+#   #1  db_format.c:~2151  db_format_compact_to_path  -- UNTESTED
+#       Reachable only via db.compactDatabase, which has its own length
+#       guard at dbverbs.c:~1232 that fires BEFORE the deep-stack check.
+#       The deep-stack defense is pure defense-in-depth; no live caller
+#       can exercise it.
+#
+#   #2  db_format.c:~2388  migrate_internal (src path) -- THIS TEST
+#       Reachable via `--system-root <long-v6-path>`. The CLI does NOT
+#       fast-fail on --system-root the way it does on --migrate, so a
+#       >255-byte path flows through hydrate_system_root_database ->
+#       ensure_database_v7 -> migrate_internal and hits the source-path
+#       copyctopstring check.
+#
+#   #3  db_format.c:~2509  migrate_internal (temp .v7.tmp path) -- sibling test
+#       See cli_system_root_temp_path_boundary_test.sh. The temp_path
+#       is db_path + ".v7.tmp", so it overflows when db_path is in
+#       [248, 255]. That boundary needs its own test.
+#
+#   #4  dbverbs.c               -- UNTESTED
+#   #5  dbverbs.c               -- UNTESTED
+#       Both have their input pre-clamped upstream by filespectopath
+#       (a Pascal-string converter that itself caps at 255). No live
+#       caller path can deliver a >255-byte string to these sites; they
+#       are pure defense-in-depth. Documented for completeness.
+#
+# What this test asserts (passes today on PR #714 / develop):
+#   1. --system-root with a >255-byte path exits non-zero.
+#   2. stderr contains the migrate_internal source-path truncation message
+#      from db_format.c:2390:
+#        "migrate_internal: source path exceeds 255 bytes and would be
+#         truncated: %s"
+#   3. No stray .v7.tmp file at the truncated-prefix location.
+#   4. Original v6 source file hash unchanged.
+#
+# Test isolation: all temp state lives under tests/tmp/integration/
+# (per testing_rules / docs/AI_SHARED_GUIDELINES.md). Cleanup via trap.
+
+set -u  # NOT set -e -- we want to inspect failing exit codes manually
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+V6_FIXTURE="$PROJECT_ROOT/tests/fixtures/v6/test.root"
+
+TMP_ROOT="$PROJECT_ROOT/tests/tmp/integration"
+mkdir -p "$TMP_ROOT"
+TMP_DIR="$(mktemp -d "$TMP_ROOT/cli_system_root_long_path.XXXXXX")"
+
+cleanup() {
+    if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+        # Recursive remove of test-only scratch dir under tests/tmp/.
+        # Pre-approved per CLAUDE.md (worktree paths / scratch space).
+        chmod -R u+w "$TMP_DIR" 2>/dev/null || true
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+    FAIL=$((FAIL + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+echo "================================================"
+echo "  --system-root long-path truncation test (issue #715, callsite #2)"
+echo "================================================"
+echo ""
+
+# Preconditions
+if [ ! -x "$CLI" ]; then
+    echo -e "${RED}ERROR${NC}: CLI binary not found at $CLI"
+    echo "Run 'make -C frontier-cli' first."
+    exit 2
+fi
+
+if [ ! -f "$V6_FIXTURE" ]; then
+    echo -e "${RED}ERROR${NC}: v6 fixture not found at $V6_FIXTURE"
+    exit 2
+fi
+
+# Construct a path that exceeds 255 bytes but stays under
+# CLI_MAX_PATH_LENGTH (1024). Each segment is ~60 chars (well under the
+# 255-byte single-component filesystem limit on APFS / ext4). Five
+# segments plus the tmp prefix + filename pushes the total to ~345 bytes.
+SEG=$(printf 'a%.0s' $(seq 1 60))
+LONG_PARENT="$TMP_DIR/$SEG/$SEG/$SEG/$SEG/$SEG"
+mkdir -p "$LONG_PARENT"
+LONG_PATH="$LONG_PARENT/test.root"
+cp "$V6_FIXTURE" "$LONG_PATH"
+
+PATH_LEN=${#LONG_PATH}
+echo "Long path constructed: ${PATH_LEN} bytes (must be > 255 and < 1024)"
+echo ""
+
+if [ "$PATH_LEN" -le 255 ]; then
+    echo -e "${RED}ERROR${NC}: Constructed path is only $PATH_LEN bytes; need > 255."
+    exit 2
+fi
+if [ "$PATH_LEN" -ge 1024 ]; then
+    echo -e "${RED}ERROR${NC}: Constructed path is $PATH_LEN bytes; would be rejected by CLI_MAX_PATH_LENGTH=1024."
+    exit 2
+fi
+
+# What the truncated prefix looks like (the 255-byte cutoff of the full path).
+TRUNCATED_PREFIX="${LONG_PATH:0:255}"
+TRUNCATED_TMP="${TRUNCATED_PREFIX}.v7.tmp"
+
+# Capture pre-state for the no-side-effects assertion.
+PRE_V6_HASH=$(shasum -a 256 "$LONG_PATH" | cut -d' ' -f1)
+
+# Run --system-root with the long v6 path. The CLI auto-migrates v6
+# system roots via ensure_database_v7 -> migrate_internal, so the
+# >255-byte db_path will reach callsite #2 in db_format.c (line 2388).
+#
+# Use --execute with a trivial script so the CLI has a reason to load
+# the system root. Add --skip-startup to keep the failure cause focused
+# on the migration step rather than startup-script noise.
+STDOUT_FILE="$TMP_DIR/stdout.txt"
+STDERR_FILE="$TMP_DIR/stderr.txt"
+
+set +e
+"$CLI" --system-root "$LONG_PATH" --skip-startup --execute 'echo("ok")' \
+    >"$STDOUT_FILE" 2>"$STDERR_FILE"
+ACTUAL_EXIT=$?
+set -e
+
+echo "--- stdout ---"
+cat "$STDOUT_FILE"
+echo "--- stderr ---"
+cat "$STDERR_FILE"
+echo "--- exit code: $ACTUAL_EXIT ---"
+echo ""
+
+# Assertion 1: non-zero exit.
+if [ "$ACTUAL_EXIT" -ne 0 ]; then
+    pass "exits non-zero on >255-byte --system-root path"
+else
+    fail "expected non-zero exit, got $ACTUAL_EXIT" \
+         "System root load appears to have succeeded with a truncated path -- silent-corruption scenario."
+fi
+
+# Assertion 2: stderr surfaces the migrate_internal source-path
+# truncation message. The exact message text from PR #714 at
+# db_format.c:2390 is:
+#   "migrate_internal: source path exceeds 255 bytes and would be truncated: <path>"
+# We grep for the distinguishing prefix that is uniquely owned by
+# callsite #2 (not callsite #1 or #3): "migrate_internal: source path".
+if grep -qE "migrate_internal: source path exceeds 255 bytes" "$STDERR_FILE"; then
+    pass "stderr contains migrate_internal source-path truncation message (callsite #2)"
+else
+    fail "stderr missing the callsite #2 truncation message" \
+         "Expected: 'migrate_internal: source path exceeds 255 bytes'. Saw the above stderr instead -- check that log_error from db_format.c:2390 is reaching stderr (not just a log file)."
+fi
+
+# Assertion 3: no stray .v7.tmp file was created at the truncated-prefix
+# location. The defense-in-depth fix should fail before opennewfile() is
+# invoked with a truncated dst, so nothing should be written.
+if [ -e "$TRUNCATED_TMP" ]; then
+    fail "stray .v7.tmp file created at truncated prefix" \
+         "Found: $TRUNCATED_TMP -- a silent truncation wrote a file at the wrong path."
+else
+    pass "no .v7.tmp file leaked at the truncated-prefix location"
+fi
+
+# Assertion 4: original v6 fixture is unchanged.
+POST_V6_HASH=$(shasum -a 256 "$LONG_PATH" | cut -d' ' -f1)
+if [ "$PRE_V6_HASH" = "$POST_V6_HASH" ]; then
+    pass "original v6 file untouched by the failed migration"
+else
+    fail "original v6 file was modified despite migration failure" \
+         "pre: $PRE_V6_HASH  post: $POST_V6_HASH"
+fi
+
+echo ""
+echo "================================================"
+echo "  Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/tests/integration/cli_system_root_temp_path_boundary_test.sh
+++ b/tests/integration/cli_system_root_temp_path_boundary_test.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# cli_system_root_temp_path_boundary_test.sh - issue #715
+#
+# Behavioral coverage for the deep-stack copyctopstring defense at
+# callsite #3 in Common/source/db_format.c (line 2509) added by PR #714
+# (#712).
+#
+# Callsite coverage matrix: see the header of
+# cli_system_root_long_path_test.sh for the full audit. Summary:
+#
+#   #1  db_format_compact_to_path          -- not live-reachable
+#   #2  migrate_internal source path       -- covered by sibling test
+#   #3  migrate_internal temp .v7.tmp path -- THIS TEST
+#   #4  dbverbs.c                          -- pre-clamped upstream
+#   #5  dbverbs.c                          -- pre-clamped upstream
+#
+# Callsite #3 is interesting because it is the ONLY case where the input
+# can pass callsite #2 (db_path <= 255 bytes) and STILL trip the deep-
+# stack guard:
+#
+#   migrate_internal:
+#       copyctopstring(db_path,   bspath)   <-- callsite #2 (<= 255 ok)
+#       ...
+#       snprintf(temp_path, ..., "%s.v7.tmp", output_path)
+#       copyctopstring(temp_path, bsdst)    <-- callsite #3 (+7 bytes)
+#
+# So temp_path = db_path + ".v7.tmp" (7 bytes longer). To exercise
+# callsite #3 specifically we need len(db_path) in [249, 255], which
+# yields len(temp_path) in [256, 262] -- passes #2, fails #3.
+#
+# Production message text from db_format.c:2511 (verified pre-write):
+#   "migrate_internal: temp path exceeds 255 bytes and would be
+#    truncated: <temp_path>"
+#
+# What this test asserts:
+#   1. --system-root with a [249..255]-byte v6 path exits non-zero.
+#   2. stderr contains the migrate_internal temp-path truncation
+#      message (callsite #3), NOT the source-path one (callsite #2).
+#      The distinction matters: a regression that lowers the limit at
+#      callsite #2 to <248 would silently mask callsite #3.
+#   3. No .v7.tmp file leaked.
+#   4. Original v6 file hash unchanged.
+#
+# Skippable on long-prefix checkouts: if the test scratch root is itself
+# so long that we cannot construct a db_path in [249, 255], we skip
+# (exit 0 with a SKIP message) rather than fail. This prevents the test
+# from going red on a developer machine with a deeply nested worktree
+# path.
+#
+# Test isolation: all temp state lives under tests/tmp/integration/
+# (per testing_rules / docs/AI_SHARED_GUIDELINES.md). Cleanup via trap.
+
+set -u  # NOT set -e -- we want to inspect failing exit codes manually
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+V6_FIXTURE="$PROJECT_ROOT/tests/fixtures/v6/test.root"
+
+TMP_ROOT="$PROJECT_ROOT/tests/tmp/integration"
+mkdir -p "$TMP_ROOT"
+TMP_DIR="$(mktemp -d "$TMP_ROOT/cli_system_root_temp_path_boundary.XXXXXX")"
+
+cleanup() {
+    if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+        chmod -R u+w "$TMP_DIR" 2>/dev/null || true
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+    FAIL=$((FAIL + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+skip() {
+    echo -e "${YELLOW}SKIP${NC}: $1"
+    echo ""
+    echo "================================================"
+    echo "  Results: SKIPPED (environmental, not a failure)"
+    echo "================================================"
+    exit 0
+}
+
+echo "================================================"
+echo "  --system-root temp-path boundary test (issue #715, callsite #3)"
+echo "================================================"
+echo ""
+
+# Preconditions
+if [ ! -x "$CLI" ]; then
+    echo -e "${RED}ERROR${NC}: CLI binary not found at $CLI"
+    echo "Run 'make -C frontier-cli' first."
+    exit 2
+fi
+
+if [ ! -f "$V6_FIXTURE" ]; then
+    echo -e "${RED}ERROR${NC}: v6 fixture not found at $V6_FIXTURE"
+    exit 2
+fi
+
+# Target: a db_path whose length lands in [249, 255] so that
+# db_path + ".v7.tmp" overflows 255.
+#
+# We construct: TMP_DIR / <pad>/test.root
+# where <pad> is a single directory whose name length we pick to land
+# the total at TARGET_LEN.
+#
+# Total = len(TMP_DIR) + 1 + len(<pad>) + 1 + len("test.root")
+#       = len(TMP_DIR) + len(<pad>) + 11
+#
+# We pick TARGET_LEN = 252 (middle of [249, 255] window, leaves a tiny
+# buffer on either side for off-by-one issues). Then:
+#   len(<pad>) = TARGET_LEN - len(TMP_DIR) - 11
+
+TARGET_LEN=252
+TMP_DIR_LEN=${#TMP_DIR}
+PAD_LEN=$((TARGET_LEN - TMP_DIR_LEN - 11))
+
+echo "TMP_DIR length: $TMP_DIR_LEN bytes"
+echo "Target db_path length: $TARGET_LEN bytes"
+echo "Required pad length: $PAD_LEN bytes"
+echo ""
+
+# Sanity bounds for the pad. The single-component limit on APFS/ext4 is
+# 255 bytes, so PAD_LEN must be in (0, 255]. If PAD_LEN is too small or
+# negative, the worktree path is already too long -- skip rather than
+# fail. (Each filesystem path component must also be non-empty.)
+#
+# Minimum useful PAD_LEN: 1. Lower limit on db_path: we want >= 249 to
+# make sure callsite #2 (which fires at >255) does NOT trip first.
+#
+# Upper limit: we want <= 255 for the same reason. At db_path == 256
+# callsite #2 fires before #3 ever runs.
+MIN_DB_PATH=249
+MAX_DB_PATH=255
+MIN_PAD=$((MIN_DB_PATH - TMP_DIR_LEN - 11))
+MAX_PAD=$((MAX_DB_PATH - TMP_DIR_LEN - 11))
+
+if [ "$MAX_PAD" -lt 1 ] || [ "$MIN_PAD" -gt 254 ]; then
+    skip "tmp prefix too long for boundary construction (need db_path in [$MIN_DB_PATH..$MAX_DB_PATH]; TMP_DIR is $TMP_DIR_LEN bytes, leaving pad window [$MIN_PAD..$MAX_PAD] which is unsatisfiable)"
+fi
+
+if [ "$PAD_LEN" -lt 1 ]; then
+    # Re-target near MAX_PAD if our nominal target produces a sub-1 pad.
+    PAD_LEN=$MAX_PAD
+    TARGET_LEN=$((TMP_DIR_LEN + PAD_LEN + 11))
+    echo "Adjusted TARGET_LEN down to $TARGET_LEN (PAD_LEN=$PAD_LEN) to fit window"
+fi
+
+# Build the pad directory name.
+PAD=$(printf 'p%.0s' $(seq 1 "$PAD_LEN"))
+
+LONG_PARENT="$TMP_DIR/$PAD"
+mkdir -p "$LONG_PARENT"
+LONG_PATH="$LONG_PARENT/test.root"
+cp "$V6_FIXTURE" "$LONG_PATH"
+
+PATH_LEN=${#LONG_PATH}
+TEMP_PATH_LEN=$((PATH_LEN + 7))  # ".v7.tmp" is 7 bytes
+echo "Constructed db_path length: $PATH_LEN bytes"
+echo "Implied temp_path length:   $TEMP_PATH_LEN bytes"
+echo ""
+
+# Hard preconditions: db_path must NOT exceed 255 (else callsite #2 wins)
+# AND temp_path must exceed 255 (else neither callsite fires).
+if [ "$PATH_LEN" -gt 255 ]; then
+    echo -e "${RED}ERROR${NC}: constructed db_path is $PATH_LEN bytes (> 255). Callsite #2 would fire before #3; reduce PAD_LEN."
+    exit 2
+fi
+if [ "$TEMP_PATH_LEN" -le 255 ]; then
+    echo -e "${RED}ERROR${NC}: implied temp_path is $TEMP_PATH_LEN bytes (<= 255). Neither callsite would fire; increase PAD_LEN."
+    exit 2
+fi
+
+# What the truncated prefix looks like (for the no-side-effects check).
+TRUNCATED_PREFIX="${LONG_PATH:0:255}"
+TRUNCATED_TMP_AT_PREFIX="${TRUNCATED_PREFIX}.v7.tmp"
+EXPECTED_TMP="${LONG_PATH}.v7.tmp"
+
+# Capture pre-state.
+PRE_V6_HASH=$(shasum -a 256 "$LONG_PATH" | cut -d' ' -f1)
+
+# Run --system-root. Auto-migration kicks in for v6 input.
+STDOUT_FILE="$TMP_DIR/stdout.txt"
+STDERR_FILE="$TMP_DIR/stderr.txt"
+
+set +e
+"$CLI" --system-root "$LONG_PATH" --skip-startup --execute 'echo("ok")' \
+    >"$STDOUT_FILE" 2>"$STDERR_FILE"
+ACTUAL_EXIT=$?
+set -e
+
+echo "--- stdout ---"
+cat "$STDOUT_FILE"
+echo "--- stderr ---"
+cat "$STDERR_FILE"
+echo "--- exit code: $ACTUAL_EXIT ---"
+echo ""
+
+# Assertion 1: non-zero exit.
+if [ "$ACTUAL_EXIT" -ne 0 ]; then
+    pass "exits non-zero on boundary-length --system-root path"
+else
+    fail "expected non-zero exit, got $ACTUAL_EXIT" \
+         "System root load appears to have succeeded with a truncated temp path -- silent-corruption scenario."
+fi
+
+# Assertion 2: stderr contains the temp-path truncation message, NOT
+# the source-path one. This is what makes the test specific to
+# callsite #3 vs the sibling test that covers callsite #2.
+if grep -qE "migrate_internal: temp path exceeds 255 bytes" "$STDERR_FILE"; then
+    pass "stderr contains migrate_internal temp-path truncation message (callsite #3)"
+else
+    fail "stderr missing the callsite #3 truncation message" \
+         "Expected: 'migrate_internal: temp path exceeds 255 bytes'. Saw the above stderr instead."
+fi
+
+# Cross-check: callsite #2 should NOT have fired (db_path is <= 255).
+# If we see the source-path message, our boundary construction was off.
+if grep -qE "migrate_internal: source path exceeds 255 bytes" "$STDERR_FILE"; then
+    fail "unexpectedly tripped callsite #2 (source path)" \
+         "Boundary construction is wrong: db_path is supposed to be <= 255 but callsite #2 fired. Investigate length calculation."
+else
+    pass "callsite #2 (source path) correctly did NOT fire"
+fi
+
+# Assertion 3: no .v7.tmp file leaked. Two places to check:
+#  - the truncated 255-byte prefix
+#  - the canonical db_path + ".v7.tmp" location
+LEAK_FOUND=0
+if [ -e "$TRUNCATED_TMP_AT_PREFIX" ]; then
+    fail "stray .v7.tmp file at truncated prefix" \
+         "Found: $TRUNCATED_TMP_AT_PREFIX"
+    LEAK_FOUND=1
+fi
+if [ -e "$EXPECTED_TMP" ]; then
+    fail "stray .v7.tmp file at canonical location" \
+         "Found: $EXPECTED_TMP -- the defense should fail BEFORE opennewfile()."
+    LEAK_FOUND=1
+fi
+if [ "$LEAK_FOUND" -eq 0 ]; then
+    pass "no .v7.tmp file leaked"
+fi
+
+# Assertion 4: original v6 fixture is unchanged.
+POST_V6_HASH=$(shasum -a 256 "$LONG_PATH" | cut -d' ' -f1)
+if [ "$PRE_V6_HASH" = "$POST_V6_HASH" ]; then
+    pass "original v6 file untouched by the failed migration"
+else
+    fail "original v6 file was modified despite migration failure" \
+         "pre: $PRE_V6_HASH  post: $POST_V6_HASH"
+fi
+
+echo ""
+echo "================================================"
+echo "  Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -308,6 +308,37 @@ if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$LONG_PATH_MIGRATE_TEST" ]; then
     fi
 fi
 
+# Shell-based test for --system-root with a >255-byte v6 path (issue #715,
+# deep-stack copyctopstring coverage). Exercises callsite #2 in
+# migrate_internal (db_format.c:2390) which is reached via the v6 auto-
+# migration path when --system-root receives a long path. The CLI has
+# no MIGRATE_MAX_PATH_BYTES fast-fail on --system-root, so the long path
+# flows through to the deep-stack defense added by PR #714.
+SYSTEM_ROOT_LONG_PATH_TEST="$PROJECT_ROOT/tests/integration/cli_system_root_long_path_test.sh"
+if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$SYSTEM_ROOT_LONG_PATH_TEST" ]; then
+    echo
+    "$SYSTEM_ROOT_LONG_PATH_TEST"
+    SYSTEM_ROOT_LONG_PATH_RC=$?
+    if [ $SYSTEM_ROOT_LONG_PATH_RC -ne 0 ]; then
+        EXIT_CODE=$SYSTEM_ROOT_LONG_PATH_RC
+    fi
+fi
+
+# Shell-based test for --system-root temp-path boundary (issue #715,
+# callsite #3). Constructs a db_path in [249..255] bytes so that the
+# source-path check passes (callsite #2) but the temp_path = db_path +
+# ".v7.tmp" overflows at callsite #3 (db_format.c:2511). Self-skips on
+# worktree paths too long to satisfy the boundary construction.
+SYSTEM_ROOT_TEMP_PATH_TEST="$PROJECT_ROOT/tests/integration/cli_system_root_temp_path_boundary_test.sh"
+if [ "$ORIG_ARG_COUNT" -eq 0 ] && [ -x "$SYSTEM_ROOT_TEMP_PATH_TEST" ]; then
+    echo
+    "$SYSTEM_ROOT_TEMP_PATH_TEST"
+    SYSTEM_ROOT_TEMP_PATH_RC=$?
+    if [ $SYSTEM_ROOT_TEMP_PATH_RC -ne 0 ]; then
+        EXIT_CODE=$SYSTEM_ROOT_TEMP_PATH_RC
+    fi
+fi
+
 # Verify integrity of every staged database after tests.
 #
 # Drift is reported as a warning only and does NOT fail EXIT_CODE. This


### PR DESCRIPTION
## Summary

Closes #715. Adds behavioral test coverage for the deep-stack `copyctopstring` truncation defenses landed in PR #714 (#712).

PR #714 introduced 5 deep-stack defenses but the only behavioral test was for the CLI fast-fail at `main.c:660`. This PR adds tests for the deep-stack callsites that are **actually reachable from a live caller path**.

### Tests added

- **`tests/integration/cli_system_root_long_path_test.sh`** (4/4 GREEN)
  Covers `db_format.c:2388` (`migrate_internal` source path). Reaches the deep-stack callsite via `--system-root <long-v6-path>` — note this is a different CLI arg from `--migrate` and does NOT have the fast-fail check. Asserts:
  - Non-zero exit
  - stderr contains `migrate_internal: source path exceeds 255 bytes and would be truncated`
  - No `.v7.tmp` leaked
  - Original v6 file untouched

- **`tests/integration/cli_system_root_temp_path_boundary_test.sh`** (5/5 GREEN)
  Covers `db_format.c:2511` (`migrate_internal` temp `.v7.tmp` path). Boundary case: constructs a path in [248, 255] so the src path passes callsite #2 but `src + ".v7.tmp"` (adds 7 bytes) trips callsite #3. Asserts:
  - Non-zero exit
  - stderr contains `migrate_internal: temp path exceeds 255 bytes and would be truncated`
  - Callsite #2 (source) correctly did NOT fire
  - No `.v7.tmp` leaked
  - Original v6 file untouched
  - Self-skips with clear message if the worktree path is so long that the boundary [248, 255] cannot be hit

### Not behaviorally tested (documented in test header, intentional)

The Plan agent's audit found that 3 of the 5 deep-stack callsites have no live caller path:

| Callsite | Why no live caller |
|----------|--------------------|
| `db_format.c:2151` (`db_format_compact_to_path` dst) | `db.compactDatabase` verb has its OWN length guard at `dbverbs.c:1232` that fires before reaching this check |
| `dbverbs.c:768` (`dbopenverb` post-migration reopen) | Input pre-clamped by `filespectopath` upstream (caps at 255) |
| `dbverbs.c:1467` (`db_migrate_reopen_if_legacy`) | Same — pre-clamped by `filespectopath` |

They remain valid defense-in-depth (catches a future regression that removes the upstream guard) but are NOT reachable from any current external caller on macOS APFS. Faking the upstream-guard removal in a test would be a source-inspection test, not a behavioral one.

This is sharper than #715's original framing ("5 callsites need coverage"). The honest answer is "2 callsites are live-reachable; the other 3 are pure defense-in-depth without a live caller."

## Test plan

- [x] `./tests/integration/cli_system_root_long_path_test.sh` direct invocation — 4/4 GREEN
- [x] `./tests/integration/cli_system_root_temp_path_boundary_test.sh` direct invocation — 5/5 GREEN
- [x] `cd tests && make test-system-root-long-path` — passes
- [x] `cd tests && make test-system-root-temp-path-boundary` — passes
- [x] Unit suite: 586/586 (unchanged — shell tests don't affect unit count)
- [x] Integration suite: 2186 pass, 21 baseline failures preserved (matches develop)

No production code changes. PR scope is tests-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
