### PR TITLE
fix(#716): item 3 — document headless getenv path; refactor legacy guard

### DIFF
--- a/Common/source/shellsysverbs.c
+++ b/Common/source/shellsysverbs.c
@@ -580,18 +580,22 @@ static boolean sysfunctionvalue (short token, hdltreenode hparam1, tyvaluerecord
 				return (setstringvalue (emptystr, v));
 			}
 
-			/* Convert C string to Pascal string and return */
+			/* Convert C string to Pascal string and return.
+			   2026-06-05 JES #716 item 3: collapse the pre-check + memmove into
+			   a single canonical post-#707 boolean check on copyctopstring's
+			   return. The truncation surface is unchanged (long env vars still
+			   produce a script-visible langerrormessage); the cost of the
+			   throwaway memmove on the overflow path is negligible since
+			   `result` is a stack local. Mirrors the post-#707 pattern used at
+			   frontier-cli/window_registry.c:116 and the langerror.c:163 fix
+			   in PR #718. */
 			{
 				bigstring result;
-				size_t len = strlen (value);
 
-				/* Check for buffer overflow - bigstring max content length is 255 */
-				if (len > 255) {
+				if (!copyctopstring (value, result)) {
 					langerrormessage (BIGSTRING ("\pCan't get environment variable because value exceeds 255 characters"));
 					return (false);
 				}
-
-				copyctopstring (value, result);
 				return (setstringvalue (result, v));
 			}
 		}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -716,6 +716,12 @@ test-system-root-temp-path-boundary:
 	@echo "Running --system-root temp-path boundary tests..."
 	@./integration/cli_system_root_temp_path_boundary_test.sh
 
+# Run sys.getenvironmentvariable >255-byte regression test (shell-based, #716 #3).
+# Locks in the headless path's heap-handle design (no bigstring truncation).
+test-sys-getenv-long-value:
+	@echo "Running sys.getenvironmentvariable long-value regression tests..."
+	@./integration/sys_getenv_long_value_test.sh
+
 # Run custom CLI args tests (shell-based, uses -e mode)
 test-custom-args:
 	@echo "Running custom CLI args tests..."
@@ -747,7 +753,7 @@ check-license:
 	@python3 ../tools/relicense_headers.py --check
 
 # Run all tests (unit + integration + CLI migration + custom args + debug + hooks + license check)
-test-all: test test-integration test-migrate-flag test-migrate-long-path test-system-root-long-path test-system-root-temp-path-boundary test-custom-args test-debug test-cow-idempotent test-ut-sync-lifecycle test-hooks check-license
+test-all: test test-integration test-migrate-flag test-migrate-long-path test-system-root-long-path test-system-root-temp-path-boundary test-sys-getenv-long-value test-custom-args test-debug test-cow-idempotent test-ut-sync-lifecycle test-hooks check-license
 	@echo "All test suites completed"
 
 # Verify Virgin.root <-> .ut corpus sync (issue #675).
@@ -839,7 +845,7 @@ verify-errors:
 	@echo "Verifying error message coverage..."
 	@../tools/verify_error_coverage.sh
 
-.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-migrate-long-path test-system-root-long-path test-system-root-temp-path-boundary test-custom-args test-debug test-hooks test-all verify-odb-sync test-odb-sync clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
+.PHONY: all test test-report test-integration test-integration-verbose test-migrate-flag test-migrate-long-path test-system-root-long-path test-system-root-temp-path-boundary test-sys-getenv-long-value test-custom-args test-debug test-hooks test-all verify-odb-sync test-odb-sync clean install uninstall help results strings_generated kernel_verbs_generated verify-errors validate-bigstrings check-python-deps
 
 check_v6_tables: check_v6_tables.c $(LANG_RUNTIME_SOURCES) ../Common/source/odbengine.c ../frontier-cli/stubs/headless_shell.c
 	$(CC) $(CFLAGS) -DFRONTIER_HEADLESS -DHEADLESS_TEST_PORTABLE_FILE -DHEADLESS_LINKS_REAL_DB -I../Common/headers -I../Common/SystemHeaders -I../portable check_v6_tables.c \

--- a/tests/headless_sys_verbs.c
+++ b/tests/headless_sys_verbs.c
@@ -372,7 +372,18 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
         case sysv_getenvironmentvariable: {
             /* @IMPLEMENTED sys.getenvironmentvariable(name) - Get environment variable value
              * Returns empty string if variable not found
-             * Uses heap-allocated string to support values > 255 characters
+             * Uses heap-allocated string (newfilledhandle / setheapvalue) to support
+             * values > 255 characters.
+             *
+             * 2026-06-05 JES #716 item 3: this is the headless path. The legacy
+             * impl at Common/source/shellsysverbs.c::getenvironmentvariablefunc
+             * (only built into the full Mac app, NOT linked into frontier-cli)
+             * uses copyctopstring into a bigstring and rejects >255-byte values
+             * with langerrormessage. The audit in #716 flagged that as a
+             * truncation surface; the headless path avoids the bigstring entirely
+             * by going straight to a heap handle, so there is no >255-byte
+             * truncation here by construction. Do not add a bigstring length
+             * guard to this path — that would be a regression.
              */
             bigstring varname;
             char cvarname[256];  /* C string buffer for environment variable name */

--- a/tests/headless_sys_verbs.c
+++ b/tests/headless_sys_verbs.c
@@ -382,8 +382,10 @@ static boolean sys_valueproc(short token, hdltreenode hparam1,
              * with langerrormessage. The audit in #716 flagged that as a
              * truncation surface; the headless path avoids the bigstring entirely
              * by going straight to a heap handle, so there is no >255-byte
-             * truncation here by construction. Do not add a bigstring length
-             * guard to this path — that would be a regression.
+             * truncation here by construction. Do not add a 255-byte bigstring
+             * length guard to this path -- that would be a regression. (An
+             * overflow-safe upper-bound check against a much larger limit
+             * remains future-compatible.)
              */
             bigstring varname;
             char cvarname[256];  /* C string buffer for environment variable name */

--- a/tests/integration/sys_getenv_long_value_test.sh
+++ b/tests/integration/sys_getenv_long_value_test.sh
@@ -92,7 +92,10 @@ else
 fi
 
 # --- 300-byte regression guard: must return full length, not truncated ---
-VALUE_300=$(printf 'y%.0s' $(seq 1 300))
+# Mixed-content payload: 150 'A's then 150 'B's. Length-only assertions
+# would pass even if internal bytes were silently rewritten; mid-buffer
+# markers around byte 150/151 catch that class of regression too.
+VALUE_300="$(printf 'A%.0s' $(seq 1 150))$(printf 'B%.0s' $(seq 1 150))"
 LEN_300=$(FRONTIER_TEST_LONG_VAR="$VALUE_300" "$CLI" --system-root "$SYSTEM_ROOT" --batch -e \
     'string.length(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"))' 2>&1 | strip_warnings | tail -1)
 
@@ -106,15 +109,17 @@ else
          "got '$LEN_300', expected 300"
 fi
 
-# --- 300-byte content fidelity: full value is preserved verbatim ---
-LAST_CHAR=$(FRONTIER_TEST_LONG_VAR="$VALUE_300" "$CLI" --system-root "$SYSTEM_ROOT" --batch -e \
-    'string.mid(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"), 300, 1)' 2>&1 | strip_warnings | tail -1)
+# --- content fidelity: A/B boundary preserved at byte 150/151, and last
+# byte (300) is the final 'B'. Together these catch length-preserving
+# corruption that a single end-of-string check would miss. ---
+PROBE=$(FRONTIER_TEST_LONG_VAR="$VALUE_300" "$CLI" --system-root "$SYSTEM_ROOT" --batch -e \
+    'string.mid(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"), 150, 1) + string.mid(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"), 151, 1) + string.mid(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"), 300, 1)' 2>&1 | strip_warnings | tail -1)
 
-if [ "$LAST_CHAR" = "y" ]; then
-    pass "300-byte env var content preserved verbatim through byte 300"
+if [ "$PROBE" = "ABB" ]; then
+    pass "300-byte env var content preserved verbatim across mid-buffer + tail markers"
 else
-    fail "300-byte env var byte 300 was not preserved" \
-         "got '$LAST_CHAR', expected 'y'"
+    fail "300-byte env var content corrupted somewhere in the buffer" \
+         "got '$PROBE', expected 'ABB' (byte 150='A', byte 151='B', byte 300='B')"
 fi
 
 echo ""

--- a/tests/integration/sys_getenv_long_value_test.sh
+++ b/tests/integration/sys_getenv_long_value_test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# sys_getenv_long_value_test.sh - issue #716 item 3
+#
+# Behavioral regression test locking in the headless behavior of
+# sys.getenvironmentvariable for OS-level env var values > 255 bytes.
+#
+# Background:
+#   The audit in #716 item 3 pointed at Common/source/shellsysverbs.c:594,
+#   which uses copyctopstring into a bigstring and rejects values > 255
+#   bytes with a langerrormessage. That file is the legacy (full Mac app)
+#   implementation; it is NOT linked into the headless frontier-cli build.
+#
+#   The actual headless path (tests/headless_sys_verbs.c::sysv_getenvironmentvariable)
+#   uses newfilledhandle + setheapvalue, returning a heap-allocated string
+#   handle that supports arbitrary length. There is no bigstring on this
+#   path, and therefore no 255-byte truncation surface.
+#
+# What this test asserts:
+#   1. A 200-byte env var (control) reads back at length 200.
+#   2. A 300-byte env var reads back at length 300 -- not 255, not an
+#      error. This is the design behavior of the heap-handle path; the
+#      test guards against a future regression that mistakenly applied
+#      a bigstring guard to the headless path.
+#   3. The value content is preserved verbatim (no truncation at any
+#      byte boundary).
+#
+# Test isolation: env var is scoped to the test's subshell only. No
+# temp files needed.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLI="$PROJECT_ROOT/frontier-cli/frontier-cli"
+SYSTEM_ROOT="$PROJECT_ROOT/dist/Frontier.root"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+    FAIL=$((FAIL + 1))
+    TOTAL=$((TOTAL + 1))
+}
+
+echo "============================================================"
+echo "  sys.getenvironmentvariable >255-byte regression (#716 #3)"
+echo "============================================================"
+echo ""
+
+if [ ! -x "$CLI" ]; then
+    echo -e "${RED}ERROR${NC}: CLI binary not found at $CLI"
+    echo "Run 'make build' first."
+    exit 2
+fi
+
+if [ ! -f "$SYSTEM_ROOT" ]; then
+    echo -e "${RED}ERROR${NC}: Frontier.root not found at $SYSTEM_ROOT"
+    echo "Run 'make build' to produce dist/Frontier.root."
+    exit 2
+fi
+
+# Filter helper: strip warning lines so the assertion sees only the
+# script's stdout result.
+strip_warnings() {
+    grep -vE '^\[(table|lang|startup|general|headless)-(WARN|ERROR|INFO)\]' || true
+}
+
+# --- 200-byte control ---
+VALUE_200=$(printf 'x%.0s' $(seq 1 200))
+LEN_200=$(FRONTIER_TEST_LONG_VAR="$VALUE_200" "$CLI" --system-root "$SYSTEM_ROOT" --batch -e \
+    'string.length(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"))' 2>&1 | strip_warnings | tail -1)
+
+if [ "$LEN_200" = "200" ]; then
+    pass "200-byte env var reads back at length 200 (control)"
+else
+    fail "200-byte env var expected length 200, got '$LEN_200'"
+fi
+
+# --- 300-byte regression guard: must return full length, not truncated ---
+VALUE_300=$(printf 'y%.0s' $(seq 1 300))
+LEN_300=$(FRONTIER_TEST_LONG_VAR="$VALUE_300" "$CLI" --system-root "$SYSTEM_ROOT" --batch -e \
+    'string.length(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"))' 2>&1 | strip_warnings | tail -1)
+
+if [ "$LEN_300" = "300" ]; then
+    pass "300-byte env var reads back at length 300 (heap-handle path, no 255-byte truncation)"
+elif [ "$LEN_300" = "255" ]; then
+    fail "300-byte env var was truncated to 255 -- regression: someone applied a bigstring guard" \
+         "got length=255, expected 300"
+else
+    fail "300-byte env var unexpected length" \
+         "got '$LEN_300', expected 300"
+fi
+
+# --- 300-byte content fidelity: full value is preserved verbatim ---
+LAST_CHAR=$(FRONTIER_TEST_LONG_VAR="$VALUE_300" "$CLI" --system-root "$SYSTEM_ROOT" --batch -e \
+    'string.mid(sys.getenvironmentvariable("FRONTIER_TEST_LONG_VAR"), 300, 1)' 2>&1 | strip_warnings | tail -1)
+
+if [ "$LAST_CHAR" = "y" ]; then
+    pass "300-byte env var content preserved verbatim through byte 300"
+else
+    fail "300-byte env var byte 300 was not preserved" \
+         "got '$LAST_CHAR', expected 'y'"
+fi
+
+echo ""
+echo "============================================================"
+echo "  Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "============================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes item 3 of #716 with two findings and a small refactor:

1. **The audit pointed at the wrong file.** `Common/source/shellsysverbs.c::getenvironmentvariablefunc` is the legacy (full Mac app) impl; it is **not linked into the headless `frontier-cli` build**. The actual headless verb dispatch goes to `tests/headless_sys_verbs.c::sysv_getenvironmentvariable`.

2. **The headless path has no truncation surface by construction.** It uses `newfilledhandle` + `setheapvalue` to return a heap-allocated string handle. There is no bigstring on this path, so the >255-byte concern raised in the issue does not apply. A regression test now locks this in.

3. **Legacy file got a small post-#707 refactor.** The legacy guard worked, but it predated the post-#707 boolean-return convention. Collapsed 12 lines to 8, matching `frontier-cli/window_registry.c:116` and PR #718's `langerror.c:163` fix. Same observable behavior, same user-visible `langerrormessage`.

## Changes

- `tests/headless_sys_verbs.c` — expand the `@IMPLEMENTED` comment to document the heap-handle design intent, explicitly call out "no bigstring truncation surface here", and mark the path as "do not add a bigstring length guard" with a back-reference to #716 item 3
- `Common/source/shellsysverbs.c` — refactor the legacy guard from `strlen + manual >255 check + unguarded copyctopstring` to the canonical post-#707 form (`copyctopstring`'s boolean return)
- `tests/integration/sys_getenv_long_value_test.sh` (new) — shell-level integration test asserting:
  - 200-byte env var reads back at length 200 (control)
  - 300-byte env var reads back at length 300 (no truncation)
  - 300-byte env var content preserved verbatim through byte 300
- `tests/Makefile` — wire `test-sys-getenv-long-value` into `test-all` and `.PHONY`

## Test plan

- [x] `make build` — clean
- [x] `./tools/run_headless_tests.sh` — **589/589 pass**
- [x] `cd tests && make test-sys-getenv-long-value` — **3/3 pass**
- [x] `cd tests && make test-integration` — 21 baseline failures match PR #717's stated baseline (html / tcp / startup flakiness, unrelated to env-var code)

## Scope

This PR addresses **only item 3** of #716. Items 2, 4, 5 remain open and will be addressed in separate PRs:
- 2: `strings.c` push-after-`copyctopstring` truncation
- 4: `langsqlite.c` `sqlite3_errmsg` truncation
- 5: `tcpverbs.c` / `WinSockNetEvents.c` INDIRECT callsites

Item 6 was already closed via PR #717's analysis.

## Investigative process

I initially wrote a test that called `sys.getenvironmentvariable` with a >255-byte env var expecting an error (matching the original issue framing). The test returned the full 300 bytes — which surfaced that the audit target wasn't on the live path. Traced the verb dispatch through the kernel-verbs generator to `tests/headless_sys_verbs.c` and found the heap-handle design. The test was reframed as a regression guard for the actual headless behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
