### PR TITLE
feat(debugger-tui): B.4 — breakpoint UI (Phase B milestone 4 of #691)

### DIFF
--- a/frontier-cli/debugger_tui.c
+++ b/frontier-cli/debugger_tui.c
@@ -26,6 +26,7 @@
  * 2026-06-06 JES Phase B.0 #691
  * 2026-06-06 JES Phase B.0 #734 round 1: terminal size + resize + dead code + quit-key
  * 2026-06-07 JES Phase B.3 #691: F5/F10/F11/Shift-F11 keybinds + debug_state machine
+ * 2026-06-07 JES Phase B.4 #691: F9 breakpoint toggle + condition modal (A.7 cursor)
  *
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2025-2026 Frontier contributors
@@ -659,6 +660,19 @@ static void draw_stack_pane(boxen_window_t *win, void *ud) {
  * debugger_tui_internal.h. */
 static void tui_dispatch_json(tui_state_t *s, const char *json) {
 	size_t len = strlen(json);
+
+	/* 2026-06-07 JES Phase B.4 #691: multi-dispatch log (test mode only).
+	 * When dispatch_log is non-NULL, record each call in order up to cap.
+	 * This runs BEFORE the single-slot capture so both are always populated. */
+	if (s->dispatch_log != NULL && s->dispatch_log_count < s->dispatch_log_cap) {
+		int slot = s->dispatch_log_count;
+		int cap  = (int)sizeof(s->dispatch_log[0]) - 1;
+		int copy = (int)len < cap ? (int)len : cap;
+		memcpy(s->dispatch_log[slot], json, (size_t)copy);
+		s->dispatch_log[slot][copy] = '\0';
+		s->dispatch_log_count++;
+	}
+
 	if (s->dispatch_capture_buf != NULL && s->dispatch_capture_cap > 0) {
 		/* Test mode: capture the JSON instead of calling into the runtime */
 		int cap = s->dispatch_capture_cap - 1;
@@ -705,6 +719,303 @@ static void tui_do_step_into(tui_state_t *s)  { tui_do_step(s, "into"); }
 static void tui_do_step_out(tui_state_t *s)   { tui_do_step(s, "out");  }
 
 /* -------------------------------------------------------------------------
+ * 2026-06-07 JES Phase B.4 #691: breakpoint toggle (F9).
+ *
+ * tui_toggle_breakpoint: toggle a breakpoint at (script_path, line).
+ *
+ * If no breakpoint exists at the line: dispatch debug/setBreakpoint.
+ * If a breakpoint exists: dispatch debug/clearBreakpoints (clears ALL), then
+ *   re-dispatch debug/setBreakpoint for every surviving breakpoint.
+ *
+ * This clear-and-readd N-1 round trip is the correct approach because
+ * handle_debug_clearbreakpoints clears ALL breakpoints (no per-line clear op
+ * exists in the current runtime).  See EXECUTION_PLAN.md B.4 "Note on clear".
+ *
+ * SENTINEL (EXECUTION_PLAN.md B.4): all these dispatches happen under the
+ * GIL with the thread suspended, so the responses arrive synchronously via
+ * write_line (the handlers run on the calling thread).  No async complication.
+ *
+ * tui_close_condition_modal: shared close path for Enter/Escape.
+ *   Hides cursor, releases modal gate, closes window, clears state field.
+ * ---------------------------------------------------------------------- */
+
+static void tui_toggle_breakpoint(tui_state_t *s, long line) {
+	/* SENTINEL: only call while TUI_DEBUG_SUSPENDED and line > 0 */
+	if (line <= 0 || s->script_path[0] == '\0') return;
+
+	/* Check if a breakpoint exists at this line in the local cache */
+	bool bp_exists = false;
+	for (int i = 0; i < s->bp_line_count; i++) {
+		if (s->bp_lines[i] == (unsigned long)line) {
+			bp_exists = true;
+			break;
+		}
+	}
+
+	char req[512];
+
+	if (!bp_exists) {
+		/* Toggle ON: just add the breakpoint */
+		snprintf(req, sizeof(req),
+		         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
+		         "\"params\":{\"script\":\"%s\",\"line\":%ld}}",
+		         next_req_id(), s->script_path, line);
+		tui_dispatch_json(s, req);
+
+		/* Update local cache */
+		if (s->bp_line_count < TUI_MAX_BREAKPOINTS) {
+			s->bp_lines[s->bp_line_count++] = (unsigned long)line;
+		}
+	} else {
+		/* Toggle OFF: clear all, re-add all except the toggled line.
+		 * Note: a future debug/clearBreakpoint (singular) op would be cleaner;
+		 * this N-1 round trip is acceptable for small breakpoint sets. */
+		snprintf(req, sizeof(req),
+		         "{\"op\":\"debug/clearBreakpoints\",\"id\":%d,"
+		         "\"params\":{\"script\":\"%s\"}}",
+		         next_req_id(), s->script_path);
+		tui_dispatch_json(s, req);
+
+		/* Re-add all breakpoints except the toggled one */
+		for (int i = 0; i < s->bp_line_count; i++) {
+			if (s->bp_lines[i] != (unsigned long)line) {
+				snprintf(req, sizeof(req),
+				         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
+				         "\"params\":{\"script\":\"%s\",\"line\":%lu}}",
+				         next_req_id(), s->script_path, s->bp_lines[i]);
+				tui_dispatch_json(s, req);
+			}
+		}
+
+		/* Update local cache: remove the toggled line */
+		int new_count = 0;
+		for (int i = 0; i < s->bp_line_count; i++) {
+			if (s->bp_lines[i] != (unsigned long)line) {
+				s->bp_lines[new_count++] = s->bp_lines[i];
+			}
+		}
+		s->bp_line_count = new_count;
+	}
+
+	if (s->script_win != NULL) boxen_window_invalidate(s->script_win);
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-07 JES Phase B.4 #691: conditional breakpoint modal.
+ *
+ * draw_condition_modal: draw callback.
+ *   Renders a centered overlay with title "Set Condition" and the current
+ *   condition_buf content followed by a visual cursor position marker.
+ *   Calls boxen_window_set_cursor via the A.7 API to position the real
+ *   terminal cursor at the input position.
+ *
+ * input_condition_modal: input callback for the modal window.
+ *   Printable characters appended to bp_condition_buf (capped at
+ *   TUI_BP_CONDITION_MAX - 1).
+ *   BACKSPACE trims the buffer.
+ *   ENTER confirms: dispatch setBreakpoint with condition, close modal.
+ *   ESCAPE cancels: close modal without dispatching.
+ *
+ * tui_close_condition_modal: shared close/cleanup path.
+ *   1. boxen_window_set_cursor_visible(modal, false)  -- hide terminal cursor
+ *   2. boxen_window_set_modal(modal, false)           -- release modal gate
+ *   3. boxen_window_close(modal)                      -- destroy window
+ *   4. s->condition_modal_win = NULL                  -- clear state
+ *   5. Refocus script_win so F-keys work again.
+ *
+ * tui_open_condition_modal: open a centered condition modal.
+ *   Creates a boxen_window_t via boxen_window_open, calls set_modal(true),
+ *   sets cursor position to content (0, 2) [the input row], calls
+ *   set_cursor_visible(true).
+ * ---------------------------------------------------------------------- */
+
+static void tui_close_condition_modal(tui_state_t *s) {
+	if (s->condition_modal_win == NULL) return;
+	/* A.7 API: hide cursor before releasing modal ownership */
+	boxen_window_set_cursor_visible(s->condition_modal_win, false);
+	/* Release modal gate -- this is the critical step that gives cursor
+	 * ownership back to the focused window. */
+	boxen_window_set_modal(s->condition_modal_win, false);
+	boxen_window_close(s->condition_modal_win);
+	s->condition_modal_win = NULL;
+	/* Restore focus to script pane so F-keys and frame navigation work */
+	if (s->script_win != NULL) boxen_window_focus(s->script_win);
+}
+
+/* Forward declaration: input_condition_modal calls tui_close_condition_modal
+ * and tui_toggle_breakpoint, which are defined above, so no forward decl
+ * needed for those.  draw_condition_modal is referenced by tui_open_ which
+ * is defined after; declare forward here. */
+static void draw_condition_modal(boxen_window_t *win, void *ud);
+
+static void input_condition_modal(boxen_window_t *win, const boxen_event_t *ev, void *ud) {
+	(void)win;
+	tui_state_t *s = (tui_state_t *)ud;
+	if (ev->type != BOXEN_EV_KEY) return;
+
+	if (ev->key.key == BOXEN_KEY_ESCAPE) {
+		/* Cancel: close without dispatching */
+		tui_close_condition_modal(s);
+		return;
+	}
+
+	if (ev->key.key == BOXEN_KEY_ENTER) {
+		/* Confirm: dispatch setBreakpoint with condition, then close.
+		 *
+		 * Build a JSON-safe condition string: escape double-quotes and
+		 * backslashes (minimum required for valid JSON string value). */
+		char escaped[TUI_BP_CONDITION_MAX * 2 + 1];
+		int ei = 0;
+		for (int i = 0; i < s->bp_condition_len && ei < (int)sizeof(escaped) - 2; i++) {
+			char c = s->bp_condition_buf[i];
+			if (c == '"' || c == '\\') {
+				escaped[ei++] = '\\';
+			}
+			escaped[ei++] = c;
+		}
+		escaped[ei] = '\0';
+
+		char req[512 + TUI_BP_CONDITION_MAX * 2];
+		snprintf(req, sizeof(req),
+		         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
+		         "\"params\":{\"script\":\"%s\",\"line\":%ld,"
+		         "\"condition\":\"%s\"}}",
+		         next_req_id(), s->script_path, s->current_line, escaped);
+
+		/* Update local cache: add or replace the conditional breakpoint.
+		 * Remove any existing unconditional entry first, then add. */
+		int new_count = 0;
+		for (int i = 0; i < s->bp_line_count; i++) {
+			if (s->bp_lines[i] != (unsigned long)s->current_line) {
+				s->bp_lines[new_count++] = s->bp_lines[i];
+			}
+		}
+		if (new_count < TUI_MAX_BREAKPOINTS) {
+			s->bp_lines[new_count++] = (unsigned long)s->current_line;
+		}
+		s->bp_line_count = new_count;
+
+		tui_close_condition_modal(s);
+		tui_dispatch_json(s, req);
+
+		if (s->script_win != NULL) boxen_window_invalidate(s->script_win);
+		return;
+	}
+
+	if (ev->key.key == BOXEN_KEY_BACKSPACE) {
+		if (s->bp_condition_len > 0) {
+			s->bp_condition_len--;
+			s->bp_condition_buf[s->bp_condition_len] = '\0';
+		}
+	} else if (ev->key.key == BOXEN_KEY_NONE && ev->key.ch >= 0x20 && ev->key.ch < 0x7F) {
+		/* Printable ASCII: append if space permits (capped at TUI_BP_CONDITION_MAX-1) */
+		if (s->bp_condition_len < TUI_BP_CONDITION_MAX - 1) {
+			s->bp_condition_buf[s->bp_condition_len++] = (char)ev->key.ch;
+			s->bp_condition_buf[s->bp_condition_len]   = '\0';
+		}
+	}
+
+	/* Reposition cursor to follow the input (A.7 API).
+	 * Modal content layout: row 0 = title, row 1 = blank, row 2 = input.
+	 * Cursor column = bp_condition_len (one past the last typed character). */
+	if (s->condition_modal_win != NULL) {
+		boxen_window_set_cursor(s->condition_modal_win,
+		                        s->bp_condition_len, 2);
+		/* Redraw so the typed character appears */
+		boxen_window_invalidate(s->condition_modal_win);
+	}
+}
+
+static void draw_condition_modal(boxen_window_t *win, void *ud) {
+	tui_state_t *s = (tui_state_t *)ud;
+	int w = boxen_window_content_width(win);
+	if (w <= 0) return;
+
+	/* Cap to linebuf capacity (B.1 round-1 P1-A lesson) */
+	char linebuf[512];
+	int  cap   = (int)sizeof(linebuf) - 1;
+	int  avail = w < cap ? w : cap;
+
+	/* Row 0: title */
+	{
+		const char *title = "Set Condition (Enter=confirm  Esc=cancel)";
+		int n = snprintf(linebuf, (size_t)(avail + 1), "%-*.*s", avail, avail, title);
+		(void)n;
+		boxen_draw_text(win, 0, 0, linebuf,
+		                BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT, BOXEN_ATTR_BOLD);
+	}
+
+	/* Row 1: blank separator */
+	{
+		memset(linebuf, ' ', (size_t)avail);
+		linebuf[avail] = '\0';
+		boxen_draw_text(win, 0, 1, linebuf,
+		                BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT, BOXEN_ATTR_NONE);
+	}
+
+	/* Row 2: condition input buffer.
+	 * Pad to avail with spaces so the input row is fully drawn. */
+	{
+		const char *cond = s != NULL ? s->bp_condition_buf : "";
+		int clen = s != NULL ? s->bp_condition_len : 0;
+		int copy = clen < avail ? clen : avail;
+		memcpy(linebuf, cond, (size_t)copy);
+		memset(linebuf + copy, ' ', (size_t)(avail - copy));
+		linebuf[avail] = '\0';
+		boxen_draw_text(win, 0, 2, linebuf,
+		                BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT, BOXEN_ATTR_NONE);
+	}
+
+	/* Position the real terminal cursor at the end of the typed text.
+	 * Uses the A.7 public API: chrome, scroll, and viewport clipping are
+	 * applied automatically.  DO NOT use the reverse-video block-cell
+	 * workaround -- the A.7 API is live (EXECUTION_PLAN.md B.4 Sentinel). */
+	if (s != NULL && s->condition_modal_win != NULL) {
+		boxen_window_set_cursor(s->condition_modal_win,
+		                        s->bp_condition_len, 2);
+	}
+}
+
+static void tui_open_condition_modal(tui_state_t *s, int tw, int th) {
+	/* Clear the condition buffer for fresh input */
+	memset(s->bp_condition_buf, 0, sizeof(s->bp_condition_buf));
+	s->bp_condition_len = 0;
+
+	/* Open a centered modal window.  Minimum useful size: 60 wide, 5 tall.
+	 * Clamp to terminal dimensions so the modal never overflows the screen. */
+	int mw = 60;
+	int mh = 5;
+	if (mw > tw - 4) mw = tw - 4;
+	if (mh > th - 4) mh = th - 4;
+	if (mw < 20) mw = 20; /* absolute minimum */
+	if (mh < 5)  mh = 5;
+
+	int mx = (tw - mw) / 2;
+	int my = (th - mh) / 2;
+	if (mx < 0) mx = 0;
+	if (my < 0) my = 0;
+
+	boxen_rect_t r = { mx, my, mw, mh };
+	s->condition_modal_win = boxen_window_open("Set Condition", r, NULL);
+	if (s->condition_modal_win == NULL) return;
+
+	boxen_window_set_draw(s->condition_modal_win,  draw_condition_modal);
+	boxen_window_set_input(s->condition_modal_win, input_condition_modal);
+	boxen_window_set_user_data(s->condition_modal_win, s);
+
+	/* A.7 API: set modal gate so cursor calls route to this window.
+	 * This also blocks cursor calls from non-modal windows (the script pane). */
+	boxen_window_set_modal(s->condition_modal_win, true);
+
+	/* Position cursor at content (0, 2) -- start of the input row.
+	 * set_cursor_visible(true) makes the terminal cursor appear. */
+	boxen_window_set_cursor(s->condition_modal_win, 0, 2);
+	boxen_window_set_cursor_visible(s->condition_modal_win, true);
+
+	boxen_window_invalidate(s->condition_modal_win);
+}
+
+/* -------------------------------------------------------------------------
  * 2026-06-07 JES Phase B.3 #691: draw_footer.
  *
  * Footer state machine (EXECUTION_PLAN.md B.3 "Footer update"):
@@ -720,7 +1031,8 @@ static void draw_footer(boxen_window_t *win, void *ud) {
 
 	const char *text;
 	if (s != NULL && s->debug_state == TUI_DEBUG_SUSPENDED) {
-		text = "F5:continue  F10:step-over  F11:step-in  S-F11:step-out  q:quit";
+		/* 2026-06-07 JES Phase B.4 #691: added F9:bp and S-F9:cond */
+		text = "F5:continue  F9:bp  S-F9:cond  F10:step-over  F11:step-in  S-F11:step-out  q:quit";
 	} else if (s != NULL && s->debug_state == TUI_DEBUG_RUNNING) {
 		text = "[running...]  q:quit";
 	} else {
@@ -903,6 +1215,33 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev, void *ud) {
 			if (s->footer_win != NULL) boxen_window_invalidate(s->footer_win);
 			return;
 		}
+		if (ev->key.key == BOXEN_KEY_F9) {
+			/* 2026-06-07 JES Phase B.4 #691: breakpoint toggle.
+			 *
+			 * F9 (no shift): toggle breakpoint at current line.
+			 * Shift-F9:      open conditional breakpoint modal.
+			 *
+			 * Guard: current_line must be > 0 (thread must be suspended in
+			 * a specific line) and script_path must be non-empty. */
+			if (ev->key.mod & BOXEN_MOD_SHIFT) {
+				/* Open condition modal.  Derive terminal dimensions from the
+				 * footer window (footer is always full-width, placed at row th-1). */
+				if (s->condition_modal_win == NULL && s->current_line > 0) {
+					int tw = 80, th = 24;
+					if (s->footer_win != NULL) {
+						boxen_rect_t fr = boxen_window_get_rect(s->footer_win);
+						tw = fr.w;
+						th = fr.y + fr.h;
+					}
+					tui_open_condition_modal(s, tw, th);
+				}
+			} else {
+				if (s->current_line > 0 && s->script_path[0] != '\0') {
+					tui_toggle_breakpoint(s, s->current_line);
+				}
+			}
+			return;
+		}
 		if (ev->key.key == BOXEN_KEY_F10) {
 			tui_do_step_over(s);
 			if (s->footer_win != NULL) boxen_window_invalidate(s->footer_win);
@@ -969,6 +1308,14 @@ void debugger_tui_state_init(tui_state_t *s, int tw, int th) {
 	/* dispatch_capture_buf is NULL by default (production mode);
 	 * tests set it explicitly after init. */
 
+	/* 2026-06-07 JES Phase B.4 #691: initialize condition modal state */
+	s->condition_modal_win = NULL;
+	s->bp_condition_len    = 0;
+	/* dispatch_log is NULL by default; tests set it for sequence verification */
+	s->dispatch_log        = NULL;
+	s->dispatch_log_cap    = 0;
+	s->dispatch_log_count  = 0;
+
 	/* Allocate heap transport (stub; B.6 wires debug_set_attach_transport) */
 	s->transport = calloc(1, sizeof(transport_t));
 	if (s->transport != NULL) {
@@ -989,6 +1336,11 @@ void debugger_tui_state_init(tui_state_t *s, int tw, int th) {
 }
 
 void debugger_tui_state_teardown(tui_state_t *s) {
+	/* 2026-06-07 JES Phase B.4 #691: close condition modal if open.
+	 * tui_close_condition_modal hides cursor + releases modal gate first. */
+	if (s->condition_modal_win != NULL) {
+		tui_close_condition_modal(s);
+	}
 	if (s->footer_win != NULL)  { boxen_window_close(s->footer_win);  s->footer_win  = NULL; }
 	if (s->stack_win  != NULL)  { boxen_window_close(s->stack_win);   s->stack_win   = NULL; }
 	if (s->script_win != NULL)  { boxen_window_close(s->script_win);  s->script_win  = NULL; }
@@ -1000,6 +1352,10 @@ void debugger_tui_state_teardown(tui_state_t *s) {
 	/* 2026-06-07 JES Phase B.3 #691: clear dispatch capture (not heap; just NULL) */
 	s->dispatch_capture_buf = NULL;
 	s->dispatch_capture_cap = 0;
+	/* 2026-06-07 JES Phase B.4 #691: clear dispatch log (not heap; just NULL) */
+	s->dispatch_log       = NULL;
+	s->dispatch_log_cap   = 0;
+	s->dispatch_log_count = 0;
 	s->debug_state = TUI_DEBUG_IDLE;
 }
 

--- a/frontier-cli/debugger_tui.c
+++ b/frontier-cli/debugger_tui.c
@@ -27,6 +27,7 @@
  * 2026-06-06 JES Phase B.0 #734 round 1: terminal size + resize + dead code + quit-key
  * 2026-06-07 JES Phase B.3 #691: F5/F10/F11/Shift-F11 keybinds + debug_state machine
  * 2026-06-07 JES Phase B.4 #691: F9 breakpoint toggle + condition modal (A.7 cursor)
+ * 2026-06-07 JES Phase B.4 #743 round 1: condition preservation + JSON escape + F9 gate
  *
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2025-2026 Frontier contributors
@@ -281,7 +282,13 @@ static void tui_store_source(tui_state_t *s, cJSON *result) {
 	 * reflects the true population of the array. */
 	s->script_line_count = count;
 
-	/* Reset breakpoints from this source load */
+	/* Reset breakpoints from this source load.
+	 * 2026-06-07 JES Phase B.4 #743 round 1: free any stored condition strings
+	 * before zeroing the count so we don't leak heap on source reload. */
+	for (int bi = 0; bi < s->bp_line_count; bi++) {
+		free(s->bp_conditions[bi]);
+		s->bp_conditions[bi] = NULL;
+	}
 	s->bp_line_count = 0;
 
 	int i = 0;
@@ -700,6 +707,9 @@ static void tui_do_continue(tui_state_t *s) {
 	         "{\"op\":\"debug/continue\",\"id\":%d,\"params\":{\"threadId\":%ld}}",
 	         next_req_id(), s->pending_thread_id);
 	s->debug_state = TUI_DEBUG_RUNNING;
+	/* 2026-06-07 JES Phase B.4 #743 round 1: clear current_line when transitioning
+	 * to RUNNING so F9 cannot fire against a stale last-suspended line position. */
+	s->current_line = 0;
 	tui_dispatch_json(s, req);
 }
 
@@ -711,12 +721,78 @@ static void tui_do_step(tui_state_t *s, const char *direction) {
 	         "{\"threadId\":%ld,\"direction\":\"%s\"}}",
 	         next_req_id(), s->pending_thread_id, direction);
 	s->debug_state = TUI_DEBUG_RUNNING;
+	/* 2026-06-07 JES Phase B.4 #743 round 1: clear current_line when transitioning
+	 * to RUNNING.  Symmetric with the continue path above. */
+	s->current_line = 0;
 	tui_dispatch_json(s, req);
 }
 
 static void tui_do_step_over(tui_state_t *s)  { tui_do_step(s, "over"); }
 static void tui_do_step_into(tui_state_t *s)  { tui_do_step(s, "into"); }
 static void tui_do_step_out(tui_state_t *s)   { tui_do_step(s, "out");  }
+
+/* -------------------------------------------------------------------------
+ * 2026-06-07 JES Phase B.4 #743 round 1: JSON string escape helper.
+ *
+ * tui_json_escape -- escape src into dst for safe interpolation into a JSON
+ * string value.  Handles: " -> \", \ -> \\, and control characters using
+ * \b \f \n \r \t and \uXXXX for all other code points < 0x20.
+ *
+ * Worst-case expansion: 6x (every byte -> \u00XX), so dst must be at least
+ * strlen(src)*6 + 1 bytes.  For a 256-byte script_path that is 1537 bytes.
+ *
+ * dst is always NUL-terminated even when src is empty.  The function returns
+ * the number of bytes written to dst (not counting the NUL).
+ *
+ * Callers allocate dst on the stack sized for the 6x worst case.  All four
+ * interpolation sites for script_path use a 1537-byte dst buffer.
+ * ---------------------------------------------------------------------- */
+static int tui_json_escape(const char *src, char *dst, size_t dst_cap) {
+	/* dst_cap must include space for the NUL terminator */
+	if (dst == NULL || dst_cap == 0) return 0;
+	int out = 0;
+	int cap = (int)dst_cap - 1; /* reserve one byte for NUL */
+	for (const char *p = src; *p != '\0'; p++) {
+		unsigned char c = (unsigned char)*p;
+		if (c == '"') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\';
+			dst[out++] = '"';
+		} else if (c == '\\') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\';
+			dst[out++] = '\\';
+		} else if (c == '\b') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\'; dst[out++] = 'b';
+		} else if (c == '\f') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\'; dst[out++] = 'f';
+		} else if (c == '\n') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\'; dst[out++] = 'n';
+		} else if (c == '\r') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\'; dst[out++] = 'r';
+		} else if (c == '\t') {
+			if (out + 2 > cap) break;
+			dst[out++] = '\\'; dst[out++] = 't';
+		} else if (c < 0x20) {
+			/* Other control characters: \u00XX */
+			if (out + 6 > cap) break;
+			dst[out++] = '\\'; dst[out++] = 'u';
+			dst[out++] = '0';  dst[out++] = '0';
+			static const char hex[] = "0123456789abcdef";
+			dst[out++] = hex[(c >> 4) & 0x0F];
+			dst[out++] = hex[c        & 0x0F];
+		} else {
+			if (out + 1 > cap) break;
+			dst[out++] = (char)c;
+		}
+	}
+	dst[out] = '\0';
+	return out;
+}
 
 /* -------------------------------------------------------------------------
  * 2026-06-07 JES Phase B.4 #691: breakpoint toggle (F9).
@@ -743,6 +819,11 @@ static void tui_toggle_breakpoint(tui_state_t *s, long line) {
 	/* SENTINEL: only call while TUI_DEBUG_SUSPENDED and line > 0 */
 	if (line <= 0 || s->script_path[0] == '\0') return;
 
+	/* 2026-06-07 JES Phase B.4 #743 round 1: JSON-escape script_path once for
+	 * all dispatch sites in this function.  Worst case: 256 bytes * 6 + NUL. */
+	char esc_path[256 * 6 + 1];
+	tui_json_escape(s->script_path, esc_path, sizeof(esc_path));
+
 	/* Check if a breakpoint exists at this line in the local cache */
 	bool bp_exists = false;
 	for (int i = 0; i < s->bp_line_count; i++) {
@@ -752,46 +833,69 @@ static void tui_toggle_breakpoint(tui_state_t *s, long line) {
 		}
 	}
 
-	char req[512];
+	/* req must hold: JSON boilerplate + esc_path (up to 1537) + condition.
+	 * Use 512 + sizeof(esc_path) + TUI_BP_CONDITION_MAX*2 for safety. */
+	char req[512 + sizeof(esc_path) + TUI_BP_CONDITION_MAX * 2];
 
 	if (!bp_exists) {
-		/* Toggle ON: just add the breakpoint */
+		/* Toggle ON: just add the unconditional breakpoint */
 		snprintf(req, sizeof(req),
 		         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
 		         "\"params\":{\"script\":\"%s\",\"line\":%ld}}",
-		         next_req_id(), s->script_path, line);
+		         next_req_id(), esc_path, line);
 		tui_dispatch_json(s, req);
 
-		/* Update local cache */
+		/* Update local cache: no condition (unconditional BP) */
 		if (s->bp_line_count < TUI_MAX_BREAKPOINTS) {
-			s->bp_lines[s->bp_line_count++] = (unsigned long)line;
+			s->bp_lines[s->bp_line_count]      = (unsigned long)line;
+			s->bp_conditions[s->bp_line_count] = NULL; /* unconditional */
+			s->bp_line_count++;
 		}
 	} else {
 		/* Toggle OFF: clear all, re-add all except the toggled line.
-		 * Note: a future debug/clearBreakpoint (singular) op would be cleaner;
-		 * this N-1 round trip is acceptable for small breakpoint sets. */
+		 * 2026-06-07 JES Phase B.4 #743 round 1: re-dispatch surviving breakpoints
+		 * WITH their stored conditions so conditions are not silently stripped. */
 		snprintf(req, sizeof(req),
 		         "{\"op\":\"debug/clearBreakpoints\",\"id\":%d,"
 		         "\"params\":{\"script\":\"%s\"}}",
-		         next_req_id(), s->script_path);
+		         next_req_id(), esc_path);
 		tui_dispatch_json(s, req);
 
-		/* Re-add all breakpoints except the toggled one */
+		/* Re-add all surviving breakpoints, preserving each one's condition */
 		for (int i = 0; i < s->bp_line_count; i++) {
 			if (s->bp_lines[i] != (unsigned long)line) {
-				snprintf(req, sizeof(req),
-				         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
-				         "\"params\":{\"script\":\"%s\",\"line\":%lu}}",
-				         next_req_id(), s->script_path, s->bp_lines[i]);
+				if (s->bp_conditions[i] != NULL) {
+					/* Conditional re-add: escape condition string */
+					char esc_cond[TUI_BP_CONDITION_MAX * 2 + 1];
+					tui_json_escape(s->bp_conditions[i], esc_cond, sizeof(esc_cond));
+					snprintf(req, sizeof(req),
+					         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
+					         "\"params\":{\"script\":\"%s\",\"line\":%lu,"
+					         "\"condition\":\"%s\"}}",
+					         next_req_id(), esc_path,
+					         s->bp_lines[i], esc_cond);
+				} else {
+					/* Unconditional re-add */
+					snprintf(req, sizeof(req),
+					         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
+					         "\"params\":{\"script\":\"%s\",\"line\":%lu}}",
+					         next_req_id(), esc_path, s->bp_lines[i]);
+				}
 				tui_dispatch_json(s, req);
 			}
 		}
 
-		/* Update local cache: remove the toggled line */
+		/* Update local cache: remove the toggled line; free its condition */
 		int new_count = 0;
 		for (int i = 0; i < s->bp_line_count; i++) {
 			if (s->bp_lines[i] != (unsigned long)line) {
-				s->bp_lines[new_count++] = s->bp_lines[i];
+				s->bp_lines[new_count]      = s->bp_lines[i];
+				s->bp_conditions[new_count] = s->bp_conditions[i];
+				new_count++;
+			} else {
+				/* Free condition string for the removed BP */
+				free(s->bp_conditions[i]);
+				s->bp_conditions[i] = NULL;
 			}
 		}
 		s->bp_line_count = new_count;
@@ -862,36 +966,46 @@ static void input_condition_modal(boxen_window_t *win, const boxen_event_t *ev, 
 	if (ev->key.key == BOXEN_KEY_ENTER) {
 		/* Confirm: dispatch setBreakpoint with condition, then close.
 		 *
-		 * Build a JSON-safe condition string: escape double-quotes and
-		 * backslashes (minimum required for valid JSON string value). */
-		char escaped[TUI_BP_CONDITION_MAX * 2 + 1];
-		int ei = 0;
-		for (int i = 0; i < s->bp_condition_len && ei < (int)sizeof(escaped) - 2; i++) {
-			char c = s->bp_condition_buf[i];
-			if (c == '"' || c == '\\') {
-				escaped[ei++] = '\\';
-			}
-			escaped[ei++] = c;
-		}
-		escaped[ei] = '\0';
+		 * 2026-06-07 JES Phase B.4 #743 round 1: use tui_json_escape for both
+		 * script_path and condition (replaces the inline escape loop that only
+		 * handled " and \ -- tui_json_escape also covers control characters). */
+		char esc_path[256 * 6 + 1];
+		tui_json_escape(s->script_path, esc_path, sizeof(esc_path));
 
-		char req[512 + TUI_BP_CONDITION_MAX * 2];
+		char esc_cond[TUI_BP_CONDITION_MAX * 6 + 1];
+		tui_json_escape(s->bp_condition_buf, esc_cond, sizeof(esc_cond));
+
+		char req[512 + sizeof(esc_path) + sizeof(esc_cond)];
 		snprintf(req, sizeof(req),
 		         "{\"op\":\"debug/setBreakpoint\",\"id\":%d,"
 		         "\"params\":{\"script\":\"%s\",\"line\":%ld,"
 		         "\"condition\":\"%s\"}}",
-		         next_req_id(), s->script_path, s->current_line, escaped);
+		         next_req_id(), esc_path, s->current_line, esc_cond);
 
 		/* Update local cache: add or replace the conditional breakpoint.
-		 * Remove any existing unconditional entry first, then add. */
+		 * Remove any existing entry for this line first (free its condition),
+		 * then insert the new conditional entry.
+		 * 2026-06-07 JES Phase B.4 #743 round 1: store condition in bp_conditions
+		 * so it survives a future toggle-off clear-and-readd cycle. */
 		int new_count = 0;
 		for (int i = 0; i < s->bp_line_count; i++) {
 			if (s->bp_lines[i] != (unsigned long)s->current_line) {
-				s->bp_lines[new_count++] = s->bp_lines[i];
+				s->bp_lines[new_count]      = s->bp_lines[i];
+				s->bp_conditions[new_count] = s->bp_conditions[i];
+				new_count++;
+			} else {
+				/* Free old condition (may be NULL if it was unconditional) */
+				free(s->bp_conditions[i]);
+				s->bp_conditions[i] = NULL;
 			}
 		}
 		if (new_count < TUI_MAX_BREAKPOINTS) {
-			s->bp_lines[new_count++] = (unsigned long)s->current_line;
+			s->bp_lines[new_count]      = (unsigned long)s->current_line;
+			/* strdup the condition so it outlives bp_condition_buf (which is
+			 * cleared on the next modal open).  NULL on OOM -- treated as
+			 * unconditional in the re-dispatch path, which is safe. */
+			s->bp_conditions[new_count] = strdup(s->bp_condition_buf);
+			new_count++;
 		}
 		s->bp_line_count = new_count;
 
@@ -1225,8 +1339,11 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev, void *ud) {
 			 * a specific line) and script_path must be non-empty. */
 			if (ev->key.mod & BOXEN_MOD_SHIFT) {
 				/* Open condition modal.  Derive terminal dimensions from the
-				 * footer window (footer is always full-width, placed at row th-1). */
-				if (s->condition_modal_win == NULL && s->current_line > 0) {
+				 * footer window (footer is always full-width, placed at row th-1).
+				 * 2026-06-07 JES Phase B.4 #743 round 1: also guard script_path
+				 * (mirrors the bare-F9 guard; modal should not open without a path). */
+				if (s->condition_modal_win == NULL && s->current_line > 0 &&
+				    s->script_path[0] != '\0') {
 					int tw = 80, th = 24;
 					if (s->footer_win != NULL) {
 						boxen_rect_t fr = boxen_window_get_rect(s->footer_win);
@@ -1345,6 +1462,12 @@ void debugger_tui_state_teardown(tui_state_t *s) {
 	if (s->stack_win  != NULL)  { boxen_window_close(s->stack_win);   s->stack_win   = NULL; }
 	if (s->script_win != NULL)  { boxen_window_close(s->script_win);  s->script_win  = NULL; }
 	if (s->transport  != NULL)  { free(s->transport);                 s->transport   = NULL; }
+	/* 2026-06-07 JES Phase B.4 #743 round 1: free heap condition strings */
+	for (int i = 0; i < s->bp_line_count; i++) {
+		free(s->bp_conditions[i]);
+		s->bp_conditions[i] = NULL;
+	}
+	s->bp_line_count = 0;
 	/* 2026-06-07 JES Phase B.1 #691: free source lines */
 	tui_free_script_lines(s);
 	/* 2026-06-07 JES Phase B.2 #691: free locals */

--- a/frontier-cli/debugger_tui_internal.h
+++ b/frontier-cli/debugger_tui_internal.h
@@ -10,6 +10,7 @@
  * 2026-06-06 JES Phase B.0 #691
  * 2026-06-07 JES Phase B.3 #691: tui_debug_state_t, dispatch capture, keybind fields
  * 2026-06-07 JES Phase B.4 #691: breakpoint UI, condition modal, dispatch log
+ * 2026-06-07 JES Phase B.4 #743 round 1: condition preservation, JSON escape, F9 gate
  */
 
 #ifndef DEBUGGER_TUI_INTERNAL_H
@@ -76,6 +77,12 @@ typedef enum {
  * surviving line) set dispatch_log to a stack array of this many slots. */
 #define TUI_DISPATCH_LOG_COUNT 32
 
+/* 2026-06-07 JES Phase B.4 #743 round 1: dispatch log slot size.
+ * Worst-case JSON-escaped script_path (256 bytes, all control chars) expands
+ * to 256*6+1 = 1537 bytes.  Slots must hold the full escaped JSON request so
+ * regression tests can inspect the complete setBreakpoint payload. */
+#define TUI_DISPATCH_LOG_SLOT  1537
+
 /* 2026-06-07 JES Phase B.1 #737 round 1 P1-B: cap source lines to prevent
  * a DoS via a malicious/oversized debug/getSource response.  ODB scripts are
  * typically <1000 lines; 10000 is generous and avoids the 80MB+ allocation
@@ -111,7 +118,12 @@ typedef struct {
 	long   current_line;            /* 1-based; -1 if not suspended */
 	long   pending_thread_id;       /* thread ID from last debug/suspended, or -1 */
 	unsigned long bp_lines[TUI_MAX_BREAKPOINTS]; /* 1-based line numbers with breakpoints */
-	int           bp_line_count;    /* number of valid entries in bp_lines */
+	/* 2026-06-07 JES Phase B.4 #743 round 1: parallel conditions array.
+	 * bp_conditions[i] is the condition string for bp_lines[i], or NULL for
+	 * unconditional.  Heap-allocated (strdup); freed in state_teardown.
+	 * Must stay in sync with bp_lines / bp_line_count at all times. */
+	char         *bp_conditions[TUI_MAX_BREAKPOINTS]; /* NULL = unconditional */
+	int           bp_line_count;    /* number of valid entries in bp_lines/bp_conditions */
 
 	/* 2026-06-07 JES Phase B.2 #691: call stack state */
 	int   frame_count;                           /* number of valid frames */
@@ -158,7 +170,7 @@ typedef struct {
 	 * is non-NULL, the existing single-slot capture still runs; the log records
 	 * all calls in addition.  Tests can use either or both.
 	 */
-	char (*dispatch_log)[256]; /* NULL in production; test array in tests */
+	char (*dispatch_log)[TUI_DISPATCH_LOG_SLOT]; /* NULL in production; test array in tests */
 	int   dispatch_log_cap;    /* number of slots in dispatch_log (0 if NULL) */
 	int   dispatch_log_count;  /* number of calls logged so far */
 

--- a/frontier-cli/debugger_tui_internal.h
+++ b/frontier-cli/debugger_tui_internal.h
@@ -9,6 +9,7 @@
  *
  * 2026-06-06 JES Phase B.0 #691
  * 2026-06-07 JES Phase B.3 #691: tui_debug_state_t, dispatch capture, keybind fields
+ * 2026-06-07 JES Phase B.4 #691: breakpoint UI, condition modal, dispatch log
  */
 
 #ifndef DEBUGGER_TUI_INTERNAL_H
@@ -63,6 +64,17 @@ typedef enum {
 
 /* Maximum number of breakpoints tracked in TUI state. */
 #define TUI_MAX_BREAKPOINTS 256
+
+/* 2026-06-07 JES Phase B.4 #691: maximum length of a conditional breakpoint
+ * expression string (including NUL terminator).  256 bytes is generous for
+ * a UserTalk expression; the modal input is capped at (TUI_BP_CONDITION_MAX - 1)
+ * printable characters before accepting Enter. */
+#define TUI_BP_CONDITION_MAX 256
+
+/* 2026-06-07 JES Phase B.4 #691: multi-dispatch log capacity for tests.
+ * Tests that verify sequences (clearBreakpoints -> setBreakpoint for each
+ * surviving line) set dispatch_log to a stack array of this many slots. */
+#define TUI_DISPATCH_LOG_COUNT 32
 
 /* 2026-06-07 JES Phase B.1 #737 round 1 P1-B: cap source lines to prevent
  * a DoS via a malicious/oversized debug/getSource response.  ODB scripts are
@@ -130,6 +142,42 @@ typedef struct {
 	 */
 	char *dispatch_capture_buf;  /* NULL in production; test buffer pointer in tests */
 	int   dispatch_capture_cap;  /* capacity of dispatch_capture_buf (0 if NULL) */
+
+	/* 2026-06-07 JES Phase B.4 #691: multi-dispatch log for sequence tests.
+	 *
+	 * Some B.4 operations issue multiple op_dispatch calls in sequence
+	 * (e.g., clearBreakpoints then setBreakpoint for each surviving line).
+	 * The single dispatch_capture_buf captures only the most-recent call.
+	 * Tests that need to verify a dispatch sequence set dispatch_log to a
+	 * stack-allocated array of TUI_DISPATCH_LOG_COUNT fixed-size string slots,
+	 * and set dispatch_log_cap to the slot count.  Each tui_dispatch_json call
+	 * appends to the log (up to cap); dispatch_log_count tracks how many
+	 * calls were made.  In production all three are zero/NULL.
+	 *
+	 * The log is secondary to dispatch_capture_buf: when dispatch_capture_buf
+	 * is non-NULL, the existing single-slot capture still runs; the log records
+	 * all calls in addition.  Tests can use either or both.
+	 */
+	char (*dispatch_log)[256]; /* NULL in production; test array in tests */
+	int   dispatch_log_cap;    /* number of slots in dispatch_log (0 if NULL) */
+	int   dispatch_log_count;  /* number of calls logged so far */
+
+	/* 2026-06-07 JES Phase B.4 #691: breakpoint condition modal state.
+	 *
+	 * condition_modal_win -- the open modal window; NULL when no modal is active.
+	 *   Heap-allocated via boxen_window_open(); closed and set to NULL when
+	 *   the user confirms (Enter) or cancels (Escape).
+	 *
+	 * bp_condition_buf -- the condition expression being typed.
+	 *   Populated one character at a time by the modal's input callback.
+	 *   Bounded to TUI_BP_CONDITION_MAX - 1 printable characters.
+	 *   Cleared on modal open; used to construct "condition" JSON param on confirm.
+	 *
+	 * bp_condition_len -- current character count in bp_condition_buf.
+	 */
+	boxen_window_t *condition_modal_win; /* NULL when modal is closed */
+	char  bp_condition_buf[TUI_BP_CONDITION_MAX]; /* condition expression buffer */
+	int   bp_condition_len;              /* current character count, 0..TUI_BP_CONDITION_MAX-1 */
 } tui_state_t;
 
 /*

--- a/tests/debugger_tui_tests.c
+++ b/tests/debugger_tui_tests.c
@@ -1272,6 +1272,479 @@ static void test_panes_refresh_on_suspended(void) {
 	teardown();
 }
 
+/* =========================================================================
+ * Phase B.4 tests -- breakpoints UI.
+ *
+ * 2026-06-07 JES Phase B.4 #691
+ *
+ * Five behavioral tests per EXECUTION_PLAN.md B.4 "Tests" section:
+ *   test_f9_toggles_breakpoint_on          -- no BP, F9, setBreakpoint dispatched
+ *   test_f9_toggles_breakpoint_off         -- BP at line 3, F9, clear+readd sequence
+ *   test_gutter_renders_breakpoint_marker  -- bp_lines[0]=5, draw, cell at (0,4)=='*'
+ *   test_condition_modal_appears_on_shift_f9 -- Shift-F9, modal window exists+topmost
+ *   test_condition_modal_enter_confirms    -- type chars, Enter, modal closed, condition
+ *
+ * Additional robustness tests (applying B.1/B.2/B.3 round-1 lessons):
+ *   test_f9_no_op_when_not_suspended       -- F9 while IDLE/RUNNING is a no-op
+ *   test_f9_no_op_when_no_current_line     -- F9 with current_line <= 0 is a no-op
+ *   test_condition_modal_escape_cancels    -- Escape cancels without dispatching
+ *   test_condition_modal_cursor_visible    -- cursor is visible while modal is open
+ *   test_condition_modal_cursor_hidden_on_close -- cursor hidden after modal closes
+ *   test_gutter_shows_current_and_bp_overlap   -- line has both bp and current mark
+ *   test_footer_shows_f9_hint_when_suspended   -- footer includes F9:bp hint
+ * ========================================================================= */
+
+/* -------------------------------------------------------------------------
+ * test_f9_toggles_breakpoint_on
+ *
+ * Spec: State: no breakpoints; current_line = 3; inject F9.
+ * Verify dispatched JSON contains "op":"debug/setBreakpoint" with "line":3.
+ * ---------------------------------------------------------------------- */
+static void test_f9_toggles_breakpoint_on(void) {
+	setup();
+	g_state.debug_state      = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id = 1;
+	g_state.current_line     = 3;
+	g_state.bp_line_count    = 0;
+	strncpy(g_state.script_path, "test.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+	reset_dispatch_capture();
+
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	int rc = debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(rc == TUI_CONTINUE);
+	/* Must dispatch setBreakpoint for line 3 */
+	assert(strstr(g_dispatch_buf, "debug/setBreakpoint") != NULL);
+	assert(strstr(g_dispatch_buf, "\"line\":3") != NULL);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_f9_toggles_breakpoint_off
+ *
+ * Spec: State: breakpoints at lines 3 and 7; current_line = 3; inject F9.
+ * Verify the dispatched sequence includes debug/clearBreakpoints first,
+ * then debug/setBreakpoint for line 7 (the surviving breakpoint) but NOT
+ * for line 3.
+ *
+ * The toggle-off implementation issues multiple op_dispatch calls in sequence.
+ * The dispatch_capture_buf captures the LAST call. Since the clear-and-readd
+ * sequence dispatches: clearBreakpoints, then setBreakpoint for each surviving
+ * line, the last dispatch will be setBreakpoint for line 7. The test also
+ * checks that a clearBreakpoints was dispatched by re-using a secondary buffer
+ * approach: we call the F9 handler with a larger capture that accumulates all
+ * calls via a counted dispatch mechanism.
+ *
+ * Simpler approach: use the multi-capture buffer technique (TUI_DISPATCH_LOG).
+ * For B.4, we use the single-buffer approach and check what the test can observe:
+ * - First F9 press when bp_line_count >= 2 must dispatch clearBreakpoints.
+ *   We verify this by checking that g_dispatch_buf at some point contained
+ *   "clearBreakpoints", using a counted-dispatch helper.
+ *
+ * Implementation note: the tui_state_t dispatch capture is a single slot that
+ * records the most-recent dispatch. For multi-step sequences, the test captures
+ * EACH dispatch call sequentially by resetting g_dispatch_buf to observe the
+ * clear step.
+ *
+ * To test multi-step dispatch: we use a dispatch log array that records all
+ * dispatches in order. This requires a new test-only mechanism: a multi-dispatch
+ * capture log in tui_state_t (see debugger_tui_internal.h B.4 additions).
+ * ---------------------------------------------------------------------- */
+static void test_f9_toggles_breakpoint_off(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 3;
+	/* Set up two breakpoints: lines 3 (to be removed) and 7 (to survive) */
+	g_state.bp_line_count     = 2;
+	g_state.bp_lines[0]       = 3;
+	g_state.bp_lines[1]       = 7;
+	strncpy(g_state.script_path, "test.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+	reset_dispatch_capture();
+
+	/* Use multi-dispatch log for sequence verification */
+	char dispatch_log[TUI_DISPATCH_LOG_COUNT][256];
+	memset(dispatch_log, 0, sizeof(dispatch_log));
+	g_state.dispatch_log      = (char (*)[256])dispatch_log;
+	g_state.dispatch_log_cap  = TUI_DISPATCH_LOG_COUNT;
+	g_state.dispatch_log_count = 0;
+
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	int rc = debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(rc == TUI_CONTINUE);
+
+	/* The sequence must be: clearBreakpoints, setBreakpoint(line=7) */
+	assert(g_state.dispatch_log_count >= 2);
+	/* First dispatch: clearBreakpoints */
+	assert(strstr(dispatch_log[0], "debug/clearBreakpoints") != NULL);
+	/* Second dispatch: setBreakpoint for line 7 (the surviving line) */
+	assert(strstr(dispatch_log[1], "debug/setBreakpoint") != NULL);
+	assert(strstr(dispatch_log[1], "\"line\":7") != NULL);
+	/* No setBreakpoint for line 3 in any dispatch */
+	bool found_line3_set = false;
+	for (int i = 0; i < g_state.dispatch_log_count; i++) {
+		if (strstr(dispatch_log[i], "debug/setBreakpoint") != NULL &&
+		    strstr(dispatch_log[i], "\"line\":3") != NULL) {
+			found_line3_set = true;
+		}
+	}
+	assert(!found_line3_set);
+
+	/* Clean up */
+	g_state.dispatch_log      = NULL;
+	g_state.dispatch_log_cap  = 0;
+	g_state.dispatch_log_count = 0;
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_gutter_renders_breakpoint_marker
+ *
+ * Spec: Set state.bp_lines[0] = 5; set state.script_line_count = 10; draw.
+ * Verify cell at content (0, 4) has ch == '*'.
+ *
+ * Off-by-one: line 5 (1-based) is content row 4 (0-based).
+ * Gutter is content column 0.
+ * Screen mapping: script_win at (0,0), borders on -> content (0,4) is at
+ *   screen (0 + 1 + 0, 0 + 1 + 4) = (1, 5).
+ * ---------------------------------------------------------------------- */
+static void test_gutter_renders_breakpoint_marker(void) {
+	setup();
+
+	fill_script_lines(&g_state, 10);
+	g_state.bp_line_count  = 1;
+	g_state.bp_lines[0]    = 5;      /* 1-based */
+	g_state.current_line   = -1;     /* not current, so plain '*' gutter */
+
+	boxen_window_invalidate(g_state.script_win);
+	boxen_present();
+
+	/* Content (0, 4) = screen (rect.x+1, rect.y+1+4) */
+	boxen_rect_t r = boxen_window_get_rect(g_state.script_win);
+	int screen_col = r.x + 1;       /* left border + content col 0 */
+	int screen_row = r.y + 1 + 4;   /* top border + content row 4 */
+	const boxen_mock_cell_t *cell = boxen_mock_cell_at(screen_col, screen_row);
+	assert(cell != NULL);
+	assert(cell->ch == (uint32_t)'*');
+
+	free_script_lines(&g_state);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_condition_modal_appears_on_shift_f9
+ *
+ * Spec: Inject Shift-F9 with current_line = 5.
+ * Verify a modal window is now the topmost window at its center cell.
+ * Specifically: g_state.condition_modal_win must be non-NULL.
+ *
+ * We test via the state field (condition_modal_win != NULL) rather than
+ * boxen_window_at, because the modal center cell calculation requires
+ * knowing the terminal dimensions and the modal rect, which is internal
+ * to the implementation. The behavioral contract is that condition_modal_win
+ * is set when the modal is open and the cursor is visible.
+ * ---------------------------------------------------------------------- */
+static void test_condition_modal_appears_on_shift_f9(void) {
+	setup();
+	g_state.debug_state      = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id = 1;
+	g_state.current_line     = 5;
+	g_state.bp_line_count    = 0;
+	strncpy(g_state.script_path, "test.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_SHIFT);
+	int rc = debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(rc == TUI_CONTINUE);
+	/* Modal must be open */
+	assert(g_state.condition_modal_win != NULL);
+	/* Cursor must be visible (A.7 API used for text input) */
+	assert(boxen_mock_cursor_visible() == true);
+
+	/* Close the modal for clean teardown */
+	if (g_state.condition_modal_win != NULL) {
+		boxen_window_set_modal(g_state.condition_modal_win, false);
+		boxen_window_close(g_state.condition_modal_win);
+		g_state.condition_modal_win = NULL;
+	}
+	boxen_window_set_cursor_visible(g_state.script_win, false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_condition_modal_enter_confirms
+ *
+ * Spec: Open modal; push characters 'x', '>', '0'; push Enter.
+ * Verify the modal is closed (condition_modal_win == NULL).
+ * Verify dispatched debug/setBreakpoint JSON contains "condition":"x>0".
+ *
+ * Procedure:
+ *   1. Open modal via Shift-F9.
+ *   2. Push printable characters through run_one_tick while modal is open.
+ *   3. Push Enter.
+ *   4. Assert modal is closed.
+ *   5. Assert dispatched JSON contains "condition":"x>0" and "line":5.
+ * ---------------------------------------------------------------------- */
+static void test_condition_modal_enter_confirms(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 5;
+	g_state.bp_line_count     = 0;
+	strncpy(g_state.script_path, "test.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+
+	/* Step 1: open modal via Shift-F9 */
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_SHIFT);
+	debugger_tui_run_one_tick(&g_state, &ev);
+	assert(g_state.condition_modal_win != NULL);
+
+	/* Step 2: type 'x', '>', '0' */
+	char chars[] = {'x', '>', '0'};
+	for (int i = 0; i < 3; i++) {
+		memset(&ev, 0, sizeof(ev));
+		ev.type    = BOXEN_EV_KEY;
+		ev.key.key = BOXEN_KEY_NONE;
+		ev.key.ch  = (uint32_t)chars[i];
+		ev.key.mod = BOXEN_MOD_NONE;
+		debugger_tui_run_one_tick(&g_state, &ev);
+	}
+
+	/* Step 3: push Enter to confirm */
+	reset_dispatch_capture();
+	memset(&ev, 0, sizeof(ev));
+	ev.type    = BOXEN_EV_KEY;
+	ev.key.key = BOXEN_KEY_ENTER;
+	ev.key.ch  = 0;
+	ev.key.mod = BOXEN_MOD_NONE;
+	int rc = debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(rc == TUI_CONTINUE);
+	/* Modal must be closed */
+	assert(g_state.condition_modal_win == NULL);
+	/* Cursor must be hidden after modal closes */
+	assert(boxen_mock_cursor_visible() == false);
+	/* Dispatch must have occurred with condition and line */
+	assert(strstr(g_dispatch_buf, "debug/setBreakpoint") != NULL);
+	assert(strstr(g_dispatch_buf, "\"condition\":\"x>0\"") != NULL);
+	assert(strstr(g_dispatch_buf, "\"line\":5") != NULL);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_f9_no_op_when_not_suspended
+ *
+ * F9 pressed while TUI_DEBUG_IDLE or TUI_DEBUG_RUNNING must be a no-op:
+ * no dispatch, state unchanged.
+ * ---------------------------------------------------------------------- */
+static void test_f9_no_op_when_not_suspended(void) {
+	setup();
+	g_state.debug_state   = TUI_DEBUG_IDLE;
+	g_state.current_line  = 3;
+	g_state.bp_line_count = 0;
+	reset_dispatch_capture();
+
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(g_dispatch_buf[0] == '\0');
+
+	/* Also verify no-op when RUNNING */
+	g_state.debug_state = TUI_DEBUG_RUNNING;
+	memset(g_dispatch_buf, 0, sizeof(g_dispatch_buf));
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(g_dispatch_buf[0] == '\0');
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_f9_no_op_when_no_current_line
+ *
+ * F9 with current_line <= 0 (no suspended line) must be a no-op.
+ * ---------------------------------------------------------------------- */
+static void test_f9_no_op_when_no_current_line(void) {
+	setup();
+	g_state.debug_state   = TUI_DEBUG_SUSPENDED;
+	g_state.current_line  = -1;   /* not suspended in any line */
+	g_state.bp_line_count = 0;
+	reset_dispatch_capture();
+
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(g_dispatch_buf[0] == '\0');
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_condition_modal_escape_cancels
+ *
+ * Open modal via Shift-F9, then press Escape.
+ * Assert: modal is closed, no dispatch occurred, cursor hidden.
+ * ---------------------------------------------------------------------- */
+static void test_condition_modal_escape_cancels(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 5;
+	g_state.bp_line_count     = 0;
+	strncpy(g_state.script_path, "test.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+	reset_dispatch_capture();
+
+	/* Open modal */
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_SHIFT);
+	debugger_tui_run_one_tick(&g_state, &ev);
+	assert(g_state.condition_modal_win != NULL);
+
+	/* Reset dispatch buf to detect if anything is dispatched on cancel */
+	memset(g_dispatch_buf, 0, sizeof(g_dispatch_buf));
+
+	/* Press Escape to cancel */
+	memset(&ev, 0, sizeof(ev));
+	ev.type    = BOXEN_EV_KEY;
+	ev.key.key = BOXEN_KEY_ESCAPE;
+	ev.key.ch  = 0;
+	ev.key.mod = BOXEN_MOD_NONE;
+	int rc = debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(rc == TUI_CONTINUE);
+	/* Modal must be closed, no dispatch */
+	assert(g_state.condition_modal_win == NULL);
+	assert(g_dispatch_buf[0] == '\0');
+	/* Cursor must be hidden */
+	assert(boxen_mock_cursor_visible() == false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_condition_modal_cursor_visible
+ *
+ * When the condition modal is open, the cursor must be visible (A.7 API).
+ * Specifically: after Shift-F9, boxen_mock_cursor_visible() == true.
+ * ---------------------------------------------------------------------- */
+static void test_condition_modal_cursor_visible(void) {
+	setup();
+	g_state.debug_state      = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id = 1;
+	g_state.current_line     = 3;
+	g_state.bp_line_count    = 0;
+	strncpy(g_state.script_path, "s.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_SHIFT);
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(g_state.condition_modal_win != NULL);
+	assert(boxen_mock_cursor_visible() == true);
+
+	/* Clean up */
+	boxen_window_set_modal(g_state.condition_modal_win, false);
+	boxen_window_close(g_state.condition_modal_win);
+	g_state.condition_modal_win = NULL;
+	boxen_window_set_cursor_visible(g_state.script_win, false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_condition_modal_cursor_hidden_on_close
+ *
+ * After the condition modal closes (via Enter or Escape), the cursor must
+ * be hidden. This verifies the modal lifecycle per EXECUTION_PLAN.md B.4
+ * sentinel: "when modal closes, MUST call boxen_window_set_cursor_visible(false)".
+ * ---------------------------------------------------------------------- */
+static void test_condition_modal_cursor_hidden_on_close(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 3;
+	g_state.bp_line_count     = 0;
+	strncpy(g_state.script_path, "s.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+	reset_dispatch_capture();
+
+	/* Open modal */
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_SHIFT);
+	debugger_tui_run_one_tick(&g_state, &ev);
+	assert(boxen_mock_cursor_visible() == true);
+
+	/* Close via Escape */
+	memset(&ev, 0, sizeof(ev));
+	ev.type    = BOXEN_EV_KEY;
+	ev.key.key = BOXEN_KEY_ESCAPE;
+	ev.key.ch  = 0;
+	ev.key.mod = BOXEN_MOD_NONE;
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(g_state.condition_modal_win == NULL);
+	assert(boxen_mock_cursor_visible() == false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_gutter_shows_current_and_bp_overlap
+ *
+ * When a line is BOTH the current execution line AND has a breakpoint,
+ * the gutter must show '>' (current-line takes precedence).
+ *
+ * Per draw_script_pane implementation: the current-line check runs first.
+ * This test verifies the priority ordering.
+ * ---------------------------------------------------------------------- */
+static void test_gutter_shows_current_and_bp_overlap(void) {
+	setup();
+
+	fill_script_lines(&g_state, 5);
+	g_state.bp_line_count  = 1;
+	g_state.bp_lines[0]    = 3;      /* breakpoint at line 3 */
+	g_state.current_line   = 3;      /* also the current line */
+
+	boxen_window_invalidate(g_state.script_win);
+	boxen_present();
+
+	/* Content row 2 = line 3.  Screen: (rect.x+1, rect.y+1+2). */
+	boxen_rect_t r = boxen_window_get_rect(g_state.script_win);
+	int screen_col = r.x + 1;
+	int screen_row = r.y + 1 + 2;
+	const boxen_mock_cell_t *cell = boxen_mock_cell_at(screen_col, screen_row);
+	assert(cell != NULL);
+	/* Current-line marker takes priority over breakpoint marker */
+	assert(cell->ch == (uint32_t)'>');
+
+	free_script_lines(&g_state);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_footer_shows_f9_hint_when_suspended
+ *
+ * When debug_state == TUI_DEBUG_SUSPENDED, footer must include "F9:bp".
+ * ---------------------------------------------------------------------- */
+static void test_footer_shows_f9_hint_when_suspended(void) {
+	setup();
+	g_state.debug_state = TUI_DEBUG_SUSPENDED;
+
+	boxen_window_invalidate(g_state.footer_win);
+	boxen_present();
+
+	assert(boxen_mock_has_text("F9:bp"));
+
+	teardown();
+}
+
 /* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
@@ -1322,6 +1795,20 @@ int main(void) {
 	TR_RUN(test_footer_shows_hints_when_suspended);
 	TR_RUN(test_suspended_resets_debug_state);
 	TR_RUN(test_panes_refresh_on_suspended);
+
+	/* B.4 tests */
+	TR_RUN(test_f9_toggles_breakpoint_on);
+	TR_RUN(test_f9_toggles_breakpoint_off);
+	TR_RUN(test_gutter_renders_breakpoint_marker);
+	TR_RUN(test_condition_modal_appears_on_shift_f9);
+	TR_RUN(test_condition_modal_enter_confirms);
+	TR_RUN(test_f9_no_op_when_not_suspended);
+	TR_RUN(test_f9_no_op_when_no_current_line);
+	TR_RUN(test_condition_modal_escape_cancels);
+	TR_RUN(test_condition_modal_cursor_visible);
+	TR_RUN(test_condition_modal_cursor_hidden_on_close);
+	TR_RUN(test_gutter_shows_current_and_bp_overlap);
+	TR_RUN(test_footer_shows_f9_hint_when_suspended);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();

--- a/tests/debugger_tui_tests.c
+++ b/tests/debugger_tui_tests.c
@@ -1366,9 +1366,9 @@ static void test_f9_toggles_breakpoint_off(void) {
 	reset_dispatch_capture();
 
 	/* Use multi-dispatch log for sequence verification */
-	char dispatch_log[TUI_DISPATCH_LOG_COUNT][256];
+	char dispatch_log[TUI_DISPATCH_LOG_COUNT][TUI_DISPATCH_LOG_SLOT];
 	memset(dispatch_log, 0, sizeof(dispatch_log));
-	g_state.dispatch_log      = (char (*)[256])dispatch_log;
+	g_state.dispatch_log      = (char (*)[TUI_DISPATCH_LOG_SLOT])dispatch_log;
 	g_state.dispatch_log_cap  = TUI_DISPATCH_LOG_COUNT;
 	g_state.dispatch_log_count = 0;
 
@@ -1745,6 +1745,211 @@ static void test_footer_shows_f9_hint_when_suspended(void) {
 	teardown();
 }
 
+/* =========================================================================
+ * Phase B.4 round-1 review regression tests (#743).
+ *
+ * 2026-06-07 JES Phase B.4 #743 round 1
+ *
+ * Three behavioral tests covering the four gate findings:
+ *   P1-A (bar-raiser):
+ *     test_toggle_off_preserves_condition  -- conditional BP survives toggle-off
+ *   P1-A (security):
+ *     test_json_escape_in_script_path      -- script_path with " is escaped in dispatch
+ *   P2 (bar-raiser):
+ *     test_f9_no_op_after_resume           -- F9 after F5 (RUNNING state) is no-op
+ * ========================================================================= */
+
+/* -------------------------------------------------------------------------
+ * test_toggle_off_preserves_condition
+ *
+ * Regression for P1-A (bar-raiser): condition stripped from surviving BPs
+ * during toggle-off clear-and-readd.
+ *
+ * Sequence:
+ *   1. Place BP at line 10 with condition "x>0" (simulate via bp_lines +
+ *      bp_conditions directly, as if it came from a prior Shift-F9 confirm).
+ *   2. Place unconditional BP at line 20.
+ *   3. Set current_line = 20; inject F9 (toggle-off line 20).
+ *   4. Assert dispatch sequence:
+ *      - slot 0: debug/clearBreakpoints
+ *      - slot 1: debug/setBreakpoint for line 10 WITH "condition":"x>0"
+ *   5. Assert slot 1 does NOT contain line 20 (removed).
+ *
+ * RED: before fix, slot 1 had no "condition" field (conditions not stored).
+ * GREEN: after fix, slot 1 contains "\"condition\":\"x>0\"".
+ * ---------------------------------------------------------------------- */
+static void test_toggle_off_preserves_condition(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 20;   /* line to toggle off */
+	strncpy(g_state.script_path, "my.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+
+	/* Set up two BPs: line 10 conditional, line 20 unconditional */
+	g_state.bp_line_count     = 2;
+	g_state.bp_lines[0]       = 10;
+	g_state.bp_conditions[0]  = strdup("x>0");  /* heap-owned condition */
+	g_state.bp_lines[1]       = 20;
+	g_state.bp_conditions[1]  = NULL;            /* unconditional */
+
+	reset_dispatch_capture();
+
+	/* Multi-dispatch log to capture the full sequence */
+	char dispatch_log[TUI_DISPATCH_LOG_COUNT][TUI_DISPATCH_LOG_SLOT];
+	memset(dispatch_log, 0, sizeof(dispatch_log));
+	g_state.dispatch_log       = (char (*)[TUI_DISPATCH_LOG_SLOT])dispatch_log;
+	g_state.dispatch_log_cap   = TUI_DISPATCH_LOG_COUNT;
+	g_state.dispatch_log_count = 0;
+
+	/* F9 on line 20: toggle off */
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	int rc = debugger_tui_run_one_tick(&g_state, &ev);
+
+	assert(rc == TUI_CONTINUE);
+
+	/* Sequence must be: clearBreakpoints, then setBreakpoint(line=10, cond) */
+	assert(g_state.dispatch_log_count >= 2);
+
+	/* Slot 0: clearBreakpoints */
+	assert(strstr(dispatch_log[0], "debug/clearBreakpoints") != NULL);
+
+	/* Slot 1: setBreakpoint for line 10 WITH condition "x>0" */
+	assert(strstr(dispatch_log[1], "debug/setBreakpoint") != NULL);
+	assert(strstr(dispatch_log[1], "\"line\":10") != NULL);
+	/* GREEN assertion: condition must be present after the fix */
+	assert(strstr(dispatch_log[1], "\"condition\":\"x>0\"") != NULL);
+
+	/* No setBreakpoint for line 20 anywhere in the log */
+	bool found_line20_set = false;
+	for (int i = 0; i < g_state.dispatch_log_count; i++) {
+		if (strstr(dispatch_log[i], "debug/setBreakpoint") != NULL &&
+		    strstr(dispatch_log[i], "\"line\":20") != NULL) {
+			found_line20_set = true;
+		}
+	}
+	assert(!found_line20_set);
+
+	/* Cleanup: bp_conditions[0] was consumed (freed) by the toggle; the teardown
+	 * path frees remaining slots, but since we mutated the count during the
+	 * toggle the slot 0 condition was already freed by tui_toggle_breakpoint.
+	 * The surviving entry (line 10) at new index 0 now has bp_conditions[0]
+	 * pointing at the re-inserted strdup from bp_conditions -- teardown frees it.
+	 * Just null out dispatch_log fields so teardown doesn't double-free. */
+	g_state.dispatch_log       = NULL;
+	g_state.dispatch_log_cap   = 0;
+	g_state.dispatch_log_count = 0;
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_json_escape_in_script_path
+ *
+ * Regression for P1-A (security): script_path containing a double-quote was
+ * interpolated unescaped into outbound JSON, producing malformed JSON.
+ *
+ * Sequence:
+ *   1. Simulate a debug/suspended notification arriving with a script path
+ *      that contains a double-quote: 'foo"bar'.
+ *   2. Set current_line = 5 and inject F9 (toggle BP on).
+ *   3. Assert the dispatched JSON correctly escapes the quote:
+ *      the captured string contains \"script\":\"foo\\\"bar\" (escaped form).
+ *
+ * RED: before fix, dispatch contained 'foo"bar' raw, breaking JSON.
+ * GREEN: after fix, dispatch contains 'foo\"bar' (the quote is escaped).
+ * ---------------------------------------------------------------------- */
+static void test_json_escape_in_script_path(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 5;
+	g_state.bp_line_count     = 0;
+
+	/* Script path with an embedded double-quote (user-influenced name) */
+	strncpy(g_state.script_path, "foo\"bar", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+
+	reset_dispatch_capture();
+
+	/* F9: toggle BP on at line 5 */
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	/* The dispatch must have occurred */
+	assert(strstr(g_dispatch_buf, "debug/setBreakpoint") != NULL);
+
+	/* GREEN: the double-quote must be escaped as \" in the JSON output.
+	 * In C string: the JSON text "foo\"bar" is represented as "foo\\\"bar" in
+	 * the dispatch buffer (the backslash is literal, the quote is literal).
+	 * We search for the 8-char sequence: f o o \ " b a r */
+	assert(strstr(g_dispatch_buf, "foo\\\"bar") != NULL);
+
+	/* Sanity: the unescaped form must NOT appear as a bare unescaped quote
+	 * in the script field.  We verify by checking the dispatch buffer does not
+	 * contain the raw JSON-breaking sequence ..."script":"foo"bar"... */
+	/* The raw unescaped form would look like "script":"foo"bar" where the
+	 * second quote terminates the value early.  After escaping the buffer
+	 * has "script":"foo\"bar" which strstr("foo\"bar") finds -- confirmed above.
+	 * The raw form "foo"bar" is definitively absent when the escaped form is present
+	 * and the buffer is parseable JSON (structural check is done implicitly). */
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_f9_no_op_after_resume
+ *
+ * Regression for P2 (bar-raiser): F9 gated on current_line > 0 but
+ * current_line was not reset on resume, so F9 could fire against the stale
+ * last-suspended line position while TUI_DEBUG_RUNNING.
+ *
+ * Note: the primary guard is debug_state == TUI_DEBUG_SUSPENDED in on_input.
+ * This test exercises the defense-in-depth: after F5, debug_state == RUNNING
+ * so F9 is blocked by the outer guard AND current_line is reset to 0.
+ *
+ * Sequence:
+ *   1. Set up SUSPENDED with current_line = 7 and script_path = "s.script".
+ *   2. Inject F5 (transitions to RUNNING; current_line must become 0).
+ *   3. Assert debug_state == TUI_DEBUG_RUNNING.
+ *   4. Assert current_line == 0.
+ *   5. Reset dispatch buffer; inject F9.
+ *   6. Assert no dispatch was captured (F9 is blocked while RUNNING).
+ *
+ * RED: before fix, current_line remained 7 after F5; a hypothetical future
+ * path that skipped the debug_state check could fire F9 at the stale line.
+ * GREEN: after fix, current_line == 0 after F5, and F9 produces no dispatch.
+ * ---------------------------------------------------------------------- */
+static void test_f9_no_op_after_resume(void) {
+	setup();
+	g_state.debug_state       = TUI_DEBUG_SUSPENDED;
+	g_state.pending_thread_id  = 1;
+	g_state.current_line      = 7;
+	strncpy(g_state.script_path, "s.script", sizeof(g_state.script_path) - 1);
+	g_state.script_path[sizeof(g_state.script_path) - 1] = '\0';
+	g_state.bp_line_count     = 0;
+	reset_dispatch_capture();
+
+	/* Step 1: inject F5 -- transitions to RUNNING and resets current_line */
+	boxen_event_t ev = make_fkey_event(BOXEN_KEY_F5, BOXEN_MOD_NONE);
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	/* Verify RUNNING state and cleared current_line */
+	assert(g_state.debug_state == TUI_DEBUG_RUNNING);
+	/* GREEN assertion: current_line must be 0 (reset by tui_do_continue) */
+	assert(g_state.current_line == 0);
+
+	/* Step 2: reset capture and inject F9 -- must be a no-op */
+	memset(g_dispatch_buf, 0, sizeof(g_dispatch_buf));
+	ev = make_fkey_event(BOXEN_KEY_F9, BOXEN_MOD_NONE);
+	debugger_tui_run_one_tick(&g_state, &ev);
+
+	/* No dispatch should have occurred */
+	assert(g_dispatch_buf[0] == '\0');
+
+	teardown();
+}
+
 /* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
@@ -1809,6 +2014,11 @@ int main(void) {
 	TR_RUN(test_condition_modal_cursor_hidden_on_close);
 	TR_RUN(test_gutter_shows_current_and_bp_overlap);
 	TR_RUN(test_footer_shows_f9_hint_when_suspended);
+
+	/* B.4 round-1 review regression tests (#743) */
+	TR_RUN(test_toggle_off_preserves_condition);
+	TR_RUN(test_json_escape_in_script_path);
+	TR_RUN(test_f9_no_op_after_resume);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();


### PR DESCRIPTION
## Summary

Implements **Milestone B.4** of `planning/phase_b/EXECUTION_PLAN.md` — breakpoint UI. Builds on B.3 (#741, merged at `6783d247d`).

**What this PR proves:** breakpoint toggle and conditional-breakpoint configuration are wired end-to-end. F9 dispatches `debug/setBreakpoint` (or the clear-and-readd sequence on toggle-off); the gutter renders `*` markers at breakpoint lines; Shift-F9 opens a modal text input that uses the **A.7 cursor API directly** (per the plan update at `ae08f3659`), submits a conditional breakpoint with `condition` parameter on Enter.

## What ships

- `frontier-cli/debugger_tui.c` — F9 toggle logic, condition modal (open/draw/input/close), `tui_close_condition_modal`, dispatch-log extension to `tui_dispatch_json`, B.4 init/teardown
- `frontier-cli/debugger_tui_internal.h` — `TUI_BP_CONDITION_MAX`, `TUI_DISPATCH_LOG_COUNT`, modal + condition buffer + dispatch-log fields
- `tests/debugger_tui_tests.c` — 12 new behavioral tests covering toggle on/off, gutter render, modal lifecycle, Enter/Escape, condition dispatch

Diff: 3 files, +892/-1.

## A.7 cursor API used directly

Per `ae08f3659`'s plan update, the condition modal uses:
- `boxen_window_set_modal(modal, true)` — routes cursor calls to the modal automatically
- `boxen_window_set_cursor(modal, cx, cy)` — content-local coords; viewport clipping handled
- `boxen_window_set_cursor_visible(modal, true)`

No reverse-video block-cell workaround anywhere. On close, both visibility and modal flags are released.

## Plan deviations (all in commit message)

1. **`test_condition_modal_appears_on_shift_f9`** asserts `g_state.condition_modal_win != NULL` and `boxen_mock_cursor_visible() == true` instead of `boxen_window_at` testing the topmost window for the modal's center cell. Behavioral contract is equivalent and more robust (doesn't depend on internal modal rect).
2. **`bp_condition_buf` placed in `tui_state_t`** instead of stack-allocated per modal invocation. Required by the hard constraint (no new file-static globals per #742). Buffer is cleared on each modal open so behavior is identical.
3. **`dispatch_log` mechanism is additive, not a deviation** — needed for the `test_f9_toggles_breakpoint_off` test to assert the clear-and-readd sequence.

## TDD red/green

RED (before implementation):
```
Assertion failed: (strstr(g_dispatch_buf, "debug/setBreakpoint") != NULL),
function test_f9_toggles_breakpoint_on, file debugger_tui_tests.c, line 1318.
[test_report] debugger_tui_tests: 37/45 tests passed (8 FAILED)
```

GREEN (after implementation):
```
[test_report] debugger_tui_tests: 45/45 tests passed
```

## Test plan

- [x] `make build` — clean (4 pre-existing typedef-redefinition warnings)
- [x] `./tools/run_headless_tests.sh` — **713/713 pass** (was 701; +12 new B.4 tests)
- [x] `cd tests && make test-integration` — 2186 pass / 21 baseline failures (failure names character-for-character identical)

## What's NOT in this PR

- Cmd-double-click + watchpoints (B.5)
- `debug_set_attach_transport` wiring (B.6)
- Scratch-eval pane (B.7)
- Shell integration test for real-terminal coverage (#736)

## Lessons-applied proactively (from B.0-B.3 review history)

- Breakpoint list capped at `TUI_MAX_BREAKPOINTS`, `calloc` not `malloc`, silent truncate (no log_warn per #740)
- Condition string capped at `TUI_BP_CONDITION_MAX = 256` with bounded copy
- Modal lifecycle: close paths release both cursor visibility AND modal flag
- New state fields cleared in `state_init`, freed in `state_teardown`
- F9 dispatch gated on `debug_state == SUSPENDED` (matches B.3 pattern)
- No new file-static globals (per #742)
- All new draw callbacks apply linebuf cap pattern (gutter render, modal render)

## Sentinel verification

GIL hot path indirectly touched (modal lifecycle, dispatch path). Per `/auto` Phase 5 criterion 8, main-session integration verification run from this worktree at HEAD `2e73e777b`. Integration failure-name set matches baseline character-for-character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
