### PR TITLE
feat(boxen): A.3 -- z-order + redraw + focus + input dispatch + modal

### DIFF
--- a/frontier-cli/boxen/boxen.c
+++ b/frontier-cli/boxen/boxen.c
@@ -1,7 +1,8 @@
 /*
- * boxen.c -- window primitive, clipping, and library lifecycle (A.2).
+ * boxen.c -- window manager core: primitive, clipping, z-order, redraw,
+ *            focus, input dispatch, modal, event loop (A.2 + A.3).
  *
- * Implements:
+ * Implements (A.2):
  *   boxen_init / boxen_shutdown         -- library lifecycle
  *   boxen_window_open / close           -- window lifecycle
  *   boxen_window_set_* / get_*          -- window property accessors
@@ -12,9 +13,17 @@
  *   boxen_window_at                     -- screen -> window-local coord mapping
  *   boxen_last_error_str                -- last error string accessor
  *
- * Out of scope at A.2 (stubs return gracefully):
- *   z-order (raise/lower/focus) -- A.3
- *   redraw / present / poll_event -- A.3
+ * Implements (A.3):
+ *   boxen_present                       -- back-to-front draw + backend->present
+ *   boxen_window_raise / lower          -- z-order manipulation
+ *   boxen_window_focus                  -- focus model + raise
+ *   boxen_window_set_modal              -- modal flag
+ *   boxen_window_invalidate             -- no-op (always-redraw model; API for future)
+ *   boxen_poll_event                    -- forwards to backend->poll_event
+ *   boxen_dispatch_event                -- focus/modal/at-point input routing
+ *   boxen_run / boxen_quit              -- convenience main loop with quit flag
+ *
+ * Stubs (later milestones):
  *   scrolling -- A.5
  *   chrome / borders / layout -- A.6
  *
@@ -41,9 +50,14 @@
 static const boxen_backend_t *g_backend    = NULL;
 static bool                   g_initialized = false;
 
-/* Window list -- simple fixed array; open appends, close swaps with last. */
+/* Window list -- simple fixed array; index 0 = bottommost, index
+ * g_window_count-1 = topmost. open appends (topmost); close swaps with last. */
 static boxen_window_t        *g_windows[BOXEN_MAX_WINDOWS];
 static int                    g_window_count = 0;
+
+/* A.3 focus and event loop state */
+static boxen_window_t        *g_focused_window = NULL;
+static bool                   g_should_quit     = false;
 
 /* -------------------------------------------------------------------------
  * Library lifecycle
@@ -94,8 +108,10 @@ void boxen_shutdown(void) {
 		g_backend->shutdown();
 	}
 
-	g_backend     = NULL;
-	g_initialized = false;
+	g_backend        = NULL;
+	g_initialized    = false;
+	g_focused_window = NULL;
+	g_should_quit    = false;
 }
 
 /* -------------------------------------------------------------------------
@@ -190,6 +206,11 @@ void boxen_window_close(boxen_window_t *win) {
 	g_windows[idx] = g_windows[--g_window_count];
 	g_windows[g_window_count] = NULL;
 
+	/* Clear focus pointer if this was the focused window. */
+	if (g_focused_window == win) {
+		g_focused_window = NULL;
+	}
+
 	win->magic = 0;  /* Mark as dead BEFORE freeing so a use-after-free read
 	                    sees a non-magic value if memory is read back. */
 	free(win->title);
@@ -282,16 +303,81 @@ void boxen_window_set_pinned(boxen_window_t *win, boxen_pin_edge_t edge) {
 	if (win != NULL) win->pinned = edge;
 }
 
-/* A.3 stubs */
-void boxen_window_raise(boxen_window_t *win)              { (void)win; }
-void boxen_window_lower(boxen_window_t *win)              { (void)win; }
-void boxen_window_focus(boxen_window_t *win)              { (void)win; }
-void boxen_window_set_modal(boxen_window_t *win, bool m)  { (void)win; (void)m; }
-void boxen_window_invalidate(boxen_window_t *win)         { (void)win; }
+/* -------------------------------------------------------------------------
+ * Z-order: raise / lower / focus
+ *
+ * The window list is ordered bottom-to-top: index 0 is the backmost window,
+ * index g_window_count-1 is the frontmost. raise() shifts a window to the
+ * top (last position); lower() shifts it to the bottom (index 0). Both
+ * preserve relative order of the other windows via a single-element shift.
+ * ---------------------------------------------------------------------- */
+
+void boxen_window_raise(boxen_window_t *win) {
+	if (win == NULL || g_window_count <= 1) return;
+
+	/* Find win in the list. */
+	int idx = -1;
+	for (int i = 0; i < g_window_count; i++) {
+		if (g_windows[i] == win) { idx = i; break; }
+	}
+	if (idx < 0 || idx == g_window_count - 1) return;  /* not found or already top */
+
+	/* Shift everything above idx down by one, place win at the top. */
+	for (int i = idx; i < g_window_count - 1; i++) {
+		g_windows[i] = g_windows[i + 1];
+	}
+	g_windows[g_window_count - 1] = win;
+}
+
+void boxen_window_lower(boxen_window_t *win) {
+	if (win == NULL || g_window_count <= 1) return;
+
+	int idx = -1;
+	for (int i = 0; i < g_window_count; i++) {
+		if (g_windows[i] == win) { idx = i; break; }
+	}
+	if (idx < 0 || idx == 0) return;  /* not found or already bottom */
+
+	/* Shift everything below idx up by one, place win at index 0. */
+	for (int i = idx; i > 0; i--) {
+		g_windows[i] = g_windows[i - 1];
+	}
+	g_windows[0] = win;
+}
+
+void boxen_window_focus(boxen_window_t *win) {
+	if (win == NULL) return;
+
+	/* Clear focused flag on all windows, then set it on win. */
+	for (int i = 0; i < g_window_count; i++) {
+		if (g_windows[i] != NULL) {
+			g_windows[i]->focused = false;
+		}
+	}
+	win->focused     = true;
+	g_focused_window = win;
+
+	/* Raise the newly focused window to the top. */
+	boxen_window_raise(win);
+}
+
+void boxen_window_set_modal(boxen_window_t *win, bool modal) {
+	if (win == NULL) return;
+	win->modal = modal;
+}
+
+/* boxen_window_invalidate: in the A.3 always-redraw model, every present()
+ * call redraws all windows regardless. This function is a no-op API surface
+ * for the future case where dirty-rect tracking is added (A.N+). */
+void boxen_window_invalidate(boxen_window_t *win) {
+	(void)win;
+	/* no-op: always-redraw model in A.3 */
+}
 
 void boxen_window_set_draw(boxen_window_t *win, boxen_draw_fn fn) {
 	if (win != NULL) win->draw_fn = fn;
 }
+
 void boxen_window_set_input(boxen_window_t *win, boxen_input_fn fn) {
 	if (win != NULL) win->input_fn = fn;
 }
@@ -324,14 +410,132 @@ void boxen_window_set_row_highlight(boxen_window_t *win, int content_row,
 	win->highlight_bg   = bg;
 }
 
-/* A.3 event loop stubs */
-boxen_result_t boxen_poll_event(boxen_event_t *out, int timeout_ms) {
-	(void)out; (void)timeout_ms;
-	return BOXEN_ERR_INVALID;
+/* -------------------------------------------------------------------------
+ * present -- back-to-front redraw + backend->present()
+ *
+ * Walks g_windows[0..g_window_count-1] (back to front) and calls each
+ * window's draw_fn callback if: (a) draw_fn is non-NULL, and (b) the
+ * window has non-zero width AND height. After all callbacks, calls
+ * backend->present() once to flush the composited frame.
+ * ---------------------------------------------------------------------- */
+
+void boxen_present(void) {
+	if (!g_initialized || g_backend == NULL) return;
+
+	for (int i = 0; i < g_window_count; i++) {
+		boxen_window_t *w = g_windows[i];
+		if (w == NULL) continue;
+		if (w->rect.w == 0 || w->rect.h == 0) continue;  /* skip degenerate/hidden */
+		if (w->draw_fn != NULL) {
+			w->draw_fn(w, w->user_data);
+		}
+	}
+
+	g_backend->present();
 }
-void boxen_present(void)  {}
-void boxen_run(void)      {}
-void boxen_quit(void)     {}
+
+/* -------------------------------------------------------------------------
+ * poll_event -- raw event fetch from the backend
+ *
+ * Returns BOXEN_OK on event, BOXEN_ERR_TIMEOUT when timeout_ms elapses
+ * with no event, or another negative error code on backend failure.
+ * Does NOT dispatch the event -- call boxen_dispatch_event() for that.
+ * ---------------------------------------------------------------------- */
+
+boxen_result_t boxen_poll_event(boxen_event_t *out, int timeout_ms) {
+	if (!g_initialized || g_backend == NULL) {
+		boxen__set_last_error("boxen not initialized");
+		return BOXEN_ERR_INVALID;
+	}
+	if (out == NULL) {
+		boxen__set_last_error("out must not be NULL");
+		return BOXEN_ERR_INVALID;
+	}
+	return g_backend->poll_event(out, timeout_ms);
+}
+
+/* -------------------------------------------------------------------------
+ * dispatch_event -- route an event to the right window(s)
+ *
+ * Key events:
+ *   If a modal window exists, dispatch to that window only.
+ *   Otherwise dispatch to the focused window (if any).
+ *
+ * Mouse events:
+ *   If a modal window exists, dispatch to the modal window only.
+ *   Otherwise dispatch to the topmost window at (ev->mouse.x, ev->mouse.y).
+ *
+ * Resize events:
+ *   Passed to the focused window (A.4 will handle clamping).
+ * ---------------------------------------------------------------------- */
+
+void boxen_dispatch_event(const boxen_event_t *ev) {
+	if (ev == NULL || !g_initialized) return;
+
+	/* Find the modal window, if any (last one with modal=true wins). */
+	boxen_window_t *modal_win = NULL;
+	for (int i = g_window_count - 1; i >= 0; i--) {
+		if (g_windows[i] != NULL && g_windows[i]->modal) {
+			modal_win = g_windows[i];
+			break;
+		}
+	}
+
+	boxen_window_t *target = NULL;
+
+	switch (ev->type) {
+	case BOXEN_EV_KEY:
+		target = (modal_win != NULL) ? modal_win : g_focused_window;
+		break;
+
+	case BOXEN_EV_MOUSE:
+		if (modal_win != NULL) {
+			target = modal_win;
+		} else {
+			/* Topmost window at (mouse.x, mouse.y) -- boxen_window_at scans
+			 * from the last (topmost) index, which is the z-order top. */
+			int cx, cy;
+			target = boxen_window_at(ev->mouse.x, ev->mouse.y, &cx, &cy);
+		}
+		break;
+
+	case BOXEN_EV_RESIZE:
+		target = g_focused_window;
+		break;
+
+	default:
+		break;
+	}
+
+	if (target != NULL && target->input_fn != NULL) {
+		target->input_fn(target, ev, target->user_data);
+	}
+}
+
+/* -------------------------------------------------------------------------
+ * run / quit -- convenience event loop
+ *
+ * Polls with a 100 ms timeout, dispatches via boxen_dispatch_event, then
+ * calls boxen_present. Exits when g_should_quit is true (set by boxen_quit).
+ * ---------------------------------------------------------------------- */
+
+void boxen_run(void) {
+	g_should_quit = false;
+
+	while (!g_should_quit) {
+		boxen_event_t ev;
+		boxen_result_t r = boxen_poll_event(&ev, 100);
+		if (r == BOXEN_OK) {
+			boxen_dispatch_event(&ev);
+		}
+		if (g_should_quit) break;
+		boxen_present();
+	}
+}
+
+void boxen_quit(void) {
+	g_should_quit = true;
+}
 
 /* A.6 layout stubs */
 void boxen_layout_split_h(boxen_rect_t total, float ratio,
@@ -481,13 +685,14 @@ void boxen_fill_rect(boxen_window_t *win, boxen_rect_t r,
 /* -------------------------------------------------------------------------
  * boxen_window_at -- screen-to-window-local coordinate mapping
  *
- * Iterates the window list from last (topmost at A.2) to first (bottommost).
+ * Iterates the window list from last (topmost in z-order) to first (bottommost).
  * Returns the first window whose rect contains (sx, sy).
  * If cx/cy are non-NULL, fills them with window-local coords.
  * ---------------------------------------------------------------------- */
 
 boxen_window_t *boxen_window_at(int sx, int sy, int *cx, int *cy) {
-	/* Scan from last (topmost in insertion order) to first. */
+	/* Scan from last (topmost in z-order) to first (bottommost). A.3 raise/lower
+	 * operations maintain g_windows[g_window_count-1] as the topmost window. */
 	for (int i = g_window_count - 1; i >= 0; i--) {
 		boxen_window_t *w = g_windows[i];
 		/* Defensive: slots 0..g_window_count-1 are invariant non-NULL

--- a/frontier-cli/boxen/boxen.c
+++ b/frontier-cli/boxen/boxen.c
@@ -55,7 +55,16 @@ static bool                   g_initialized = false;
 static boxen_window_t        *g_windows[BOXEN_MAX_WINDOWS];
 static int                    g_window_count = 0;
 
-/* A.3 focus and event loop state */
+/* A.3 focus and event loop state.
+ *
+ * Threading: both are plain (non-_Atomic) and assume single-threaded access
+ * under the caller's external lock (Frontier GIL). Concurrent focus mutation
+ * + dispatch read would be a torn-pointer race on g_focused_window;
+ * concurrent quit + run-loop read would be a data race on g_should_quit.
+ * If a future caller needs to set g_should_quit from a signal handler or
+ * other non-GIL context (e.g. SIGINT in a standalone consumer), upgrade
+ * to `_Atomic bool` with relaxed store/load. Same guidance applies to
+ * g_focused_window if cross-thread focus changes ever become a requirement. */
 static boxen_window_t        *g_focused_window = NULL;
 static bool                   g_should_quit     = false;
 
@@ -96,9 +105,14 @@ void boxen_shutdown(void) {
 		return;
 	}
 
-	/* Close all open windows in reverse order to avoid swap-with-last skipping. */
+	/* Close all open windows in reverse order to avoid swap-with-last skipping.
+	 * Zero the magic field before free so a stale caller pointer to a freed
+	 * window struct is rejected by find_live_window_index (if the heap
+	 * memory still reads back the zeroed magic). Matches the close-path
+	 * mark-dead step. */
 	while (g_window_count > 0) {
 		boxen_window_t *w = g_windows[g_window_count - 1];
+		w->magic = 0;
 		free(w->title);
 		free(w);
 		g_window_count--;
@@ -312,14 +326,25 @@ void boxen_window_set_pinned(boxen_window_t *win, boxen_pin_edge_t edge) {
  * preserve relative order of the other windows via a single-element shift.
  * ---------------------------------------------------------------------- */
 
-void boxen_window_raise(boxen_window_t *win) {
-	if (win == NULL || g_window_count <= 1) return;
-
-	/* Find win in the list. */
-	int idx = -1;
+/* Returns the index of win in g_windows[] if win is a live, in-list window,
+ * or -1 otherwise. Used by all the window mutators to reject stale, foreign,
+ * or post-shutdown pointers BEFORE writing anything -- without this guard a
+ * caller passing a freed or unrelated pointer could plant a dangling pointer
+ * in g_focused_window (UAF on next dispatch) or stomp arbitrary memory via
+ * a stray field write. The magic-field check is best-effort; the list-scan
+ * is authoritative. */
+static int find_live_window_index(const boxen_window_t *win) {
+	if (win == NULL) return -1;
+	if (win->magic != BOXEN_WINDOW_MAGIC) return -1;
 	for (int i = 0; i < g_window_count; i++) {
-		if (g_windows[i] == win) { idx = i; break; }
+		if (g_windows[i] == win) return i;
 	}
+	return -1;
+}
+
+void boxen_window_raise(boxen_window_t *win) {
+	if (g_window_count <= 1) return;
+	int idx = find_live_window_index(win);
 	if (idx < 0 || idx == g_window_count - 1) return;  /* not found or already top */
 
 	/* Shift everything above idx down by one, place win at the top. */
@@ -330,12 +355,8 @@ void boxen_window_raise(boxen_window_t *win) {
 }
 
 void boxen_window_lower(boxen_window_t *win) {
-	if (win == NULL || g_window_count <= 1) return;
-
-	int idx = -1;
-	for (int i = 0; i < g_window_count; i++) {
-		if (g_windows[i] == win) { idx = i; break; }
-	}
+	if (g_window_count <= 1) return;
+	int idx = find_live_window_index(win);
 	if (idx < 0 || idx == 0) return;  /* not found or already bottom */
 
 	/* Shift everything below idx up by one, place win at index 0. */
@@ -346,7 +367,11 @@ void boxen_window_lower(boxen_window_t *win) {
 }
 
 void boxen_window_focus(boxen_window_t *win) {
-	if (win == NULL) return;
+	/* Validate BEFORE writing anything. Without this, a caller passing a
+	 * stale pointer could leave g_focused_window pointing at freed memory,
+	 * which boxen_dispatch_event would then deref on the next key/resize
+	 * event -- UAF. */
+	if (find_live_window_index(win) < 0) return;
 
 	/* Clear focused flag on all windows, then set it on win. */
 	for (int i = 0; i < g_window_count; i++) {
@@ -362,7 +387,7 @@ void boxen_window_focus(boxen_window_t *win) {
 }
 
 void boxen_window_set_modal(boxen_window_t *win, bool modal) {
-	if (win == NULL) return;
+	if (find_live_window_index(win) < 0) return;
 	win->modal = modal;
 }
 
@@ -375,11 +400,13 @@ void boxen_window_invalidate(boxen_window_t *win) {
 }
 
 void boxen_window_set_draw(boxen_window_t *win, boxen_draw_fn fn) {
-	if (win != NULL) win->draw_fn = fn;
+	if (find_live_window_index(win) < 0) return;
+	win->draw_fn = fn;
 }
 
 void boxen_window_set_input(boxen_window_t *win, boxen_input_fn fn) {
-	if (win != NULL) win->input_fn = fn;
+	if (find_live_window_index(win) < 0) return;
+	win->input_fn = fn;
 }
 
 /* A.5 stubs */
@@ -466,7 +493,13 @@ boxen_result_t boxen_poll_event(boxen_event_t *out, int timeout_ms) {
  *   Otherwise dispatch to the topmost window at (ev->mouse.x, ev->mouse.y).
  *
  * Resize events:
- *   Passed to the focused window (A.4 will handle clamping).
+ *   Passed to the focused window. If no window has focus yet (e.g. before
+ *   the first boxen_window_focus call), the resize event is silently
+ *   dropped at this layer -- A.4 will replace this with terminal-resize
+ *   clamping logic that touches every window regardless of focus. Until
+ *   then, consumers that need pre-focus resize handling should call
+ *   boxen_poll_event() directly and handle BOXEN_EV_RESIZE before
+ *   delegating remaining events to boxen_dispatch_event().
  * ---------------------------------------------------------------------- */
 
 void boxen_dispatch_event(const boxen_event_t *ev) {
@@ -527,6 +560,13 @@ void boxen_run(void) {
 		boxen_result_t r = boxen_poll_event(&ev, 100);
 		if (r == BOXEN_OK) {
 			boxen_dispatch_event(&ev);
+		} else if (r != BOXEN_ERR_TIMEOUT) {
+			/* Persistent backend failure (terminal detached, broken pipe,
+			 * etc.). Without this break the loop would busy-spin at full
+			 * CPU until external quit. Surface the error to the caller by
+			 * exiting; standalone consumers can inspect via the log hook. */
+			boxen__set_last_error("boxen_run: backend poll failed");
+			break;
 		}
 		if (g_should_quit) break;
 		boxen_present();

--- a/frontier-cli/boxen/boxen.h
+++ b/frontier-cli/boxen/boxen.h
@@ -409,8 +409,23 @@ void boxen_present(void);
 
 /* Convenience main loop for standalone programs. Polls events with a 100 ms
  * timeout, dispatches via boxen_dispatch_event, then calls boxen_present.
- * Exits when boxen_quit() is called from an input callback. */
+ * Exits when boxen_quit() is called from an input callback, or when the
+ * backend returns a persistent (non-timeout) error.
+ *
+ * THREADING WARNING: boxen_run() holds the caller's external lock (e.g.
+ * Frontier's GIL) for its entire duration -- it does NOT release the lock
+ * around boxen_poll_event(). Calling boxen_run() from a Frontier runtime
+ * callback or any GIL-holding context will block all other Frontier threads
+ * for as long as the loop runs (i.e., until quit is called). Frontier
+ * surfaces MUST use boxen_poll_event() + boxen_dispatch_event() directly,
+ * wrapping the poll with a GIL release/reacquire as documented in the
+ * debugger TUI handoff. boxen_run() is intended for standalone consumers
+ * (examples, future non-Frontier programs) only. */
 void boxen_run(void);
+
+/* Signal boxen_run()'s loop to exit at the next iteration boundary. Typically
+ * called from an input callback. Safe to call when boxen_run() is not active
+ * (the flag is reset at the start of each boxen_run() call). */
 void boxen_quit(void);
 
 /* -------------------------------------------------------------------------

--- a/frontier-cli/boxen/boxen.h
+++ b/frontier-cli/boxen/boxen.h
@@ -384,13 +384,32 @@ void boxen_window_set_row_highlight(boxen_window_t *win, int content_row,
  * Event loop (A.3+)
  * ---------------------------------------------------------------------- */
 
-/* Low-level: poll for one event. Returns BOXEN_OK or BOXEN_ERR_TIMEOUT. */
+/* Low-level: poll for one event. Returns BOXEN_OK or BOXEN_ERR_TIMEOUT.
+ * Does NOT dispatch the event -- use boxen_dispatch_event() for that.
+ * The caller is responsible for GIL release/reacquire around blocking polls. */
 boxen_result_t boxen_poll_event(boxen_event_t *out, int timeout_ms);
+
+/* Dispatch an event to the appropriate window(s) according to focus and
+ * modal rules:
+ *   - If a modal window is present, key events go to the modal window only.
+ *   - Otherwise key events go to the focused window.
+ *   - Mouse events go to the topmost window at (ev->mouse.x, ev->mouse.y),
+ *     unless a modal window is present (in which case modal receives them).
+ *   - Resize events are passed to the focused window.
+ *
+ * Surface code that wants to interleave Frontier runtime events with boxen
+ * events should call boxen_poll_event() and then boxen_dispatch_event()
+ * separately. boxen_run() calls both internally.
+ *
+ * Calling from outside a boxen_run() loop is safe and supported. */
+void boxen_dispatch_event(const boxen_event_t *ev);
 
 /* Composite all windows and flush to the terminal. */
 void boxen_present(void);
 
-/* Convenience main loop for standalone programs. */
+/* Convenience main loop for standalone programs. Polls events with a 100 ms
+ * timeout, dispatches via boxen_dispatch_event, then calls boxen_present.
+ * Exits when boxen_quit() is called from an input callback. */
 void boxen_run(void);
 void boxen_quit(void);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -223,7 +223,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge copyctopstring_tests ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests boxen_backend_tests boxen_core_tests
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge copyctopstring_tests ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests boxen_backend_tests boxen_core_tests boxen_input_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -526,6 +526,11 @@ BOXEN_CORE_TEST_SRCS = \
 
 boxen_core_tests: boxen_core_tests.c $(BOXEN_CORE_TEST_SRCS)
 	$(CC) $(CFLAGS) -I$(BOXEN_DIR) boxen_core_tests.c $(BOXEN_CORE_TEST_SRCS) -o $@ $(LINK_LIBS)
+
+# boxen Phase A.3 -- z-order, redraw, focus, input dispatch, modal tests.
+# Same link set as A.2 (boxen.c is the unit under test).
+boxen_input_tests: boxen_input_tests.c $(BOXEN_CORE_TEST_SRCS)
+	$(CC) $(CFLAGS) -I$(BOXEN_DIR) boxen_input_tests.c $(BOXEN_CORE_TEST_SRCS) -o $@ $(LINK_LIBS)
 
 # Pure helper for arg-injection — no Frontier runtime / handle deps, so it
 # compiles with palette_arg_inject.c standalone. The test exercises escape

--- a/tests/boxen_input_tests.c
+++ b/tests/boxen_input_tests.c
@@ -1,0 +1,437 @@
+/*
+ * boxen_input_tests.c -- unit tests for boxen A.3 (z-order, redraw, focus, input dispatch, modal).
+ *
+ * Covers:
+ *   - boxen_present() calls draw_fn back-to-front and skips zero-size windows
+ *   - boxen_window_raise() / boxen_window_lower() reorders the window stack
+ *   - boxen_window_focus() sets the focused flag and raises the window
+ *   - Key events dispatched to the focused window only
+ *   - Modal input blocking: non-modal windows do not receive input when a modal is present
+ *   - Mouse events dispatched to the topmost window at the event's (x, y)
+ *   - boxen_run() loop terminates when boxen_quit() is called from an input callback
+ *   - boxen_dispatch_event() dispatches correctly when called manually
+ *
+ * Links: boxen_log.c, boxen_wcwidth.c, backend_mock.c, boxen.c
+ * No Frontier runtime dependency.
+ *
+ * Run: make -C tests boxen_input_tests && ./tests/boxen_input_tests
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "boxen.h"
+#include "backend_mock.h"
+#include "test_report.h"
+
+/* -------------------------------------------------------------------------
+ * Test helpers
+ * ---------------------------------------------------------------------- */
+
+static void setup(void) {
+	boxen_mock_reset(80, 24);
+	boxen_result_t r = boxen_init(boxen_mock_backend(), NULL, NULL);
+	assert(r == BOXEN_OK);
+}
+
+static void teardown(void) {
+	boxen_shutdown();
+}
+
+/* -------------------------------------------------------------------------
+ * Shared callback tracking globals.
+ * Reset at the top of each test that uses them.
+ * ---------------------------------------------------------------------- */
+
+static int g_draw_order[8];   /* records indices of windows in the order draw_fn fires */
+static int g_draw_count = 0;
+
+static bool g_input_a_fired = false;
+static bool g_input_b_fired = false;
+
+/* draw callbacks that record call order by writing a tag int */
+static void draw_fn_tag(boxen_window_t *win, void *user_data) {
+	(void)win;
+	if (g_draw_count < 8) {
+		g_draw_order[g_draw_count++] = *(int *)user_data;
+	}
+}
+
+/* input callbacks that flip a flag */
+static void input_fn_a(boxen_window_t *win, const boxen_event_t *ev, void *user_data) {
+	(void)win; (void)ev; (void)user_data;
+	g_input_a_fired = true;
+}
+
+static void input_fn_b(boxen_window_t *win, const boxen_event_t *ev, void *user_data) {
+	(void)win; (void)ev; (void)user_data;
+	g_input_b_fired = true;
+}
+
+/* input callback that calls boxen_quit(), used by test_quit_terminates_run_loop */
+static void input_fn_quit(boxen_window_t *win, const boxen_event_t *ev, void *user_data) {
+	(void)win; (void)ev; (void)user_data;
+	boxen_quit();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 1: present() calls draw_fn back-to-front
+ *
+ * Open window A (back), then window B (front).  A.draw_fn must fire before
+ * B.draw_fn when boxen_present() is called.
+ * ---------------------------------------------------------------------- */
+
+static void test_present_walks_windows_back_to_front(void) {
+	setup();
+
+	g_draw_count = 0;
+	memset(g_draw_order, 0, sizeof(g_draw_order));
+
+	static int tag_a = 1;
+	static int tag_b = 2;
+
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 20, 10}, NULL);
+	assert(a != NULL);
+	boxen_window_set_draw(a, draw_fn_tag);
+	boxen_window_set_user_data(a, &tag_a);
+
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){20, 0, 20, 10}, NULL);
+	assert(b != NULL);
+	boxen_window_set_draw(b, draw_fn_tag);
+	boxen_window_set_user_data(b, &tag_b);
+
+	boxen_present();
+
+	/* A (tag 1) must have been drawn before B (tag 2) */
+	assert(g_draw_count == 2);
+	assert(g_draw_order[0] == 1);  /* A first */
+	assert(g_draw_order[1] == 2);  /* B second */
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 2: present() skips zero-size windows
+ *
+ * A window with rect.w == 0 must not have its draw_fn called.
+ * ---------------------------------------------------------------------- */
+
+static void test_present_skips_zero_size_window(void) {
+	setup();
+
+	g_draw_count = 0;
+	memset(g_draw_order, 0, sizeof(g_draw_order));
+
+	static int tag_normal = 10;
+	static int tag_zero   = 20;
+
+	/* Normal window */
+	boxen_window_t *normal = boxen_window_open("N", (boxen_rect_t){0, 0, 20, 10}, NULL);
+	assert(normal != NULL);
+	boxen_window_set_draw(normal, draw_fn_tag);
+	boxen_window_set_user_data(normal, &tag_normal);
+
+	/* Zero-width window -- draw_fn must NOT fire */
+	boxen_window_t *zero = boxen_window_open("Z", (boxen_rect_t){30, 0, 0, 10}, NULL);
+	assert(zero != NULL);
+	boxen_window_set_draw(zero, draw_fn_tag);
+	boxen_window_set_user_data(zero, &tag_zero);
+
+	boxen_present();
+
+	/* Only the normal window's draw_fn should have fired */
+	assert(g_draw_count == 1);
+	assert(g_draw_order[0] == 10);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 3: raise() moves a window to the top of the z-order
+ *
+ * Open A then B (B is on top by creation order).  Raise A.  Verify A is
+ * now on top by calling boxen_window_at() at the overlapping point.
+ * ---------------------------------------------------------------------- */
+
+static void test_raise_moves_window_to_top(void) {
+	setup();
+
+	/* Both windows overlap at (5, 5) */
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 20, 20}, NULL);
+	assert(a != NULL);
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){0, 0, 20, 20}, NULL);
+	assert(b != NULL);
+
+	/* Before raise: B is on top (created last) */
+	int cx, cy;
+	boxen_window_t *top = boxen_window_at(5, 5, &cx, &cy);
+	assert(top == b);
+
+	/* Raise A: A should now be on top */
+	boxen_window_raise(a);
+	top = boxen_window_at(5, 5, &cx, &cy);
+	assert(top == a);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 4: lower() moves a window to the bottom of the z-order
+ *
+ * Open A then B.  Lower B.  A should now be on top.
+ * ---------------------------------------------------------------------- */
+
+static void test_lower_moves_window_to_bottom(void) {
+	setup();
+
+	/* Both windows overlap */
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 20, 20}, NULL);
+	assert(a != NULL);
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){0, 0, 20, 20}, NULL);
+	assert(b != NULL);
+
+	/* Before lower: B is on top */
+	int cx, cy;
+	assert(boxen_window_at(5, 5, &cx, &cy) == b);
+
+	/* Lower B: A should now be on top */
+	boxen_window_lower(b);
+	assert(boxen_window_at(5, 5, &cx, &cy) == a);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 5: focus() sets the focused flag on the target window
+ *
+ * Verify w->focused is set after boxen_window_focus(w).  We probe this
+ * indirectly through input dispatch: only the focused window receives the key.
+ * ---------------------------------------------------------------------- */
+
+static void test_focus_sets_focused_flag(void) {
+	setup();
+
+	g_input_a_fired = false;
+	g_input_b_fired = false;
+
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 40, 24}, NULL);
+	assert(a != NULL);
+	boxen_window_set_input(a, input_fn_a);
+
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){0, 0, 40, 24}, NULL);
+	assert(b != NULL);
+	boxen_window_set_input(b, input_fn_b);
+
+	/* Focus A */
+	boxen_window_focus(a);
+
+	/* Push and dispatch a key event */
+	boxen_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.type     = BOXEN_EV_KEY;
+	ev.key.key  = BOXEN_KEY_F1;
+	boxen_dispatch_event(&ev);
+
+	/* Only A should have received the event */
+	assert(g_input_a_fired == true);
+	assert(g_input_b_fired == false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 6: focus() raises the target window to the top
+ *
+ * Open A then B (B on top).  Focus A.  A must now be topmost.
+ * ---------------------------------------------------------------------- */
+
+static void test_focus_raises_window(void) {
+	setup();
+
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 20, 20}, NULL);
+	assert(a != NULL);
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){0, 0, 20, 20}, NULL);
+	assert(b != NULL);
+
+	/* Sanity: B is on top before focus */
+	int cx, cy;
+	assert(boxen_window_at(5, 5, &cx, &cy) == b);
+
+	/* Focus A: must raise A to top */
+	boxen_window_focus(a);
+	assert(boxen_window_at(5, 5, &cx, &cy) == a);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 7: key event dispatched to focused window only
+ *
+ * Open A and B.  Focus A.  Push a key event via boxen_dispatch_event.
+ * A's input_fn fires; B's does not.
+ * ---------------------------------------------------------------------- */
+
+static void test_key_event_dispatches_to_focused(void) {
+	setup();
+
+	g_input_a_fired = false;
+	g_input_b_fired = false;
+
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 40, 24}, NULL);
+	assert(a != NULL);
+	boxen_window_set_input(a, input_fn_a);
+
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){0, 0, 40, 24}, NULL);
+	assert(b != NULL);
+	boxen_window_set_input(b, input_fn_b);
+
+	boxen_window_focus(a);
+
+	boxen_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.type    = BOXEN_EV_KEY;
+	ev.key.key = BOXEN_KEY_ENTER;
+	boxen_dispatch_event(&ev);
+
+	assert(g_input_a_fired == true);
+	assert(g_input_b_fired == false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 8: modal window blocks input to non-modal windows
+ *
+ * Open non-modal window A (with input_fn) and modal window B.
+ * Push a key event.  B's input_fn fires; A's does not.
+ * ---------------------------------------------------------------------- */
+
+static void test_modal_blocks_input_to_non_modal(void) {
+	setup();
+
+	g_input_a_fired = false;
+	g_input_b_fired = false;
+
+	/* A is the background, non-modal window */
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 80, 24}, NULL);
+	assert(a != NULL);
+	boxen_window_set_input(a, input_fn_a);
+	boxen_window_focus(a);  /* A is focused */
+
+	/* B is the modal overlay */
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){20, 5, 40, 14}, NULL);
+	assert(b != NULL);
+	boxen_window_set_input(b, input_fn_b);
+	boxen_window_set_modal(b, true);
+
+	/* Key event -- must go to modal B, not to A */
+	boxen_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.type    = BOXEN_EV_KEY;
+	ev.key.key = BOXEN_KEY_ESCAPE;
+	boxen_dispatch_event(&ev);
+
+	assert(g_input_a_fired == false);  /* modal blocked A */
+	assert(g_input_b_fired == true);   /* modal received it */
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 9: mouse event dispatched to topmost window at click point
+ *
+ * Open A (left half) and B (right half), non-overlapping.  Push a mouse
+ * press at a point inside B.  B's input_fn fires; A's does not.
+ * ---------------------------------------------------------------------- */
+
+static void test_mouse_event_dispatches_to_window_at_point(void) {
+	setup();
+
+	g_input_a_fired = false;
+	g_input_b_fired = false;
+
+	/* A occupies the left half: x=[0,39], y=[0,23] */
+	boxen_window_t *a = boxen_window_open("A", (boxen_rect_t){0, 0, 40, 24}, NULL);
+	assert(a != NULL);
+	boxen_window_set_input(a, input_fn_a);
+
+	/* B occupies the right half: x=[40,79], y=[0,23] */
+	boxen_window_t *b = boxen_window_open("B", (boxen_rect_t){40, 0, 40, 24}, NULL);
+	assert(b != NULL);
+	boxen_window_set_input(b, input_fn_b);
+
+	/* No modal; focus A, but click is inside B */
+	boxen_window_focus(a);
+
+	/* Mouse press at (60, 10) -- inside B's rect */
+	boxen_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.type          = BOXEN_EV_MOUSE;
+	ev.mouse.x       = 60;
+	ev.mouse.y       = 10;
+	ev.mouse.button  = 1;
+	ev.mouse.pressed = true;
+	boxen_dispatch_event(&ev);
+
+	assert(g_input_a_fired == false);
+	assert(g_input_b_fired == true);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 10: boxen_run() terminates when boxen_quit() is called
+ *
+ * Pre-load one key event, then call boxen_run().  The input_fn calls
+ * boxen_quit().  boxen_run() must return promptly.
+ *
+ * Because boxen_run() uses timeout_ms=100 internally, the mock backend
+ * will return BOXEN_ERR_TIMEOUT after the pre-loaded event queue drains,
+ * at which point the quit flag should already be set and the loop exits.
+ * ---------------------------------------------------------------------- */
+
+static void test_quit_terminates_run_loop(void) {
+	setup();
+
+	boxen_window_t *w = boxen_window_open("W", (boxen_rect_t){0, 0, 80, 24}, NULL);
+	assert(w != NULL);
+	boxen_window_set_input(w, input_fn_quit);
+	boxen_window_focus(w);
+
+	/* Pre-load a key event so the first poll returns immediately */
+	boxen_mock_push_key(BOXEN_KEY_ESCAPE, 0, 0);
+
+	/* boxen_run() should dispatch the event, call boxen_quit(), and exit.
+	 * The loop polls with a short timeout; after the event is consumed and
+	 * g_should_quit is set, it exits on the next timeout iteration. */
+	boxen_run();
+
+	/* If we reach here, the loop terminated. */
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * main
+ * ---------------------------------------------------------------------- */
+
+int main(void) {
+	TR_INIT("boxen_input_tests");
+
+	TR_RUN(test_present_walks_windows_back_to_front);
+	TR_RUN(test_present_skips_zero_size_window);
+	TR_RUN(test_raise_moves_window_to_top);
+	TR_RUN(test_lower_moves_window_to_bottom);
+	TR_RUN(test_focus_sets_focused_flag);
+	TR_RUN(test_focus_raises_window);
+	TR_RUN(test_key_event_dispatches_to_focused);
+	TR_RUN(test_modal_blocks_input_to_non_modal);
+	TR_RUN(test_mouse_event_dispatches_to_window_at_point);
+	TR_RUN(test_quit_terminates_run_loop);
+
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}

--- a/tests/boxen_input_tests.c
+++ b/tests/boxen_input_tests.c
@@ -415,6 +415,62 @@ static void test_quit_terminates_run_loop(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * Test 11: focus rejects stale (closed) pointer
+ *
+ * Regression test for the security review P1: boxen_window_focus must not
+ * plant g_focused_window with a pointer to a closed/freed window, because
+ * the next dispatch would deref it and UAF. We open a window, close it,
+ * then call focus(stale) and verify dispatch with KEY routes to NO window
+ * (input_fn not invoked anywhere).
+ * ---------------------------------------------------------------------- */
+
+static int g_stale_input_count = 0;
+static void stale_input_fn(boxen_window_t *win, const boxen_event_t *ev,
+                           void *user_data) {
+	(void)win; (void)ev; (void)user_data;
+	g_stale_input_count++;
+}
+
+static void test_focus_rejects_stale_pointer(void) {
+	setup();
+	g_stale_input_count = 0;
+
+	/* Open a live window, then open + close another. */
+	boxen_rect_t r = {0, 0, 10, 5};
+	boxen_window_t *live  = boxen_window_open("live",  r, NULL);
+	boxen_window_t *stale = boxen_window_open("stale", r, NULL);
+	assert(live != NULL);
+	assert(stale != NULL);
+	boxen_window_set_input(live,  stale_input_fn);
+	boxen_window_set_input(stale, stale_input_fn);
+
+	boxen_window_close(stale);
+	/* `stale` is now a dangling pointer (struct freed). */
+
+	/* Attempt to focus the stale pointer: must reject silently. */
+	boxen_window_focus(stale);
+
+	/* Dispatch a key event. With the P1 fix, g_focused_window is unchanged
+	 * (still NULL because we never focused `live`), so no input_fn fires.
+	 * Pre-fix behavior: g_focused_window would point at freed memory and
+	 * dispatch would deref it (UAF). */
+	boxen_event_t ev = {0};
+	ev.type     = BOXEN_EV_KEY;
+	ev.key.key  = BOXEN_KEY_ENTER;
+	boxen_dispatch_event(&ev);
+
+	assert(g_stale_input_count == 0);
+
+	/* Sanity: focusing a LIVE window still works. */
+	boxen_window_focus(live);
+	boxen_dispatch_event(&ev);
+	assert(g_stale_input_count == 1);
+
+	boxen_window_close(live);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 
@@ -431,6 +487,7 @@ int main(void) {
 	TR_RUN(test_modal_blocks_input_to_non_modal);
 	TR_RUN(test_mouse_event_dispatches_to_window_at_point);
 	TR_RUN(test_quit_terminates_run_loop);
+	TR_RUN(test_focus_rejects_stale_pointer);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();


### PR DESCRIPTION
## Summary

Fourth PR in the boxen Phase A chain. Implements z-order + redraw + focus + input dispatch + modal precedence + convenience main loop on top of the A.2 window primitive. The substrate is now a real window manager — surfaces can install draw + input callbacks, focus a window, mark a window modal, and run the event loop.

### What's new

- **`boxen_present`** — walks `g_windows[0..count-1]` back-to-front, calls each window's `draw_fn`, then `backend->present()`. Skips degenerate windows.
- **`boxen_window_raise` / `lower`** — single-element shifts; `g_windows[count-1]` is always topmost.
- **`boxen_window_focus`** — clears focused flag on all windows, sets it on the target, raises it.
- **`boxen_window_set_modal`** — modal windows take input precedence in dispatch.
- **`boxen_window_set_draw` / `set_input`** — callback setters.
- **`boxen_window_invalidate`** — no-op for A.3 (always-redraw); API preserved for future dirty-rect optimization.
- **`boxen_poll_event`** — forwards to backend. Does NOT dispatch — consumers wrap this with their own discipline (e.g., Frontier's GIL release per `DEBUGGER_TUI_HANDOFF.md`).
- **`boxen_dispatch_event(ev)`** — **NEW public function**. Modal precedence (last modal wins), key/resize to focused, mouse to the window at the cursor. Separated from poll so surfaces can interleave; convenience for standalone consumers via `boxen_run`.
- **`boxen_run` / `boxen_quit`** — convenience main loop for standalone programs.

### Test coverage

`tests/boxen_input_tests.c` — 10 functions, all green:

1. `test_present_walks_windows_back_to_front`
2. `test_present_skips_zero_size_window`
3. `test_raise_moves_window_to_top`
4. `test_lower_moves_window_to_bottom`
5. `test_focus_sets_focused_flag`
6. `test_focus_raises_window`
7. `test_key_event_dispatches_to_focused`
8. `test_modal_blocks_input_to_non_modal`
9. `test_mouse_event_dispatches_to_window_at_point`
10. `test_quit_terminates_run_loop`

## Test plan

- [x] `make -C frontier-cli clean && make -C frontier-cli` clean, no new warnings
- [x] `make -C frontier-cli tb2-smoke && ./frontier-cli/tb2-smoke` green
- [x] `make -C tests boxen_input_tests && ./tests/boxen_input_tests` — **10/10**
- [x] `./tests/boxen_backend_tests` — 10/10 (A.1 regression)
- [x] `./tests/boxen_core_tests` — 15/15 (A.2 regression)
- [x] `./tools/run_headless_tests.sh` — **626/626** (was 616; +10 additive)
- [x] `cd tests && make test-integration` — **2186 pass / 21 baseline fail** (preserved)
- [x] `grep -rn 'tb_\|TB_' frontier-cli/boxen/ | grep -v backend_tb2.c` — empty
- [x] `grep -rn '#include.*boxen_internal' tests/` — empty

## Scope discipline

Strictly out of scope (deferred to later milestones):
- A.4: resize/move state machine
- A.5: scrolling
- A.6: chrome (borders/titles/scrollbars) + layout helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code) /auto
