### PR TITLE
fix(#716): item 5 — bound >255-byte hostname in tcp_address_to_name

### DIFF
--- a/Common/headers/tcpverbs.h
+++ b/Common/headers/tcpverbs.h
@@ -136,6 +136,11 @@ long tcp_count_connections(void);
 boolean tcp_open_stream_name(bigstring hostname, long port, long *stream_id_out);
 boolean tcp_name_to_address(bigstring domain_name, long *addr_out);
 boolean tcp_address_to_name(long addr, bigstring name_out);
+/* #716 item 5: testable helper -- packs a resolved C-string hostname into
+   the bigstring, falling back to dotted-decimal IP if the hostname exceeds
+   the 255-byte bigstring limit. Returns true if the hostname fit, false if
+   the IP fallback was used. */
+boolean tcp_address_to_name_pack(long addr, const char *hostname, bigstring name_out);
 boolean tcp_address_encode(bigstring ip_string, long *addr_out);
 boolean tcp_address_decode(long addr, bigstring ip_string_out);
 

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -1259,6 +1259,21 @@ boolean tcp_name_to_address(bigstring domain_name, long *addr_out) {
  * getnameinfo() itself fails. Pattern matches
  * frontier-cli/window_registry.c:116 and the post-#707 callsites
  * updated in PR #714.
+ *
+ * Why dotted-decimal IP fallback rather than empty / langerrormessage:
+ * the function's documented contract is "always returns true; either the
+ * hostname or the IP string". An empty string risks UserTalk callers
+ * treating it as a wildcard or skipping an identity check; an error
+ * breaks the contract and breaks scripts that rely on it. The IP
+ * literal also cannot be mistaken for a hostname suffix match (a
+ * substring check for "victim.com" against "192.168.1.1" is
+ * unambiguous), so fail-closed-to-IP is the safest choice.
+ *
+ * Why log_warn omits the hostname: the truncated hostname is
+ * attacker-controlled and up to 1025 bytes. Logging it raw would create
+ * a log-injection vector (newlines, ANSI escapes, format specifiers)
+ * and a size-amplification risk. The addr alone is enough for an
+ * operator to investigate via separate dig/host queries.
  */
 boolean tcp_address_to_name_pack(long addr, const char *hostname,
                                   bigstring name_out) {

--- a/Common/source/tcpverbs.c
+++ b/Common/source/tcpverbs.c
@@ -1239,6 +1239,40 @@ boolean tcp_name_to_address(bigstring domain_name, long *addr_out) {
  *
  * To detect if reverse DNS succeeded, compare the result with the original
  * IP address string - if they match, reverse lookup failed. */
+/*
+ * 2026-06-05 JES #716 item 5: helper extracted from tcp_address_to_name so
+ * the >255-byte hostname truncation path is testable without mocking
+ * getnameinfo(). Takes a resolved C-string hostname plus the original
+ * address for the fallback path; writes the bigstring result and returns
+ * true if the hostname fit, false if it was rejected and the IP fallback
+ * was used instead.
+ *
+ * NI_MAXHOST is 1025 (macOS, Linux) to accommodate non-DNS resolution
+ * sources (NIS, LDAP, /etc/hosts), but UserTalk bigstring max payload
+ * is 255. A long PTR record or attacker-controlled reverse lookup result
+ * would silently truncate via copyctopstring's clamp, producing a partial
+ * hostname that could confuse UserTalk-level identity checks (e.g.
+ * "did we connect to evil.com?" if the PTR was crafted as
+ * "evil.com.padding-padding-...-victim.com" and got clipped past the
+ * "evil.com" prefix). Surface as an explicit warning and fall back to
+ * the dotted-decimal IP string -- the same fallback path used when
+ * getnameinfo() itself fails. Pattern matches
+ * frontier-cli/window_registry.c:116 and the post-#707 callsites
+ * updated in PR #714.
+ */
+boolean tcp_address_to_name_pack(long addr, const char *hostname,
+                                  bigstring name_out) {
+    if (!copyctopstring(hostname, name_out)) {
+        log_warn(LOG_COMP_LANG,
+                 "tcp_address_to_name: resolved hostname exceeded 255 bytes; "
+                 "falling back to IP string (addr=%ld)",
+                 addr);
+        tcp_address_decode(addr, name_out);
+        return false;
+    }
+    return true;
+}
+
 /* tcp.addressToName(addr) -> string
  *
  * NOTE: Boolean return always true by design. This function cannot fail - it either
@@ -1270,9 +1304,8 @@ boolean tcp_address_to_name(long addr, bigstring name_out) {
         return true;
     }
 
-    copyctopstring(hostname, name_out);
-
-    log_info(LOG_COMP_LANG, "tcp_address_to_name: resolved to hostname");
+    if (tcp_address_to_name_pack(addr, hostname, name_out))
+        log_info(LOG_COMP_LANG, "tcp_address_to_name: resolved to hostname");
 
     return true;
 }

--- a/tests/tcp_phase1a_unit_tests.c
+++ b/tests/tcp_phase1a_unit_tests.c
@@ -389,6 +389,74 @@ TEST(address_encode_invalid_format) {
     }
 }
 
+/*
+ * Test 3.8: tcp_address_to_name_pack rejects >255-byte hostname and falls
+ * back to IP string (issue #716 item 5)
+ *
+ * Purpose: When getnameinfo returns a hostname longer than the 255-byte
+ * bigstring payload limit (NI_MAXHOST is 1025 on macOS/Linux), the legacy
+ * code path silently truncated via copyctopstring. A long PTR record could
+ * confuse UserTalk-level identity checks ("did we connect to evil.com?" if
+ * an attacker crafted "evil.com.<padding>.victim.com" past the 255 cutoff).
+ * The fix surfaces the truncation as a log warning and falls back to the
+ * dotted-decimal IP string -- same as the getnameinfo() failure path.
+ *
+ * Why a behavioral test is possible: tcp_address_to_name_pack was extracted
+ * from tcp_address_to_name specifically so this branch can be exercised
+ * without mocking getnameinfo. The helper takes the resolved C string and
+ * the original address, so we drive it directly with a synthetic 300-byte
+ * hostname.
+ *
+ * Reference: tcpverbs.c:tcp_address_to_name_pack(), PR #716 item 5
+ */
+TEST(address_to_name_pack_long_hostname_falls_back_to_ip) {
+    bigstring name_out;
+    char long_hostname[400];
+    long addr = 0xC0A80101L;  /* 192.168.1.1 */
+    boolean fit;
+
+    /* Construct a 300-byte hostname (well over the 255 bigstring limit). */
+    memset(long_hostname, 'x', 300);
+    long_hostname[300] = '\0';
+
+    fit = tcp_address_to_name_pack(addr, long_hostname, name_out);
+
+    /* The helper should report it didn't fit. */
+    ASSERT_FALSE(fit);
+
+    /* And name_out should contain the dotted-decimal IP fallback, NOT a
+       255-byte truncation of the synthetic hostname. */
+    char name_cstr[16];
+    copyptocstring(name_out, name_cstr);
+    ASSERT_EQ(strcmp(name_cstr, "192.168.1.1"), 0);
+}
+
+/*
+ * Test 3.9: tcp_address_to_name_pack writes the hostname verbatim when it
+ * fits (issue #716 item 5 -- happy path)
+ *
+ * Purpose: Regression guard alongside test 3.8. Verifies the success path
+ * preserves the hostname exactly when it is under the bigstring limit, so
+ * the new branch in tcp_address_to_name doesn't accidentally rewrite short
+ * hostnames as IPs.
+ *
+ * Reference: tcpverbs.c:tcp_address_to_name_pack()
+ */
+TEST(address_to_name_pack_short_hostname_preserved) {
+    bigstring name_out;
+    const char *short_hostname = "example.com";
+    long addr = 0xC0A80101L;  /* 192.168.1.1 -- not used on this branch */
+    boolean fit;
+
+    fit = tcp_address_to_name_pack(addr, short_hostname, name_out);
+
+    ASSERT_TRUE(fit);
+
+    char name_cstr[64];
+    copyptocstring(name_out, name_cstr);
+    ASSERT_EQ(strcmp(name_cstr, "example.com"), 0);
+}
+
 /* ========================================================================
  * Test Category 4: Error Handling Tests
  * ======================================================================== */
@@ -804,6 +872,8 @@ int main(void) {
     TR_RUN(test_address_decode_to_string);
     TR_RUN(test_address_roundtrip_conversion);
     TR_RUN(test_address_encode_invalid_format);
+    TR_RUN(test_address_to_name_pack_long_hostname_falls_back_to_ip);
+    TR_RUN(test_address_to_name_pack_short_hostname_preserved);
 
     printf("\nTest Category 4: Error Handling\n");
     TR_RUN(test_error_invalid_stream_id_zero);

--- a/tests/tcp_phase1a_unit_tests.c
+++ b/tests/tcp_phase1a_unit_tests.c
@@ -415,6 +415,11 @@ TEST(address_to_name_pack_long_hostname_falls_back_to_ip) {
     long addr = 0xC0A80101L;  /* 192.168.1.1 */
     boolean fit;
 
+    /* Zero the bigstring so a future regression that early-returns without
+       writing would surface as a deterministic empty string rather than
+       reading stack garbage. */
+    memset(name_out, 0, sizeof(name_out));
+
     /* Construct a 300-byte hostname (well over the 255 bigstring limit). */
     memset(long_hostname, 'x', 300);
     long_hostname[300] = '\0';
@@ -447,6 +452,9 @@ TEST(address_to_name_pack_short_hostname_preserved) {
     const char *short_hostname = "example.com";
     long addr = 0xC0A80101L;  /* 192.168.1.1 -- not used on this branch */
     boolean fit;
+
+    /* Zero the bigstring (see preceding test's rationale). */
+    memset(name_out, 0, sizeof(name_out));
 
     fit = tcp_address_to_name_pack(addr, short_hostname, name_out);
 


### PR DESCRIPTION
## Summary

Closes item 5 of #716 — the only remaining open item. (Items 1, 3 already closed via PRs #718, #719; items 2, 4, 6 closed as documentation-only per audit reconciliation.)

**The bug.** `tcp_address_to_name` uses `getnameinfo()` to do a reverse DNS lookup, writing into a `char hostname[NI_MAXHOST]` buffer. `NI_MAXHOST` is 1025 on macOS/Linux to accommodate non-DNS resolution sources (NIS, LDAP, `/etc/hosts`). The resolved hostname is then handed to `copyctopstring(hostname, name_out)` where `name_out` is a 256-byte UserTalk bigstring. Per PR #707, `copyctopstring` clamps the payload to 255 bytes and **returns `false`** on truncation — but the existing code at `tcpverbs.c:1273` discarded that return value, silently writing a truncated hostname.

A long PTR record — or an attacker-controlled reverse lookup result like `evil.com.<padding>...<more padding>.victim.com` — could leave the prefix `evil.com` visible to UserTalk-level identity checks while the actual lookup intent was concealed past the 255-byte cutoff.

**The fix.** Check `copyctopstring`'s boolean return. On truncation, emit a `log_warn` and fall back to the dotted-decimal IP string — the same fallback path used when `getnameinfo()` itself fails. Pattern matches `frontier-cli/window_registry.c:116` and PR #714's post-#707 callsites.

**Testability refactor.** Extracted the post-`getnameinfo` hostname-to-bigstring decision into a new helper `tcp_address_to_name_pack` so the truncation branch is exercisable without mocking `getnameinfo`. The helper takes the resolved C string and the original address, writing the bigstring + fallback.

## Other tcpverbs.c callsites audited

Verified bounded by construction; no other fixes needed:

| Site | Source | Bound |
|------|--------|-------|
| `tcp_set_error` (line 387) | `char[256]` from `snprintf` | 255 (matches bigstring cap) |
| `tcp_address_decode` (line 666) | `INET_ADDRSTRLEN` (16) | 15 + NUL |
| 9 status-string sites | String literals | <= 10 bytes |

`WinSockNetEvents.c` is Windows-only — not linked into headless build.

## Test plan

- [x] `make build` — clean
- [x] `./tools/run_headless_tests.sh` — **591/591 pass** (was 589; +2 new in `tcp_phase1a_unit_tests`)
- [x] Direct `./tests/tcp_phase1a_unit_tests` — 33/33 (was 31; new tests at 3.8 and 3.9 exercise the helper directly)
- [ ] `cd tests && make test-integration` — in progress at PR open; will confirm matches 21-baseline before merge

## Behavioral tests added

```c
TEST(address_to_name_pack_long_hostname_falls_back_to_ip)
TEST(address_to_name_pack_short_hostname_preserved)
```

Long-hostname test: constructs a 300-byte synthetic C string, calls `tcp_address_to_name_pack`, asserts:
1. Helper returns `false` (signaling fallback used)
2. `name_out` contains `"192.168.1.1"` (the dotted-decimal IP), NOT a 255-byte truncation of the synthetic hostname

Short-hostname test: passes `"example.com"`, asserts helper returns `true` and `name_out` contains `"example.com"` verbatim.

## Scope

This PR closes the last code-touching item of #716. The audit-tail issue can be closed after this merges.

## Discovery process

Original audit framing: "DNS-spec'd 253 bytes for hostnames, which is safely under 255". This turned out to be only half the story — DNS labels are bounded, but `getnameinfo` returns into `NI_MAXHOST` (1025) which can hold longer names from non-DNS sources. The actual truncation surface only appears when you trace from the `copyctopstring` call site upward through the buffer that feeds it, not just the spec for the most-common input source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
