### PR TITLE
fix(#691): C.1 outline editor -- Unicode triangle glyphs + bump node cap to 16384

### DIFF
--- a/frontier-cli/boxen/backend_mock.c
+++ b/frontier-cli/boxen/backend_mock.c
@@ -210,6 +210,17 @@ bool boxen_mock_has_text(const char *s) {
 	return false;
 }
 
+/* 2026-06-10 JES #691 C.1.x: codepoint-based grid scan.
+ * Use for non-ASCII glyphs that boxen_mock_has_text can't match. */
+bool boxen_mock_has_codepoint(uint32_t cp) {
+	for (int y = 0; y < g_height; y++) {
+		for (int x = 0; x < g_width; x++) {
+			if (g_grid[y][x].ch == cp) return true;
+		}
+	}
+	return false;
+}
+
 /* -------------------------------------------------------------------------
  * Event injection
  * ---------------------------------------------------------------------- */

--- a/frontier-cli/boxen/backend_mock.h
+++ b/frontier-cli/boxen/backend_mock.h
@@ -66,6 +66,12 @@ const boxen_mock_cell_t *boxen_mock_cell_at(int x, int y);
  * inputs will not match correctly -- pass ASCII literals only. */
 bool boxen_mock_has_text(const char *s);
 
+/* 2026-06-10 JES #691 C.1.x: returns true if the given Unicode codepoint
+ * appears in any cell of the composited frame.  Use this instead of
+ * boxen_mock_has_text when checking for non-ASCII glyphs (e.g. wedge
+ * triangles, bullet, box-drawing). */
+bool boxen_mock_has_codepoint(uint32_t cp);
+
 /* -------------------------------------------------------------------------
  * Cursor inspection (A.7+)
  *

--- a/frontier-cli/boxen_outline.c
+++ b/frontier-cli/boxen_outline.c
@@ -69,10 +69,31 @@
 /* Gutter width: 1 column for breakpoint marker + 1 space */
 #define OUTLINE_GUTTER_WIDTH 2
 
-/* Marker column strings (NUL-terminated, drawn in the marker column) */
-#define MARKER_EXPANDED   "v"
-#define MARKER_COLLAPSED  ">"
-#define MARKER_LEAF       "o"
+/* Marker column strings (NUL-terminated, drawn in the marker column).
+ *
+ * 2026-06-09 JES #691 Phase C.1.x: switched from ASCII v/>/o to Unicode
+ * triangles + bullet.  Matches legacy Frontier desktop convention and
+ * modern outliner UI.  Multi-byte UTF-8 sequences (3 bytes per glyph for
+ * triangles, 3 bytes for bullet) -- boxen_draw_text decodes UTF-8 and
+ * advances the column by boxen_wcwidth (1 cell per codepoint here), so
+ * the visual layout reads as one column per marker even though the byte
+ * count differs.  PR #754's locale fix ensures these glyphs render
+ * (otherwise termbox2's iswprint() would replace them with U+FFFD).
+ *
+ *   U+25BC  BLACK DOWN-POINTING TRIANGLE     -- expanded (children visible)
+ *   U+25B6  BLACK RIGHT-POINTING TRIANGLE    -- collapsed (children hidden)
+ *   U+25B7  WHITE RIGHT-POINTING TRIANGLE    -- leaf (no children)
+ *
+ * Semantic distinction: filled triangles signal an actionable disclosure
+ * control; outlined triangle signals an inert node with no contents.  The
+ * leaf glyph matches the orientation of the collapsed glyph so they pair
+ * visually, but the fill/no-fill makes the affordance unambiguous.
+ *
+ * Checkbox markers remain ASCII [x]/[ ] for now -- 3 cells of explicit
+ * width is intentional for a checkbox affordance. */
+#define MARKER_EXPANDED   "\xE2\x96\xBC"   /* U+25BC */
+#define MARKER_COLLAPSED  "\xE2\x96\xB6"   /* U+25B6 */
+#define MARKER_LEAF       "\xE2\x96\xB7"   /* U+25B7 */
 #define MARKER_CHECKED    "[x]"
 #define MARKER_UNCHECKED  "[ ]"
 #define MARKER_BREAKPOINT "*"

--- a/frontier-cli/boxen_outline_internal.h
+++ b/frontier-cli/boxen_outline_internal.h
@@ -35,10 +35,17 @@
  * ---------------------------------------------------------------------- */
 
 /* Maximum nodes in the editor's flat display list.
- * C.1 renders outlines up to this depth.  An outline exceeding this cap
- * renders the first BOXEN_OUTLINE_MAX_NODES visible nodes; deeper nodes
- * are silently omitted.  Increase in a later milestone if needed. */
-#define BOXEN_OUTLINE_MAX_NODES 4096
+ *
+ * C.1 renders outlines up to this size.  An outline exceeding this cap
+ * renders the first BOXEN_OUTLINE_MAX_NODES visible nodes; further nodes
+ * are silently omitted with a one-shot log_warn.
+ *
+ * 2026-06-09 JES #691 Phase C.1.x: bumped from 4096 to 16384 per JES.  At
+ * sizeof(boxen_outline_node_t) ~= 545 bytes, the state struct's nodes[]
+ * array is ~8.5 MB -- well within reason for a per-window heap alloc on
+ * any modern system, and gives headroom for real Frontier.root outlines
+ * which can easily exceed 4K visible nodes when expanded. */
+#define BOXEN_OUTLINE_MAX_NODES 16384
 
 /* Maximum bytes for a single headline's text (display, NUL-terminated). */
 #define BOXEN_OUTLINE_TEXT_MAX 512

--- a/tests/boxen_outline_tests.c
+++ b/tests/boxen_outline_tests.c
@@ -548,9 +548,10 @@ static void test_checkbox_attribute_renders_box(void) {
 	 * boxen_mock_has_text scans the composited frame for any ASCII substring. */
 	assert(boxen_mock_has_text("[x]"));
 	assert(boxen_mock_has_text("[ ]"));
-	/* Leaf marker: the draw function renders " o " for a plain leaf.
-	 * We check for the 'o' character surrounded by spaces. */
-	assert(boxen_mock_has_text(" o "));
+	/* 2026-06-10 JES #691 C.1.x: leaf marker is now U+25B7 (WHITE
+	 * RIGHT-POINTING TRIANGLE), multi-byte UTF-8.  Use the codepoint
+	 * scanner instead of has_text (which is ASCII-only). */
+	assert(boxen_mock_has_codepoint(0x25B7));
 
 	boxen_outline_state_teardown(&cs);
 	boxen_shutdown();


### PR DESCRIPTION
## Summary

Two improvements to the C.1 outline editor, both surfaced from manual testing of PR #759.

## 1. Unicode triangle glyphs (per JES request)

Replaces ASCII `v`/`>`/`o` with proper Unicode wedge/leaf markers:

| Old | New | Codepoint | Meaning |
|-----|-----|-----------|---------|
| `v` | ▼ | U+25BC BLACK DOWN-POINTING TRIANGLE | expanded (children visible) |
| `>` | ▶ | U+25B6 BLACK RIGHT-POINTING TRIANGLE | collapsed (children hidden) |
| `o` | ▷ | U+25B7 WHITE RIGHT-POINTING TRIANGLE | leaf (no children) |

**Filled vs outlined is the affordance.** Filled triangles signal an actionable disclosure control; the outlined triangle signals an inert leaf node. Matches legacy Frontier desktop convention and modern outliner UI.

PR #754's locale fix (`boxen_init` promotes default C locale to environment locale) ensures `iswprint()` accepts these glyphs so termbox2 renders them correctly instead of replacing with U+FFFD.

All three codepoints have `wcwidth == 1`, so visual layout reads as one column per marker even though each takes 3 UTF-8 bytes. No code change in the draw loop is needed — `boxen_draw_text` decodes UTF-8 and advances `x` by `boxen_wcwidth` per codepoint, so the byte-by-byte copy into `linebuf` still works correctly.

Checkbox markers (`[x]` / `[ ]`) remain ASCII for now — the explicit 3-cell width is intentional for the checkbox affordance.

## 2. Bump `BOXEN_OUTLINE_MAX_NODES` from 4096 to 16384

Per JES feedback that 4096 is too conservative for real-world Frontier.root outlines. At ~545 bytes per `boxen_outline_node_t`, the state struct's `nodes[]` array is ~8.5 MB — well within reason for a per-window heap alloc, and gives headroom for realistic outline sizes.

## Test infrastructure

New `boxen_mock_has_codepoint(uint32_t cp)` helper in `backend_mock.h`/`.c` for non-ASCII glyph assertions in tests. The existing `boxen_mock_has_text(const char *s)` is ASCII-only (it compares bytes against the grid cells' Unicode codepoints, which only works for ASCII). Updated `test_checkbox_attribute_renders_box` to use the new scanner for the leaf marker assertion — the `[x]` and `[ ]` checkbox assertions still use the ASCII path since those markers remain ASCII.

## Test plan

- [x] Unit: 776/776 pass
- [x] Integration: 2186/21 baseline character-for-character
- [x] Build: clean (only pre-existing warnings)
- [ ] Manual: launch `dist/frontier-cli --debug-tui`, run `/edit @system.verbs.builtins.userland.cleanRoot`, verify triangles render correctly in your terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
