### PR TITLE
feat(repl): C.0.1 boxen REPL persistent command history

### DIFF
--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -292,6 +292,290 @@ void boxen_repl_append_scrollback(boxen_repl_state_t *s, const char *line) {
 }
 
 /* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: persistent command history.
+ *
+ * History ring constants.
+ * MUST stay byte-identical with repl.c:85-86 until linenoise REPL is
+ * removed in milestone C.6 (see planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md).
+ * Both REPLs read/write the same ~/.frontier_history file.
+ * ---------------------------------------------------------------------- */
+#define BOXEN_REPL_HISTORY_FILE  ".frontier_history"
+
+/* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: test-only path override.
+ *
+ * Compiled only under BOXEN_REPL_OMIT_MAIN (test builds).  Redirects
+ * ~/.frontier_history resolution to a caller-supplied path so tests can
+ * exercise load/save without touching the real history file.
+ * ---------------------------------------------------------------------- */
+#ifdef BOXEN_REPL_OMIT_MAIN
+static char g_test_history_path[1024];
+static bool g_test_history_path_set = false;
+
+void boxen_repl_set_history_path_for_test(const char *path) {
+	if (path == NULL) {
+		g_test_history_path_set = false;
+		g_test_history_path[0]  = '\0';
+		return;
+	}
+	snprintf(g_test_history_path, sizeof(g_test_history_path), "%s", path);
+	g_test_history_path_set = true;
+}
+#endif /* BOXEN_REPL_OMIT_MAIN */
+
+/* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: resolve_history_path.
+ *
+ * Fills `out` (capacity `cap`) with the path to the history file.
+ * In test builds, uses the override path if set.
+ * In production builds, reads $HOME and appends BOXEN_REPL_HISTORY_FILE.
+ * Returns true on success, false if the path could not be resolved.
+ * ---------------------------------------------------------------------- */
+static bool resolve_history_path(char *out, size_t cap) {
+#ifdef BOXEN_REPL_OMIT_MAIN
+	if (g_test_history_path_set) {
+		snprintf(out, cap, "%s", g_test_history_path);
+		return true;
+	}
+#endif
+	const char *home = getenv("HOME");
+	if (home == NULL) {
+		log_warn(LOG_COMP_GENERAL, "boxen_repl: HOME not set; history disabled");
+		return false;
+	}
+	int written = snprintf(out, cap, "%s/%s", home, BOXEN_REPL_HISTORY_FILE);
+	if (written < 0 || (size_t)written >= cap) {
+		log_warn(LOG_COMP_GENERAL, "boxen_repl: HOME path too long; history disabled");
+		return false;
+	}
+	return true;
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: boxen_repl_history_append.
+ *
+ * Appends `line` to the history ring.  Skips NULL/empty lines and
+ * duplicates of the most-recent entry.  Resets navigation state.
+ * ---------------------------------------------------------------------- */
+void boxen_repl_history_append(boxen_repl_state_t *s, const char *line) {
+	if (s == NULL || line == NULL || line[0] == '\0') return;
+
+	/* Dedup: skip if equal to the most-recent entry */
+	if (s->history_count > 0) {
+		int prev_idx = (s->history_head - 1 + BOXEN_REPL_HISTORY_SIZE)
+		               % BOXEN_REPL_HISTORY_SIZE;
+		if (strcmp(s->history[prev_idx], line) == 0) {
+			/* Duplicate -- reset nav and return */
+			s->history_nav_idx         = -1;
+			s->history_saved_input[0]  = '\0';
+			return;
+		}
+	}
+
+	/* Write to ring */
+	snprintf(s->history[s->history_head],
+	         BOXEN_REPL_INPUT_MAX, "%s", line);
+	s->history_head = (s->history_head + 1) % BOXEN_REPL_HISTORY_SIZE;
+	if (s->history_count < BOXEN_REPL_HISTORY_SIZE) {
+		s->history_count++;
+	}
+
+	/* Reset navigation */
+	s->history_nav_idx        = -1;
+	s->history_saved_input[0] = '\0';
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: boxen_repl_history_load.
+ *
+ * Loads history from the on-disk file into the ring.  Silent no-op if the
+ * file cannot be opened (first run, or no $HOME).  Strips trailing \r/\n;
+ * skips empty lines.
+ * ---------------------------------------------------------------------- */
+void boxen_repl_history_load(boxen_repl_state_t *s) {
+	if (s == NULL) return;
+
+	char path[1024];
+	if (!resolve_history_path(path, sizeof(path))) return;
+
+	FILE *f = fopen(path, "r");
+	if (f == NULL) return;  /* silent no-op on first run */
+
+	char line[BOXEN_REPL_INPUT_MAX];
+	while (fgets(line, sizeof(line), f)) {
+		/* Strip trailing \r and/or \n */
+		size_t len = strlen(line);
+		while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+			line[--len] = '\0';
+		}
+		if (len == 0) continue;
+		boxen_repl_history_append(s, line);
+	}
+	fclose(f);
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: boxen_repl_history_save.
+ *
+ * Merges the session ring with the existing on-disk file (read-merge-write),
+ * deduplicates, trims to BOXEN_REPL_HISTORY_SIZE, and writes back.
+ *
+ * Mirrors repl.c::merge_and_save_history (lines 1782-1884).
+ * ---------------------------------------------------------------------- */
+void boxen_repl_history_save(boxen_repl_state_t *s) {
+	if (s == NULL) return;
+
+	char path[1024];
+	if (!resolve_history_path(path, sizeof(path))) return;
+
+	/* ---- Step 1: read existing file into a dynamic array ---- */
+	char **file_lines   = NULL;
+	size_t file_count   = 0;
+	size_t file_cap     = 0;
+
+	FILE *f = fopen(path, "r");
+	if (f != NULL) {
+		char line[BOXEN_REPL_INPUT_MAX];
+		while (fgets(line, sizeof(line), f)) {
+			/* Strip trailing \r/\n */
+			size_t len = strlen(line);
+			while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+				line[--len] = '\0';
+			}
+			if (len == 0) continue;
+
+			/* Grow array if needed */
+			if (file_count >= file_cap) {
+				file_cap = file_cap ? file_cap * 2 : 256;
+				char **tmp = realloc(file_lines, file_cap * sizeof(char *));
+				if (tmp == NULL) break;
+				file_lines = tmp;
+			}
+			file_lines[file_count] = strdup(line);
+			if (file_lines[file_count] != NULL) file_count++;
+		}
+		fclose(f);
+	}
+
+	/* ---- Step 2: build session view (oldest -> newest walk of ring) ---- */
+	/* Ring layout: history_head points at next-write; oldest is
+	 * (head - count + SIZE) % SIZE, newest is (head - 1 + SIZE) % SIZE. */
+	int    session_count = s->history_count;
+	int    session_start = (s->history_head - session_count
+	                        + BOXEN_REPL_HISTORY_SIZE) % BOXEN_REPL_HISTORY_SIZE;
+
+	/* ---- Step 3: merge file lines (skip those that match any session entry) ---- */
+	size_t total = (size_t)session_count + file_count;
+	if (total == 0) {
+		free(file_lines);
+		return;
+	}
+
+	char **merged = malloc(total * sizeof(char *));
+	if (merged == NULL) {
+		for (size_t i = 0; i < file_count; i++) free(file_lines[i]);
+		free(file_lines);
+		return;
+	}
+	size_t merged_count = 0;
+
+	/* Add file lines that are NOT in the session ring */
+	for (size_t i = 0; i < file_count; i++) {
+		int is_dup = 0;
+		for (int j = 0; j < session_count && !is_dup; j++) {
+			int idx = (session_start + j) % BOXEN_REPL_HISTORY_SIZE;
+			if (strcmp(file_lines[i], s->history[idx]) == 0) {
+				is_dup = 1;
+			}
+		}
+		if (!is_dup) {
+			merged[merged_count++] = file_lines[i];
+		} else {
+			free(file_lines[i]);
+		}
+	}
+
+	/* Append all session entries (oldest to newest) */
+	for (int j = 0; j < session_count; j++) {
+		int idx = (session_start + j) % BOXEN_REPL_HISTORY_SIZE;
+		char *dup = strdup(s->history[idx]);
+		if (dup != NULL) {
+			merged[merged_count++] = dup;
+		}
+	}
+
+	/* ---- Step 4: trim to BOXEN_REPL_HISTORY_SIZE (keep most recent) ---- */
+	size_t start = 0;
+	if (merged_count > BOXEN_REPL_HISTORY_SIZE) {
+		start = merged_count - BOXEN_REPL_HISTORY_SIZE;
+		for (size_t i = 0; i < start; i++) {
+			free(merged[i]);
+		}
+	}
+
+	/* ---- Step 5: write back ---- */
+	f = fopen(path, "w");
+	if (f != NULL) {
+		for (size_t i = start; i < merged_count; i++) {
+			fprintf(f, "%s\n", merged[i]);
+		}
+		fclose(f);
+	}
+
+	/* ---- Cleanup ---- */
+	for (size_t i = start; i < merged_count; i++) {
+		free(merged[i]);
+	}
+	free(merged);
+	free(file_lines);
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-09 JES #691 Phase C.0.1: history_nav_up / history_nav_down.
+ *
+ * Called from on_input when UP/DOWN arrows are received.  Navigate the
+ * history ring and update input_buf / input_cursor accordingly.
+ * ---------------------------------------------------------------------- */
+static void history_nav_up(boxen_repl_state_t *s) {
+	if (s->history_count == 0) return;
+
+	if (s->history_nav_idx == -1) {
+		/* Save whatever the user has typed so far */
+		snprintf(s->history_saved_input, BOXEN_REPL_INPUT_MAX, "%s", s->input_buf);
+		s->history_nav_idx = 0;
+	} else if (s->history_nav_idx < s->history_count - 1) {
+		s->history_nav_idx++;
+	}
+	/* else already at oldest entry -- clamp */
+
+	int ring_idx = (s->history_head - 1 - s->history_nav_idx
+	                + BOXEN_REPL_HISTORY_SIZE) % BOXEN_REPL_HISTORY_SIZE;
+	snprintf(s->input_buf, BOXEN_REPL_INPUT_MAX, "%s", s->history[ring_idx]);
+	s->input_cursor = (int)strlen(s->input_buf);
+
+	if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+}
+
+static void history_nav_down(boxen_repl_state_t *s) {
+	if (s->history_nav_idx == -1) return;  /* not navigating */
+
+	if (s->history_nav_idx > 0) {
+		s->history_nav_idx--;
+		int ring_idx = (s->history_head - 1 - s->history_nav_idx
+		                + BOXEN_REPL_HISTORY_SIZE) % BOXEN_REPL_HISTORY_SIZE;
+		snprintf(s->input_buf, BOXEN_REPL_INPUT_MAX, "%s", s->history[ring_idx]);
+	} else {
+		/* nav_idx == 0: restore the saved typing */
+		snprintf(s->input_buf, BOXEN_REPL_INPUT_MAX, "%s", s->history_saved_input);
+		s->history_nav_idx        = -1;
+		s->history_saved_input[0] = '\0';
+	}
+	s->input_cursor = (int)strlen(s->input_buf);
+
+	if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+}
+
+/* -------------------------------------------------------------------------
  * 2026-06-08 JES Phase C.0 #691: submit_input.
  *
  * Called on Enter.  Echoes the input line to the scrollback, dispatches,
@@ -302,6 +586,10 @@ static void submit_input(boxen_repl_state_t *s) {
 		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 		return;
 	}
+
+	/* 2026-06-09 JES #691 Phase C.0.1: append to history ring before dispatch.
+	 * Dedup-with-latest is enforced inside boxen_repl_history_append. */
+	boxen_repl_history_append(s, s->input_buf);
 
 	/* Echo with "> " prefix */
 	char echo_buf[BOXEN_REPL_INPUT_MAX + 4];
@@ -416,10 +704,12 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 		return;
 	}
 
-	/* Escape: clear input line */
+	/* Escape: clear input line (also reset history nav state) */
 	if (ev->key.key == BOXEN_KEY_ESCAPE) {
-		s->input_buf[0] = '\0';
-		s->input_cursor = 0;
+		s->input_buf[0]           = '\0';
+		s->input_cursor           = 0;
+		s->history_nav_idx        = -1;
+		s->history_saved_input[0] = '\0';
 		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 		return;
 	}
@@ -430,8 +720,23 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 		return;
 	}
 
+	/* 2026-06-09 JES #691 Phase C.0.1: history navigation. */
+	if (ev->key.key == BOXEN_KEY_UP) {
+		history_nav_up(s);
+		return;
+	}
+	if (ev->key.key == BOXEN_KEY_DOWN) {
+		history_nav_down(s);
+		return;
+	}
+
 	/* Backspace: delete last character */
 	if (ev->key.key == BOXEN_KEY_BACKSPACE) {
+		/* If user edits during history nav, abandon navigation. */
+		if (s->history_nav_idx != -1) {
+			s->history_nav_idx        = -1;
+			s->history_saved_input[0] = '\0';
+		}
 		if (s->input_cursor > 0) {
 			s->input_cursor--;
 			s->input_buf[s->input_cursor] = '\0';
@@ -448,6 +753,11 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 	 * multi-byte handling and a Unicode-aware input cursor; that is deferred
 	 * to a future milestone. */
 	if (ev->key.key == BOXEN_KEY_NONE && ev->key.ch >= 0x20 && ev->key.ch < 0x7F) {
+		/* If user types during history nav, abandon navigation. */
+		if (s->history_nav_idx != -1) {
+			s->history_nav_idx        = -1;
+			s->history_saved_input[0] = '\0';
+		}
 		if (s->input_cursor < BOXEN_REPL_INPUT_MAX - 1) {
 			s->input_buf[s->input_cursor]     = (char)ev->key.ch;
 			s->input_buf[s->input_cursor + 1] = '\0';
@@ -483,6 +793,9 @@ void boxen_repl_state_init(boxen_repl_state_t *s, int tw, int th) {
 
 	repl_build_layout(s, tw, th);
 	repl_wire_callbacks(s);
+
+	/* 2026-06-09 JES #691 Phase C.0.1: hydrate history ring from disk. */
+	boxen_repl_history_load(s);
 }
 
 void boxen_repl_state_teardown(boxen_repl_state_t *s) {
@@ -985,6 +1298,12 @@ int boxen_repl_main(const cli_options_t *opts) {
 
 	/* Step 8: mark REPL session inactive (P1). */
 	repl_set_active(false);
+
+	/* 2026-06-09 JES #691 Phase C.0.1: persist history before tearing down state.
+	 * Placed after repl_set_active(false) (Step 8) and before
+	 * repl_uninstall_verb_host() (Step 9) to match the plan's save contract:
+	 * save runs on clean exit, NOT in state_teardown (tests would silently write). */
+	boxen_repl_history_save(state);
 
 	/* Step 9: uninstall verb host before teardown (P1-3). */
 	repl_uninstall_verb_host();

--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -42,6 +42,7 @@
 #include <unistd.h>    /* dup, dup2, pipe, close, read */
 #include <fcntl.h>     /* fcntl, F_SETFL, O_NONBLOCK */
 #include <errno.h>     /* EAGAIN, EWOULDBLOCK */
+#include <sys/stat.h>  /* umask, fchmod, mode_t -- 2026-06-09 JES #691 Phase C.0.1 */
 
 /* -------------------------------------------------------------------------
  * Forward declarations for draw and input callbacks
@@ -408,6 +409,21 @@ void boxen_repl_history_load(boxen_repl_state_t *s) {
 		while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
 			line[--len] = '\0';
 		}
+
+		/* 2026-06-09 JES #691 Phase C.0.1 P1: drop linenoise-written entries
+		 * that exceed BOXEN_REPL_INPUT_MAX rather than splitting them.
+		 * Preserves the invariant that every ring entry is something the user
+		 * could type in the boxen REPL, and avoids corrupting the shared
+		 * ~/.frontier_history file when linenoise had recorded a >INPUT_MAX
+		 * entry.  A full-capacity fgets read (sizeof(line)-1 bytes) with no
+		 * trailing newline AND not at EOF means the line continues. */
+		if (len == BOXEN_REPL_INPUT_MAX - 1 && !feof(f)) {
+			/* Line was too long: drain the rest and skip it. */
+			int c;
+			while ((c = fgetc(f)) != EOF && c != '\n') { /* discard */ }
+			continue;
+		}
+
 		if (len == 0) continue;
 		boxen_repl_history_append(s, line);
 	}
@@ -514,8 +530,15 @@ void boxen_repl_history_save(boxen_repl_state_t *s) {
 	}
 
 	/* ---- Step 5: write back ---- */
+	/* 2026-06-09 JES #691 Phase C.0.1: force ~/.frontier_history to mode 0600.
+	 * Matches linenoise.c behavior in repl.c to prevent world-readable history
+	 * across the migration window.  We save/restore the process umask rather
+	 * than relying on the ambient value (which may be 0022 -> file 0644). */
+	mode_t old_umask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
 	f = fopen(path, "w");
+	umask(old_umask);
 	if (f != NULL) {
+		fchmod(fileno(f), S_IRUSR | S_IWUSR);
 		for (size_t i = start; i < merged_count; i++) {
 			fprintf(f, "%s\n", merged[i]);
 		}
@@ -774,6 +797,13 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 
 void boxen_repl_state_init(boxen_repl_state_t *s, int tw, int th) {
 	memset(s, 0, sizeof(boxen_repl_state_t));
+
+	/* 2026-06-09 JES #691 Phase C.0.1: memset zeros history_nav_idx, but the
+	 * sentinel meaning "not navigating" is -1, not 0.  Set it explicitly here
+	 * so first-run users (no ~/.frontier_history file, so history_load is a
+	 * no-op and history_append is never called) don't have nav_idx stuck at 0.
+	 * Without this, pressing DOWN before typing anything silently wiped input. */
+	s->history_nav_idx = -1;
 
 	/* Production hooks (only set when not in test build).
 	 * BOXEN_REPL_OMIT_MAIN guards the production-only symbols (repl_eval_script,

--- a/frontier-cli/boxen_repl_internal.h
+++ b/frontier-cli/boxen_repl_internal.h
@@ -54,6 +54,17 @@
 #define BOXEN_REPL_INPUT_MAX 1024
 
 /* -------------------------------------------------------------------------
+ * History ring constants
+ *
+ * 2026-06-09 JES #691 Phase C.0.1: persistent command history.
+ *
+ * MUST stay byte-identical with repl.c:85-86 until linenoise REPL is removed
+ * in milestone C.6 (see planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md).
+ * Both REPLs read/write the same ~/.frontier_history file.
+ * ---------------------------------------------------------------------- */
+#define BOXEN_REPL_HISTORY_SIZE 1000
+
+/* -------------------------------------------------------------------------
  * Hook function-pointer typedefs
  *
  * These seams allow tests to intercept dispatch without linking the full
@@ -171,6 +182,30 @@ typedef struct {
 	 * directly to verify teardown NULLs it.
 	 */
 	transport_t *launch_transport;               /* heap-alloc'd; NULL if no auto-launch */
+
+	/* 2026-06-09 JES #691 Phase C.0.1: persistent command history.
+	 *
+	 * Ring of past commands.  Shared on-disk format with repl.c
+	 * (~/.frontier_history) so users can switch between boxen and linenoise
+	 * REPLs without losing history.  See repl.c:1782+ for the merge-on-save
+	 * pattern this mirrors.
+	 *
+	 * Sizing: BOXEN_REPL_HISTORY_SIZE * BOXEN_REPL_INPUT_MAX = ~1 MiB per
+	 * state.  Acceptable for the single heap-allocated state used by
+	 * boxen_repl_main; keeps the append hot path malloc-free.
+	 *
+	 * Navigation:
+	 *   history_nav_idx == -1: input_buf shows freshly-typed input.
+	 *   history_nav_idx ==  0: input_buf shows most-recent history entry.
+	 *   history_nav_idx ==  N: input_buf shows the Nth-from-newest entry.
+	 *
+	 * Thread-safety: not thread-safe; must be accessed with the GIL held.
+	 * Boxen REPL runs single-threaded; no other thread touches this struct. */
+	char  history[BOXEN_REPL_HISTORY_SIZE][BOXEN_REPL_INPUT_MAX];
+	int   history_count;          /* valid entries (0..BOXEN_REPL_HISTORY_SIZE) */
+	int   history_head;           /* next write index */
+	int   history_nav_idx;        /* -1 = not navigating; else nth-from-newest */
+	char  history_saved_input[BOXEN_REPL_INPUT_MAX]; /* preserved typing during nav */
 } boxen_repl_state_t;
 
 /* -------------------------------------------------------------------------
@@ -210,6 +245,16 @@ int boxen_repl_run_one_tick(boxen_repl_state_t *s, const boxen_event_t *ev);
  * Thread-safety: not thread-safe; must be called with the GIL held.
  */
 void boxen_repl_append_scrollback(boxen_repl_state_t *s, const char *line);
+
+/* 2026-06-09 JES #691 Phase C.0.1: history ring + persistence API. */
+void boxen_repl_history_append(boxen_repl_state_t *s, const char *line);
+void boxen_repl_history_load(boxen_repl_state_t *s);
+void boxen_repl_history_save(boxen_repl_state_t *s);
+#ifdef BOXEN_REPL_OMIT_MAIN
+/* Test-only seam: redirects ~/.frontier_history resolution to `path`.
+ * Pass NULL to clear the override and revert to $HOME. */
+void boxen_repl_set_history_path_for_test(const char *path);
+#endif
 
 /*
  * drain_stdout_into_scrollback -- read bytes from fd and append complete lines

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -298,6 +298,7 @@ static void test_scrollback_ring_drops_oldest_when_full(void) {
  * ---------------------------------------------------------------------- */
 #include <unistd.h>   /* pipe, write, close, getpid */
 #include <fcntl.h>    /* fcntl, F_SETFL, O_NONBLOCK */
+#include <sys/stat.h> /* stat, st_mode -- 2026-06-09 JES #691 Phase C.0.1 */
 
 static void test_stdout_capture_routes_to_scrollback(void) {
 	setup();
@@ -509,6 +510,14 @@ static void test_history_persists_via_file_roundtrip(void) {
 	/* Step 5: save -- merge and write back */
 	boxen_repl_history_save(&g_state);
 
+	/* Step 5a: verify file was created with mode 0600 (P1-1 regression guard).
+	 * 2026-06-09 JES #691 Phase C.0.1 */
+	{
+		struct stat st;
+		assert(stat(g_tmp_history_path, &st) == 0);
+		assert((st.st_mode & 0777) == 0600);
+	}
+
 	/* Step 6: re-read and verify order: older1, older2, session_cmd */
 	FILE *fin = fopen(g_tmp_history_path, "r");
 	assert(fin != NULL);
@@ -538,6 +547,101 @@ static void test_history_persists_via_file_roundtrip(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * Test 10: test_history_load_drops_overlong_lines
+ *
+ * 2026-06-09 JES #691 Phase C.0.1 P1-2 regression guard.
+ *
+ * A 2KB entry written by linenoise exceeds BOXEN_REPL_INPUT_MAX (1024).
+ * Without the fix, fgets would split it into two ring entries and both
+ * would be saved back, permanently corrupting the shared history file.
+ * With the fix, overlong lines are drained and skipped entirely.
+ *
+ * This test writes a file with:
+ *   - one 2048-char line  (overlong: must be dropped)
+ *   - one normal "ok_cmd" (must be kept)
+ *
+ * After load: history_count == 1 and the entry is "ok_cmd".
+ * ---------------------------------------------------------------------- */
+static void test_history_load_drops_overlong_lines(void) {
+	char tmp_path[256];
+	snprintf(tmp_path, sizeof(tmp_path),
+	         "/tmp/boxen_repl_test_overlong_%d.txt", (int)getpid());
+	(void)remove(tmp_path);
+
+	FILE *fout = fopen(tmp_path, "w");
+	assert(fout != NULL);
+	/* Write a 2048-char line (no newline until the very end). */
+	for (int i = 0; i < 2048; i++) fputc('x', fout);
+	fputc('\n', fout);
+	/* Write a normal command that must survive. */
+	fprintf(fout, "ok_cmd\n");
+	fclose(fout);
+
+	boxen_repl_set_history_path_for_test(tmp_path);
+	setup();
+
+	/* Overlong line dropped; only "ok_cmd" loaded. */
+	assert(g_state.history_count == 1);
+	/* The one entry in the ring must be "ok_cmd". */
+	int idx = (g_state.history_head - 1 + BOXEN_REPL_HISTORY_SIZE)
+	          % BOXEN_REPL_HISTORY_SIZE;
+	assert(strcmp(g_state.history[idx], "ok_cmd") == 0);
+
+	boxen_repl_set_history_path_for_test(NULL);
+	(void)remove(tmp_path);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 11 (P0 regression guard): test_history_down_arrow_preserves_input_when_empty
+ *
+ * 2026-06-09 JES #691 Phase C.0.1 P0 regression guard.
+ *
+ * First-run scenario: no history file, so history_load is a no-op and
+ * history_count == 0.  Before the fix, boxen_repl_state_init left
+ * history_nav_idx == 0 (memset zero) instead of -1.  Pressing DOWN
+ * before any append caused history_nav_down to skip its early-return
+ * guard (nav_idx == 0, not -1), take the "restore saved input" branch,
+ * copy history_saved_input (all zeros from memset) into input_buf, and
+ * wipe whatever the user had typed.
+ *
+ * This test verifies:
+ *   1. After init with no history file, history_nav_idx == -1.
+ *   2. Typing "hello" works normally.
+ *   3. Pressing DOWN does NOT clear input_buf.
+ *   4. history_nav_idx remains -1 after the spurious DOWN.
+ * ---------------------------------------------------------------------- */
+static void test_history_down_arrow_preserves_input_when_empty(void) {
+	/* Point at a file that does not exist -- load is a silent no-op. */
+	boxen_repl_set_history_path_for_test(
+	    "/tmp/boxen_repl_test_nosuchfile_p0_down.txt");
+	setup();
+
+	/* After init with no history file: count == 0, nav_idx must be -1. */
+	assert(g_state.history_count == 0);
+	assert(g_state.history_nav_idx == -1);
+
+	/* Type "hello" one char at a time. */
+	const char *word = "hello";
+	for (const char *p = word; *p != '\0'; p++) {
+		boxen_event_t ev = make_char_event(*p);
+		boxen_repl_run_one_tick(&g_state, &ev);
+	}
+	assert(strcmp(g_state.input_buf, "hello") == 0);
+
+	/* Press DOWN -- must be a no-op when history is empty and nav == -1. */
+	boxen_event_t down = make_down_event();
+	boxen_repl_run_one_tick(&g_state, &down);
+
+	/* Input must be preserved. */
+	assert(strcmp(g_state.input_buf, "hello") == 0);
+	assert(g_state.history_nav_idx == -1);
+
+	boxen_repl_set_history_path_for_test(NULL);
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 int main(void) {
@@ -552,6 +656,8 @@ int main(void) {
 	TR_RUN(test_launch_transport_heap_alloc_and_teardown);
 	TR_RUN(test_history_up_arrow_loads_previous);
 	TR_RUN(test_history_persists_via_file_roundtrip);
+	TR_RUN(test_history_load_drops_overlong_lines);
+	TR_RUN(test_history_down_arrow_preserves_input_when_empty);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -296,7 +296,7 @@ static void test_scrollback_ring_drops_oldest_when_full(void) {
  * not set up the stdout dup2 path -- tests must NOT have their own stdout
  * hijacked by default.  Only the drain helper is called here.
  * ---------------------------------------------------------------------- */
-#include <unistd.h>   /* pipe, write, close */
+#include <unistd.h>   /* pipe, write, close, getpid */
 #include <fcntl.h>    /* fcntl, F_SETFL, O_NONBLOCK */
 
 static void test_stdout_capture_routes_to_scrollback(void) {
@@ -380,6 +380,164 @@ static void test_launch_transport_heap_alloc_and_teardown(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * History test helpers
+ * 2026-06-09 JES #691 Phase C.0.1
+ * ---------------------------------------------------------------------- */
+static boxen_event_t make_up_event(void)   { return make_key_event(BOXEN_KEY_UP); }
+static boxen_event_t make_down_event(void) { return make_key_event(BOXEN_KEY_DOWN); }
+
+static char g_tmp_history_path[256];
+static void make_tmp_history_path(void) {
+	snprintf(g_tmp_history_path, sizeof(g_tmp_history_path),
+	         "/tmp/boxen_repl_test_history_%d.txt", (int)getpid());
+}
+
+/* -------------------------------------------------------------------------
+ * Test 8: test_history_up_arrow_loads_previous
+ *
+ * 2026-06-09 JES #691 Phase C.0.1: history ring navigation.
+ *
+ * Inject three entries into the history ring directly (oldest -> newest:
+ * "cmd_a", "cmd_b", "cmd_c").  Then simulate:
+ *   1. UP: input_buf shows "cmd_c" (most recent), nav_idx = 0.
+ *   2. UP: input_buf shows "cmd_b", nav_idx = 1.
+ *   3. UP: input_buf shows "cmd_a" (oldest), nav_idx = 2.
+ *   4. UP again: stays at "cmd_a" (clamp at oldest).
+ *   5. DOWN: input_buf shows "cmd_b", nav_idx = 1.
+ *   6. DOWN: input_buf shows "cmd_c", nav_idx = 0.
+ *   7. DOWN: input_buf restored to saved typing, nav_idx = -1.
+ * ---------------------------------------------------------------------- */
+static void test_history_up_arrow_loads_previous(void) {
+	/* Point history at a nonexistent file so state_init's load is a no-op.
+	 * Without this, a real ~/.frontier_history would shift history_head and
+	 * break the ring-index assertions below. */
+	boxen_repl_set_history_path_for_test("/tmp/boxen_repl_test_nosuchfile_nav.txt");
+	setup();
+
+	/* Pre-load 3 commands into the ring by calling the append function. */
+	boxen_repl_history_append(&g_state, "cmd_a");
+	boxen_repl_history_append(&g_state, "cmd_b");
+	boxen_repl_history_append(&g_state, "cmd_c");
+
+	/* Simulate user having typed "partial" into the input bar */
+	strncpy(g_state.input_buf, "partial", sizeof(g_state.input_buf) - 1);
+	g_state.input_cursor = (int)strlen("partial");
+
+	boxen_event_t up   = make_up_event();
+	boxen_event_t down = make_down_event();
+
+	/* UP x1: most recent = cmd_c */
+	boxen_repl_run_one_tick(&g_state, &up);
+	assert(strcmp(g_state.input_buf, "cmd_c") == 0);
+	assert(g_state.history_nav_idx == 0);
+
+	/* UP x2: cmd_b */
+	boxen_repl_run_one_tick(&g_state, &up);
+	assert(strcmp(g_state.input_buf, "cmd_b") == 0);
+	assert(g_state.history_nav_idx == 1);
+
+	/* UP x3: cmd_a (oldest) */
+	boxen_repl_run_one_tick(&g_state, &up);
+	assert(strcmp(g_state.input_buf, "cmd_a") == 0);
+	assert(g_state.history_nav_idx == 2);
+
+	/* UP x4: clamp at oldest -- still cmd_a */
+	boxen_repl_run_one_tick(&g_state, &up);
+	assert(strcmp(g_state.input_buf, "cmd_a") == 0);
+	assert(g_state.history_nav_idx == 2);
+
+	/* DOWN x1: cmd_b */
+	boxen_repl_run_one_tick(&g_state, &down);
+	assert(strcmp(g_state.input_buf, "cmd_b") == 0);
+	assert(g_state.history_nav_idx == 1);
+
+	/* DOWN x2: cmd_c */
+	boxen_repl_run_one_tick(&g_state, &down);
+	assert(strcmp(g_state.input_buf, "cmd_c") == 0);
+	assert(g_state.history_nav_idx == 0);
+
+	/* DOWN x3: restore saved typing */
+	boxen_repl_run_one_tick(&g_state, &down);
+	assert(strcmp(g_state.input_buf, "partial") == 0);
+	assert(g_state.history_nav_idx == -1);
+
+	boxen_repl_set_history_path_for_test(NULL);  /* clear override */
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 9: test_history_persists_via_file_roundtrip
+ *
+ * 2026-06-09 JES #691 Phase C.0.1: on-disk persistence.
+ *
+ * 1. Write a file with "older1\nolder2\n" to g_tmp_history_path.
+ * 2. Point the history override seam at that path.
+ * 3. Call boxen_repl_history_load: ring should contain older1 then older2.
+ * 4. Append "session_cmd" to the ring.
+ * 5. Call boxen_repl_history_save: merged file written.
+ * 6. Re-read the file and assert it contains "older1", "older2",
+ *    "session_cmd" in that order (older entries first, session entry last).
+ * 7. Clean up temp file.
+ * ---------------------------------------------------------------------- */
+static void test_history_persists_via_file_roundtrip(void) {
+	make_tmp_history_path();
+	/* Remove any leftover from a prior run */
+	(void)remove(g_tmp_history_path);
+
+	/* Step 1: write pre-existing history file */
+	FILE *fout = fopen(g_tmp_history_path, "w");
+	assert(fout != NULL);
+	fprintf(fout, "older1\n");
+	fprintf(fout, "older2\n");
+	fclose(fout);
+
+	/* Step 2: redirect history path to temp file BEFORE setup() so that
+	 * boxen_repl_state_init's load reads from our controlled file (not
+	 * from the real ~/.frontier_history, which would give unpredictable
+	 * history_count). */
+	boxen_repl_set_history_path_for_test(g_tmp_history_path);
+
+	setup();
+
+	/* Step 3: after setup, ring should have 2 entries from the file */
+	assert(g_state.history_count == 2);
+
+	/* Step 4: append a session command */
+	boxen_repl_history_append(&g_state, "session_cmd");
+	assert(g_state.history_count == 3);
+
+	/* Step 5: save -- merge and write back */
+	boxen_repl_history_save(&g_state);
+
+	/* Step 6: re-read and verify order: older1, older2, session_cmd */
+	FILE *fin = fopen(g_tmp_history_path, "r");
+	assert(fin != NULL);
+
+	char lines[10][256];
+	int  line_count = 0;
+	while (line_count < 10 && fgets(lines[line_count], sizeof(lines[0]), fin)) {
+		/* Strip trailing newline */
+		size_t len = strlen(lines[line_count]);
+		if (len > 0 && lines[line_count][len - 1] == '\n') {
+			lines[line_count][len - 1] = '\0';
+		}
+		line_count++;
+	}
+	fclose(fin);
+
+	assert(line_count == 3);
+	assert(strcmp(lines[0], "older1")      == 0);
+	assert(strcmp(lines[1], "older2")      == 0);
+	assert(strcmp(lines[2], "session_cmd") == 0);
+
+	/* Step 7: clear override + clean up */
+	boxen_repl_set_history_path_for_test(NULL);
+	(void)remove(g_tmp_history_path);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 int main(void) {
@@ -392,6 +550,8 @@ int main(void) {
 	TR_RUN(test_scrollback_ring_drops_oldest_when_full);
 	TR_RUN(test_stdout_capture_routes_to_scrollback);
 	TR_RUN(test_launch_transport_heap_alloc_and_teardown);
+	TR_RUN(test_history_up_arrow_loads_previous);
+	TR_RUN(test_history_persists_via_file_roundtrip);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();


### PR DESCRIPTION
## Summary

Adds persistent command history (Up/Down arrow navigation + on-disk persistence) to the boxen `--debug-tui` REPL, using the same `~/.frontier_history` file format and constants (HISTORY_SIZE=1000) as the legacy linenoise REPL. Users can switch between the two REPLs without losing history.

This is milestone **C.0.1** from [planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md](https://github.com/jsavin/Frontier/blob/develop/planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md) Section 1 — the first step toward closing the REPL schism between linenoise (default) and boxen (`--debug-tui`).

## Changes

**State + ring (`boxen_repl_internal.h`)**
- Add `BOXEN_REPL_HISTORY_SIZE 1000` (intentionally duplicated with `repl.c:85-86` during the migration window; both REPLs share the on-disk file)
- 4 new fields on `boxen_repl_state_t`: 1000-entry fixed 2D ring (~1 MiB; keeps append hot path malloc-free), `history_count`, `history_head`, `history_nav_idx`, and `history_saved_input` for preserving typed input while navigating
- Internal-API prototypes for load/save/append; test-only `boxen_repl_set_history_path_for_test` guarded by `#ifdef BOXEN_REPL_OMIT_MAIN`

**Implementation (`boxen_repl.c`)**
- `boxen_repl_history_append` with dedup-against-most-recent (matches linenoise)
- `boxen_repl_history_load` (silent no-op if file missing; drops overlong lines rather than splitting them)
- `boxen_repl_history_save` mirrors `repl.c::merge_and_save_history` — reads existing file, dedupes file entries that match ring entries, appends ring entries, trims to HISTORY_SIZE keeping most-recent, writes back as byte-identical `%s\n` lines. Forces 0600 perms via umask+fchmod (matches linenoise)
- `history_nav_up/down` with saved-input restore on DOWN-past-newest
- Wiring: load in `state_init`; save in `boxen_repl_main` exit (NOT `state_teardown` — test hygiene); UP/DOWN keys + nav-reset on Backspace/printable/Escape; append in `submit_input` before dispatch

**Tests (`tests/boxen_repl_tests.c`)**
- `test_history_up_arrow_loads_previous` — UP/DOWN navigation, clamping at oldest, restore-saved-input on DOWN-past-newest
- `test_history_persists_via_file_roundtrip` — pre-write file, load, append, save, re-read; asserts merged content + 0600 mode
- `test_history_load_drops_overlong_lines` — 2KB line dropped, normal line preserved
- `test_history_down_arrow_preserves_input_when_empty` — regression for the round-1 P0 (DOWN on empty history must preserve typed input)

## Review history

Local `/gate` round 1 (3 reviewers: bar-raiser, security, concurrency) found:
- **P0**: DOWN-arrow erased input on first-run (nav_idx left at 0 by memset). Fixed by explicit `nav_idx = -1` after init + regression test.
- **P1**: File-permission regression vs linenoise (0644 instead of 0600). Fixed by umask + fchmod.
- **P1**: Cross-REPL line-length asymmetry could corrupt the shared file. Fixed by dropping overlong lines on load.

Round-1 report posted as a PR comment for the audit trail.

## Test plan

- [x] Unit: 780/780 (was 776 pre-milestone; +4 new tests)
- [x] Integration: 2186 pass / 21 known-baseline failures (character-for-character match against `/tmp/integ-failures-bf51d18.txt`)
- [x] Production `dist/` build clean
- [x] Local `/gate` PASS WITH NOTES (after round-1 P0+P1 fixes)
- [ ] Manual: `dist/frontier-cli --debug-tui`, type three commands, exit, relaunch, press UP three times — see commands in reverse order; cross-check `tail ~/.frontier_history` and that legacy `dist/frontier-cli` sees them too

## Out of scope (per execution plan)

- Ctrl-R inverse search → deferred
- Fuzzy completion / multi-line history → deferred to C.0.5
- Non-atomic save (tmp+rename) → P2, not blocking
- Removing constant duplication with repl.c:85-86 → milestone C.6 when linenoise REPL is removed

Refs: #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
