### PR TITLE
fix(#691): C.1 outline editor -- hide text cursor while editor has focus

### DIFF
--- a/frontier-cli/boxen_outline.c
+++ b/frontier-cli/boxen_outline.c
@@ -759,6 +759,29 @@ void boxen_outline_draw(boxen_outline_state_t *s, boxen_window_t *win) {
 		boxen_draw_text(win, 0, draw_row, linebuf,
 		                BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT, attr);
 	}
+
+	/* 2026-06-10 JES #691 C.1.x: hide the text cursor while the outline
+	 * editor has focus.
+	 *
+	 * The outline editor is a navigation surface, not a text-input surface;
+	 * the bar cursor (BOXEN_ATTR_REVERSE on the current row) already shows
+	 * "where you are."  A blinking text caret would be visually competing
+	 * noise.
+	 *
+	 * Also fixes a stale-cursor bug visible in PR #759 manual testing.
+	 * When the editor opens, focus moves to it but the REPL input window
+	 * may have last positioned the cursor mid-prompt (e.g. after the user
+	 * types "/edit @path<Enter>", the cursor is at column 14).  After focus
+	 * shifts, the REPL's draw_input_bar's set_cursor call is rejected by
+	 * the boxen focus gate (cursor_owner_allowed at boxen.c:1682), so the
+	 * cursor stays at column 14 over the prompt instead of moving to the
+	 * empty post-submit cursor position.  Hiding the cursor here paints
+	 * over that stale state cleanly.
+	 *
+	 * The cursor reappears at the correct column when the editor closes
+	 * and focus returns to the REPL input window, because draw_input_bar
+	 * then runs as the focus-owner and its set_cursor call is allowed. */
+	boxen_window_set_cursor_visible(win, false);
 }
 
 /* -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the third bug from the PR #759 manual testing screenshot — the text cursor stays at the wrong column after `/edit` opens the outline editor.

## Root cause

When `/edit` opens an outline window:

1. `submit_input` echoes the command and dispatches it.
2. `boxen_outline_open` creates the window and calls `boxen_window_focus(s->win)` — focus transfers from the REPL input to the outline window.
3. `submit_input` then clears `s->input_buf` and `s->input_cursor` to 0.
4. `boxen_window_invalidate(s->input_win)` queues a redraw.
5. On the next `boxen_present`, `draw_input_bar` runs and calls `boxen_window_set_cursor(input_win, 2, 0)` to put the cursor right after the `> ` prompt.

**But** the boxen focus gate (`cursor_owner_allowed` in `boxen.c:1682`) only allows the focused window — or the topmost modal — to control the cursor. The input window is no longer focused, so the call is silently rejected. The outline window's draw doesn't touch the cursor either. Result: the cursor stays at the last successfully-set position, which was column 14 (the end of `> /edit @system.startup.startupScript`).

## Fix

`boxen_outline_draw` now ends with:

```c
boxen_window_set_cursor_visible(win, false);
```

The outline editor is a navigation surface, not a text-input surface — the bar cursor (`BOXEN_ATTR_REVERSE` on the current row) already shows where you are. Hiding the text caret eliminates the stale-position visual noise.

When the editor closes and focus returns to the REPL, `draw_input_bar` runs as the focus-owner and its `set_cursor` call is allowed. The cursor reappears at the correct prompt position.

## Test plan

- [x] Unit: 776/776 (mock tests don't exercise the focus gate; no regression)
- [x] Integration: 2186/21 baseline
- [x] Build clean
- [ ] Manual: launch `dist/frontier-cli --debug-tui`, `/edit @some.path`, verify no stray cursor in the editor; close the editor, verify cursor is back at the REPL prompt

## Context

Completes the trio of bugs from the PR #759 manual testing screenshot:
- Ctrl-C freeze: fixed in #763
- Cumulative indentation: fixed in #764
- **Cursor at wrong column**: this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
