### PR TITLE
feat(boxen): A.7 -- public window_set_cursor + visible wrappers

### DIFF
--- a/frontier-cli/boxen/backend_mock.c
+++ b/frontier-cli/boxen/backend_mock.c
@@ -30,6 +30,12 @@ static boxen_mock_cell_t g_grid[MOCK_MAX_HEIGHT][MOCK_MAX_WIDTH];
 static int g_width  = 80;
 static int g_height = 24;
 
+/* Cursor state for A.7 test accessors. boxen_mock_reset() restores these
+ * to the "never called" defaults (-1, -1, false). */
+static int  g_cursor_x       = -1;
+static int  g_cursor_y       = -1;
+static bool g_cursor_visible = false;
+
 /* -------------------------------------------------------------------------
  * Event queue (FIFO ring buffer)
  * ---------------------------------------------------------------------- */
@@ -153,6 +159,19 @@ void boxen_mock_reset(int width, int height) {
 
 	g_last_press.valid = false;
 	g_default_clock_ms = 0;
+
+	g_cursor_x       = -1;
+	g_cursor_y       = -1;
+	g_cursor_visible = false;
+}
+
+void boxen_mock_get_cursor(int *x, int *y) {
+	if (x) *x = g_cursor_x;
+	if (y) *y = g_cursor_y;
+}
+
+bool boxen_mock_cursor_visible(void) {
+	return g_cursor_visible;
 }
 
 void boxen_mock_width_set(int w) {
@@ -277,12 +296,12 @@ static void mock_set_cell(int x, int y, uint32_t ch,
 }
 
 static void mock_set_cursor(int x, int y) {
-	(void)x;
-	(void)y;
+	g_cursor_x = x;
+	g_cursor_y = y;
 }
 
 static void mock_set_cursor_visible(bool visible) {
-	(void)visible;
+	g_cursor_visible = visible;
 }
 
 static void mock_present(void) {

--- a/frontier-cli/boxen/backend_mock.h
+++ b/frontier-cli/boxen/backend_mock.h
@@ -67,6 +67,26 @@ const boxen_mock_cell_t *boxen_mock_cell_at(int x, int y);
 bool boxen_mock_has_text(const char *s);
 
 /* -------------------------------------------------------------------------
+ * Cursor inspection (A.7+)
+ *
+ * Tests for boxen_window_set_cursor / boxen_window_set_cursor_visible read
+ * back the most recent backend call via these accessors. The mock tracks
+ * the last (x, y) passed to backend->set_cursor and the last visibility
+ * flag passed to backend->set_cursor_visible. boxen_mock_reset() resets
+ * both to (-1, -1) and false respectively, matching the terminal's
+ * initial state after init.
+ * ---------------------------------------------------------------------- */
+
+/* Returns the last cursor (x, y) set via backend->set_cursor.
+ * Writes the screen-absolute coordinates passed by the last call.
+ * Returns -1, -1 if set_cursor was never called since boxen_mock_reset. */
+void boxen_mock_get_cursor(int *x, int *y);
+
+/* Returns the last visibility passed to backend->set_cursor_visible.
+ * Defaults to false (matches terminal initial state after init). */
+bool boxen_mock_cursor_visible(void);
+
+/* -------------------------------------------------------------------------
  * Event injection
  * ---------------------------------------------------------------------- */
 

--- a/frontier-cli/boxen/boxen.c
+++ b/frontier-cli/boxen/boxen.c
@@ -1578,7 +1578,8 @@ void boxen_set_cell(boxen_window_t *win, int x, int y,
  *   surfaces from racing to position a single terminal cursor.
  *   Implicitly validates the win pointer: a non-live pointer can equal
  *   neither g_focused_window (cleared on close) nor a current modal
- *   (cleared on close + modal flag scrubbed on close).
+ *   (closed windows are removed from g_windows[] before free, so
+ *   find_topmost_modal cannot return them).
  * ---------------------------------------------------------------------- */
 
 static boxen_window_t *find_topmost_modal(void) {
@@ -1600,7 +1601,8 @@ static bool cursor_owner_allowed(boxen_window_t *win) {
 /* -------------------------------------------------------------------------
  * boxen_window_set_cursor -- content-coord cursor positioning
  *
- * Translation pipeline mirrors boxen_set_cell:
+ * After the focus gate (cursor_owner_allowed), the translation pipeline
+ * mirrors boxen_set_cell:
  *   1. BOXEN_MAX_DIMENSION input guard (overflow prevention).
  *   2. Subtract scroll offset to get window-local screen coord.
  *   3. Compute viewport dimensions (border-aware, scrollbar-aware).

--- a/frontier-cli/boxen/boxen.c
+++ b/frontier-cli/boxen/boxen.c
@@ -1564,6 +1564,115 @@ void boxen_set_cell(boxen_window_t *win, int x, int y,
 }
 
 /* -------------------------------------------------------------------------
+ * Cursor positioning helpers (A.7)
+ *
+ * find_topmost_modal:
+ *   Walks the window stack from topmost to bottom and returns the first
+ *   live window with modal=true. NULL if none. Matches the modal lookup
+ *   pattern used by boxen_dispatch_event.
+ *
+ * cursor_owner_allowed:
+ *   The focus gate. Only the focused window OR the topmost modal may
+ *   drive the terminal cursor. When a modal is present, ONLY that modal
+ *   may drive (the focused window is shadowed). This prevents two
+ *   surfaces from racing to position a single terminal cursor.
+ *   Implicitly validates the win pointer: a non-live pointer can equal
+ *   neither g_focused_window (cleared on close) nor a current modal
+ *   (cleared on close + modal flag scrubbed on close).
+ * ---------------------------------------------------------------------- */
+
+static boxen_window_t *find_topmost_modal(void) {
+	for (int i = g_window_count - 1; i >= 0; i--) {
+		if (g_windows[i] != NULL && g_windows[i]->modal) {
+			return g_windows[i];
+		}
+	}
+	return NULL;
+}
+
+static bool cursor_owner_allowed(boxen_window_t *win) {
+	if (win == NULL) return false;
+	boxen_window_t *modal = find_topmost_modal();
+	if (modal != NULL) return win == modal;
+	return win == g_focused_window;
+}
+
+/* -------------------------------------------------------------------------
+ * boxen_window_set_cursor -- content-coord cursor positioning
+ *
+ * Translation pipeline mirrors boxen_set_cell:
+ *   1. BOXEN_MAX_DIMENSION input guard (overflow prevention).
+ *   2. Subtract scroll offset to get window-local screen coord.
+ *   3. Compute viewport dimensions (border-aware, scrollbar-aware).
+ *   4. Out-of-viewport target -> hide and bail.
+ *   5. Add window terminal origin (rect.x/y + border) -> terminal coord.
+ *
+ * Beyond set_cell:
+ *   - Focus gate (cursor_owner_allowed) gates the call entirely.
+ *   - Modal-occlusion check after translation: if a different modal
+ *     covers the target screen cell, hide and bail.
+ * ---------------------------------------------------------------------- */
+
+void boxen_window_set_cursor(boxen_window_t *win, int cx, int cy) {
+	if (win == NULL || g_backend == NULL) return;
+	if (!cursor_owner_allowed(win)) return;
+
+	if (cx < -BOXEN_MAX_DIMENSION || cx > BOXEN_MAX_DIMENSION) return;
+	if (cy < -BOXEN_MAX_DIMENSION || cy > BOXEN_MAX_DIMENSION) return;
+
+	int sx = cx - win->scroll_x;
+	int sy = cy - win->scroll_y;
+
+	int vw = win->borders ? (win->rect.w > 2 ? win->rect.w - 2 : 0) : win->rect.w;
+	int vh = win->borders ? (win->rect.h > 2 ? win->rect.h - 2 : 0) : win->rect.h;
+	if (win->borders && vh > 0 && win->content_h > vh && vw > 0) {
+		vw -= 1;
+	}
+
+	if (sx < 0 || sx >= vw || sy < 0 || sy >= vh) {
+		g_backend->set_cursor_visible(false);
+		return;
+	}
+
+	int border = win->borders ? 1 : 0;
+	int tx = win->rect.x + border + sx;
+	int ty = win->rect.y + border + sy;
+
+	/* Modal-occlusion check: if a modal window other than win covers the
+	 * target screen cell, hide the cursor rather than draw beneath the
+	 * modal. The cursor_owner_allowed gate above already ensures that
+	 * when a modal is present, win IS that modal -- so in practice this
+	 * branch is only reachable if a future change relaxes the gate.
+	 * Kept as defense-in-depth: an explicit hide is cheaper than a
+	 * surprise stale-cursor render. */
+	boxen_window_t *modal = find_topmost_modal();
+	if (modal != NULL && modal != win) {
+		if (tx >= modal->rect.x && tx < modal->rect.x + modal->rect.w &&
+		    ty >= modal->rect.y && ty < modal->rect.y + modal->rect.h) {
+			g_backend->set_cursor_visible(false);
+			return;
+		}
+	}
+
+	g_backend->set_cursor(tx, ty);
+	g_backend->set_cursor_visible(true);
+}
+
+/* -------------------------------------------------------------------------
+ * boxen_window_set_cursor_visible -- toggle cursor visibility
+ *
+ * Independent of position (does NOT re-issue a set_cursor). Obeys the
+ * focus gate so non-focused, non-modal callers cannot blindly hide
+ * another surface's cursor.
+ * ---------------------------------------------------------------------- */
+
+void boxen_window_set_cursor_visible(boxen_window_t *win, bool visible) {
+	if (win == NULL || g_backend == NULL) return;
+	if (!cursor_owner_allowed(win)) return;
+	g_backend->set_cursor_visible(visible);
+}
+
+/* -------------------------------------------------------------------------
  * Minimal UTF-8 decoder
  *
  * Decodes one Unicode codepoint from *p and advances *p past it.

--- a/frontier-cli/boxen/boxen.h
+++ b/frontier-cli/boxen/boxen.h
@@ -389,6 +389,49 @@ void boxen_fill_rect(boxen_window_t *win, boxen_rect_t r,
                      uint32_t ch, uint16_t fg, uint16_t bg, uint16_t attr);
 
 /* -------------------------------------------------------------------------
+ * Cursor positioning (A.7+, content-coord semantics)
+ *
+ * Position the terminal cursor at a content-relative coordinate inside the
+ * given window. Mirrors boxen_set_cell's translation pipeline -- chrome
+ * (border) offset, scroll offset, and content-viewport clipping all apply
+ * identically. Beyond the set_cell pipeline these wrappers add two checks:
+ *
+ *   Modal-occlusion check:
+ *     If a modal window is present and covers the target screen cell, the
+ *     cursor is hidden (set_cursor_visible(false)) instead of drawn under
+ *     the modal. The modal itself bypasses the check for its own writes.
+ *
+ *   Focus gate:
+ *     Only the focused window OR the topmost modal window may drive the
+ *     terminal cursor. Calls from a non-focused, non-modal window are
+ *     silently ignored. This is deliberate footgun prevention -- two
+ *     windows fighting over a single terminal cursor produces undefined
+ *     behavior. Surfaces that need a non-focused indicator should draw a
+ *     cell-based caret with boxen_set_cell + BOXEN_ATTR_REVERSE.
+ *
+ * Out-of-viewport target:
+ *   When the translated screen coord falls outside the content viewport
+ *   (scroll-adjusted, clip-checked), the cursor is hidden rather than
+ *   left at a stale position. The call still succeeds.
+ *
+ * Visibility toggle:
+ *   boxen_window_set_cursor_visible is independent of position -- a hide
+ *   followed by a show restores the cursor at the last set_cursor coord.
+ *   It also obeys the focus gate: a non-focused, non-modal caller is
+ *   silently ignored.
+ *
+ * Coordinates are validated against BOXEN_MAX_DIMENSION to prevent signed-
+ * int overflow in the translation arithmetic.
+ *
+ * First consumer: Phase B debugger TUI (issue #733) -- the breakpoint
+ * condition modal (B.4) and scratch-eval pane (B.7) both need cursor
+ * positioning in content coords.
+ * ---------------------------------------------------------------------- */
+
+void boxen_window_set_cursor(boxen_window_t *win, int cx, int cy);
+void boxen_window_set_cursor_visible(boxen_window_t *win, bool visible);
+
+/* -------------------------------------------------------------------------
  * Screen-to-window coordinate mapping (A.2+)
  * Given screen position (sx, sy), find the topmost window there and
  * return window-local content coordinates in (*cx, *cy).

--- a/frontier-cli/boxen/boxen.h
+++ b/frontier-cli/boxen/boxen.h
@@ -419,6 +419,9 @@ void boxen_fill_rect(boxen_window_t *win, boxen_rect_t r,
  *   followed by a show restores the cursor at the last set_cursor coord.
  *   It also obeys the focus gate: a non-focused, non-modal caller is
  *   silently ignored.
+ *   If no prior boxen_window_set_cursor call successfully placed the cursor,
+ *   set_cursor_visible(true) makes the cursor visible at the backend's
+ *   default position (typically (0, 0) after init).
  *
  * Coordinates are validated against BOXEN_MAX_DIMENSION to prevent signed-
  * int overflow in the translation arithmetic.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -223,7 +223,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge copyctopstring_tests ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests boxen_backend_tests boxen_core_tests boxen_input_tests boxen_resize_tests boxen_scroll_tests boxen_chrome_tests
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge copyctopstring_tests ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests boxen_backend_tests boxen_core_tests boxen_input_tests boxen_resize_tests boxen_scroll_tests boxen_chrome_tests boxen_cursor_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -546,6 +546,11 @@ boxen_scroll_tests: boxen_scroll_tests.c $(BOXEN_CORE_TEST_SRCS)
 # Same link set as A.5 (boxen.c is the unit under test).
 boxen_chrome_tests: boxen_chrome_tests.c $(BOXEN_CORE_TEST_SRCS)
 	$(CC) $(CFLAGS) -I$(BOXEN_DIR) boxen_chrome_tests.c $(BOXEN_CORE_TEST_SRCS) -o $@ $(LINK_LIBS)
+
+# boxen Phase A.7 -- public window-aware cursor positioning API.
+# Same link set as A.6 (boxen.c is the unit under test).
+boxen_cursor_tests: boxen_cursor_tests.c $(BOXEN_CORE_TEST_SRCS)
+	$(CC) $(CFLAGS) -I$(BOXEN_DIR) boxen_cursor_tests.c $(BOXEN_CORE_TEST_SRCS) -o $@ $(LINK_LIBS)
 
 # Pure helper for arg-injection — no Frontier runtime / handle deps, so it
 # compiles with palette_arg_inject.c standalone. The test exercises escape

--- a/tests/boxen_cursor_tests.c
+++ b/tests/boxen_cursor_tests.c
@@ -1,0 +1,339 @@
+/*
+ * boxen_cursor_tests.c -- unit tests for boxen A.7 (public window-aware
+ *                         cursor positioning API).
+ *
+ * Covers:
+ *   1. test_set_cursor_in_bounds_translates
+ *      With borders on (default) and a focused window at (2,3,10,6),
+ *      content (0,0) maps to terminal (3,4); visible=true.
+ *   2. test_set_cursor_chrome_offset_with_borders_off
+ *      Same focused window with borders off: content (0,0) maps to
+ *      terminal (rect.x, rect.y) = (2,3).
+ *   3. test_set_cursor_respects_scroll
+ *      Content size > viewport; scroll non-zero. set_cursor at content
+ *      (scroll_x, scroll_y) lands at terminal (rect.x + border, rect.y +
+ *      border) and is visible.
+ *   4. test_set_cursor_clipped_hides
+ *      Content coord outside the visible viewport causes visible=false;
+ *      the call must succeed (no crash).
+ *   5. test_set_cursor_occluded_by_modal_hides
+ *      A modal window B occludes a screen cell A is trying to write to.
+ *      set_cursor from A hides; a coord outside B's rect is visible.
+ *   6. test_set_cursor_ignored_for_non_focused_non_modal
+ *      Focus gate: non-focused, non-modal window cannot move the cursor.
+ *      Deliberate footgun-prevention policy -- documented as such.
+ *   7. test_set_cursor_visible_independent_of_position
+ *      Toggling visibility does not affect the last-set position; both
+ *      set_cursor and set_cursor_visible obey the focus gate.
+ *
+ * Links: boxen_log.c, boxen_wcwidth.c, backend_mock.c, boxen.c
+ * No Frontier runtime dependency.
+ *
+ * Run: make -C tests boxen_cursor_tests && ./tests/boxen_cursor_tests
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "boxen.h"
+#include "backend_mock.h"
+#include "test_report.h"
+
+/* -------------------------------------------------------------------------
+ * Helpers
+ * ---------------------------------------------------------------------- */
+
+static void setup(void) {
+	/* Defensive: if a prior test failed mid-run (teardown never called), shut
+	 * down first so boxen_init doesn't return BOXEN_ERR_ALREADY. */
+	boxen_shutdown();
+	boxen_mock_reset(80, 24);
+	boxen_result_t r = boxen_init(boxen_mock_backend(), NULL, NULL);
+	assert(r == BOXEN_OK);
+}
+
+static void teardown(void) {
+	boxen_shutdown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 1: in-bounds content coord translates with chrome offset
+ *
+ * Focused window at rect (2, 3, 10, 6), borders on (default).
+ * Content (0, 0) maps to terminal (rect.x + 1, rect.y + 1) = (3, 4).
+ * Visibility is set true.
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_in_bounds_translates(void) {
+	setup();
+
+	boxen_window_t *win = boxen_window_open("W",
+		(boxen_rect_t){2, 3, 10, 6}, NULL);
+	assert(win != NULL);
+	boxen_window_focus(win);
+
+	boxen_window_set_cursor(win, 0, 0);
+
+	int cx = -99, cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == 3);
+	assert(cy == 4);
+	assert(boxen_mock_cursor_visible() == true);
+
+	boxen_window_close(win);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 2: borders off -- content origin is rect origin
+ *
+ * Same focused 10x6 window at (2, 3). After borders=false, content (0,0)
+ * lands at terminal (2, 3).
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_chrome_offset_with_borders_off(void) {
+	setup();
+
+	boxen_window_t *win = boxen_window_open("W",
+		(boxen_rect_t){2, 3, 10, 6}, NULL);
+	assert(win != NULL);
+	boxen_window_set_borders(win, false);
+	boxen_window_focus(win);
+
+	boxen_window_set_cursor(win, 0, 0);
+
+	int cx = -99, cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == 2);
+	assert(cy == 3);
+	assert(boxen_mock_cursor_visible() == true);
+
+	boxen_window_close(win);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 3: scroll offsets the content -> screen mapping
+ *
+ * Focused 10x6 window at (2, 3), borders on. content_size 20x20, scroll
+ * (5, 4). Content (5, 4) - scroll (5, 4) = local (0, 0) = terminal (3, 4).
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_respects_scroll(void) {
+	setup();
+
+	boxen_window_t *win = boxen_window_open("W",
+		(boxen_rect_t){2, 3, 10, 6}, NULL);
+	assert(win != NULL);
+	boxen_window_focus(win);
+	boxen_window_set_content_size(win, 20, 20);
+	boxen_window_set_scroll(win, 5, 4);
+
+	boxen_window_set_cursor(win, 5, 4);
+
+	int cx = -99, cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == 3);
+	assert(cy == 4);
+	assert(boxen_mock_cursor_visible() == true);
+
+	boxen_window_close(win);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 4: out-of-viewport content coord hides the cursor
+ *
+ * Focused window at (2, 3, 10, 6), borders on. set_cursor at content
+ * (100, 100) lies far outside the visible viewport. Visibility must
+ * become false. Position is intentionally unspecified when hidden;
+ * the call must not crash.
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_clipped_hides(void) {
+	setup();
+
+	boxen_window_t *win = boxen_window_open("W",
+		(boxen_rect_t){2, 3, 10, 6}, NULL);
+	assert(win != NULL);
+	boxen_window_focus(win);
+
+	boxen_window_set_cursor(win, 100, 100);
+
+	assert(boxen_mock_cursor_visible() == false);
+
+	boxen_window_close(win);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 5: modal window occludes cursor from below
+ *
+ * A is focused and covers (0, 0, 20, 10). B is modal at (5, 2, 10, 6).
+ *
+ * NOTE: modal blocks A from owning the cursor at all (only modal or
+ * the modal itself may drive the cursor when a modal is present). So
+ * both attempts from A are silently rejected by the focus gate -- the
+ * mock cursor never updates, and visible stays false from the boxen_init
+ * default state. The test asserts visible==false in both branches, which
+ * is consistent with both "occluded -> hide" and "focus-gate-rejected ->
+ * no update". The next test isolates the focus-gate behavior, and the
+ * scroll/in-bounds tests above exercise the visibility-true path.
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_occluded_by_modal_hides(void) {
+	setup();
+
+	boxen_window_t *a = boxen_window_open("A",
+		(boxen_rect_t){0, 0, 20, 10}, NULL);
+	assert(a != NULL);
+	boxen_window_focus(a);
+
+	boxen_window_t *b = boxen_window_open("B",
+		(boxen_rect_t){5, 2, 10, 6}, NULL);
+	assert(b != NULL);
+	boxen_window_set_modal(b, true);
+
+	/* From A, target content (6, 3) -> screen (6+1, 3+1) = (7, 4),
+	 * which falls inside B's rect (5,2)-(15,8). Hidden either way. */
+	boxen_window_set_cursor(a, 6, 3);
+	assert(boxen_mock_cursor_visible() == false);
+
+	/* From A, target content (17, 5) -> screen (17+1, 5+1) = (18, 6),
+	 * which is outside B's rect. Still hidden because the focus gate
+	 * routes cursor ownership to the modal when one is present. */
+	boxen_window_set_cursor(a, 17, 5);
+	assert(boxen_mock_cursor_visible() == false);
+
+	/* But the modal itself owns the cursor: a normal in-bounds call from
+	 * B at content (0, 0) (borders on -> screen (5+1, 2+1) = (6, 3))
+	 * succeeds. This anchors the "modal occlusion check applies to
+	 * non-modal callers" half of the contract. */
+	boxen_window_set_cursor(b, 0, 0);
+	assert(boxen_mock_cursor_visible() == true);
+	int cx = -99, cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == 6);
+	assert(cy == 3);
+
+	boxen_window_close(b);
+	boxen_window_close(a);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 6: focus gate -- non-focused, non-modal windows cannot move cursor
+ *
+ * Open A focused, B not focused and not modal. set_cursor from B must
+ * be silently ignored: the mock cursor remains at its reset state
+ * (-1, -1) with visible=false.
+ *
+ * This is deliberate footgun-prevention: two non-modal windows racing
+ * to position the terminal cursor produces undefined behavior in a
+ * terminal. Only the focused window OR a modal window may drive it.
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_ignored_for_non_focused_non_modal(void) {
+	setup();
+
+	boxen_window_t *a = boxen_window_open("A",
+		(boxen_rect_t){0, 0, 40, 20}, NULL);
+	assert(a != NULL);
+	boxen_window_focus(a);
+
+	boxen_window_t *b = boxen_window_open("B",
+		(boxen_rect_t){40, 0, 40, 20}, NULL);
+	assert(b != NULL);
+	/* Note: opening B does NOT auto-focus it -- only explicit focus()
+	 * sets the focused window. (The A.3 focus model only mutates focus
+	 * on explicit focus() calls or focus-stealing dispatch paths.) */
+
+	boxen_window_set_cursor(b, 0, 0);
+
+	/* Mock cursor state untouched -- still at reset defaults. */
+	int cx = 0, cy = 0;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == -1);
+	assert(cy == -1);
+	assert(boxen_mock_cursor_visible() == false);
+
+	boxen_window_close(b);
+	boxen_window_close(a);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 7: visibility toggle independent of position; obeys focus gate
+ *
+ * Focused window: set_cursor places cursor at (3, 4); subsequent
+ * set_cursor_visible(false) hides without changing position; (true)
+ * shows again, still at the last position.
+ *
+ * Also verifies that set_cursor_visible respects the focus gate: a call
+ * from a non-focused, non-modal window does not change the visibility
+ * flag.
+ * ---------------------------------------------------------------------- */
+
+static void test_set_cursor_visible_independent_of_position(void) {
+	setup();
+
+	boxen_window_t *a = boxen_window_open("A",
+		(boxen_rect_t){2, 3, 10, 6}, NULL);
+	assert(a != NULL);
+	boxen_window_focus(a);
+
+	boxen_window_set_cursor(a, 1, 1);
+	int cx = -99, cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	/* borders on: terminal (rect.x + 1 + 1, rect.y + 1 + 1) = (4, 5). */
+	assert(cx == 4);
+	assert(cy == 5);
+	assert(boxen_mock_cursor_visible() == true);
+
+	boxen_window_set_cursor_visible(a, false);
+	assert(boxen_mock_cursor_visible() == false);
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == 4);  /* position preserved */
+	assert(cy == 5);
+
+	boxen_window_set_cursor_visible(a, true);
+	assert(boxen_mock_cursor_visible() == true);
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == 4);
+	assert(cy == 5);
+
+	/* Focus gate: a non-focused, non-modal window cannot toggle. */
+	boxen_window_t *b = boxen_window_open("B",
+		(boxen_rect_t){40, 0, 10, 6}, NULL);
+	assert(b != NULL);
+
+	boxen_window_set_cursor_visible(b, false);
+	/* Visibility flag unchanged -- still true from the prior call. */
+	assert(boxen_mock_cursor_visible() == true);
+
+	boxen_window_close(b);
+	boxen_window_close(a);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * main
+ * ---------------------------------------------------------------------- */
+
+int main(void) {
+	TR_INIT("boxen_cursor_tests");
+
+	TR_RUN(test_set_cursor_in_bounds_translates);
+	TR_RUN(test_set_cursor_chrome_offset_with_borders_off);
+	TR_RUN(test_set_cursor_respects_scroll);
+	TR_RUN(test_set_cursor_clipped_hides);
+	TR_RUN(test_set_cursor_occluded_by_modal_hides);
+	TR_RUN(test_set_cursor_ignored_for_non_focused_non_modal);
+	TR_RUN(test_set_cursor_visible_independent_of_position);
+
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}

--- a/tests/boxen_cursor_tests.c
+++ b/tests/boxen_cursor_tests.c
@@ -16,9 +16,11 @@
  *   4. test_set_cursor_clipped_hides
  *      Content coord outside the visible viewport causes visible=false;
  *      the call must succeed (no crash).
- *   5. test_set_cursor_occluded_by_modal_hides
- *      A modal window B occludes a screen cell A is trying to write to.
- *      set_cursor from A hides; a coord outside B's rect is visible.
+ *   5. test_modal_blocks_non_modal_from_cursor
+ *      When a modal B exists, the focus gate redirects all cursor
+ *      ownership to the modal. Non-modal A's set_cursor calls are
+ *      silently ignored regardless of target position; modal B itself
+ *      can still drive the cursor.
  *   6. test_set_cursor_ignored_for_non_focused_non_modal
  *      Focus gate: non-focused, non-modal window cannot move the cursor.
  *      Deliberate footgun-prevention policy -- documented as such.
@@ -170,21 +172,26 @@ static void test_set_cursor_clipped_hides(void) {
 }
 
 /* -------------------------------------------------------------------------
- * Test 5: modal window occludes cursor from below
+ * Test 5: modal presence blocks non-modal callers from cursor ownership
  *
  * A is focused and covers (0, 0, 20, 10). B is modal at (5, 2, 10, 6).
  *
- * NOTE: modal blocks A from owning the cursor at all (only modal or
- * the modal itself may drive the cursor when a modal is present). So
- * both attempts from A are silently rejected by the focus gate -- the
- * mock cursor never updates, and visible stays false from the boxen_init
- * default state. The test asserts visible==false in both branches, which
- * is consistent with both "occluded -> hide" and "focus-gate-rejected ->
- * no update". The next test isolates the focus-gate behavior, and the
- * scroll/in-bounds tests above exercise the visibility-true path.
+ * When a modal exists, cursor_owner_allowed redirects all cursor
+ * ownership to the modal regardless of target position; non-modal
+ * callers are silently ignored before any translation or
+ * modal-occlusion check runs. This test asserts that A's calls do not
+ * touch the mock cursor at all -- get_cursor still returns (-1, -1) --
+ * which catches a regression where the focus gate accepts the call but
+ * the cursor is updated anyway.
+ *
+ * The modal-occlusion branch inside boxen_window_set_cursor exists as
+ * defense-in-depth for future gate-policy changes, but is currently
+ * unreachable from the public API, so this test does not exercise it
+ * directly. The positive assertion that modal B itself can drive the
+ * cursor anchors that the API does work for the right caller.
  * ---------------------------------------------------------------------- */
 
-static void test_set_cursor_occluded_by_modal_hides(void) {
+static void test_modal_blocks_non_modal_from_cursor(void) {
 	setup();
 
 	boxen_window_t *a = boxen_window_open("A",
@@ -197,24 +204,29 @@ static void test_set_cursor_occluded_by_modal_hides(void) {
 	assert(b != NULL);
 	boxen_window_set_modal(b, true);
 
-	/* From A, target content (6, 3) -> screen (6+1, 3+1) = (7, 4),
-	 * which falls inside B's rect (5,2)-(15,8). Hidden either way. */
+	/* From A, target content (6, 3) -> would-be screen (7, 4), inside B's
+	 * rect. Focus gate rejects before translation; cursor untouched. */
 	boxen_window_set_cursor(a, 6, 3);
 	assert(boxen_mock_cursor_visible() == false);
+	int cx = -99, cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == -1);
+	assert(cy == -1);
 
-	/* From A, target content (17, 5) -> screen (17+1, 5+1) = (18, 6),
-	 * which is outside B's rect. Still hidden because the focus gate
-	 * routes cursor ownership to the modal when one is present. */
+	/* From A, target content (17, 5) -> would-be screen (18, 6), outside
+	 * B's rect. Same: focus gate rejects before any check. */
 	boxen_window_set_cursor(a, 17, 5);
 	assert(boxen_mock_cursor_visible() == false);
+	cx = -99; cy = -99;
+	boxen_mock_get_cursor(&cx, &cy);
+	assert(cx == -1);
+	assert(cy == -1);
 
-	/* But the modal itself owns the cursor: a normal in-bounds call from
+	/* The modal itself owns the cursor: a normal in-bounds call from
 	 * B at content (0, 0) (borders on -> screen (5+1, 2+1) = (6, 3))
-	 * succeeds. This anchors the "modal occlusion check applies to
-	 * non-modal callers" half of the contract. */
+	 * succeeds. This anchors that the API works for the right caller. */
 	boxen_window_set_cursor(b, 0, 0);
 	assert(boxen_mock_cursor_visible() == true);
-	int cx = -99, cy = -99;
 	boxen_mock_get_cursor(&cx, &cy);
 	assert(cx == 6);
 	assert(cy == 3);
@@ -272,9 +284,9 @@ static void test_set_cursor_ignored_for_non_focused_non_modal(void) {
  * set_cursor_visible(false) hides without changing position; (true)
  * shows again, still at the last position.
  *
- * Also verifies that set_cursor_visible respects the focus gate: a call
- * from a non-focused, non-modal window does not change the visibility
- * flag.
+ * Also verifies that set_cursor_visible respects the focus gate in
+ * BOTH directions: a call from a non-focused, non-modal window does not
+ * change the visibility flag whether attempting to hide or to show.
  * ---------------------------------------------------------------------- */
 
 static void test_set_cursor_visible_independent_of_position(void) {
@@ -314,6 +326,15 @@ static void test_set_cursor_visible_independent_of_position(void) {
 	/* Visibility flag unchanged -- still true from the prior call. */
 	assert(boxen_mock_cursor_visible() == true);
 
+	/* Symmetric: explicitly drop to false via focused A, then verify that
+	 * non-focused B cannot flip it back on either. */
+	boxen_window_set_cursor_visible(a, false);
+	assert(boxen_mock_cursor_visible() == false);
+
+	boxen_window_set_cursor_visible(b, true);
+	/* Visibility flag unchanged -- still false, focus gate rejects show. */
+	assert(boxen_mock_cursor_visible() == false);
+
 	boxen_window_close(b);
 	boxen_window_close(a);
 	teardown();
@@ -330,7 +351,7 @@ int main(void) {
 	TR_RUN(test_set_cursor_chrome_offset_with_borders_off);
 	TR_RUN(test_set_cursor_respects_scroll);
 	TR_RUN(test_set_cursor_clipped_hides);
-	TR_RUN(test_set_cursor_occluded_by_modal_hides);
+	TR_RUN(test_modal_blocks_non_modal_from_cursor);
 	TR_RUN(test_set_cursor_ignored_for_non_focused_non_modal);
 	TR_RUN(test_set_cursor_visible_independent_of_position);
 


### PR DESCRIPTION
Closes #733.

## Summary

Adds two public window-aware cursor APIs to boxen, closing the first-consumer gap surfaced by Phase B (debugger TUI):

- `boxen_window_set_cursor(win, cx, cy)` — content-coord cursor positioning, mirroring `boxen_set_cell`'s chrome / scroll / clip translation
- `boxen_window_set_cursor_visible(win, visible)` — visibility toggle independent of position

Together they replace the reverse-video block-cell workaround currently planned for B.4 (breakpoint condition modal) and B.7 (scratch-eval pane).

## Semantics

| Situation | Behavior |
|-----------|----------|
| Focused window calls with in-viewport coords | Cursor moved + shown |
| Out-of-viewport coords (clipped or scrolled out) | Cursor hidden |
| Modal window calls | Treated as the legitimate owner (overrides focused window) |
| Non-focused, non-modal window calls | Silently ignored (footgun prevention) |
| Visibility toggle | Independent of position; same ownership rules |

The focus gate is a deliberate design choice — terminals have one cursor, and two windows fighting over it is undefined behavior at the UX level. The substrate decides ownership once, at API entry.

## Implementation notes

- `cursor_owner_allowed(win)` returns true if `win` is the topmost modal (when any modal is open) or the focused window (when no modal). Mirrors the modal-priority dispatch logic already used by `boxen_dispatch_event`.
- `find_topmost_modal()` helper scans `g_windows` back-to-front (matches existing modal scan in `boxen_dispatch_event`).
- Coordinate translation reuses the exact arithmetic from `boxen_set_cell`: scroll subtraction, BOXEN_MAX_DIMENSION cap, viewport clipping (with scrollbar shrink when applicable), and border offset.
- A defensive modal-occlusion check after translation hides the cursor if a modal covers the target. The focus gate currently makes this branch unreachable under live state (any non-modal caller is gated out earlier), but it's left in as defense-in-depth and is documented as such — a future change to the gate policy would re-activate it.

## Tests

7 new behavioral tests in `tests/boxen_cursor_tests.c`:

1. `test_set_cursor_in_bounds_translates` — focused window, content (0,0) → terminal (rect.x+1, rect.y+1) with borders on
2. `test_set_cursor_chrome_offset_with_borders_off` — borders off, content (0,0) → terminal (rect.x, rect.y)
3. `test_set_cursor_respects_scroll` — content coord + scroll = correct terminal position
4. `test_set_cursor_clipped_hides` — out-of-viewport target hides cursor (visible=false)
5. `test_set_cursor_occluded_by_modal_hides` — non-modal window's cursor calls hidden when modal is present
6. `test_set_cursor_ignored_for_non_focused_non_modal` — focus gate silently ignores
7. `test_set_cursor_visible_independent_of_position` — toggle works without re-positioning

Mock backend extended with `boxen_mock_get_cursor(int *x, int *y)` and `boxen_mock_cursor_visible(void)` for test inspection.

## Tests run

- `boxen_cursor_tests`: 7/7 pass
- Full boxen sweep: 10 + 15 + 11 + 13 + 10 + 11 + 7 = **77/77** (was 70 pre-A.7)
- Full unit suite: **668/668 across 62 executables** (no regressions)

## Test plan

- [x] boxen_cursor_tests pass locally
- [x] All 7 boxen test binaries green
- [x] Full unit suite green
- [ ] CI green on macos + ubuntu
- [ ] /gate review (bar-raiser + security + concurrency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
