### PR TITLE
fix(boxen): promote default C locale before backend init

### DIFF
--- a/frontier-cli/boxen/boxen.c
+++ b/frontier-cli/boxen/boxen.c
@@ -75,6 +75,7 @@
  * equivalent external lock. No internal synchronization.
  */
 
+#include <locale.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -184,6 +185,23 @@ boxen_result_t boxen_init(const boxen_backend_t *backend,
 	if (backend == NULL) {
 		boxen__set_last_error("backend must not be NULL");
 		return BOXEN_ERR_INVALID;
+	}
+
+	/* 2026-06-07 JES: opt LC_CTYPE into the user's UTF-8 locale before the
+	 * backend initializes its terminal layer. termbox2 (and any other
+	 * iswprint-based renderer) filters out non-ASCII codepoints under the
+	 * default "C" locale, replacing box-drawing chars with U+FFFD -- which
+	 * shows up as the diamond-question-mark glyph in macOS Terminal.
+	 *
+	 * Override-friendly: if the embedder has already set LC_CTYPE to anything
+	 * other than the C/POSIX defaults, leave their choice intact. Only flip
+	 * to the environment locale when the process is still in the startup
+	 * default state. */
+	const char *current_ctype = setlocale(LC_CTYPE, NULL);
+	if (current_ctype == NULL ||
+	    strcmp(current_ctype, "C") == 0 ||
+	    strcmp(current_ctype, "POSIX") == 0) {
+		setlocale(LC_CTYPE, "");
 	}
 
 	int rc = backend->init(backend_config);

--- a/tests/boxen_core_tests.c
+++ b/tests/boxen_core_tests.c
@@ -12,6 +12,7 @@
  */
 
 #include <assert.h>
+#include <locale.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -460,6 +461,73 @@ static void test_double_close_rejected(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * Test: boxen_init promotes the default "C" locale to the environment
+ * locale so non-ASCII codepoints (box-drawing chars, etc.) render.
+ *
+ * Regression for the diamond-question-mark glyph bug: termbox2's send_cluster
+ * calls iswprint(), which only knows ASCII under the default startup locale.
+ * Box-drawing characters got replaced with U+FFFD and showed up as the macOS
+ * Terminal missing-glyph placeholder.
+ * ---------------------------------------------------------------------- */
+
+static void test_boxen_init_promotes_default_locale(void) {
+	/* Reset to the C startup default. */
+	setlocale(LC_CTYPE, "C");
+	const char *before = setlocale(LC_CTYPE, NULL);
+	assert(before != NULL);
+	assert(strcmp(before, "C") == 0 || strcmp(before, "POSIX") == 0);
+
+	boxen_shutdown();   /* defensive */
+	boxen_mock_reset(80, 24);
+	boxen_result_t r = boxen_init(boxen_mock_backend(), NULL, NULL);
+	assert(r == BOXEN_OK);
+
+	const char *after = setlocale(LC_CTYPE, NULL);
+	assert(after != NULL);
+	/* Promotion happened: LC_CTYPE is no longer the C/POSIX default.
+	 * We can't assert an exact name because it depends on the host LANG. */
+	assert(strcmp(after, "C") != 0 && strcmp(after, "POSIX") != 0);
+
+	boxen_shutdown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test: boxen_init respects a caller-set non-default locale.
+ *
+ * If an embedder has already chosen LC_CTYPE deliberately, boxen must not
+ * silently overwrite it with the environment locale.
+ * ---------------------------------------------------------------------- */
+
+static void test_boxen_init_respects_caller_locale(void) {
+	/* Try a likely-installed UTF-8 locale. If the host doesn't have it,
+	 * setlocale returns NULL and the test becomes a no-op for that locale
+	 * choice -- still meaningful for the C/POSIX guard branch coverage above. */
+	const char *chosen = setlocale(LC_CTYPE, "en_US.UTF-8");
+	if (chosen == NULL) {
+		setlocale(LC_CTYPE, "C");
+		return;   /* host lacks en_US.UTF-8 -- skip */
+	}
+	const char *before = setlocale(LC_CTYPE, NULL);
+	assert(before != NULL);
+	char before_copy[64];
+	strncpy(before_copy, before, sizeof(before_copy) - 1);
+	before_copy[sizeof(before_copy) - 1] = '\0';
+
+	boxen_shutdown();
+	boxen_mock_reset(80, 24);
+	boxen_result_t r = boxen_init(boxen_mock_backend(), NULL, NULL);
+	assert(r == BOXEN_OK);
+
+	const char *after = setlocale(LC_CTYPE, NULL);
+	assert(after != NULL);
+	/* boxen must NOT have overwritten the caller's choice. */
+	assert(strcmp(after, before_copy) == 0);
+
+	boxen_shutdown();
+	setlocale(LC_CTYPE, "C");   /* tidy for subsequent tests */
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 
@@ -467,6 +535,8 @@ int main(void) {
 	TR_INIT("boxen_core_tests");
 
 	TR_RUN(test_init_shutdown_lifecycle);
+	TR_RUN(test_boxen_init_promotes_default_locale);
+	TR_RUN(test_boxen_init_respects_caller_locale);
 	TR_RUN(test_window_open_close);
 	TR_RUN(test_set_cell_writes_correct_terminal_coords);
 	TR_RUN(test_clip_left);


### PR DESCRIPTION
## Summary

Fixes the diamond-question-mark glyph corruption visible in `--debug-tui` on macOS Terminal (and any other terminal where the box-drawing chars rendered as U+FFFD).

## Root cause

termbox2's `send_cluster` calls `iswprint()` on every codepoint and replaces non-printable ones with U+FFFD. Under the C startup locale, `iswprint` only recognizes ASCII -- so every U+2500-series box-drawing character (and any non-ASCII content) was getting replaced. The C runtime stays in the `"C"` locale until `setlocale` is called, regardless of `$LANG` in the environment.

Symptoms in `--debug-tui`: every border, every gutter divider, every horizontal/vertical rule rendered as the macOS "missing glyph" placeholder. The footer keybind text also collapsed to just `q:quit` because most of it ran through the same iswprint filter.

## Fix

`boxen_init` now calls `setlocale(LC_CTYPE, "")` before delegating to the backend's init, but only when the current locale is the C/POSIX default. If an embedder has already chosen a locale deliberately (e.g. `setlocale(LC_CTYPE, "en_US.UTF-8")` earlier in startup), boxen leaves their choice intact.

Two new unit tests in `boxen_core_tests`:

- `test_boxen_init_promotes_default_locale` -- starts in `C`, asserts post-init locale is no longer the default.
- `test_boxen_init_respects_caller_locale` -- starts in `en_US.UTF-8` (if available), asserts post-init locale is unchanged.

## Test plan

- [x] Unit tests: 755/755 pass (was 753; +2 new locale tests)
- [x] `make -C frontier-cli dist` produces clean build
- [ ] Manual visual verification in real terminal that `dist/frontier-cli --debug-tui` now renders box-drawing chars correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
