### PR TITLE
feat(repl): C.0.3a palette render-backend abstraction (refactor only)

### DIFF
--- a/frontier-cli/palette.c
+++ b/frontier-cli/palette.c
@@ -656,6 +656,10 @@ bool palette_open_ex(palette_state_t *st, int term_rows, int term_cols,
 	if (st->menu_count <= 0) return false;
 
 	st->backend = backend ? backend : &s_pane_backend;
+	/* 2026-06-10 JES #691 Phase C.0.3a: active flips true BEFORE
+	 * backend->open() so the backend's open callback can call palette
+	 * helpers that gate on active.  On failure (open returns false),
+	 * the rollback path resets state to all-zero. */
 	st->active = true;
 	st->menubar_cursor = 0;
 	st->open_depth = 0;
@@ -665,7 +669,9 @@ bool palette_open_ex(palette_state_t *st, int term_rows, int term_cols,
 	st->exec_arg[0] = '\0';
 
 	if (!st->backend->open(st, st->backend->ctx)) {
-		st->active = false;
+		/* 2026-06-10 JES #691 Phase C.0.3a: zero state on backend-open failure
+		 * so callers cannot observe partial layout_menubar fields. */
+		memset(st, 0, sizeof(*st));
 		return false;
 	}
 	return true;
@@ -678,13 +684,13 @@ bool palette_open(palette_state_t *st, int term_rows, int term_cols,
 }
 
 void palette_paint_teardown(palette_state_t *st) {
-	if (!st || !st->active) return;
+	if (!st || !st->active || !st->backend) return;
 	st->backend->paint_teardown(st, st->backend->ctx);
 }
 
 void palette_close(palette_state_t *st) {
 	if (!st) return;
-	if (!st->active) return;
+	if (!st->active || !st->backend) return;
 	close_all_levels(st);
 	st->backend->close(st, st->backend->ctx);
 	memset(st->menu_labels, 0, sizeof(st->menu_labels));
@@ -1008,12 +1014,12 @@ palette_done_t palette_feed_mouse(palette_state_t *st, const mouse_event_t *ev) 
 }
 
 void palette_render_state(palette_state_t *st) {
-	if (!st || !st->active) return;
+	if (!st || !st->active || !st->backend) return;
 	st->backend->paint(st, st->backend->ctx);
 }
 
 void palette_on_resize(palette_state_t *st, int term_rows, int term_cols) {
-	if (!st || !st->active) return;
+	if (!st || !st->active || !st->backend) return;
 	if (term_cols < 4 || term_rows < 2) return;
 	st->term_rows = term_rows;
 	st->term_cols = term_cols;

--- a/frontier-cli/palette.c
+++ b/frontier-cli/palette.c
@@ -515,11 +515,109 @@ static void close_all_levels(palette_state_t *st) {
 	while (st->open_depth > 0) close_deepest_level(st);
 }
 
+/* ---------- Pane render backend (default) ----------
+ *
+ * The five static functions below are TEXT-MOVE extractions of the
+ * rendering logic that previously lived inline in palette_open,
+ * palette_paint_teardown, palette_close, palette_render_state, and
+ * palette_on_resize. No logic has been changed; the functions are
+ * only moved here so they can be named in the s_pane_backend vtable.
+ *
+ * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction.
+ */
+
+static bool pane_backend_open(palette_state_t *st, void *ctx) {
+	(void)ctx;
+	/* Menubar strip: full-width, single row, one row below the prompt. */
+	pane_init(&st->menubar, 0, st->prompt_row + 1, st->term_cols, 1);
+	compositor_register(&st->menubar);
+	return true;
+}
+
+static void pane_backend_paint(palette_state_t *st, void *ctx) {
+	(void)ctx;
+	render_menubar(st);
+	for (int d = 0; d < st->open_depth; ++d) {
+		render_level(st, d);
+	}
+}
+
+static void pane_backend_paint_teardown(palette_state_t *st, void *ctx) {
+	(void)ctx;
+	/* pane_clear zeroes every cell (ch=0, fg=0, bg=0, attr=0). The
+	 * compositor renders ch=0 as ' ' and emits no SGR for fg/bg/attr
+	 * == 0 (default), so the next compositor_render() emits a "go back
+	 * to terminal default" frame for every cell these panes cover. */
+	for (int d = 0; d < st->open_depth && d < PALETTE_MAX_DEPTH; ++d) {
+		pane_clear(&st->levels[d].pane);
+	}
+	pane_clear(&st->menubar);
+}
+
+static void pane_backend_on_resize(palette_state_t *st, int term_rows,
+                                   int term_cols, void *ctx) {
+	(void)ctx;
+	/* Clamp the menubar's anchor if the new height made the old row
+	 * fall off the bottom.  prompt_row never moves up automatically on
+	 * resize (the REPL prompt position is not tracked), so the menubar
+	 * stays at its original row unless that row would now be past the
+	 * bottom -- in that case we slide it up. */
+	int desired_y = st->prompt_row + 1;
+	if (desired_y >= term_rows) {
+		desired_y = term_rows - 1;
+		st->prompt_row = desired_y - 1;
+		if (st->prompt_row < 0) st->prompt_row = 0;
+	}
+	pane_move(&st->menubar, 0, desired_y);
+	pane_resize(&st->menubar, term_cols, 1);
+
+	if (st->menubar_cursor >= st->menu_count) {
+		st->menubar_cursor = imax(0, st->menu_count - 1);
+	}
+
+	/* Reposition open cascade strips.  Each level lives at
+	 * menubar.y + 1 + d; close any level that no longer fits. */
+	for (int d = 0; d < st->open_depth; /* incremented inside */) {
+		palette_level_t *lvl = &st->levels[d];
+		int px = 0, py = 0, pw = 0, ph = 0;
+		if (!place_cascade_strip(st, d, &px, &py, &pw, &ph)) {
+			while (st->open_depth > d) close_deepest_level(st);
+			break;
+		}
+		pane_move(&lvl->pane, px, py);
+		pane_resize(&lvl->pane, pw, ph);
+		if (lvl->cursor >= lvl->item_count) {
+			lvl->cursor = imax(0, lvl->item_count - 1);
+		}
+		++d;
+	}
+}
+
+static void pane_backend_close(palette_state_t *st, void *ctx) {
+	(void)ctx;
+	compositor_unregister(&st->menubar);
+	pane_destroy(&st->menubar);
+}
+
+static const palette_render_backend_t s_pane_backend = {
+	NULL,                      /* ctx */
+	pane_backend_open,
+	pane_backend_paint,
+	pane_backend_paint_teardown,
+	pane_backend_on_resize,
+	pane_backend_close,
+};
+
+const palette_render_backend_t *palette_render_pane_backend(void) {
+	return &s_pane_backend;
+}
+
 /* ---------- Public API ---------- */
 
-bool palette_open(palette_state_t *st, int term_rows, int term_cols,
-                  int prompt_row,
-                  const palette_menu_source_t *source) {
+bool palette_open_ex(palette_state_t *st, int term_rows, int term_cols,
+                     int prompt_row,
+                     const palette_menu_source_t *source,
+                     const palette_render_backend_t *backend) {
 	if (!st || !source) return false;
 	if (term_cols < 4 || term_rows < 2) return false;
 
@@ -557,9 +655,7 @@ bool palette_open(palette_state_t *st, int term_rows, int term_cols,
 	layout_menubar(st);
 	if (st->menu_count <= 0) return false;
 
-	/* Menubar strip: full-width, single row, one row below the prompt. */
-	pane_init(&st->menubar, 0, prompt_row + 1, st->term_cols, 1);
-	compositor_register(&st->menubar);
+	st->backend = backend ? backend : &s_pane_backend;
 	st->active = true;
 	st->menubar_cursor = 0;
 	st->open_depth = 0;
@@ -567,28 +663,30 @@ bool palette_open(palette_state_t *st, int term_rows, int term_cols,
 	st->csi_len = 0;
 	st->exec_script = NULL;
 	st->exec_arg[0] = '\0';
+
+	if (!st->backend->open(st, st->backend->ctx)) {
+		st->active = false;
+		return false;
+	}
 	return true;
 }
 
+bool palette_open(palette_state_t *st, int term_rows, int term_cols,
+                  int prompt_row,
+                  const palette_menu_source_t *source) {
+	return palette_open_ex(st, term_rows, term_cols, prompt_row, source, NULL);
+}
+
 void palette_paint_teardown(palette_state_t *st) {
-	if (!st) return;
-	if (!st->active) return;
-	/* pane_clear zeroes every cell (ch=0, fg=0, bg=0, attr=0). The
-	 * compositor renders ch=0 as ' ' and emits no SGR for fg/bg/attr
-	 * == 0 (default), so the next compositor_render() emits a "go back
-	 * to terminal default" frame for every cell these panes cover. */
-	for (int d = 0; d < st->open_depth && d < PALETTE_MAX_DEPTH; ++d) {
-		pane_clear(&st->levels[d].pane);
-	}
-	pane_clear(&st->menubar);
+	if (!st || !st->active) return;
+	st->backend->paint_teardown(st, st->backend->ctx);
 }
 
 void palette_close(palette_state_t *st) {
 	if (!st) return;
 	if (!st->active) return;
 	close_all_levels(st);
-	compositor_unregister(&st->menubar);
-	pane_destroy(&st->menubar);
+	st->backend->close(st, st->backend->ctx);
 	memset(st->menu_labels, 0, sizeof(st->menu_labels));
 	st->active = false;
 }
@@ -911,10 +1009,7 @@ palette_done_t palette_feed_mouse(palette_state_t *st, const mouse_event_t *ev) 
 
 void palette_render_state(palette_state_t *st) {
 	if (!st || !st->active) return;
-	render_menubar(st);
-	for (int d = 0; d < st->open_depth; ++d) {
-		render_level(st, d);
-	}
+	st->backend->paint(st, st->backend->ctx);
 }
 
 void palette_on_resize(palette_state_t *st, int term_rows, int term_cols) {
@@ -922,39 +1017,5 @@ void palette_on_resize(palette_state_t *st, int term_rows, int term_cols) {
 	if (term_cols < 4 || term_rows < 2) return;
 	st->term_rows = term_rows;
 	st->term_cols = term_cols;
-
-	/* Clamp the menubar's anchor if the new height made the old row
-	 * fall off the bottom.  prompt_row never moves up automatically on
-	 * resize (the REPL prompt position is not tracked), so the menubar
-	 * stays at its original row unless that row would now be past the
-	 * bottom -- in that case we slide it up. */
-	int desired_y = st->prompt_row + 1;
-	if (desired_y >= term_rows) {
-		desired_y = term_rows - 1;
-		st->prompt_row = desired_y - 1;
-		if (st->prompt_row < 0) st->prompt_row = 0;
-	}
-	pane_move(&st->menubar, 0, desired_y);
-	pane_resize(&st->menubar, term_cols, 1);
-
-	if (st->menubar_cursor >= st->menu_count) {
-		st->menubar_cursor = imax(0, st->menu_count - 1);
-	}
-
-	/* Reposition open cascade strips.  Each level lives at
-	 * menubar.y + 1 + d; close any level that no longer fits. */
-	for (int d = 0; d < st->open_depth; /* incremented inside */) {
-		palette_level_t *lvl = &st->levels[d];
-		int px = 0, py = 0, pw = 0, ph = 0;
-		if (!place_cascade_strip(st, d, &px, &py, &pw, &ph)) {
-			while (st->open_depth > d) close_deepest_level(st);
-			break;
-		}
-		pane_move(&lvl->pane, px, py);
-		pane_resize(&lvl->pane, pw, ph);
-		if (lvl->cursor >= lvl->item_count) {
-			lvl->cursor = imax(0, lvl->item_count - 1);
-		}
-		++d;
-	}
+	st->backend->on_resize(st, term_rows, term_cols, st->backend->ctx);
 }

--- a/frontier-cli/palette.h
+++ b/frontier-cli/palette.h
@@ -382,7 +382,33 @@ typedef struct palette_state {
 	int arg_len;
 
 	const palette_menu_source_t *source;
+
+	/* 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction.
+	 * NULL is never stored here at runtime -- palette_open and palette_open_ex
+	 * both resolve NULL to the default pane backend before first use. */
+	const struct palette_render_backend *backend;
 } palette_state_t;
+
+/* ---------- Render backend abstraction (C.0.3a) ----------
+ *
+ * A function-pointer vtable that decouples the palette state machine
+ * from its concrete renderer. The existing pane-compositor path is
+ * wrapped as the DEFAULT backend, returned by palette_render_pane_backend().
+ * A future boxen-window backend (C.0.3b) will provide a second implementation.
+ *
+ * All five functions are REQUIRED (no NULL slots). ctx is opaque to the
+ * palette; the backend stores per-instance state there.
+ *
+ * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction.
+ */
+typedef struct palette_render_backend {
+	void *ctx;  /* opaque, backend-private */
+	bool (*open)(palette_state_t *st, void *ctx);
+	void (*paint)(palette_state_t *st, void *ctx);
+	void (*paint_teardown)(palette_state_t *st, void *ctx);
+	void (*on_resize)(palette_state_t *st, int term_rows, int term_cols, void *ctx);
+	void (*close)(palette_state_t *st, void *ctx);
+} palette_render_backend_t;
 
 /* ---------- Public API ---------- */
 
@@ -394,16 +420,38 @@ typedef struct palette_state {
  * (PR 3). `source` must remain valid until palette_close().
  *
  * On entry the compositor must have been initialised with
- * compositor_on_resize(term_rows, term_cols) — palette does not call it.
+ * compositor_on_resize(term_rows, term_cols) -- palette does not call it.
  *
  * Returns true on success, false if the menubar source has zero menus or
  * the terminal is too small to render the menubar at all (cols < 4).
  *
  * GIL: must be held by the caller. The source vtable callbacks
- * (count_menus, menu_describe) run inline and may touch the ODB. */
+ * (count_menus, menu_describe) run inline and may touch the ODB.
+ *
+ * This is a thin wrapper around palette_open_ex that passes NULL as the
+ * backend, which resolves to the default pane backend. */
 bool palette_open(palette_state_t *st, int term_rows, int term_cols,
                   int prompt_row,
                   const palette_menu_source_t *source);
+
+/* Extended open: same contract as palette_open but accepts an explicit
+ * render backend. When `backend` is NULL the default pane-compositor
+ * backend is used (identical behavior to palette_open). Non-NULL backends
+ * are used by alternative renderers (e.g. boxen-window backend, C.0.3b).
+ *
+ * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction. */
+bool palette_open_ex(palette_state_t *st, int term_rows, int term_cols,
+                     int prompt_row,
+                     const palette_menu_source_t *source,
+                     const palette_render_backend_t *backend);
+
+/* Return a pointer to the singleton default pane-compositor render backend.
+ * The returned pointer is valid for the lifetime of the process.
+ * Use this when you need to name the default backend explicitly, e.g. in
+ * tests that want to assert st.backend == palette_render_pane_backend().
+ *
+ * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction. */
+const palette_render_backend_t *palette_render_pane_backend(void);
 
 /* Close the palette. Unregisters all panes from the compositor and
  * destroys their cell buffers. Idempotent.

--- a/frontier-cli/palette.h
+++ b/frontier-cli/palette.h
@@ -383,9 +383,12 @@ typedef struct palette_state {
 
 	const palette_menu_source_t *source;
 
-	/* 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction.
-	 * NULL is never stored here at runtime -- palette_open and palette_open_ex
-	 * both resolve NULL to the default pane backend before first use. */
+	/* Render backend dispatch table.  NULL between palette_close() and the
+	 * next palette_open(_ex), or in zero-initialized state structs.  Public
+	 * dispatchers gate on st->active before dereferencing this, so a NULL
+	 * backend is never observable to backend code.  Set by palette_open_ex
+	 * (NULL caller-supplied backend resolves to &s_pane_backend).
+	 * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction. */
 	const struct palette_render_backend *backend;
 } palette_state_t;
 
@@ -403,6 +406,10 @@ typedef struct palette_state {
  */
 typedef struct palette_render_backend {
 	void *ctx;  /* opaque, backend-private */
+	/* Called by palette_open_ex during init.  Returns false on hard
+	 * failure -- in which case the backend MUST have cleaned up any
+	 * partial state itself; palette_open_ex will not call close() after
+	 * a failed open(). */
 	bool (*open)(palette_state_t *st, void *ctx);
 	void (*paint)(palette_state_t *st, void *ctx);
 	void (*paint_teardown)(palette_state_t *st, void *ctx);
@@ -438,6 +445,9 @@ bool palette_open(palette_state_t *st, int term_rows, int term_cols,
  * render backend. When `backend` is NULL the default pane-compositor
  * backend is used (identical behavior to palette_open). Non-NULL backends
  * are used by alternative renderers (e.g. boxen-window backend, C.0.3b).
+ *
+ * `backend` (when non-NULL) must remain valid until palette_close() returns,
+ * like `source` (see the lifetime note above).
  *
  * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction. */
 bool palette_open_ex(palette_state_t *st, int term_rows, int term_cols,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -223,7 +223,7 @@ USERTALK_OBJECT_TESTS = \
 	test_usertalk_runner
 
 # Buildable test executables on this branch
-RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge copyctopstring_tests ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests boxen_backend_tests boxen_core_tests boxen_input_tests boxen_resize_tests boxen_scroll_tests boxen_chrome_tests boxen_cursor_tests debugger_tui_tests boxen_repl_tests boxen_outline_tests
+RUN_BUILDABLE = core_tests db_format_tests runtime_tests parser_tests save_migration_tests test_efp_augmentation file_portable_tests file_readline_tests file_verb_tests handle_tests cli_runtime_tests paige_text_tests oppack_tests hashpack_modern_tests hash_corruption_tests langvalue_64_tests table_operations_integration refcon_tests refcon_phase2_tests op_context_tests table_context_tests time_portability_test test_sys_shell_command_verbs headless_selection_tests opattributes_stub_tests headless_thread_registry_tests test_callback_infrastructure tcp_phase1a_unit_tests menu_v7_refcon_tests menudata_headless_tests menu_list_describe_tests meuserselected_headless_tests test_stringerrorlist pane_compositor_tests mouse_parser_tests terminal_control_tests terminal_control_dsr_tests palette_state_tests palette_render_snapshot_tests palette_render_backend_tests palette_arg_inject_tests palette_arg_inject_concurrency_tests repl_palette_source_tests repl_verbs_tests repl_slash_resolver_tests scrollback_pane_tests lang_causedby_snapshot_tests test_getsystemtablescript test_window_bridge copyctopstring_tests ut_sync_canonicalize_tests ut_sync_pathmap_tests ut_sync_pctcodec_tests ut_sync_export_tests ut_sync_decanonicalize_tests ut_sync_import_tests boxen_backend_tests boxen_core_tests boxen_input_tests boxen_resize_tests boxen_scroll_tests boxen_chrome_tests boxen_cursor_tests debugger_tui_tests boxen_repl_tests boxen_outline_tests
 # Note: table_verb_tests skipped - pre-existing macOS path detection issue
 # Note: test_error_messages skipped - needs full runtime linking (tracked in separate task)
 # Note: test_table_sorting skipped - script execution errors cause segfault (Issue #449)
@@ -494,6 +494,12 @@ palette_state_tests: palette_state_tests.c ../frontier-cli/pane.c ../frontier-cl
 
 palette_render_snapshot_tests: palette_render_snapshot_tests.c ../frontier-cli/pane.c ../frontier-cli/pane.h ../frontier-cli/palette.c ../frontier-cli/palette.h
 	$(CC) $(CFLAGS) -I../frontier-cli palette_render_snapshot_tests.c ../frontier-cli/pane.c ../frontier-cli/palette.c -o $@ $(LINK_LIBS)
+
+# palette render-backend abstraction tests (C.0.3a).
+# Standalone -- links pane.c and palette.c only (same slice as snapshot tests).
+# 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction.
+palette_render_backend_tests: palette_render_backend_tests.c ../frontier-cli/pane.c ../frontier-cli/pane.h ../frontier-cli/palette.c ../frontier-cli/palette.h
+	$(CC) $(CFLAGS) -I../frontier-cli palette_render_backend_tests.c ../frontier-cli/pane.c ../frontier-cli/palette.c -o $@ $(LINK_LIBS)
 
 # Scrollback pane + palette-aware async output router (issue #593).
 # Standalone — links pane.c, scrollback_pane.c, repl_output_async.c.

--- a/tests/palette_render_backend_tests.c
+++ b/tests/palette_render_backend_tests.c
@@ -1,0 +1,231 @@
+/*
+ * palette_render_backend_tests.c - Behavioural tests for the
+ * palette render-backend vtable abstraction (C.0.3a).
+ *
+ * Three tests validate the dispatch mechanism introduced by
+ * palette_render_backend_t:
+ *
+ *   1. test_default_backend_is_pane
+ *      Open via the legacy palette_open signature; assert that
+ *      st.backend points at palette_render_pane_backend().
+ *
+ *   2. test_paint_dispatch_calls_backend_fn
+ *      Install a mock backend with a paint counter; call
+ *      palette_render_state(&st); assert counter > 0.
+ *
+ *   3. test_open_close_resize_lifecycle_calls_backend_fns
+ *      Mock backend records call order; assert sequence
+ *      open -> paint -> on_resize -> paint -> paint_teardown -> close.
+ *
+ * 2026-06-10 JES #691 Phase C.0.3a: render backend abstraction.
+ *
+ * License
+ * -------
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Frontier contributors.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "pane.h"
+#include "palette.h"
+#include "test_report.h"
+
+extern void compositor_test_reset(void);
+
+/* ---------- Mock backend plumbing ---------- */
+
+typedef struct {
+	int open_count;
+	int paint_count;
+	int teardown_count;
+	int resize_count;
+	int close_count;
+	/* Small recorded sequence for lifecycle test. Each char is the
+	 * initial letter of the function that ran: O P T R C (open, paint,
+	 * teardown, resize, close). */
+	char call_log[256];
+	int call_log_len;
+} mock_backend_state_t;
+
+static void mock_log(mock_backend_state_t *m, char c) {
+	if (m->call_log_len < (int)(sizeof(m->call_log) - 1)) {
+		m->call_log[m->call_log_len++] = c;
+		m->call_log[m->call_log_len]   = '\0';
+	}
+}
+
+static bool mock_open(palette_state_t *st, void *ctx) {
+	(void)st;
+	mock_backend_state_t *m = (mock_backend_state_t *)ctx;
+	m->open_count++;
+	mock_log(m, 'O');
+	return true;
+}
+
+static void mock_paint(palette_state_t *st, void *ctx) {
+	(void)st;
+	mock_backend_state_t *m = (mock_backend_state_t *)ctx;
+	m->paint_count++;
+	mock_log(m, 'P');
+}
+
+static void mock_paint_teardown(palette_state_t *st, void *ctx) {
+	(void)st;
+	mock_backend_state_t *m = (mock_backend_state_t *)ctx;
+	m->teardown_count++;
+	mock_log(m, 'T');
+}
+
+static void mock_on_resize(palette_state_t *st, int rows, int cols, void *ctx) {
+	(void)st; (void)rows; (void)cols;
+	mock_backend_state_t *m = (mock_backend_state_t *)ctx;
+	m->resize_count++;
+	mock_log(m, 'R');
+}
+
+static void mock_close(palette_state_t *st, void *ctx) {
+	(void)st;
+	mock_backend_state_t *m = (mock_backend_state_t *)ctx;
+	m->close_count++;
+	mock_log(m, 'C');
+}
+
+/* ---------- Synthetic source (minimal, 2-menu fixture) ---------- */
+
+static int src_count(void *ctx) { (void)ctx; return 2; }
+static bool src_describe(void *ctx, int idx, char *out, size_t cap, char *hk) {
+	(void)ctx;
+	if (idx == 0) { snprintf(out, cap, "REPL"); *hk = 'R'; return true; }
+	if (idx == 1) { snprintf(out, cap, "File"); *hk = 'F'; return true; }
+	return false;
+}
+static int src_item_count(void *ctx, int mi, void *po) {
+	(void)ctx; (void)mi; (void)po; return 0;
+}
+static bool src_item_describe(void *ctx, int mi, void *po, int ii,
+                               palette_item_t *out) {
+	(void)ctx; (void)mi; (void)po; (void)ii; (void)out; return false;
+}
+
+static palette_menu_source_t make_src(void) {
+	palette_menu_source_t s;
+	memset(&s, 0, sizeof(s));
+	s.ctx = NULL;
+	s.count_menus    = src_count;
+	s.menu_describe  = src_describe;
+	s.item_count     = src_item_count;
+	s.item_describe  = src_item_describe;
+	return s;
+}
+
+/* ---------- Tests ---------- */
+
+/* 1. Legacy palette_open stores the pane backend pointer. */
+static void test_default_backend_is_pane(void) {
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+	palette_state_t st;
+	palette_menu_source_t src = make_src();
+
+	bool ok = palette_open(&st, 24, 80, 0, &src);
+	assert(ok);
+
+	/* st.backend must be the canonical pane backend, not NULL. */
+	assert(st.backend != NULL);
+	assert(st.backend == palette_render_pane_backend());
+
+	palette_close(&st);
+}
+
+/* 2. palette_render_state dispatches to the backend's paint fn. */
+static void test_paint_dispatch_calls_backend_fn(void) {
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+
+	mock_backend_state_t m;
+	memset(&m, 0, sizeof(m));
+
+	palette_render_backend_t mock_be;
+	memset(&mock_be, 0, sizeof(mock_be));
+	mock_be.ctx            = &m;
+	mock_be.open           = mock_open;
+	mock_be.paint          = mock_paint;
+	mock_be.paint_teardown = mock_paint_teardown;
+	mock_be.on_resize      = mock_on_resize;
+	mock_be.close          = mock_close;
+
+	palette_state_t st;
+	palette_menu_source_t src = make_src();
+
+	bool ok = palette_open_ex(&st, 24, 80, 0, &src, &mock_be);
+	assert(ok);
+	assert(m.open_count == 1);
+
+	int paint_before = m.paint_count;
+	palette_render_state(&st);
+	assert(m.paint_count > paint_before);
+
+	palette_close(&st);
+	assert(m.close_count == 1);
+}
+
+/* 3. Full lifecycle: open -> paint -> on_resize -> paint -> teardown -> close.
+ * The call_log must record exactly "OPRPTC". */
+static void test_open_close_resize_lifecycle_calls_backend_fns(void) {
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+
+	mock_backend_state_t m;
+	memset(&m, 0, sizeof(m));
+
+	palette_render_backend_t mock_be;
+	memset(&mock_be, 0, sizeof(mock_be));
+	mock_be.ctx            = &m;
+	mock_be.open           = mock_open;
+	mock_be.paint          = mock_paint;
+	mock_be.paint_teardown = mock_paint_teardown;
+	mock_be.on_resize      = mock_on_resize;
+	mock_be.close          = mock_close;
+
+	palette_state_t st;
+	palette_menu_source_t src = make_src();
+
+	/* open: logs 'O' */
+	bool ok = palette_open_ex(&st, 24, 80, 0, &src, &mock_be);
+	assert(ok);
+
+	/* paint: logs 'P' */
+	palette_render_state(&st);
+
+	/* on_resize: logs 'R' */
+	palette_on_resize(&st, 30, 100);
+
+	/* paint again: logs 'P' */
+	palette_render_state(&st);
+
+	/* paint_teardown: logs 'T' */
+	palette_paint_teardown(&st);
+
+	/* close: logs 'C' */
+	palette_close(&st);
+
+	/* Expected: O P R P T C */
+	assert(strcmp(m.call_log, "OPRPTC") == 0);
+}
+
+/* ---------- Main ---------- */
+
+int main(void) {
+	TR_INIT("palette_render_backend_tests");
+	TR_RUN(test_default_backend_is_pane);
+	TR_RUN(test_paint_dispatch_calls_backend_fn);
+	TR_RUN(test_open_close_resize_lifecycle_calls_backend_fns);
+	TR_SUMMARY();
+	return TR_EXIT_CODE();
+}

--- a/tests/palette_render_snapshot_tests.c
+++ b/tests/palette_render_snapshot_tests.c
@@ -171,7 +171,7 @@ static void test_menubar_strip_full_width(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	render_all(&st);
 
 	int y = st.menubar.y;
@@ -207,7 +207,7 @@ static void test_horizontal_strip_full_width(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	palette_feed_byte(&st, '\r');           /* open REPL menu */
 	render_all(&st);
 
@@ -245,7 +245,7 @@ static void test_item_bracket_reservation(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 
 	palette_feed_byte(&st, '\r');           /* open REPL */
 	render_all(&st);
@@ -297,7 +297,7 @@ static void test_selected_item_has_brackets(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 
 	palette_feed_byte(&st, '\r');           /* open REPL, cursor on Help */
 	render_all(&st);
@@ -341,7 +341,7 @@ static void test_hotkey_bold_yellow_when_not_selected(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 
 	palette_feed_byte(&st, '\r');           /* cursor on Help (item 0) */
 	render_all(&st);
@@ -370,7 +370,7 @@ static void test_hotkey_bold_only_when_selected(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 
 	palette_feed_byte(&st, '\r');           /* cursor on Help (selected) */
 	render_all(&st);
@@ -416,7 +416,7 @@ static void test_checked_item_draws_check_glyph(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_edit_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	palette_feed_byte(&st, '\r');           /* open Edit menu */
 	render_all(&st);
 
@@ -453,7 +453,7 @@ static void test_separator_draws_dim_divider(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_edit_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	palette_feed_byte(&st, '\r');           /* open Edit menu */
 	render_all(&st);
 
@@ -482,7 +482,7 @@ static void test_cursor_skips_separator(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_edit_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	palette_feed_byte(&st, '\r');           /* open Edit menu */
 
 	assert(st.levels[0].cursor == 0);       /* Wrap, not the separator */
@@ -529,7 +529,7 @@ static void test_wide_menu_keeps_cursor_item_visible(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_wide_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	palette_feed_byte(&st, '\r');           /* open Edit menu */
 
 	/* Step RIGHT to the last item (index 4). */
@@ -593,7 +593,7 @@ static void test_menubar_hotkey_styling(void) {
 	compositor_on_resize(24, 80);
 	palette_state_t st;
 	palette_menu_source_t src = snap_source(&g_src);
-	palette_open(&st, 24, 80, 0, &src);
+	palette_open_ex(&st, 24, 80, 0, &src, palette_render_pane_backend());
 	render_all(&st);
 
 	int y = st.menubar.y;


### PR DESCRIPTION
## Summary

Introduces a function-pointer render-backend abstraction in `palette.h` so the existing pane-compositor rendering becomes one backend (`palette_render_pane_backend`). **Refactor only — no behavior change.** This is the first half of the C.0.3 split (the abstraction); C.0.3b will add the boxen-window backend.

This is milestone **C.0.3a** from [planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md](https://github.com/jsavin/Frontier/blob/develop/planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md) Section 3 — third of seven boxen-parity steps before the C.6 default flip.

## Why split

The original execution plan assumed palette.c renders via raw termbox2. The Plan agent discovered it actually renders ANSI escape sequences directly to stdout via `pane.c` (`fputs(..., stdout)` / `fflush(stdout)`). In boxen mode, stdout is captured into a pipe AND boxen's termbox2 backend owns the framebuffer — so palette rendering inside boxen would either be swallowed (invisible) or corrupt the framebuffer.

Splitting de-risks: this PR is a pure refactor locked in by 11 byte-identical SGR-output snapshot tests. C.0.3b adds the boxen backend on a clean abstraction with the snapshot baseline soaked.

## Changes

**New public API (`palette.h`)**
- `palette_render_backend_t` function-pointer vtable: open / paint / paint_teardown / on_resize / close
- `palette_open_ex(...)` — new sibling of `palette_open`, takes an explicit backend
- `palette_render_pane_backend()` — returns the default pane backend pointer
- New `backend` field on `palette_state_t`

**Internal extraction (`palette.c`)**
- 5 static `pane_backend_*` functions extracted from the inlined logic in `palette_open`, `palette_render_state`, `palette_paint_teardown`, `palette_on_resize`, `palette_close`
- `s_pane_backend` const vtable instance
- Public dispatchers become 2-3 line dispatches through `st->backend`
- `palette_open` reimplemented as a 2-line wrapper around `palette_open_ex(..., NULL)`
- NULL backend implicitly resolves to the pane backend → full back-compat with every existing caller

**Tests (`tests/palette_render_backend_tests.c`, NEW)**
- `test_default_backend_is_pane` — legacy `palette_open` sets `backend` to pane
- `test_paint_dispatch_calls_backend_fn` — `palette_render_state` invokes the backend's paint
- `test_open_close_resize_lifecycle_calls_backend_fns` — full lifecycle dispatch sequence verified

`tests/palette_render_snapshot_tests.c` updated to use `palette_open_ex(..., palette_render_pane_backend())` explicitly. **All 11 snapshot tests pass byte-identical** — this is the regression net for the SGR output the linenoise REPL produces.

## Behavioral contract

| Surface | Today | After C.0.3a |
|---|---|---|
| `palette_open(...)` | Implicit pane rendering | Wrapper around `palette_open_ex(..., NULL)`, identical |
| `palette_render_state(...)` | Inlined pane paint | Dispatches via `st->backend->paint`; default = pane (byte-identical SGR) |
| Linenoise REPL `/` flow | Opens palette, pane rendering | Identical observable behavior, identical SGR output |
| Boxen REPL `/` flow | `/` typed into input_buf | Unchanged (boxen wiring is C.0.3b) |
| Existing palette tests | Pass | Pass unchanged |

## Test plan

- [x] Unit: 787/787 (+3 new; was 784 after C.0.2)
- [x] Integration: 2186 pass / 21 baseline (character-for-character match)
- [x] **palette_render_snapshot_tests: 11/11 byte-identical** (the canonical regression net)
- [x] `make -C frontier-cli` clean
- [ ] Manual (linenoise REPL): `dist/frontier-cli`, type `/`, palette opens with same visual layout, same key handling, same slot dispatch as develop
- [ ] Manual (boxen REPL): `dist/frontier-cli --debug-tui`, type `/`, still typed into input_buf (proves no boxen behavior change)

## Out of scope (deferred to C.0.3b)

- Actual boxen-window backend wiring
- `/` key in boxen REPL opening the palette
- `palette_open_hook` test seam on `boxen_repl_state_t`

## Next

C.0.3b will be a separate PR: implement `palette_render_boxen_backend()`, wire boxen REPL `/` key, add modal lifecycle / focus restoration. The Plan agent's forward-looking sketch is captured at the bottom of the C.0.3 plan in this PR's review thread.

Refs: #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
