### PR TITLE
fix(#691): C.1.x Ctrl-C freeze -- boxen application-global key pre-dispatch

### DIFF
--- a/frontier-cli/boxen/boxen.c
+++ b/frontier-cli/boxen/boxen.c
@@ -112,6 +112,12 @@ static int                    g_window_count = 0;
 static boxen_window_t        *g_focused_window = NULL;
 static bool                   g_should_quit     = false;
 
+/* 2026-06-10 JES #691 C.1.x: application-global key pre-dispatch.
+ * Storage for boxen_set_global_key_handler.  See boxen.h for rationale.
+ * Both NULL means "no global key routing". */
+static boxen_window_t              *g_global_key_target = NULL;
+static boxen_global_key_filter_fn   g_global_key_filter = NULL;
+
 /* -------------------------------------------------------------------------
  * A.4 drag/resize state machine
  *
@@ -380,6 +386,15 @@ void boxen_window_close(boxen_window_t *win) {
 	if (g_drag.win == win) {
 		g_drag.state = DRAG_NONE;
 		g_drag.win   = NULL;
+	}
+
+	/* 2026-06-10 JES #691 C.1.x: clear global key target if this window
+	 * was registered as it.  Same UAF-prevention rationale as focus and
+	 * drag above -- the next boxen_dispatch_event would deref freed memory
+	 * if we routed an event to a dead target. */
+	if (g_global_key_target == win) {
+		g_global_key_target = NULL;
+		g_global_key_filter = NULL;
 	}
 
 	win->magic = 0;  /* Mark as dead BEFORE freeing so a use-after-free read
@@ -825,6 +840,27 @@ void boxen_window_focus(boxen_window_t *win) {
 void boxen_window_set_modal(boxen_window_t *win, bool modal) {
 	if (find_live_window_index(win) < 0) return;
 	win->modal = modal;
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-10 JES #691 C.1.x: application-global key pre-dispatch.
+ *
+ * Setter for g_global_key_target / g_global_key_filter (declared at the
+ * top of this file alongside g_focused_window).  See boxen.h for
+ * rationale.  The dispatch check lives inside boxen_dispatch_event below.
+ * ---------------------------------------------------------------------- */
+
+void boxen_set_global_key_handler(boxen_window_t *target,
+                                  boxen_global_key_filter_fn filter) {
+	/* If a target was passed, validate it is live.  If invalid, treat both
+	 * as a clear (NULL/NULL) -- safer than leaving a dangling target. */
+	if (target != NULL && find_live_window_index(target) < 0) {
+		g_global_key_target = NULL;
+		g_global_key_filter = NULL;
+		return;
+	}
+	g_global_key_target = target;
+	g_global_key_filter = filter;
 }
 
 /* boxen_window_invalidate: in the A.3 always-redraw model, every present()
@@ -1313,7 +1349,25 @@ void boxen_dispatch_event(const boxen_event_t *ev) {
 			return;
 		}
 
-		target = (modal_win != NULL) ? modal_win : g_focused_window;
+		/* 2026-06-10 JES #691 C.1.x: application-global key pre-dispatch.
+		 *
+		 * If a global key target + filter are registered and the filter
+		 * accepts this event, route it to the global target instead of
+		 * the focused window.  Modal windows still win over globals
+		 * because modal semantics are stronger (e.g. a confirmation
+		 * dialog should not have Ctrl-C exit the app).
+		 *
+		 * If the global target was the focused window, this is a no-op
+		 * (same destination either way); we don't bother optimizing the
+		 * lookup. */
+		if (modal_win == NULL &&
+		    g_global_key_target != NULL &&
+		    g_global_key_filter != NULL &&
+		    g_global_key_filter(ev)) {
+			target = g_global_key_target;
+		} else {
+			target = (modal_win != NULL) ? modal_win : g_focused_window;
+		}
 		break;
 
 	case BOXEN_EV_MOUSE:

--- a/frontier-cli/boxen/boxen.h
+++ b/frontier-cli/boxen/boxen.h
@@ -347,6 +347,35 @@ void boxen_window_set_modal(boxen_window_t *win, bool modal);
 void boxen_window_invalidate(boxen_window_t *win);
 
 /* -------------------------------------------------------------------------
+ * 2026-06-10 JES #691 C.1.x: application-global key pre-dispatch.
+ *
+ * Application-level keys like Ctrl-C (quit) and `/` (slash-menu palette)
+ * should reach the REPL even when an editor window has focus.  Otherwise
+ * the user types Ctrl-C in an outline editor and nothing happens because
+ * the editor's input_fn doesn't recognize it.
+ *
+ * Usage: the application designates one window as the "global key target"
+ * (typically the REPL's input window) and a predicate that decides which
+ * key events qualify as global.  Before dispatching a key event to the
+ * focused window (or a modal), boxen_dispatch_event checks the predicate;
+ * if it returns true, the event goes to the global target instead.
+ *
+ * Mouse events are NEVER routed to the global target -- they always go
+ * to the at-point window or focused window per the standard rules.
+ *
+ * Pass NULL for either to clear the registration.  Reading both as NULL
+ * (the default) disables global pre-dispatch entirely.
+ *
+ * Threading: like all boxen state, this is GIL-protected at the
+ * application layer.  No internal locking.
+ * ---------------------------------------------------------------------- */
+
+typedef bool (*boxen_global_key_filter_fn)(const boxen_event_t *ev);
+
+void boxen_set_global_key_handler(boxen_window_t *target,
+                                  boxen_global_key_filter_fn filter);
+
+/* -------------------------------------------------------------------------
  * Draw callbacks (A.3+)
  * ---------------------------------------------------------------------- */
 

--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -119,6 +119,25 @@ static void repl_build_layout(boxen_repl_state_t *s, int tw, int th) {
 /* -------------------------------------------------------------------------
  * 2026-06-08 JES Phase C.0 #691: repl_wire_callbacks.
  * ---------------------------------------------------------------------- */
+/* 2026-06-10 JES #691 C.1.x: filter for boxen application-global keys.
+ *
+ * Returns true for keys that should always reach the REPL's on_input
+ * regardless of which window has focus.  Currently just Ctrl-C: without
+ * this, opening an outline editor with /edit @path would trap Ctrl-C
+ * inside the editor (which doesn't recognize it) and the user couldn't
+ * exit the REPL.
+ *
+ * Future additions (deferred):
+ *   - `/` to launch the slash-menu palette (palette migration is its own
+ *     follow-up milestone; not yet integrated with boxen REPL).
+ *   - Application function keys for window switching (cmd-`, etc.) if /
+ *     when multi-window editor focus becomes a UX problem. */
+static bool repl_is_global_key(const boxen_event_t *ev) {
+	if (ev == NULL || ev->type != BOXEN_EV_KEY) return false;
+	if (ev->key.key == BOXEN_KEY_CTRL_C) return true;
+	return false;
+}
+
 static void repl_wire_callbacks(boxen_repl_state_t *s) {
 	if (s->output_win != NULL) {
 		boxen_window_set_draw(s->output_win, draw_output_pane);
@@ -137,6 +156,12 @@ static void repl_wire_callbacks(boxen_repl_state_t *s) {
 	/* Focus the input bar so key events route to on_input */
 	if (s->input_win != NULL) {
 		boxen_window_focus(s->input_win);
+
+		/* 2026-06-10 JES #691 C.1.x: register the REPL input as the global
+		 * key target.  Ctrl-C (and any future global keys) will route here
+		 * before the focused window sees them, so an outline editor or
+		 * other child window can't trap them. */
+		boxen_set_global_key_handler(s->input_win, repl_is_global_key);
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the freeze you reported: opening an outline editor with `/edit @path` and then pressing Ctrl-C does nothing. The editor traps the event because its `input_fn` doesn't recognize Ctrl-C, and the REPL's `on_input` (which DOES handle Ctrl-C) never sees it.

Generalizes the fix as a small new boxen API for application-global keys.

## What it does

```c
typedef bool (*boxen_global_key_filter_fn)(const boxen_event_t *ev);

void boxen_set_global_key_handler(boxen_window_t *target,
                                  boxen_global_key_filter_fn filter);
```

The application designates one window as the "global key target" (typically the REPL's input window) and a predicate that decides which keys qualify. Before `boxen_dispatch_event` routes a key event to the focused window, it checks the predicate; if true, the event goes to the global target instead.

REPL setup wires it in `repl_wire_callbacks`:

```c
static bool repl_is_global_key(const boxen_event_t *ev) {
    if (ev == NULL || ev->type != BOXEN_EV_KEY) return false;
    if (ev->key.key == BOXEN_KEY_CTRL_C) return true;
    return false;
}

/* ... in repl_wire_callbacks ... */
boxen_set_global_key_handler(s->input_win, repl_is_global_key);
```

Future global keys (like `/` for the palette once that migration lands) extend the filter — no boxen API change.

## Design choices

- **Modal beats global.** If a modal window is open (confirmation dialog, etc.), keys go to the modal regardless. The modal contract is stronger than "Ctrl-C exits the app."
- **Mouse events never route through globals.** Mouse always follows at-point/focused-window rules.
- **Single target / single filter.** Simpler than a list of handlers; the filter can be as complex as needed. Application owns the policy.
- **UAF prevention.** When `boxen_window_close` runs on the global target window, the global pointer is cleared — same pattern used for `g_focused_window` and `g_drag.win`.

## Test plan

- [x] Unit: 776/776
- [x] Integration: 2186/21 baseline
- [x] Build clean (only pre-existing warnings)
- [ ] Manual: launch `dist/frontier-cli --debug-tui`, `/edit @system.verbs.builtins.userland.cleanRoot`, press Ctrl-C, REPL exits cleanly

## Related

Surfaced from manual testing of PR #759 (the C.1 outline editor merge). Two other issues from the same testing session are still outstanding:

1. Indentation in real script outlines looks too deep (still investigating)
2. Input cursor stays at the wrong column after `/edit` submits

Those are tracked separately and aren't fixed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
