### PR TITLE
feat(#691): TUI launch -- positional script, -e, : eval from RUNNING

### DIFF
--- a/docs/TUI_DEBUGGER_GUIDE.md
+++ b/docs/TUI_DEBUGGER_GUIDE.md
@@ -11,9 +11,45 @@ For the protocol-level interface (used by IDEs and external tools), see [`docs/C
 
 ## Launching
 
+### Attach-only (wait for a breakpoint to fire)
+
 ```bash
 ./frontier-cli/frontier-cli --debug-tui
 ```
+
+The TUI opens in RUNNING state with no script loaded. Any `thread.callScript` thread that hits a breakpoint will lazy-attach and deliver a suspension notification. This is the workflow for debugging menu-triggered code.
+
+### Launch and debug a specific ODB script
+
+```bash
+./frontier-cli/frontier-cli --debug-tui @workspace.myVerb
+```
+
+The TUI starts, compiles the source body of `workspace.myVerb`, and spawns a debug thread that suspends at the first statement before executing anything. The source pane loads immediately; the user is dropped into the entry suspension with all F-key controls live.
+
+The `@path` form is a "bare ODB address": it must start with `@` and the rest must be a dotted identifier using only `[A-Za-z0-9_.]`. If the path has whitespace, parens, or operators, it is treated as a free-form expression (see below).
+
+Running the script body is the right semantic for debugging: most Frontier.root scripts have a bundle pattern at the bottom that calls the script's entry point with test arguments. That bundle is part of the script body and runs when you F5 from the entry suspension.
+
+### Launch with an inline expression
+
+```bash
+./frontier-cli/frontier-cli --debug-tui -e "local (t); new (tableType, @t); myScript (@t)"
+```
+
+Multi-statement expressions and any expression that is not a bare ODB address are passed through to the compiler verbatim. The expression is compiled and the resulting thread starts suspended at its first statement.
+
+### Launch from a .ut source file
+
+```bash
+./frontier-cli/frontier-cli --debug-tui path/to/script.ut
+```
+
+The file is read and its contents are dispatched as an inline expression. Useful for developing and testing UserTalk scripts that live outside the system root.
+
+---
+
+All three launch forms start the debug thread suspended at the first statement (`start_suspended=true`). This is the entry-suspension behavior: you are halted before any code runs, regardless of whether breakpoints are already saved in the script. Press **F5** to run until the next saved or in-session breakpoint.
 
 Requirements:
 
@@ -82,14 +118,30 @@ In the modal:
 
 ### Scratch eval pane
 
-| Key | Action |
-|-----|--------|
-| **`:`** (SUSPENDED only) | Activates the single-line eval pane (vi-command-mode style). |
-| typing | Builds the expression. |
-| **Enter** | Dispatches `script/eval` against the suspended frame; result appears in the history above the input row. |
-| **Escape** | Dismisses the pane (the partial expression is dropped). |
+| Key | State | Action |
+|-----|-------|--------|
+| **`:`** | RUNNING (no attached thread) | Activates the eval pane for a new debug-run launch. |
+| **`:`** | SUSPENDED | Activates the eval pane to evaluate in the current frame. |
+| typing | (pane active) | Builds the expression. |
+| **Enter** | RUNNING pane | Dispatches a `debug/run`; the new thread starts suspended at the first statement. Bare ODB addresses (`@some.path`) are resolved to source text first; all other expressions pass through verbatim. |
+| **Enter** | SUSPENDED pane | Dispatches `script/eval` against the suspended frame; result appears in the history above the input row. |
+| **Escape** | (pane active) | Dismisses the pane (the partial expression is preserved for re-activation). |
+
+`:` is a no-op in IDLE state (no transport thread is active).
 
 While the eval pane is active, `q` and `:` are typed into the expression — they don't trigger quit or re-activate the pane. The eval pane is suppressed while a modal (condition / watchpoint) is open.
+
+#### Setting persistent breakpoints
+
+Breakpoints set via F9 and Shift-F9 are stored in the scriptType external for the relevant script and persist when the `.root` saves (which happens automatically at exit). This means you can install breakpoints in a prior TUI session (or via `--protocol`), save, and then relaunch with `--debug-tui @that.script` in a fresh session. You will suspend at the first statement as usual; press F5 to run until the first saved breakpoint fires.
+
+The canonical workflow for debugging an existing Frontier.root script:
+
+1. Open the script in any tool (REPL, prior TUI session, or `--protocol` from an IDE).
+2. Set breakpoints with F9 (toggle plain) or Shift-F9 (conditional).
+3. Exit so the `.root` saves the breakpoints.
+4. `./frontier-cli/frontier-cli --debug-tui @workspace.myScript`
+5. TUI opens suspended at the first statement. Press F5 to run until the first saved breakpoint.
 
 History rendering caps the visible expression at 80 characters per entry and keeps a small ring of recent results.
 
@@ -127,7 +179,13 @@ The TUI is the supported way to debug menu-triggered UserTalk code that runs on 
 4. Step or continue. Set additional breakpoints with F9. When the thread completes, the TUI returns to RUNNING.
 5. Press `q` to exit.
 
-To stop at the very first line of a known verb (e.g. `commands.open`), set the breakpoint via the protocol-level `debug/setBreakpoint` op before triggering the menu. (Setting breakpoints purely from inside the TUI when no thread is yet suspended is a Phase C convenience; not in B.)
+To stop at the very first line of a known verb (e.g. `commands.open`), use the launch-from-address form:
+
+```bash
+./frontier-cli/frontier-cli --debug-tui @commands.open
+```
+
+The TUI launches and immediately suspends at the first statement of `commands.open`. No need to set a breakpoint first; the entry suspension is unconditional. See "Setting persistent breakpoints" above if you want subsequent breakpoints to fire on F5.
 
 ---
 
@@ -171,8 +229,8 @@ These are deliberate scope cuts, not bugs:
 |---------|-------|-----|
 | "boxen_init failed" then immediate exit | Stdin/stdout not a TTY (piped or redirected). | Run from a real terminal. The TUI cannot operate without `/dev/tty`. |
 | "--debug-tui and --protocol are mutually exclusive" | Both flags on the command line. | Pick one. |
-| Step/continue keys ignored | State is RUNNING — no frame is suspended. | Wait for a breakpoint to fire, or set one and trigger the code path. |
-| Eval pane `:` does nothing | State is RUNNING, or a modal is open. | Suspend first; close any open modal with Escape. |
+| Step/continue keys ignored | State is RUNNING — no frame is suspended. | Wait for a breakpoint to fire, or press `:` to launch a new debug-run from a script address or expression. |
+| Eval pane `:` does nothing | State is IDLE (no transport), or a modal is open. | Close any open modal with Escape. In IDLE state there is no active thread; launch with `--debug-tui @path` or `:` is available once the TUI is in RUNNING or SUSPENDED. |
 | Cmd-double-click does nothing | Click landed in the gutter column, or the identifier isn't in current locals, or state is RUNNING. | Click on the source text portion (right of the line number), while suspended, on a local identifier. |
 | Quit hangs briefly | Drain step waiting for a lazy-attached thread to release the transport. | Normal; should complete in milliseconds. If it hangs >5s, investigate runtime thread state via `--protocol` from a separate session. |
 

--- a/frontier-cli/cli_parser.c
+++ b/frontier-cli/cli_parser.c
@@ -219,6 +219,16 @@ boolean cli_validate_options(const cli_options_t* options) {
 		return false;
 	}
 
+	/* 2026-06-07 JES Phase B.8 #691: --debug-tui with both inline_script AND
+	 * script_file is ambiguous -- reject the combination.  Either one alone is
+	 * valid: the startup-launch path in debugger_tui_main handles each. */
+	if (options->tui_mode &&
+	    options->script_file != NULL && options->inline_script != NULL) {
+		log_error(LOG_COMP_GENERAL,
+		          "Error: --debug-tui cannot combine -e (inline) and a script file");
+		return false;
+	}
+
 	// Note: Conflict validation for positional .root argument is handled in cli_parse_arguments()
 	// when we detect a .root file and system_root is already set.
 

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -2070,6 +2070,85 @@ void handle_debug_getstack(int id, const char *json_line, transport_t *transport
 }
 
 /*
+ * 2026-06-08 JES Phase B.8 #691 P2-7: shared ODB source-fetch helper.
+ *
+ * Walk the ODB for `path_no_at` and return a heap Handle of its source text.
+ * Caller owns the returned Handle (must call disposehandle on success).
+ * Returns nil on any error.
+ *
+ * Extracted to eliminate the parallel implementation that was in
+ * tui_real_odb_fetch (debugger_tui.c).  See debug_handler.h for full contract.
+ */
+Handle debug_get_script_source(const char *path_no_at) {
+	/* Parse the dotted path to find the containing table and leaf name. */
+	int pathlen = (int)strlen(path_no_at);
+	if (pathlen > 255) pathlen = 255;
+	bigstring bsfullpath;
+	bsfullpath[0] = (unsigned char)pathlen;
+	memcpy(bsfullpath + 1, path_no_at, (size_t)pathlen);
+
+	/* Find the last dot to split into table path + name */
+	int lastdot = -1;
+	for (int i = pathlen; i > 0; i--) {
+		if (bsfullpath[i] == '.') {
+			lastdot = i;
+			break;
+		}
+	}
+
+	if (lastdot < 0)
+		return nil;
+
+	/* Split: table path is bsfullpath[1..lastdot-1], name is bsfullpath[lastdot+1..] */
+	bigstring bstablepath, bsname;
+	bstablepath[0] = (unsigned char)(lastdot - 1);
+	memcpy(bstablepath + 1, bsfullpath + 1, (size_t)(lastdot - 1));
+
+	int namelen = pathlen - lastdot;
+	bsname[0] = (unsigned char)namelen;
+	memcpy(bsname + 1, bsfullpath + lastdot + 1, (size_t)namelen);
+
+	/* Navigate to the table */
+	hdlhashtable htable;
+	if (!langfastaddresstotable(roottable, bstablepath, &htable))
+		return nil;
+
+	/* Look up the script */
+	tyvaluerecord val;
+	hdlhashnode hnode;
+	if (!hashtablelookup(htable, bsname, &val, &hnode))
+		return nil;
+
+	Handle htext = nil;
+	if (val.valuetype == externalvaluetype) {
+		hdlexternalvariable hv = (hdlexternalvariable)val.data.externalvalue;
+
+		/* Load from database if not yet in memory. */
+		if (!(**hv).flinmemory) {
+			db_context ctx;
+			if ((**hv).hdatabase != nil && db_format_is_legacy_db((**hv).hdatabase)) {
+				db_context_init_legacy_read(&ctx, (**hv).hdatabase);
+			} else {
+				db_context_init(&ctx);
+				if ((**hv).hdatabase != nil)
+					ctx.database = (**hv).hdatabase;
+			}
+			if (!opverbinmemory(&ctx, hv))
+				return nil;
+		}
+
+		hdloutlinerecord houtline = (hdloutlinerecord)(**hv).variabledata;
+		if (houtline != nil) {
+			oppushoutline(houtline);
+			opgetlangtext(houtline, false, &htext);
+			oppopoutline();
+		}
+	}
+
+	return htext;
+}
+
+/*
  * debug/getSource — View script source with line numbers.
  *
  * Resolves a script path in the ODB, extracts the outline text,
@@ -2106,100 +2185,11 @@ void handle_debug_getsource(int id, const char *json_line, transport_t *transpor
 	if (script_path[0] == '@')
 		script_path++;
 
-	/* Resolve the script path.
-	 * Use script/eval to evaluate string(scriptAddress) — simpler than
-	 * navigating the ODB directly and handles all edge cases. */
-
-	/* Parse the dotted path to find the containing table and leaf name */
-	bigstring bsfullpath;
-	int pathlen = (int)strlen(script_path);
-	if (pathlen > 255) pathlen = 255;
-	bsfullpath[0] = (unsigned char)pathlen;
-	memcpy(bsfullpath + 1, script_path, (size_t)pathlen);
-
-	/* Find the last dot to split into table path + name */
-	int lastdot = -1;
-	for (int i = pathlen; i > 0; i--) {
-		if (bsfullpath[i] == '.') {
-			lastdot = i;
-			break;
-		}
-	}
-
-	if (lastdot < 0) {
-		char err[512];
-		snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Script path must be fully qualified (e.g. system.temp.myFunc)\"},\"success\":false}", id);
-		transport->write_line(transport->ctx, err, strlen(err));
-		cJSON_Delete(root);
-		return;
-	}
-
-	/* Split: table path is bsfullpath[1..lastdot-1], name is bsfullpath[lastdot+1..] */
-	bigstring bstablepath, bsname;
-	bstablepath[0] = (unsigned char)(lastdot - 1);
-	memcpy(bstablepath + 1, bsfullpath + 1, (size_t)(lastdot - 1));
-
-	int namelen = pathlen - lastdot;
-	bsname[0] = (unsigned char)namelen;
-	memcpy(bsname + 1, bsfullpath + lastdot + 1, (size_t)namelen);
-
-	/* Navigate to the table */
-	hdlhashtable htable;
-	if (!langfastaddresstotable(roottable, bstablepath, &htable)) {
-		char err[512];
-		snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Table not found in path\"},\"success\":false}", id);
-		transport->write_line(transport->ctx, err, strlen(err));
-		cJSON_Delete(root);
-		return;
-	}
-
-	/* Look up the script */
-	tyvaluerecord val;
-	hdlhashnode hnode;
-	if (!hashtablelookup(htable, bsname, &val, &hnode)) {
-		char err[512];
-		snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Script not found\"},\"success\":false}", id);
-		transport->write_line(transport->ctx, err, strlen(err));
-		cJSON_Delete(root);
-		return;
-	}
-
-	/* Get the script text via opgetlangtext. The protocol handler holds the GIL
-	 * (acquired before dispatch in protocol_handler.c), so ODB operations are safe. */
-	Handle htext = nil;
-
-	if (val.valuetype == externalvaluetype) {
-		hdlexternalvariable hv = (hdlexternalvariable)val.data.externalvalue;
-
-		/* Load from database if not yet in memory.
-		 * Use format-aware context to handle both v6 and v7 databases. */
-		if (!(**hv).flinmemory) {
-			db_context ctx;
-			if ((**hv).hdatabase != nil && db_format_is_legacy_db((**hv).hdatabase)) {
-				db_context_init_legacy_read(&ctx, (**hv).hdatabase);
-			} else {
-				db_context_init(&ctx);
-				if ((**hv).hdatabase != nil)
-					ctx.database = (**hv).hdatabase;
-			}
-			if (!opverbinmemory(&ctx, hv)) {
-				char err[512];
-				snprintf(err, sizeof(err),
-						 "{\"id\":%d,\"error\":{\"message\":\"Failed to load script from database\"},\"success\":false}", id);
-				transport->write_line(transport->ctx, err, strlen(err));
-				cJSON_Delete(root);
-				return;
-			}
-		}
-
-		hdloutlinerecord houtline = (hdloutlinerecord)(**hv).variabledata;
-
-		if (houtline != nil) {
-			oppushoutline(houtline);
-			opgetlangtext(houtline, false, &htext);
-			oppopoutline();
-		}
-	}
+	/* 2026-06-08 JES Phase B.8 #691 P2-7: delegate to shared helper.
+	 * debug_get_script_source handles all ODB path parsing, table navigation,
+	 * opverbinmemory loading, and opgetlangtext extraction.  Previously this
+	 * function duplicated that ~90-line body from tui_real_odb_fetch. */
+	Handle htext = debug_get_script_source(script_path);
 
 	if (htext == nil) {
 		char err[512];

--- a/frontier-cli/debug_handler.c
+++ b/frontier-cli/debug_handler.c
@@ -2079,7 +2079,13 @@ void handle_debug_getstack(int id, const char *json_line, transport_t *transport
  * Extracted to eliminate the parallel implementation that was in
  * tui_real_odb_fetch (debugger_tui.c).  See debug_handler.h for full contract.
  */
-Handle debug_get_script_source(const char *path_no_at) {
+Handle debug_get_script_source(const char *path_no_at, dbg_source_reason *out_reason) {
+	/* Helper macro: set reason if caller asked for it, then return nil. */
+	#define DBG_SRC_FAIL(code) do { \
+		if (out_reason != NULL) *out_reason = (code); \
+		return nil; \
+	} while (0)
+
 	/* Parse the dotted path to find the containing table and leaf name. */
 	int pathlen = (int)strlen(path_no_at);
 	if (pathlen > 255) pathlen = 255;
@@ -2097,7 +2103,7 @@ Handle debug_get_script_source(const char *path_no_at) {
 	}
 
 	if (lastdot < 0)
-		return nil;
+		DBG_SRC_FAIL(DBG_SRC_PATH_NOT_QUALIFIED);
 
 	/* Split: table path is bsfullpath[1..lastdot-1], name is bsfullpath[lastdot+1..] */
 	bigstring bstablepath, bsname;
@@ -2111,13 +2117,13 @@ Handle debug_get_script_source(const char *path_no_at) {
 	/* Navigate to the table */
 	hdlhashtable htable;
 	if (!langfastaddresstotable(roottable, bstablepath, &htable))
-		return nil;
+		DBG_SRC_FAIL(DBG_SRC_TABLE_NOT_FOUND);
 
 	/* Look up the script */
 	tyvaluerecord val;
 	hdlhashnode hnode;
 	if (!hashtablelookup(htable, bsname, &val, &hnode))
-		return nil;
+		DBG_SRC_FAIL(DBG_SRC_SCRIPT_NOT_FOUND);
 
 	Handle htext = nil;
 	if (val.valuetype == externalvaluetype) {
@@ -2134,18 +2140,30 @@ Handle debug_get_script_source(const char *path_no_at) {
 					ctx.database = (**hv).hdatabase;
 			}
 			if (!opverbinmemory(&ctx, hv))
-				return nil;
+				DBG_SRC_FAIL(DBG_SRC_LOAD_FAILED);
 		}
 
 		hdloutlinerecord houtline = (hdloutlinerecord)(**hv).variabledata;
 		if (houtline != nil) {
+			/* 2026-06-08 JES Phase B.8 #691 round 2 P2: longjmp assumption.
+			 * Frontier's runtime propagates errors through the
+			 * langcallbacks.errormessagecallback mechanism, not setjmp/longjmp,
+			 * so opgetlangtext returns normally on failure and oppopoutline
+			 * always runs.  If this ever changes, the push/pop pair becomes
+			 * a silent outline-stack imbalance hazard. */
 			oppushoutline(houtline);
 			opgetlangtext(houtline, false, &htext);
 			oppopoutline();
 		}
 	}
 
+	if (htext == nil)
+		DBG_SRC_FAIL(DBG_SRC_NO_TEXT);
+
+	if (out_reason != NULL) *out_reason = DBG_SRC_OK;
 	return htext;
+
+	#undef DBG_SRC_FAIL
 }
 
 /*
@@ -2188,12 +2206,37 @@ void handle_debug_getsource(int id, const char *json_line, transport_t *transpor
 	/* 2026-06-08 JES Phase B.8 #691 P2-7: delegate to shared helper.
 	 * debug_get_script_source handles all ODB path parsing, table navigation,
 	 * opverbinmemory loading, and opgetlangtext extraction.  Previously this
-	 * function duplicated that ~90-line body from tui_real_odb_fetch. */
-	Handle htext = debug_get_script_source(script_path);
+	 * function duplicated that ~90-line body from tui_real_odb_fetch.
+	 *
+	 * 2026-06-08 JES Phase B.8 #691 round 2 P2: pass out_reason so we can
+	 * preserve the specific user-facing error messages from the pre-extraction
+	 * implementation (path-not-qualified / table-not-found / script-not-found
+	 * / load-failed / no-text). */
+	dbg_source_reason reason = DBG_SRC_OK;
+	Handle htext = debug_get_script_source(script_path, &reason);
 
 	if (htext == nil) {
+		const char *msg;
+		switch (reason) {
+		case DBG_SRC_PATH_NOT_QUALIFIED:
+			msg = "Script path must be fully qualified (e.g. system.temp.myFunc)";
+			break;
+		case DBG_SRC_TABLE_NOT_FOUND:
+			msg = "Table not found in path";
+			break;
+		case DBG_SRC_SCRIPT_NOT_FOUND:
+			msg = "Script not found";
+			break;
+		case DBG_SRC_LOAD_FAILED:
+			msg = "Failed to load script from database";
+			break;
+		case DBG_SRC_NO_TEXT:
+		default:
+			msg = "Could not get script source";
+			break;
+		}
 		char err[512];
-		snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"Could not get script source\"},\"success\":false}", id);
+		snprintf(err, sizeof(err), "{\"id\":%d,\"error\":{\"message\":\"%s\"},\"success\":false}", id, msg);
 		transport->write_line(transport->ctx, err, strlen(err));
 		cJSON_Delete(root);
 		return;

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -268,14 +268,31 @@ void debug_unregister_thread(long threadid);
  * source text on success.  The caller owns the returned Handle and must call
  * disposehandle() when done.
  *
- * Returns nil on any error (path not found, not a script, ODB load failure).
+ * Returns nil on any error.  When out_reason is non-NULL on entry, it is
+ * populated with a fine-grained reason code so callers can map back to a
+ * specific user-facing error message.  Pass NULL when the caller does not
+ * need the discrimination (TUI logs a generic warning).
  *
  * GIL: must be called with GIL held (ODB operations are not thread-safe).
  *
  * Extracted from handle_debug_getsource to eliminate the parallel
  * implementation in tui_real_odb_fetch (debugger_tui.c).  Both call sites
  * now delegate to this helper.
+ *
+ * 2026-06-08 JES Phase B.8 #691 round 2 P2: added out_reason discrimination
+ * so handle_debug_getsource can preserve its pre-extraction wire-level error
+ * messages (path-not-qualified / table-not-found / script-not-found /
+ * load-failed / could-not-get).
  */
-Handle debug_get_script_source(const char *path_no_at);
+typedef enum {
+	DBG_SRC_OK = 0,            /* success -- htext returned */
+	DBG_SRC_PATH_NOT_QUALIFIED, /* path has no '.', cannot split into table+name */
+	DBG_SRC_TABLE_NOT_FOUND,    /* langfastaddresstotable failed */
+	DBG_SRC_SCRIPT_NOT_FOUND,   /* hashtablelookup returned false */
+	DBG_SRC_LOAD_FAILED,        /* opverbinmemory failed */
+	DBG_SRC_NO_TEXT             /* value not an external, or opgetlangtext returned nil */
+} dbg_source_reason;
+
+Handle debug_get_script_source(const char *path_no_at, dbg_source_reason *out_reason);
 
 #endif /* DEBUG_HANDLER_H */

--- a/frontier-cli/debug_handler.h
+++ b/frontier-cli/debug_handler.h
@@ -260,4 +260,22 @@ tydebugstate *debug_register_thread(long threadid, transport_t *transport,
  */
 void debug_unregister_thread(long threadid);
 
+/*
+ * 2026-06-08 JES Phase B.8 #691 P2-7: shared ODB source-fetch helper.
+ *
+ * Walk the ODB for the script at `path_no_at` (dotted path WITHOUT leading '@'),
+ * extract the outline text via opgetlangtext, and return a heap Handle of the
+ * source text on success.  The caller owns the returned Handle and must call
+ * disposehandle() when done.
+ *
+ * Returns nil on any error (path not found, not a script, ODB load failure).
+ *
+ * GIL: must be called with GIL held (ODB operations are not thread-safe).
+ *
+ * Extracted from handle_debug_getsource to eliminate the parallel
+ * implementation in tui_real_odb_fetch (debugger_tui.c).  Both call sites
+ * now delegate to this helper.
+ */
+Handle debug_get_script_source(const char *path_no_at);
+
 #endif /* DEBUG_HANDLER_H */

--- a/frontier-cli/debugger_tui.c
+++ b/frontier-cli/debugger_tui.c
@@ -49,6 +49,8 @@
  * 2026-06-07 JES Phase B.6 #691 #738 #740 #742 #744 #746: lazy-attach wiring + polish
  * 2026-06-07 JES Phase B.7 #691: scratch-eval pane
  * 2026-06-07 JES Phase B.7 #750: eval polish -- clear dispatched id, expr tag, monotonic [N], OOM fix
+ * 2026-06-08 JES Phase B.8 #691: TUI launch entry points (positional script,
+ *   -e expression, : eval-from-RUNNING)
  *
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2025-2026 Frontier contributors
@@ -74,6 +76,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <assert.h>       /* assert -- used in tui_real_odb_fetch GIL precondition */
+#include <stdio.h>        /* fileno */
+#include <sys/stat.h>     /* fstat, struct stat, S_ISREG */
 
 /* -------------------------------------------------------------------------
  * 2026-06-07 JES Phase B.2 #691: locals state helpers.
@@ -881,7 +886,7 @@ static int tui_json_escape(const char *src, char *dst, size_t dst_cap) {
 }
 
 /* -------------------------------------------------------------------------
- * 2026-06-07 JES Phase B.8 #691: bare ODB address detection and source fetch.
+ * 2026-06-08 JES Phase B.8 #691: bare ODB address detection and source fetch.
  *
  * tui_is_bare_odb_address -- detection rule per spec:
  *   Returns true iff s starts with '@' AND every subsequent character is
@@ -917,7 +922,7 @@ bool tui_is_bare_odb_address(const char *s) {
  * ODB scripts are typically < 32 KB; 64 KB is generous. */
 #define TUI_ODB_SOURCE_MAX 65536
 
-/* 2026-06-07 JES Phase B.8 #691: dispatch a debug/run with the given expression.
+/* 2026-06-08 JES Phase B.8 #691: dispatch a debug/run with the given expression.
  *
  * Wire format verified at debug_handler.c:1248 (handle_debug_run):
  *   request:  {"op":"debug/run","id":N,"params":{"expression":"<escaped>"}}
@@ -928,18 +933,30 @@ bool tui_is_bare_odb_address(const char *s) {
  * routes to op_dispatch -> handle_debug_run -> headless_spawn_script_thread
  * with start_suspended=true (hardcoded in handle_debug_run:1333). */
 static void tui_dispatch_debug_run(tui_state_t *s, const char *expr_text) {
-	/* JSON-escape the expression before interpolation (B.4 P1 class). */
-	char esc_expr[TUI_ODB_SOURCE_MAX * 2 + 1];
-	tui_json_escape(expr_text, esc_expr, sizeof(esc_expr));
+	/* JSON-escape the expression before interpolation (B.4 P1 class).
+	 *
+	 * tui_json_escape worst-case is 6x for control bytes (\u00XX expansion).
+	 * Allocate dynamically based on input length so the escape buffer is
+	 * always large enough.  The previous static char[TUI_ODB_SOURCE_MAX*2+1]
+	 * was sized for 2x, which would silently truncate on a source with many
+	 * control bytes.  (P1-1 fix: /gate round 1 bar-raiser + security.) */
+	size_t in_len = strlen(expr_text);
+	size_t esc_sz = in_len * 6 + 64;  /* 6x worst-case + NUL + margin */
+	char *esc_expr = malloc(esc_sz);
+	if (esc_expr == NULL) {
+		log_warn(LOG_COMP_GENERAL, "tui_dispatch_debug_run: OOM allocating escape buffer");
+		return;
+	}
+	tui_json_escape(expr_text, esc_expr, esc_sz);
 
 	int req_id = next_req_id(s);
 
-	/* +64 for JSON framing overhead; esc_expr is already escaped so the
-	 * worst-case size is 2*TUI_ODB_SOURCE_MAX + framing. */
-	size_t req_sz = sizeof(esc_expr) + 64;
+	/* +64 for JSON framing overhead. */
+	size_t req_sz = esc_sz + 64;
 	char *req = malloc(req_sz);
 	if (req == NULL) {
 		log_warn(LOG_COMP_GENERAL, "tui_dispatch_debug_run: OOM allocating request");
+		free(esc_expr);
 		return;
 	}
 	snprintf(req, req_sz,
@@ -948,9 +965,10 @@ static void tui_dispatch_debug_run(tui_state_t *s, const char *expr_text) {
 	         req_id, esc_expr);
 	tui_dispatch_json(s, req);
 	free(req);
+	free(esc_expr);
 }
 
-/* 2026-06-07 JES Phase B.8 #691: startup script launch.
+/* 2026-06-08 JES Phase B.8 #691: startup script launch.
  *
  * Called from debugger_tui_main after transport registration, and exposed
  * in the internal header for direct unit tests.
@@ -1006,7 +1024,15 @@ bool tui_launch_startup_script(tui_state_t *s,
 	/* script_file path: read the whole file, dispatch its contents */
 #ifndef DEBUGGER_TUI_OMIT_MAIN
 	/* File I/O is available in production builds.
-	 * Use stdio: script files are typically small .ut source files. */
+	 * Use stdio: script files are typically small .ut source files.
+	 *
+	 * P1-2 fix (/gate round 1 security + bar-raiser): defensive checks added.
+	 *   a. fstat and reject non-regular files (FIFOs, character devices) to prevent
+	 *      hangs (/dev/zero) or blocking (FIFO with no writer).
+	 *   b. Check ferror() after fread to distinguish read error from empty file.
+	 *   c. Reject empty files with a clear log message.
+	 *   d. Warn if file was larger than TUI_ODB_SOURCE_MAX-1 bytes (truncation
+	 *      silently produces a compilation error with no breadcrumb otherwise). */
 	{
 		FILE *f = fopen(script_file, "r");
 		if (f == NULL) {
@@ -1014,6 +1040,17 @@ bool tui_launch_startup_script(tui_state_t *s,
 			         "tui_launch_startup_script: cannot open %s", script_file);
 			return false;
 		}
+
+		/* Reject non-regular files: FIFOs hang on fread; /dev/zero fills buffer */
+		struct stat st;
+		if (fstat(fileno(f), &st) != 0 || !S_ISREG(st.st_mode)) {
+			log_warn(LOG_COMP_GENERAL,
+			         "tui_launch_startup_script: script file %s is not a regular file",
+			         script_file);
+			fclose(f);
+			return false;
+		}
+
 		char *buf = malloc(TUI_ODB_SOURCE_MAX);
 		if (buf == NULL) {
 			log_warn(LOG_COMP_GENERAL,
@@ -1022,7 +1059,28 @@ bool tui_launch_startup_script(tui_state_t *s,
 			return false;
 		}
 		size_t n = fread(buf, 1, TUI_ODB_SOURCE_MAX - 1, f);
+		int had_error = ferror(f);
 		fclose(f);
+
+		if (had_error) {
+			log_warn(LOG_COMP_GENERAL,
+			         "tui_launch_startup_script: read error on %s", script_file);
+			free(buf);
+			return false;
+		}
+		if (n == 0) {
+			log_warn(LOG_COMP_GENERAL,
+			         "tui_launch_startup_script: empty file %s", script_file);
+			free(buf);
+			return false;
+		}
+		/* Warn if the file was truncated (actual file is larger than buffer) */
+		if (n == TUI_ODB_SOURCE_MAX - 1 && st.st_size > (off_t)(TUI_ODB_SOURCE_MAX - 1)) {
+			log_warn(LOG_COMP_GENERAL,
+			         "tui_launch_startup_script: script file %s truncated at %d bytes "
+			         "(file is %lld bytes); expression may be incomplete",
+			         script_file, TUI_ODB_SOURCE_MAX - 1, (long long)st.st_size);
+		}
 		buf[n] = '\0';
 		tui_dispatch_debug_run(s, buf);
 		free(buf);
@@ -1035,7 +1093,7 @@ bool tui_launch_startup_script(tui_state_t *s,
 #endif
 }
 
-/* 2026-06-07 JES Phase B.8 #691: real ODB source fetch (production only).
+/* 2026-06-08 JES Phase B.8 #691: real ODB source fetch (production only).
  *
  * Replicates debug_handler.c:2105-2202 as a self-contained helper.  Called
  * through the odb_fetch_hook pointer in tui_state_t; never called from test
@@ -1046,96 +1104,39 @@ bool tui_launch_startup_script(tui_state_t *s,
  * out_bufsz  -- must be TUI_ODB_SOURCE_MAX
  *
  * GIL: must be called with GIL held (ODB operations are not thread-safe).
- * In the event loop all non-poll code holds the GIL, so this is satisfied.
+ * Called from (a) the startup-launch path in debugger_tui_main BEFORE the
+ * event loop begins (GIL held throughout) or (b) tui_eval_submit during the
+ * event loop AFTER pthread_mutex_lock reacquires the GIL post-poll. Both
+ * paths hold the GIL.  (P2-14 comment; P1-4 assert added at function entry.)
  */
 #ifndef DEBUGGER_TUI_OMIT_MAIN
-/* These includes are for tui_real_odb_fetch only.  They mirror the include
- * list in debug_handler.c (handle_debug_getsource uses the same types).
- * All are guarded by DEBUGGER_TUI_OMIT_MAIN for the same reason as the
- * debugger_tui_main includes below: these bring in GIL and ODB symbols that
- * are not linked in the test binary. */
-#include "debug_handler.h"                       /* langfastaddresstotable */
+/* These includes are for tui_real_odb_fetch only (and later debugger_tui_main).
+ * All are guarded by DEBUGGER_TUI_OMIT_MAIN because they bring in GIL and ODB
+ * symbols not linked in the test binary.
+ *
+ * After the P2-7 refactor (extracting debug_get_script_source), this function
+ * no longer duplicates the ODB-traversal body; the ODB-specific includes
+ * (tablestructure.h, langinternal.h, langexternal.h, opverbs.h, op.h,
+ * db_format.h) have been removed.  debug_handler.h (which provides
+ * debug_get_script_source) also pulls in frontier.h -> Handle type.
+ * gethandlesize/disposehandle come from memory.h (included below with
+ * debugger_tui_main). */
+#include "debug_handler.h"                       /* debug_get_script_source, Handle types */
 #include "headless_threading.h"                  /* frontier_gil, hthreadglobals */
-#include "../Common/headers/tablestructure.h"    /* roottable */
-#include "../Common/headers/langinternal.h"      /* langfastaddresstotable */
-#include "../Common/headers/langexternal.h"      /* hdlexternalvariable */
-#include "../Common/headers/opverbs.h"           /* opverbinmemory */
-#include "../Common/headers/op.h"                /* oppushoutline, opgetlangtext, oppopoutline */
-#include "db_format.h"                           /* db_context, db_context_init */
 
 static bool tui_real_odb_fetch(const char *path_no_at,
                                 char *out_buf, size_t out_bufsz) {
-	/* Parse the dotted path to find the containing table and leaf name.
-	 * Mirrors debug_handler.c:2114-2144 exactly. */
-	int pathlen = (int)strlen(path_no_at);
-	if (pathlen > 255) pathlen = 255;
-	bigstring bsfullpath;
-	bsfullpath[0] = (unsigned char)pathlen;
-	memcpy(bsfullpath + 1, path_no_at, (size_t)pathlen);
+	/* P1-4 fix (/gate round 1 concurrency): assert GIL is held.
+	 * hthreadglobals is per-thread and only non-nil when this thread holds
+	 * runtime state (i.e., the GIL).  Both call sites (startup-launch in
+	 * debugger_tui_main and tui_eval_submit post-poll) hold the GIL; this
+	 * assert catches future callers that do not.  Pattern from debug_handler.c. */
+	assert(hthreadglobals != nil);
 
-	int lastdot = -1;
-	for (int i = pathlen; i > 0; i--) {
-		if (bsfullpath[i] == '.') {
-			lastdot = i;
-			break;
-		}
-	}
-	if (lastdot < 0) {
-		log_warn(LOG_COMP_GENERAL,
-		         "tui_real_odb_fetch: path not fully qualified: %s", path_no_at);
-		return false;
-	}
-
-	bigstring bstablepath, bsname;
-	bstablepath[0] = (unsigned char)(lastdot - 1);
-	memcpy(bstablepath + 1, bsfullpath + 1, (size_t)(lastdot - 1));
-
-	int namelen = pathlen - lastdot;
-	bsname[0] = (unsigned char)namelen;
-	memcpy(bsname + 1, bsfullpath + lastdot + 1, (size_t)namelen);
-
-	hdlhashtable htable;
-	if (!langfastaddresstotable(roottable, bstablepath, &htable)) {
-		log_warn(LOG_COMP_GENERAL,
-		         "tui_real_odb_fetch: table not found for %s", path_no_at);
-		return false;
-	}
-
-	tyvaluerecord val;
-	hdlhashnode hnode;
-	if (!hashtablelookup(htable, bsname, &val, &hnode)) {
-		log_warn(LOG_COMP_GENERAL,
-		         "tui_real_odb_fetch: script not found: %s", path_no_at);
-		return false;
-	}
-
-	Handle htext = nil;
-	if (val.valuetype == externalvaluetype) {
-		hdlexternalvariable hv = (hdlexternalvariable)val.data.externalvalue;
-		if (!(**hv).flinmemory) {
-			db_context ctx;
-			if ((**hv).hdatabase != nil && db_format_is_legacy_db((**hv).hdatabase)) {
-				db_context_init_legacy_read(&ctx, (**hv).hdatabase);
-			} else {
-				db_context_init(&ctx);
-				if ((**hv).hdatabase != nil)
-					ctx.database = (**hv).hdatabase;
-			}
-			if (!opverbinmemory(&ctx, hv)) {
-				log_warn(LOG_COMP_GENERAL,
-				         "tui_real_odb_fetch: opverbinmemory failed for %s",
-				         path_no_at);
-				return false;
-			}
-		}
-		hdloutlinerecord houtline = (hdloutlinerecord)(**hv).variabledata;
-		if (houtline != nil) {
-			oppushoutline(houtline);
-			opgetlangtext(houtline, false, &htext);
-			oppopoutline();
-		}
-	}
-
+	/* P2-7 refactor (/gate round 1): delegate to the shared helper extracted
+	 * from debug_handler.c to eliminate the ~90-line duplicated ODB-traversal
+	 * body (P2-7 fix, /gate round 1 bar-raiser). */
+	Handle htext = debug_get_script_source(path_no_at);
 	if (htext == nil) {
 		log_warn(LOG_COMP_GENERAL,
 		         "tui_real_odb_fetch: no source text for %s", path_no_at);
@@ -1201,7 +1202,7 @@ static bool tui_real_odb_fetch(const char *path_no_at,
 
 void tui_eval_activate(tui_state_t *s) {
 	if (s == NULL) return;
-	/* 2026-06-07 JES Phase B.8 #691: accept both SUSPENDED and RUNNING.
+	/* 2026-06-08 JES Phase B.8 #691: accept both SUSPENDED and RUNNING.
 	 * SUSPENDED -> evaluates in current frame (existing script/eval path).
 	 * RUNNING   -> launches a new debug-run (new tui_eval_submit branch).
 	 * IDLE remains excluded: no transport thread to dispatch to. */
@@ -1320,7 +1321,7 @@ void tui_eval_submit(tui_state_t *s) {
 	if (s == NULL) return;
 	if (s->eval_input_buf[0] == '\0') return; /* empty: nothing to evaluate */
 
-	/* 2026-06-07 JES Phase B.8 #691: branch on debug_state.
+	/* 2026-06-08 JES Phase B.8 #691: branch on debug_state.
 	 *
 	 * RUNNING  -> new debug-run launch.  The expression (possibly a bare ODB
 	 *   address resolved to source text) is dispatched as debug/run.  This
@@ -1332,17 +1333,30 @@ void tui_eval_submit(tui_state_t *s) {
 	 * Other states (IDLE): tui_eval_activate already prevents reaching here.
 	 */
 	if (s->debug_state == TUI_DEBUG_RUNNING) {
-		/* 2026-06-07 JES Phase B.8 #691: RUNNING path -- new debug-run launch.
+		/* 2026-06-08 JES Phase B.8 #691 P1-3 fix: RUNNING path -- new debug-run launch.
 		 *
 		 * Detection: is the input a bare ODB address?
 		 *   Yes -> resolve source via odb_fetch_hook, dispatch debug/run
 		 *   No  -> dispatch debug/run with verbatim expression
 		 *
 		 * tui_launch_startup_script handles both sub-cases.  We pass
-		 * eval_input_buf as inline_expr and NULL as script_file. */
-		tui_launch_startup_script(s, s->eval_input_buf, NULL);
-
-		/* Clear input after dispatch; dismiss pane */
+		 * eval_input_buf as inline_expr and NULL as script_file.
+		 *
+		 * P1-3 fix (/gate round 1 bar-raiser): capture the return value.
+		 *   On failure: surface an error entry to the eval history so the user
+		 *   sees something, and preserve eval_input_buf so they can fix and retry.
+		 *   On success: clear input and dismiss as before. */
+		bool ok = tui_launch_startup_script(s, s->eval_input_buf, NULL);
+		if (!ok) {
+			/* Surface failure in the eval history so the user sees it.
+			 * Do NOT clear eval_input_buf -- preserve for retry. */
+			tui_eval_append_result(s, s->eval_input_buf, "error: launch failed (see log)");
+			/* Invalidate footer so the history entry renders immediately. */
+			if (s->footer_win != NULL)
+				boxen_window_invalidate(s->footer_win);
+			return;
+		}
+		/* Success: clear input and dismiss pane */
 		s->eval_input_buf[0] = '\0';
 		s->eval_input_cursor = 0;
 		tui_eval_dismiss(s);
@@ -2477,7 +2491,7 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev, void *ud) {
 		return;
 	}
 
-	/* 2026-06-07 JES Phase B.8 #691: ':' activates the eval pane.
+	/* 2026-06-08 JES Phase B.8 #691: ':' activates the eval pane.
 	 * Available when SUSPENDED (evaluate in frame) or RUNNING (new debug-run
 	 * launch).  IDLE is excluded: no transport thread to dispatch to.
 	 * When pane is already active, ':' is caught by the eval handler above
@@ -2644,7 +2658,7 @@ void debugger_tui_state_init(tui_state_t *s, int tw, int th) {
 	s->eval_last_expr[0]         = '\0';
 	s->eval_display_counter      = 0;
 
-	/* 2026-06-07 JES Phase B.8 #691: ODB source-fetch hook.
+	/* 2026-06-08 JES Phase B.8 #691: ODB source-fetch hook.
 	 * Production sets this to tui_real_odb_fetch (inside OMIT_MAIN guard below).
 	 * Test builds leave it NULL; tests that exercise the ODB path set it
 	 * explicitly to a mock before calling tui_eval_submit or
@@ -2725,6 +2739,10 @@ void debugger_tui_state_teardown(tui_state_t *s) {
 	/* 2026-06-07 JES Phase B.7 #750: zero polish fields */
 	s->eval_last_expr[0]         = '\0';
 	s->eval_display_counter      = 0;
+	/* 2026-06-08 JES Phase B.8 #691 P2-15: NULL odb_fetch_hook for defense-in-depth.
+	 * After teardown the hook pointer is stale; zeroing it prevents a future
+	 * accidental call through a dangling function pointer. */
+	s->odb_fetch_hook = NULL;
 	s->debug_state = TUI_DEBUG_IDLE;
 }
 
@@ -2858,17 +2876,19 @@ int debugger_tui_main(const cli_options_t *opts) {
 	 * See planning/phase_b/EXECUTION_PLAN.md B.6 "Teardown sequence". */
 	debug_set_attach_transport(state->transport);
 
-	/* 2026-06-07 JES Phase B.8 #691: startup-script launch.
+	/* 2026-06-08 JES Phase B.8 #691: startup-script launch.
 	 *
 	 * If the user passed a script argument (--debug-tui @path, --debug-tui -e expr,
 	 * or --debug-tui file.ut), kick off the debug-run now -- after transport
 	 * registration so the suspended notification can arrive through the transport
 	 * and the TUI can display it.
 	 *
-	 * state->debug_state starts at TUI_DEBUG_IDLE; the thread spawned by
-	 * handle_debug_run will suspend at its first statement and send a
-	 * debug/suspended notification via write_line, which transitions the TUI to
-	 * TUI_DEBUG_SUSPENDED and loads the source pane.
+	 * state->debug_state starts at TUI_DEBUG_IDLE; this call will asynchronously
+	 * transition the TUI to TUI_DEBUG_SUSPENDED and load the source pane when the
+	 * spawned thread suspends at its entry point and calls back through
+	 * tui_write_line.  The transition is NOT synchronous with the call below --
+	 * it occurs during a future boxen_poll_event GIL yield.
+	 * (P1-5 fix: /gate round 1 concurrency -- corrected sync-implying comment.)
 	 */
 	if (opts->inline_script != NULL || opts->script_file != NULL) {
 		tui_launch_startup_script(state, opts->inline_script, opts->script_file);

--- a/frontier-cli/debugger_tui.c
+++ b/frontier-cli/debugger_tui.c
@@ -881,6 +881,279 @@ static int tui_json_escape(const char *src, char *dst, size_t dst_cap) {
 }
 
 /* -------------------------------------------------------------------------
+ * 2026-06-07 JES Phase B.8 #691: bare ODB address detection and source fetch.
+ *
+ * tui_is_bare_odb_address -- detection rule per spec:
+ *   Returns true iff s starts with '@' AND every subsequent character is
+ *   [A-Za-z0-9_.].  No whitespace, no parens, no operators.
+ *
+ * tui_real_odb_fetch -- production ODB source lookup (inside OMIT_MAIN guard).
+ *   Replicates the pipeline from debug_handler.c:2105-2202.  Not compiled in
+ *   test builds; the odb_fetch_hook on tui_state_t is NULL in that case.
+ *
+ * tui_dispatch_debug_run -- dispatch a debug/run JSON with the given source
+ *   expression text.  Used by both tui_eval_submit (RUNNING path) and
+ *   tui_launch_startup_script.
+ * ---------------------------------------------------------------------- */
+
+bool tui_is_bare_odb_address(const char *s) {
+	if (s == NULL || s[0] != '@') return false;
+	const char *p = s + 1;
+	if (*p == '\0') return false;  /* bare '@' alone is not an address */
+	while (*p != '\0') {
+		char c = *p;
+		if (!((c >= 'A' && c <= 'Z') ||
+		      (c >= 'a' && c <= 'z') ||
+		      (c >= '0' && c <= '9') ||
+		      c == '_' || c == '.')) {
+			return false;
+		}
+		p++;
+	}
+	return true;
+}
+
+/* Maximum source buffer size for bare-address resolution.
+ * ODB scripts are typically < 32 KB; 64 KB is generous. */
+#define TUI_ODB_SOURCE_MAX 65536
+
+/* 2026-06-07 JES Phase B.8 #691: dispatch a debug/run with the given expression.
+ *
+ * Wire format verified at debug_handler.c:1248 (handle_debug_run):
+ *   request:  {"op":"debug/run","id":N,"params":{"expression":"<escaped>"}}
+ *   response: {"id":N,"result":{"threadId":T,"status":"started"},"success":true}
+ *
+ * The TUI dispatches this via tui_dispatch_json.  In test builds the dispatch
+ * is captured in dispatch_capture_buf (no runtime call).  In production it
+ * routes to op_dispatch -> handle_debug_run -> headless_spawn_script_thread
+ * with start_suspended=true (hardcoded in handle_debug_run:1333). */
+static void tui_dispatch_debug_run(tui_state_t *s, const char *expr_text) {
+	/* JSON-escape the expression before interpolation (B.4 P1 class). */
+	char esc_expr[TUI_ODB_SOURCE_MAX * 2 + 1];
+	tui_json_escape(expr_text, esc_expr, sizeof(esc_expr));
+
+	int req_id = next_req_id(s);
+
+	/* +64 for JSON framing overhead; esc_expr is already escaped so the
+	 * worst-case size is 2*TUI_ODB_SOURCE_MAX + framing. */
+	size_t req_sz = sizeof(esc_expr) + 64;
+	char *req = malloc(req_sz);
+	if (req == NULL) {
+		log_warn(LOG_COMP_GENERAL, "tui_dispatch_debug_run: OOM allocating request");
+		return;
+	}
+	snprintf(req, req_sz,
+	         "{\"op\":\"debug/run\",\"id\":%d,"
+	         "\"params\":{\"expression\":\"%s\"}}",
+	         req_id, esc_expr);
+	tui_dispatch_json(s, req);
+	free(req);
+}
+
+/* 2026-06-07 JES Phase B.8 #691: startup script launch.
+ *
+ * Called from debugger_tui_main after transport registration, and exposed
+ * in the internal header for direct unit tests.
+ *
+ * Resolution rules:
+ *   - If inline_expr is a bare ODB address (@path): call odb_fetch_hook to
+ *     get the source text, then dispatch debug/run with that source.
+ *   - If inline_expr is freeform: dispatch debug/run verbatim.
+ *   - If script_file is non-NULL: read the file, dispatch debug/run.
+ *   - Both NULL or both non-NULL: no-op, return false.
+ */
+bool tui_launch_startup_script(tui_state_t *s,
+                                const char *inline_expr,
+                                const char *script_file) {
+	if (s == NULL) return false;
+	if (inline_expr == NULL && script_file == NULL) return false;
+	if (inline_expr != NULL && script_file != NULL) return false;
+
+	if (inline_expr != NULL) {
+		if (tui_is_bare_odb_address(inline_expr)) {
+			/* Resolve ODB source via hook */
+			if (s->odb_fetch_hook == NULL) {
+				log_warn(LOG_COMP_GENERAL,
+				         "tui_launch_startup_script: odb_fetch_hook is NULL, "
+				         "cannot resolve %s", inline_expr);
+				return false;
+			}
+			char *src = malloc(TUI_ODB_SOURCE_MAX);
+			if (src == NULL) {
+				log_warn(LOG_COMP_GENERAL,
+				         "tui_launch_startup_script: OOM allocating source buffer");
+				return false;
+			}
+			bool ok = s->odb_fetch_hook(inline_expr + 1 /* skip '@' */,
+			                            src, (size_t)TUI_ODB_SOURCE_MAX);
+			if (!ok) {
+				log_warn(LOG_COMP_GENERAL,
+				         "tui_launch_startup_script: ODB source fetch failed for %s",
+				         inline_expr);
+				free(src);
+				return false;
+			}
+			tui_dispatch_debug_run(s, src);
+			free(src);
+			return true;
+		} else {
+			/* Freeform expression: pass through verbatim */
+			tui_dispatch_debug_run(s, inline_expr);
+			return true;
+		}
+	}
+
+	/* script_file path: read the whole file, dispatch its contents */
+#ifndef DEBUGGER_TUI_OMIT_MAIN
+	/* File I/O is available in production builds.
+	 * Use stdio: script files are typically small .ut source files. */
+	{
+		FILE *f = fopen(script_file, "r");
+		if (f == NULL) {
+			log_warn(LOG_COMP_GENERAL,
+			         "tui_launch_startup_script: cannot open %s", script_file);
+			return false;
+		}
+		char *buf = malloc(TUI_ODB_SOURCE_MAX);
+		if (buf == NULL) {
+			log_warn(LOG_COMP_GENERAL,
+			         "tui_launch_startup_script: OOM allocating file buffer");
+			fclose(f);
+			return false;
+		}
+		size_t n = fread(buf, 1, TUI_ODB_SOURCE_MAX - 1, f);
+		fclose(f);
+		buf[n] = '\0';
+		tui_dispatch_debug_run(s, buf);
+		free(buf);
+		return true;
+	}
+#else
+	/* Test builds: script_file path is not exercised (tests use inline_expr). */
+	(void)script_file;
+	return false;
+#endif
+}
+
+/* 2026-06-07 JES Phase B.8 #691: real ODB source fetch (production only).
+ *
+ * Replicates debug_handler.c:2105-2202 as a self-contained helper.  Called
+ * through the odb_fetch_hook pointer in tui_state_t; never called from test
+ * builds (the pointer is NULL in OMIT_MAIN builds).
+ *
+ * path_no_at -- dotted ODB path without leading '@' (e.g. "workspace.foo")
+ * out_buf    -- caller-allocated buffer, TUI_ODB_SOURCE_MAX bytes
+ * out_bufsz  -- must be TUI_ODB_SOURCE_MAX
+ *
+ * GIL: must be called with GIL held (ODB operations are not thread-safe).
+ * In the event loop all non-poll code holds the GIL, so this is satisfied.
+ */
+#ifndef DEBUGGER_TUI_OMIT_MAIN
+/* These includes are for tui_real_odb_fetch only.  They mirror the include
+ * list in debug_handler.c (handle_debug_getsource uses the same types).
+ * All are guarded by DEBUGGER_TUI_OMIT_MAIN for the same reason as the
+ * debugger_tui_main includes below: these bring in GIL and ODB symbols that
+ * are not linked in the test binary. */
+#include "debug_handler.h"                       /* langfastaddresstotable */
+#include "headless_threading.h"                  /* frontier_gil, hthreadglobals */
+#include "../Common/headers/tablestructure.h"    /* roottable */
+#include "../Common/headers/langinternal.h"      /* langfastaddresstotable */
+#include "../Common/headers/langexternal.h"      /* hdlexternalvariable */
+#include "../Common/headers/opverbs.h"           /* opverbinmemory */
+#include "../Common/headers/op.h"                /* oppushoutline, opgetlangtext, oppopoutline */
+#include "db_format.h"                           /* db_context, db_context_init */
+
+static bool tui_real_odb_fetch(const char *path_no_at,
+                                char *out_buf, size_t out_bufsz) {
+	/* Parse the dotted path to find the containing table and leaf name.
+	 * Mirrors debug_handler.c:2114-2144 exactly. */
+	int pathlen = (int)strlen(path_no_at);
+	if (pathlen > 255) pathlen = 255;
+	bigstring bsfullpath;
+	bsfullpath[0] = (unsigned char)pathlen;
+	memcpy(bsfullpath + 1, path_no_at, (size_t)pathlen);
+
+	int lastdot = -1;
+	for (int i = pathlen; i > 0; i--) {
+		if (bsfullpath[i] == '.') {
+			lastdot = i;
+			break;
+		}
+	}
+	if (lastdot < 0) {
+		log_warn(LOG_COMP_GENERAL,
+		         "tui_real_odb_fetch: path not fully qualified: %s", path_no_at);
+		return false;
+	}
+
+	bigstring bstablepath, bsname;
+	bstablepath[0] = (unsigned char)(lastdot - 1);
+	memcpy(bstablepath + 1, bsfullpath + 1, (size_t)(lastdot - 1));
+
+	int namelen = pathlen - lastdot;
+	bsname[0] = (unsigned char)namelen;
+	memcpy(bsname + 1, bsfullpath + lastdot + 1, (size_t)namelen);
+
+	hdlhashtable htable;
+	if (!langfastaddresstotable(roottable, bstablepath, &htable)) {
+		log_warn(LOG_COMP_GENERAL,
+		         "tui_real_odb_fetch: table not found for %s", path_no_at);
+		return false;
+	}
+
+	tyvaluerecord val;
+	hdlhashnode hnode;
+	if (!hashtablelookup(htable, bsname, &val, &hnode)) {
+		log_warn(LOG_COMP_GENERAL,
+		         "tui_real_odb_fetch: script not found: %s", path_no_at);
+		return false;
+	}
+
+	Handle htext = nil;
+	if (val.valuetype == externalvaluetype) {
+		hdlexternalvariable hv = (hdlexternalvariable)val.data.externalvalue;
+		if (!(**hv).flinmemory) {
+			db_context ctx;
+			if ((**hv).hdatabase != nil && db_format_is_legacy_db((**hv).hdatabase)) {
+				db_context_init_legacy_read(&ctx, (**hv).hdatabase);
+			} else {
+				db_context_init(&ctx);
+				if ((**hv).hdatabase != nil)
+					ctx.database = (**hv).hdatabase;
+			}
+			if (!opverbinmemory(&ctx, hv)) {
+				log_warn(LOG_COMP_GENERAL,
+				         "tui_real_odb_fetch: opverbinmemory failed for %s",
+				         path_no_at);
+				return false;
+			}
+		}
+		hdloutlinerecord houtline = (hdloutlinerecord)(**hv).variabledata;
+		if (houtline != nil) {
+			oppushoutline(houtline);
+			opgetlangtext(houtline, false, &htext);
+			oppopoutline();
+		}
+	}
+
+	if (htext == nil) {
+		log_warn(LOG_COMP_GENERAL,
+		         "tui_real_odb_fetch: no source text for %s", path_no_at);
+		return false;
+	}
+
+	/* Copy handle contents to out_buf (NUL-terminated, truncated if needed) */
+	long hsize = gethandlesize(htext);
+	long copy_len = hsize;
+	if (copy_len >= (long)out_bufsz) copy_len = (long)out_bufsz - 1;
+	memcpy(out_buf, *htext, (size_t)copy_len);
+	out_buf[copy_len] = '\0';
+	disposehandle(htext);
+	return true;
+}
+#endif /* !DEBUGGER_TUI_OMIT_MAIN */
+
+/* -------------------------------------------------------------------------
  * 2026-06-07 JES Phase B.7 #691: scratch-eval pane helpers.
  *
  * tui_eval_activate   -- enter ':' eval mode: set eval_pane_active, show cursor
@@ -928,7 +1201,11 @@ static int tui_json_escape(const char *src, char *dst, size_t dst_cap) {
 
 void tui_eval_activate(tui_state_t *s) {
 	if (s == NULL) return;
-	if (s->debug_state != TUI_DEBUG_SUSPENDED) return; /* guard: SUSPENDED only */
+	/* 2026-06-07 JES Phase B.8 #691: accept both SUSPENDED and RUNNING.
+	 * SUSPENDED -> evaluates in current frame (existing script/eval path).
+	 * RUNNING   -> launches a new debug-run (new tui_eval_submit branch).
+	 * IDLE remains excluded: no transport thread to dispatch to. */
+	if (s->debug_state == TUI_DEBUG_IDLE) return;
 	if (s->eval_pane_active) return;                   /* already active */
 
 	s->eval_pane_active = true;
@@ -1042,6 +1319,37 @@ void tui_eval_append_result(tui_state_t *s, const char *expr, const char *result
 void tui_eval_submit(tui_state_t *s) {
 	if (s == NULL) return;
 	if (s->eval_input_buf[0] == '\0') return; /* empty: nothing to evaluate */
+
+	/* 2026-06-07 JES Phase B.8 #691: branch on debug_state.
+	 *
+	 * RUNNING  -> new debug-run launch.  The expression (possibly a bare ODB
+	 *   address resolved to source text) is dispatched as debug/run.  This
+	 *   starts a new thread suspended at the first statement.
+	 *
+	 * SUSPENDED -> existing script/eval path (evaluate in current frame).
+	 *   Unchanged from B.7.
+	 *
+	 * Other states (IDLE): tui_eval_activate already prevents reaching here.
+	 */
+	if (s->debug_state == TUI_DEBUG_RUNNING) {
+		/* 2026-06-07 JES Phase B.8 #691: RUNNING path -- new debug-run launch.
+		 *
+		 * Detection: is the input a bare ODB address?
+		 *   Yes -> resolve source via odb_fetch_hook, dispatch debug/run
+		 *   No  -> dispatch debug/run with verbatim expression
+		 *
+		 * tui_launch_startup_script handles both sub-cases.  We pass
+		 * eval_input_buf as inline_expr and NULL as script_file. */
+		tui_launch_startup_script(s, s->eval_input_buf, NULL);
+
+		/* Clear input after dispatch; dismiss pane */
+		s->eval_input_buf[0] = '\0';
+		s->eval_input_cursor = 0;
+		tui_eval_dismiss(s);
+		return;
+	}
+
+	/* SUSPENDED path: existing script/eval dispatch (unchanged from B.7). */
 
 	/* SENTINEL: tui_json_escape the expression before JSON interpolation.
 	 * B.4 P1 security class: user input MUST be escaped.
@@ -2169,11 +2477,14 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev, void *ud) {
 		return;
 	}
 
-	/* 2026-06-07 JES Phase B.7 #691: ':' activates the eval pane.
-	 * Only available when SUSPENDED and pane not already active.
-	 * When active, ':' is caught by the eval handler above. */
+	/* 2026-06-07 JES Phase B.8 #691: ':' activates the eval pane.
+	 * Available when SUSPENDED (evaluate in frame) or RUNNING (new debug-run
+	 * launch).  IDLE is excluded: no transport thread to dispatch to.
+	 * When pane is already active, ':' is caught by the eval handler above
+	 * (typed into the expression buffer).
+	 * tui_eval_activate enforces the IDLE guard internally. */
 	if (ev->key.key == BOXEN_KEY_NONE && ev->key.ch == ':' &&
-	    s->debug_state == TUI_DEBUG_SUSPENDED && !s->eval_pane_active) {
+	    s->debug_state != TUI_DEBUG_IDLE && !s->eval_pane_active) {
 		tui_eval_activate(s);
 		return;
 	}
@@ -2333,6 +2644,16 @@ void debugger_tui_state_init(tui_state_t *s, int tw, int th) {
 	s->eval_last_expr[0]         = '\0';
 	s->eval_display_counter      = 0;
 
+	/* 2026-06-07 JES Phase B.8 #691: ODB source-fetch hook.
+	 * Production sets this to tui_real_odb_fetch (inside OMIT_MAIN guard below).
+	 * Test builds leave it NULL; tests that exercise the ODB path set it
+	 * explicitly to a mock before calling tui_eval_submit or
+	 * tui_launch_startup_script. */
+	s->odb_fetch_hook = NULL;
+#ifndef DEBUGGER_TUI_OMIT_MAIN
+	s->odb_fetch_hook = tui_real_odb_fetch;
+#endif
+
 	/* Allocate heap transport (stub; B.6 wires debug_set_attach_transport) */
 	s->transport = calloc(1, sizeof(transport_t));
 	if (s->transport != NULL) {
@@ -2466,7 +2787,6 @@ int debugger_tui_run_one_tick(tui_state_t *s, const boxen_event_t *ev) {
 #include <pthread.h>
 
 int debugger_tui_main(const cli_options_t *opts) {
-	(void)opts;
 
 	/* 2026-06-07 JES Phase B.6 #691 #738: heap-allocate tui_state_t.
 	 *
@@ -2537,6 +2857,22 @@ int debugger_tui_main(const cli_options_t *opts) {
 	 * Pattern mirrors protocol_handler.c:412-424 exactly.
 	 * See planning/phase_b/EXECUTION_PLAN.md B.6 "Teardown sequence". */
 	debug_set_attach_transport(state->transport);
+
+	/* 2026-06-07 JES Phase B.8 #691: startup-script launch.
+	 *
+	 * If the user passed a script argument (--debug-tui @path, --debug-tui -e expr,
+	 * or --debug-tui file.ut), kick off the debug-run now -- after transport
+	 * registration so the suspended notification can arrive through the transport
+	 * and the TUI can display it.
+	 *
+	 * state->debug_state starts at TUI_DEBUG_IDLE; the thread spawned by
+	 * handle_debug_run will suspend at its first statement and send a
+	 * debug/suspended notification via write_line, which transitions the TUI to
+	 * TUI_DEBUG_SUSPENDED and loads the source pane.
+	 */
+	if (opts->inline_script != NULL || opts->script_file != NULL) {
+		tui_launch_startup_script(state, opts->inline_script, opts->script_file);
+	}
 
 	log_info(LOG_COMP_GENERAL, "Debugger TUI: entering event loop (q/Esc/Ctrl-C to quit)");
 

--- a/frontier-cli/debugger_tui.c
+++ b/frontier-cli/debugger_tui.c
@@ -1135,8 +1135,13 @@ static bool tui_real_odb_fetch(const char *path_no_at,
 
 	/* P2-7 refactor (/gate round 1): delegate to the shared helper extracted
 	 * from debug_handler.c to eliminate the ~90-line duplicated ODB-traversal
-	 * body (P2-7 fix, /gate round 1 bar-raiser). */
-	Handle htext = debug_get_script_source(path_no_at);
+	 * body (P2-7 fix, /gate round 1 bar-raiser).
+	 *
+	 * 2026-06-08 JES Phase B.8 #691 round 2 P2: pass NULL for out_reason -- the
+	 * TUI logs a generic warning regardless of which step failed, so it does not
+	 * need the fine-grained discrimination that handle_debug_getsource needs to
+	 * preserve its protocol-level error messages. */
+	Handle htext = debug_get_script_source(path_no_at, NULL);
 	if (htext == nil) {
 		log_warn(LOG_COMP_GENERAL,
 		         "tui_real_odb_fetch: no source text for %s", path_no_at);

--- a/frontier-cli/debugger_tui_internal.h
+++ b/frontier-cli/debugger_tui_internal.h
@@ -16,6 +16,8 @@
  * 2026-06-07 JES Phase B.6 #744: TUI_DISPATCH_LOG_SLOT widened to 2048
  * 2026-06-07 JES Phase B.7 #691: scratch-eval pane fields and constants
  * 2026-06-07 JES Phase B.7 #750: eval_last_expr, eval_display_counter added
+ * 2026-06-07 JES Phase B.8 #691: odb_fetch_hook, tui_launch_startup_script,
+ *   tui_is_bare_odb_address
  */
 
 #ifndef DEBUGGER_TUI_INTERNAL_H
@@ -321,6 +323,27 @@ typedef struct {
 	 *   past EVAL_HISTORY_MAX as expected. */
 	char  eval_last_expr[EVAL_INPUT_MAX];
 	int   eval_display_counter;
+
+	/* 2026-06-07 JES Phase B.8 #691: ODB source-fetch hook.
+	 *
+	 * In production (non-OMIT_MAIN), debugger_tui_state_init sets this to
+	 * tui_real_odb_fetch -- the static helper that replicates the
+	 * handle_debug_getsource ODB-address-to-source-text pipeline (see
+	 * debug_handler.c:2105-2202).
+	 *
+	 * In test builds (DEBUGGER_TUI_OMIT_MAIN), tui_real_odb_fetch is not
+	 * compiled in.  Tests set odb_fetch_hook to a local mock before calling
+	 * tui_eval_submit or tui_launch_startup_script.  When the hook is NULL,
+	 * the fetch silently returns false (same outcome as an ODB error).
+	 *
+	 * Signature:
+	 *   path_no_at -- dotted ODB path WITHOUT the leading '@' (e.g. "some.address")
+	 *   out_buf    -- caller-supplied buffer to receive NUL-terminated source text
+	 *   out_bufsz  -- size of out_buf in bytes
+	 * Returns true on success, false on any failure (path not found, ODB error,
+	 * buffer too small after truncation would corrupt, etc.).
+	 */
+	bool (*odb_fetch_hook)(const char *path_no_at, char *out_buf, size_t out_bufsz);
 } tui_state_t;
 
 /*
@@ -400,5 +423,42 @@ void debugger_tui_state_init(tui_state_t *s, int tw, int th);
  * Caller is responsible for calling boxen_shutdown() afterwards.
  */
 void debugger_tui_state_teardown(tui_state_t *s);
+
+/*
+ * 2026-06-07 JES Phase B.8 #691: bare ODB address detection.
+ *
+ * Returns true iff `s` starts with '@' AND every subsequent character is
+ * [A-Za-z0-9_.] (no whitespace, no parens, no operators).
+ *
+ * This is the canonical detection rule: input is a bare ODB address iff
+ * it starts with '@' and the rest is purely a dotted identifier.  Anything
+ * else (multi-statement, expression with operators, etc.) is free-form and
+ * passes through verbatim.
+ */
+bool tui_is_bare_odb_address(const char *s);
+
+/*
+ * 2026-06-07 JES Phase B.8 #691: startup script launch.
+ *
+ * Resolves `script_expr` (bare ODB address or freeform expression), compiles
+ * it, and dispatches a debug/run request.  Called from debugger_tui_main after
+ * transport registration when the user passed --debug-tui with a script argument.
+ *
+ * Parameters:
+ *   s           -- TUI state (must be initialized; transport set up).
+ *   inline_expr -- inline expression string ("-e ...") or bare ODB address
+ *                  ("@workspace.foo"), or NULL if launching from a .ut file.
+ *   script_file -- path to a .ut file, or NULL if using inline_expr.
+ *
+ * Exactly one of inline_expr / script_file must be non-NULL.
+ * Does nothing (returns false) if both are NULL or both are non-NULL.
+ *
+ * Returns true if dispatch was sent, false on resolution / read failure.
+ *
+ * Exposed in the internal header so tests can call it directly.
+ */
+bool tui_launch_startup_script(tui_state_t *s,
+                                const char *inline_expr,
+                                const char *script_file);
 
 #endif /* DEBUGGER_TUI_INTERNAL_H */

--- a/frontier-cli/debugger_tui_internal.h
+++ b/frontier-cli/debugger_tui_internal.h
@@ -16,7 +16,7 @@
  * 2026-06-07 JES Phase B.6 #744: TUI_DISPATCH_LOG_SLOT widened to 2048
  * 2026-06-07 JES Phase B.7 #691: scratch-eval pane fields and constants
  * 2026-06-07 JES Phase B.7 #750: eval_last_expr, eval_display_counter added
- * 2026-06-07 JES Phase B.8 #691: odb_fetch_hook, tui_launch_startup_script,
+ * 2026-06-08 JES Phase B.8 #691: odb_fetch_hook, tui_launch_startup_script,
  *   tui_is_bare_odb_address
  */
 
@@ -324,7 +324,7 @@ typedef struct {
 	char  eval_last_expr[EVAL_INPUT_MAX];
 	int   eval_display_counter;
 
-	/* 2026-06-07 JES Phase B.8 #691: ODB source-fetch hook.
+	/* 2026-06-08 JES Phase B.8 #691: ODB source-fetch hook.
 	 *
 	 * In production (non-OMIT_MAIN), debugger_tui_state_init sets this to
 	 * tui_real_odb_fetch -- the static helper that replicates the
@@ -342,6 +342,9 @@ typedef struct {
 	 *   out_bufsz  -- size of out_buf in bytes
 	 * Returns true on success, false on any failure (path not found, ODB error,
 	 * buffer too small after truncation would corrupt, etc.).
+	 *
+	 * Thread safety: written once at init; never reassigned. Read from main
+	 * thread only. No synchronization required.
 	 */
 	bool (*odb_fetch_hook)(const char *path_no_at, char *out_buf, size_t out_bufsz);
 } tui_state_t;
@@ -425,7 +428,7 @@ void debugger_tui_state_init(tui_state_t *s, int tw, int th);
 void debugger_tui_state_teardown(tui_state_t *s);
 
 /*
- * 2026-06-07 JES Phase B.8 #691: bare ODB address detection.
+ * 2026-06-08 JES Phase B.8 #691: bare ODB address detection.
  *
  * Returns true iff `s` starts with '@' AND every subsequent character is
  * [A-Za-z0-9_.] (no whitespace, no parens, no operators).
@@ -438,7 +441,7 @@ void debugger_tui_state_teardown(tui_state_t *s);
 bool tui_is_bare_odb_address(const char *s);
 
 /*
- * 2026-06-07 JES Phase B.8 #691: startup script launch.
+ * 2026-06-08 JES Phase B.8 #691: startup script launch.
  *
  * Resolves `script_expr` (bare ODB address or freeform expression), compiles
  * it, and dispatches a debug/run request.  Called from debugger_tui_main after

--- a/tests/debugger_tui_tests.c
+++ b/tests/debugger_tui_tests.c
@@ -3787,6 +3787,69 @@ static void test_colon_activates_eval_pane_when_running(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * test_eval_submit_running_failure_path
+ *
+ * 2026-06-08 JES Phase B.8 #691 P1-3 fix: /gate round 1 bar-raiser.
+ *
+ * Before the fix, tui_eval_submit RUNNING branch ignored the return value of
+ * tui_launch_startup_script.  On failure: input was silently cleared, pane
+ * dismissed, and no feedback given to the user.
+ *
+ * After the fix, on failure:
+ *   1. An error entry appears in the eval history.
+ *   2. eval_input_buf is NOT cleared (preserved for retry).
+ *   3. The pane is NOT dismissed (eval_pane_active stays true).
+ *
+ * This test hooks the failure path by setting odb_fetch_hook to a mock that
+ * returns false (simulating an ODB lookup failure on a bare address).
+ * ---------------------------------------------------------------------- */
+
+static bool mock_odb_fetch_fail(const char *path_no_at, char *out_buf, size_t out_bufsz) {
+	(void)path_no_at;
+	(void)out_buf;
+	(void)out_bufsz;
+	return false; /* Always fail */
+}
+
+static void test_eval_submit_running_failure_path(void) {
+	setup();
+	g_state.debug_state = TUI_DEBUG_RUNNING;
+	reset_dispatch_capture();
+	g_state.odb_fetch_hook = mock_odb_fetch_fail;
+
+	/* Load a bare ODB address into the eval input (will trigger ODB fetch
+	 * which the mock will fail, exercising the P1-3 failure path). */
+	strncpy(g_state.eval_input_buf, "@some.bad.path",
+	        sizeof(g_state.eval_input_buf) - 1);
+	g_state.eval_input_buf[sizeof(g_state.eval_input_buf) - 1] = '\0';
+	g_state.eval_input_cursor = (int)strlen(g_state.eval_input_buf);
+	g_state.eval_pane_active  = true;
+
+	int history_before = g_state.eval_history_count;
+
+	tui_eval_submit(&g_state);
+
+	/* P1-3 assertion 1: eval history must have gained one entry (error entry) */
+	assert(g_state.eval_history_count == history_before + 1);
+	/* Find the most-recent history slot and verify it contains "error" */
+	int last_slot = (g_state.eval_history_head + g_state.eval_history_count - 1)
+	                % EVAL_HISTORY_MAX;
+	assert(g_state.eval_history[last_slot] != NULL);
+	assert(strstr(g_state.eval_history[last_slot], "error") != NULL);
+
+	/* P1-3 assertion 2: eval_input_buf must NOT be cleared (preserved for retry) */
+	assert(strcmp(g_state.eval_input_buf, "@some.bad.path") == 0);
+
+	/* P1-3 assertion 3: pane must NOT be dismissed */
+	assert(g_state.eval_pane_active == true);
+
+	/* No dispatch must have happened (launch failed before dispatch) */
+	assert(g_dispatch_buf[0] == '\0');
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 
@@ -3909,6 +3972,9 @@ int main(void) {
 	TR_RUN(test_launch_with_inline_script_starts_suspended);
 	TR_RUN(test_launch_with_bare_address_resolves_source);
 	TR_RUN(test_colon_activates_eval_pane_when_running);
+
+	/* B.8 /gate round 1 P1-3 fix: failure-path regression guard */
+	TR_RUN(test_eval_submit_running_failure_path);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();

--- a/tests/debugger_tui_tests.c
+++ b/tests/debugger_tui_tests.c
@@ -2883,9 +2883,15 @@ static void test_escape_dismisses_eval_pane(void) {
 /* -------------------------------------------------------------------------
  * test_eval_pane_hidden_when_not_suspended
  *
+ * 2026-06-07 JES Phase B.8 #691: updated -- ':' now activates in RUNNING too.
+ *
  * Spec: State: debug_state = TUI_DEBUG_IDLE; inject ':'.
- * Verify: state.eval_pane_active == false (colon is a no-op outside SUSPENDED).
- * Also verify when TUI_DEBUG_RUNNING.
+ * Verify: state.eval_pane_active == false (colon is a no-op only in IDLE).
+ *
+ * Note: RUNNING behavior is tested separately in
+ * test_colon_activates_eval_pane_when_running.  The RUNNING assertion in
+ * the old version of this test has been removed because ':' in RUNNING now
+ * activates the eval pane (for new-debug-run launch).
  * ---------------------------------------------------------------------- */
 static void test_eval_pane_hidden_when_not_suspended(void) {
 	setup();
@@ -2897,13 +2903,8 @@ static void test_eval_pane_hidden_when_not_suspended(void) {
 	ev.key.ch  = ':';
 	ev.key.mod = BOXEN_MOD_NONE;
 
-	/* IDLE state */
+	/* IDLE state: ':' must still be a no-op (no thread to attach to) */
 	g_state.debug_state = TUI_DEBUG_IDLE;
-	debugger_tui_run_one_tick(&g_state, &ev);
-	assert(g_state.eval_pane_active == false);
-
-	/* RUNNING state */
-	g_state.debug_state = TUI_DEBUG_RUNNING;
 	debugger_tui_run_one_tick(&g_state, &ev);
 	assert(g_state.eval_pane_active == false);
 
@@ -3559,6 +3560,232 @@ static void test_eval_modal_open_colon_does_not_activate_eval_pane(void) {
 	teardown();
 }
 
+/* =========================================================================
+ * 2026-06-07 JES Phase B.8 #691: TUI launch -- test seam and new tests.
+ *
+ * Four new tests for the launch-script feature:
+ *
+ *   test_eval_bare_address_resolves_to_source
+ *   test_eval_freeform_expression_passes_through
+ *   test_launch_with_inline_script_starts_suspended
+ *   test_launch_with_bare_address_resolves_source
+ *
+ * Also one test that updates the existing RUNNING-state ':' assertion:
+ *
+ *   test_colon_activates_eval_pane_when_running
+ *
+ * Seam design: tui_state_t carries an odb_fetch_hook function pointer.
+ * Tests set it to a local mock that returns a canned string without
+ * touching the ODB.  Production sets it to the real ODB lookup helper
+ * (inside #ifndef DEBUGGER_TUI_OMIT_MAIN).  When the hook is NULL the
+ * source fetch silently fails (returns false) -- the same result as an
+ * ODB lookup error.
+ * ========================================================================= */
+
+/* Mock ODB fetch: simulates a successful ODB source lookup.
+ * Returns the canned source text regardless of the path. */
+static bool g_mock_odb_called = false;
+static const char *g_mock_odb_source = "local x = 42\nlog(\"hello\")";
+
+static bool mock_odb_fetch(const char *path_no_at, char *out_buf, size_t out_bufsz) {
+	(void)path_no_at;
+	g_mock_odb_called = true;
+	size_t src_len = strlen(g_mock_odb_source);
+	if (src_len >= out_bufsz) src_len = out_bufsz - 1;
+	memcpy(out_buf, g_mock_odb_source, src_len);
+	out_buf[src_len] = '\0';
+	return true;
+}
+
+/* -------------------------------------------------------------------------
+ * test_eval_bare_address_resolves_to_source
+ *
+ * 2026-06-07 JES Phase B.8 #691.
+ *
+ * State: TUI_DEBUG_RUNNING, eval pane active, input = "@some.address".
+ * Submit via tui_eval_submit.
+ *
+ * Assert:
+ *   - odb_fetch_hook WAS called (bare address detected).
+ *   - The dispatched JSON contains the resolved source text
+ *     ("local x = 42"), NOT the literal "@some.address".
+ *   - The dispatch is a debug/run request (not script/eval).
+ * ---------------------------------------------------------------------- */
+static void test_eval_bare_address_resolves_to_source(void) {
+	setup();
+	g_state.debug_state = TUI_DEBUG_RUNNING;
+	reset_dispatch_capture();
+	g_mock_odb_called   = false;
+	g_state.odb_fetch_hook = mock_odb_fetch;
+
+	/* Load eval input directly (simulates what run_one_tick does on keypress) */
+	strncpy(g_state.eval_input_buf, "@some.address",
+	        sizeof(g_state.eval_input_buf) - 1);
+	g_state.eval_input_buf[sizeof(g_state.eval_input_buf) - 1] = '\0';
+	g_state.eval_input_cursor = (int)strlen(g_state.eval_input_buf);
+	g_state.eval_pane_active  = true;
+
+	tui_eval_submit(&g_state);
+
+	/* ODB hook must have been called (bare address was detected) */
+	assert(g_mock_odb_called == true);
+
+	/* Dispatched JSON must contain resolved source, not the bare address */
+	assert(strstr(g_dispatch_buf, "@some.address") == NULL);
+	assert(strstr(g_dispatch_buf, "local x = 42") != NULL);
+
+	/* Must be a debug/run request, not script/eval */
+	assert(strstr(g_dispatch_buf, "debug/run") != NULL);
+	assert(strstr(g_dispatch_buf, "script/eval") == NULL);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_eval_freeform_expression_passes_through
+ *
+ * 2026-06-07 JES Phase B.8 #691.
+ *
+ * State: TUI_DEBUG_RUNNING, input = "local (t); new (tableType, @t); myScript(@t)".
+ * Submit via tui_eval_submit.
+ *
+ * Assert:
+ *   - odb_fetch_hook was NOT called (not a bare address).
+ *   - Dispatched JSON contains the verbatim expression.
+ *   - Dispatch is a debug/run request.
+ * ---------------------------------------------------------------------- */
+static void test_eval_freeform_expression_passes_through(void) {
+	setup();
+	g_state.debug_state = TUI_DEBUG_RUNNING;
+	reset_dispatch_capture();
+	g_mock_odb_called   = false;
+	g_state.odb_fetch_hook = mock_odb_fetch;   /* would be called if wrong path taken */
+
+	const char *freeform = "local (t); new (tableType, @t); myScript(@t)";
+	strncpy(g_state.eval_input_buf, freeform, sizeof(g_state.eval_input_buf) - 1);
+	g_state.eval_input_buf[sizeof(g_state.eval_input_buf) - 1] = '\0';
+	g_state.eval_input_cursor = (int)strlen(g_state.eval_input_buf);
+	g_state.eval_pane_active  = true;
+
+	tui_eval_submit(&g_state);
+
+	/* ODB hook must NOT have been called */
+	assert(g_mock_odb_called == false);
+
+	/* Expression must appear verbatim in the dispatch */
+	assert(strstr(g_dispatch_buf, "local (t)") != NULL);
+	assert(strstr(g_dispatch_buf, "debug/run") != NULL);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_launch_with_inline_script_starts_suspended
+ *
+ * 2026-06-07 JES Phase B.8 #691.
+ *
+ * Verify the startup-launch helper dispatches a debug/run with the inline
+ * expression and that start_suspended semantics are represented (the debug/run
+ * op in the existing runtime always starts suspended; the test verifies the
+ * dispatch shape rather than a runtime boolean since start_suspended is
+ * hardcoded in handle_debug_run).
+ *
+ * Call tui_launch_startup_script with inline_script = "log(\"x\")".
+ *
+ * Assert:
+ *   - Dispatch happened (g_dispatch_buf non-empty).
+ *   - Dispatched op is "debug/run".
+ *   - Expression in dispatch matches the inline_script.
+ *   - odb_fetch_hook was NOT called (not a bare address).
+ * ---------------------------------------------------------------------- */
+static void test_launch_with_inline_script_starts_suspended(void) {
+	setup();
+	reset_dispatch_capture();
+	g_mock_odb_called   = false;
+	g_state.odb_fetch_hook = mock_odb_fetch;
+
+	tui_launch_startup_script(&g_state, "log(\"x\")", NULL);
+
+	/* Dispatch must have happened */
+	assert(g_dispatch_buf[0] != '\0');
+
+	/* Op must be debug/run */
+	assert(strstr(g_dispatch_buf, "debug/run") != NULL);
+
+	/* Expression must be the inline script */
+	assert(strstr(g_dispatch_buf, "log") != NULL);
+
+	/* ODB hook was not called (freeform expression, not a bare address) */
+	assert(g_mock_odb_called == false);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_launch_with_bare_address_resolves_source
+ *
+ * 2026-06-07 JES Phase B.8 #691.
+ *
+ * Call tui_launch_startup_script with inline_script = "@some.address".
+ *
+ * Assert:
+ *   - odb_fetch_hook WAS called.
+ *   - Dispatched op is "debug/run".
+ *   - Expression in dispatch is the resolved source (not "@some.address").
+ * ---------------------------------------------------------------------- */
+static void test_launch_with_bare_address_resolves_source(void) {
+	setup();
+	reset_dispatch_capture();
+	g_mock_odb_called   = false;
+	g_state.odb_fetch_hook = mock_odb_fetch;
+
+	tui_launch_startup_script(&g_state, "@some.address", NULL);
+
+	/* ODB hook must have been called */
+	assert(g_mock_odb_called == true);
+
+	/* Op must be debug/run */
+	assert(strstr(g_dispatch_buf, "debug/run") != NULL);
+
+	/* Resolved source must appear, not the bare address */
+	assert(strstr(g_dispatch_buf, "@some.address") == NULL);
+	assert(strstr(g_dispatch_buf, "local x = 42") != NULL);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_colon_activates_eval_pane_when_running
+ *
+ * 2026-06-07 JES Phase B.8 #691.
+ *
+ * ':' in TUI_DEBUG_RUNNING state must NOW activate the eval pane so the
+ * user can launch a new debug-run from the RUNNING state (no attached thread).
+ *
+ * This replaces the previous assertion in test_eval_pane_hidden_when_not_suspended
+ * that `:` was a no-op while RUNNING.  The IDLE no-op is preserved.
+ * ---------------------------------------------------------------------- */
+static void test_colon_activates_eval_pane_when_running(void) {
+	setup();
+
+	boxen_event_t ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.type    = BOXEN_EV_KEY;
+	ev.key.key = BOXEN_KEY_NONE;
+	ev.key.ch  = ':';
+	ev.key.mod = BOXEN_MOD_NONE;
+
+	/* RUNNING state: ':' must activate the eval pane */
+	g_state.debug_state = TUI_DEBUG_RUNNING;
+	debugger_tui_run_one_tick(&g_state, &ev);
+	assert(g_state.eval_pane_active == true);
+
+	/* Cleanup: dismiss pane so teardown is clean */
+	tui_eval_dismiss(&g_state);
+
+	teardown();
+}
+
 /* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
@@ -3675,6 +3902,13 @@ int main(void) {
 	TR_RUN(test_eval_history_entry_contains_expression);
 	TR_RUN(test_eval_display_counter_monotonic_past_wrap);
 	TR_RUN(test_eval_modal_open_colon_does_not_activate_eval_pane);
+
+	/* B.8 tests (#691: TUI launch -- bare address, freeform, startup) */
+	TR_RUN(test_eval_bare_address_resolves_to_source);
+	TR_RUN(test_eval_freeform_expression_passes_through);
+	TR_RUN(test_launch_with_inline_script_starts_suspended);
+	TR_RUN(test_launch_with_bare_address_resolves_source);
+	TR_RUN(test_colon_activates_eval_pane_when_running);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();


### PR DESCRIPTION
## Summary

Adds three ways to launch a debug session in `--debug-tui` directly at a specific script, eliminating the need to attach to already-running code. Closes the "I don't know how to use this thing" UX gap from manual testing.

```bash
frontier-cli --debug-tui @workspace.myVerb        # resolve ODB source, spawn suspended
frontier-cli --debug-tui -e "local (t); foo(@t)"  # compile expression, spawn suspended
frontier-cli --debug-tui path/to/script.ut        # read file, spawn suspended
```

All three spawn a debug thread with `start_suspended=true`, dropping the user at the first statement with source loaded and F-keys live. Saved breakpoints (which persist in scriptType externals across `.root` saves) fire on F5 from the entry suspension.

Also: pressing `:` in the RUNNING state now activates the eval pane, mirroring SUSPENDED. Enter dispatches `debug/run` (with the same bare-address-vs-freeform detection). SUSPENDED behavior unchanged (`script/eval` against current frame).

## Implementation

- `tui_is_bare_odb_address` -- detection rule: starts with `@`, only `[A-Za-z0-9_.]` after
- `tui_real_odb_fetch` -- ODB source-text lookup for bare addresses (delegates to new shared helper)
- `tui_dispatch_debug_run` -- builds and dispatches `debug/run` request, heap-allocated escape buffer sized to the actual 6x JSON escape worst-case
- `tui_launch_startup_script` -- handles both `inline_script` and `script_file` paths with `fstat`/`S_ISREG` validation, ferror checks, empty-file rejection, truncation warning
- `debug_get_script_source` -- shared ODB helper extracted from `handle_debug_getsource` to eliminate ~90 lines of duplicated traversal (P2-7 from /gate round 1). Takes optional `out_reason` enum so the protocol op preserves its specific per-failure error messages
- `odb_fetch_hook` -- function-pointer seam on `tui_state_t` so unit tests can mock ODB lookups without dragging the runtime into the test binary

State machine: SUSPENDED `:` -> existing `script/eval` (unchanged). RUNNING `:` -> new `debug/run`. IDLE `:` -> no-op (no thread to attach to).

## /gate

Two rounds (per the project flow), both fully addressed before submitting:

**Round 1** (FAIL, 5 P1s):
- esc_expr buffer sized 2x but `tui_json_escape` is 6x -- now heap-allocated to true worst case
- script_file path now `fstat`+`S_ISREG`-validated, rejecting FIFOs/character devices that would hang the TUI on read; ferror + empty-file + truncation diagnostics added
- RUNNING-mode `:` launch now captures return value, surfaces failure to eval history, preserves input on failure
- GIL-held precondition now asserted at `tui_real_odb_fetch` entry
- Async-transition comment corrected at `debugger_tui_main` startup site

**Round 2** (PASS WITH NOTES, 2 cheap P2s addressed):
- Restored 4 specific protocol-level error messages in `debug/getSource` that the P2-7 extraction had collapsed to a single generic string
- Added missing longjmp-safety doc comment at `oppushoutline`/`oppopoutline` pair (Frontier uses callback-based error propagation, so this is docs hygiene)

Remaining unreachable defense-in-depth items filed as #755.

## Persistent breakpoints

The canonical workflow for debugging an existing Frontier.root script:

1. Open the script in any tool (REPL, TUI session, etc.), set breakpoints, save (or exit -- `.root` autosaves).
2. `frontier-cli --debug-tui @that.script`
3. TUI launches, thread suspends at first statement. F5 to run until next saved breakpoint, F9 to add ad-hoc ones, F10/F11 to step.

Saved breakpoints live in the scriptType externals themselves, so this is cross-tool and cross-session.

## Test plan

- [x] Unit: 759/759 pass (+5 new behavioral tests for the launch entry points + failure path)
- [x] Integration: 2186 pass / 21 baseline failures, character-for-character match against documented baseline
- [x] `/gate` round 1 FAIL -> round 2 PASS WITH NOTES, remaining items filed as #755
- [ ] Manual: launch `frontier-cli --debug-tui @some.script`, verify suspension at first statement, F5 hits saved breakpoints, `:` works in both RUNNING and SUSPENDED states

## Closes

Closes the launch-debugging UX gap on #691.

Followup: #755 (defensive-depth cleanups)
