### PR TITLE
fix(#691): C.1 outline walker -- swap headlinkdown/headlinkright (data-model bug)

### DIFF
--- a/frontier-cli/boxen_outline.c
+++ b/frontier-cli/boxen_outline.c
@@ -973,17 +973,33 @@ static int boxen_outline_walk_nodes(hdloutlinerecord houtline,
 
 		/*
 		 * Read node fields.
-		 * tyheadrecord fields (op.h:71-131):
-		 *   headlinkdown  hdlheadrecord  -- first child
-		 *   headlinkright hdlheadrecord  -- next sibling
-		 *   headlevel     short          -- indent level
-		 *   flexpanded    boolean:1
-		 *   flbreakpoint  boolean:1
-		 *   flcomment     boolean:1
-		 *   headstring    Handle         -- text (getheadstring -> bigstring)
+		 * tyheadrecord fields (op.h:71-131) per the LEGACY data model
+		 * (see Common/source/opops.c:201-213 and opstructure.c:1825-1829):
+		 *
+		 *   headlinkup    -- previous sibling (or self if first in list)
+		 *   headlinkdown  -- next sibling     (or self if last in list)
+		 *   headlinkleft  -- parent           (or self if top-level)
+		 *   headlinkright -- FIRST CHILD      (or self if no children)
+		 *   headlevel     -- indent level (canonical)
+		 *   flexpanded    -- bool:1
+		 *   flbreakpoint  -- bool:1
+		 *   flcomment     -- bool:1
+		 *   headstring    -- Handle (text)
+		 *
+		 * 2026-06-10 JES #691 C.1.x: corrected from the initial C.1
+		 * implementation which had headlinkright/headlinkdown swapped.
+		 * The bug caused siblings to be walked as if they were children
+		 * (wrong indent / progressively deeper level) -- visible in the
+		 * startup script /edit screenshot from PR #759 manual testing.
+		 *
+		 * "Self-pointer means none" sentinel: a leaf node's headlinkright
+		 * is itself; a last-in-list node's headlinkdown is itself.  Always
+		 * check `link != hnode` before treating it as a real pointer.
 		 */
-		hdlheadrecord hfirst_child = (**hnode).headlinkdown;
-		hdlheadrecord hnext_sibling = (**hnode).headlinkright;
+		hdlheadrecord hfirst_child  = (**hnode).headlinkright;
+		hdlheadrecord hnext_sibling = (**hnode).headlinkdown;
+		if (hfirst_child  == hnode) hfirst_child  = nil;
+		if (hnext_sibling == hnode) hnext_sibling = nil;
 		boolean       fexpanded    = (**hnode).flexpanded;
 		boolean       fbreakpoint  = (**hnode).flbreakpoint;
 		boolean       fcomment     = (**hnode).flcomment;


### PR DESCRIPTION
## Summary

The initial C.1 outline walker had the legacy Frontier outline data model wrong. It treated `headlinkdown` as "first child" and `headlinkright` as "next sibling". The actual model (per `Common/source/opops.c:201-213` and `opstructure.c:1825-1829`) is the opposite:

| Field | Meaning |
|-------|---------|
| `headlinkup` | previous sibling (or self if first in list) |
| `headlinkdown` | next sibling (or self if last in list) |
| `headlinkleft` | parent (or self if top-level) |
| **`headlinkright`** | **first child** (or self if no children) |

Also: the link convention is **"self-pointer means none"**, not nil. A leaf has `headlinkright == hnode`; the last sibling has `headlinkdown == hnode`. The walker now treats self-pointing links as nil.

## Visible effect of the bug

In production: siblings were rendered as if they were children, producing progressively-deeper indentation for sequential statements in real scripts.

In the startup script `/edit` screenshot from manual testing of PR #759, statements like:
- `new (tabletype, @system.temp.Frontier)`
- `system.temp.Frontier.startupTime = clock.now()`

should have been at the same indent level (siblings inside the same `if` block) but appeared at different depths.

## Why tests didn't catch this

Unit tests use a mock fetch hook that populates the node array directly from canned `boxen_outline_node_t` structs. The bug is entirely in the **production** fetch hook (`boxen_outline_real_fetch` → `boxen_outline_walk_nodes`) which is the only path that touches the real `hdlheadrecord` link fields.

This coverage gap is the same one called out as a follow-up in #760 ("Real-fetch production-path test").

## Test plan

- [x] Unit: 776/776 (unchanged — mock-fetch tests still pass)
- [x] Integration: 2186/21 baseline character-for-character
- [x] Build clean
- [ ] Manual: launch `dist/frontier-cli --debug-tui`, run `/edit @system.startup.startupScript`, verify sibling statements render at the same indent level

## Related

Surfaced from PR #759 manual testing. Builds on the open Ctrl-C fix in #763 (which makes the editor actually exitable so you can test this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
