### PR TITLE
feat(repl): C.0.4 async output regression guards + post-dispatch drain

### DIFF
--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -1360,7 +1360,17 @@ int boxen_repl_main(const cli_options_t *opts) {
 	 * if needed.
 	 *
 	 * On any pipe setup failure, we fall through without capture (display will
-	 * be corrupted by raw stdout writes, but the REPL is still functional). */
+	 * be corrupted by raw stdout writes, but the REPL is still functional).
+	 *
+	 * 2026-06-10 JES #691 Phase C.0.4 follow-up:
+	 *   - Post-dispatch drain added (after boxen_repl_run_one_tick): slash
+	 *     output now reaches the scrollback before the next boxen_present().
+	 *   - The 100ms boxen_poll_event timeout means drain runs at >= 10 Hz even
+	 *     with zero input.  A full pipe stalls the producer at most one drain
+	 *     period (100ms); no hang is possible because the read end is O_NONBLOCK
+	 *     and drain_stdout_into_scrollback always empties the pipe before returning.
+	 *   - drain never touches input_buf or input_cursor -- async output during
+	 *     in-progress typing is safe.  See test_stdout_drain_during_typing_does_not_corrupt_input. */
 	int pipefd[2];
 	bool capture_active = false;
 	if (pipe(pipefd) == 0) {
@@ -1489,6 +1499,14 @@ int boxen_repl_main(const cli_options_t *opts) {
 		}
 
 		boxen_repl_run_one_tick(state, &ev);
+
+		/* 2026-06-10 JES #691 Phase C.0.4: post-dispatch drain.
+		 * Slash dispatch / eval may have written to stdout; drain promptly so
+		 * output reaches the scrollback before the next boxen_present(). */
+		if (capture_active) {
+			drain_stdout_into_scrollback(state, state->pipe_read_fd);
+		}
+
 		boxen_present();
 	}
 

--- a/frontier-cli/boxen_repl_internal.h
+++ b/frontier-cli/boxen_repl_internal.h
@@ -349,10 +349,19 @@ void boxen_repl_set_history_path_for_test(const char *path);
  * '\n') are held in s->partial_line until the next drain call completes them.
  *
  * In production: called after every boxen_poll_event returns (event OR
- * timeout) to drain the stdout-capture pipe into the scrollback.
+ * timeout) to drain the stdout-capture pipe into the scrollback, AND once
+ * more immediately after boxen_repl_run_one_tick (Phase C.0.4 post-dispatch
+ * drain) so slash / eval output reaches scrollback before the next
+ * boxen_present().
  *
  * In test builds: called directly with a test-supplied pipe fd to verify
  * the drain behavior without touching real stdout.
+ *
+ * 2026-06-10 JES #691 Phase C.0.4: async-input invariant.
+ * Drain only mutates state->scrollback + state->partial_line.  It NEVER
+ * touches state->input_buf or state->input_cursor, so concurrent
+ * typing (or any input-bar state) is preserved across drain calls.
+ * Tested by test_stdout_drain_during_typing_does_not_corrupt_input.
  *
  * Parameters:
  *   s  -- REPL state; partial_line / partial_line_len accumulate across calls

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -986,6 +986,109 @@ static void test_slash_mid_input_still_inserts(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * test_stdout_drain_during_typing_does_not_corrupt_input
+ *
+ * 2026-06-10 JES #691 Phase C.0.4: regression guard for async-input invariant.
+ *
+ * Verifies that calling drain_stdout_into_scrollback() while the input bar
+ * holds in-progress typed characters leaves input_buf and input_cursor
+ * completely untouched.  Also confirms that scrollback_count grows by exactly
+ * one (the single "async-msg\n" line written to the test pipe).
+ * ---------------------------------------------------------------------- */
+static void test_stdout_drain_during_typing_does_not_corrupt_input(void) {
+	setup();
+
+	/* Type "abc" into the input bar */
+	boxen_event_t a = make_char_event('a');
+	boxen_event_t b = make_char_event('b');
+	boxen_event_t c = make_char_event('c');
+	boxen_repl_run_one_tick(&g_state, &a);
+	boxen_repl_run_one_tick(&g_state, &b);
+	boxen_repl_run_one_tick(&g_state, &c);
+
+	/* Create a test pipe, write one async line, then drain it */
+	int pipefd[2];
+	assert(pipe(pipefd) == 0);
+	fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
+	const char *msg = "async-msg\n";
+	ssize_t w = write(pipefd[1], msg, strlen(msg));
+	assert(w == (ssize_t)strlen(msg));
+	close(pipefd[1]);
+
+	int ring_before = g_state.scrollback_count;
+
+	drain_stdout_into_scrollback(&g_state, pipefd[0]);
+	close(pipefd[0]);
+
+	/* Input bar must be completely untouched */
+	assert(strcmp(g_state.input_buf, "abc") == 0);
+	assert(g_state.input_cursor == 3);
+
+	/* Scrollback grew by exactly one line */
+	assert(g_state.scrollback_count == ring_before + 1);
+	int newest = (g_state.scrollback_head - 1 + BOXEN_REPL_SCROLLBACK_SIZE) %
+	             BOXEN_REPL_SCROLLBACK_SIZE;
+	assert(g_state.scrollback[newest] != NULL);
+	assert(strstr(g_state.scrollback[newest], "async-msg") != NULL);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * test_long_output_does_not_deadlock_event_loop
+ *
+ * 2026-06-10 JES #691 Phase C.0.4: regression guard for no-hang invariant.
+ *
+ * Writes >100 KB to a non-blocking pipe and drains on backpressure.  Proves
+ * that the consumer (drain_stdout_into_scrollback) makes room promptly enough
+ * that the producer never loops more than 1000 times, and that scrollback
+ * does grow (data actually reached the ring).
+ *
+ * This mirrors the 10 Hz drain guarantee in production: the read end is
+ * O_NONBLOCK, so drain loops until EAGAIN without blocking the event loop.
+ * A full pipe triggers EAGAIN / EWOULDBLOCK on the write side; draining first
+ * makes room for the next write.
+ * ---------------------------------------------------------------------- */
+static void test_long_output_does_not_deadlock_event_loop(void) {
+	setup();
+
+	int pipefd[2];
+	assert(pipe(pipefd) == 0);
+	fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
+	fcntl(pipefd[1], F_SETFL, O_NONBLOCK);
+
+	const size_t target = 100 * 1024;
+	char chunk[256];
+	memset(chunk, 'x', sizeof(chunk));
+	chunk[sizeof(chunk) - 1] = '\n';  /* ensure every chunk terminates a line */
+
+	size_t total_written = 0;
+	int    drain_iters   = 0;
+	int    ring_before   = g_state.scrollback_count;
+
+	while (total_written < target && drain_iters < 1000) {
+		ssize_t nw = write(pipefd[1], chunk, sizeof(chunk));
+		if (nw < 0) {
+			/* Pipe full -- drain and retry; proves consumer makes room */
+			drain_stdout_into_scrollback(&g_state, pipefd[0]);
+			drain_iters++;
+			continue;
+		}
+		total_written += (size_t)nw;
+	}
+	/* Final drain: consume whatever remains in the pipe */
+	drain_stdout_into_scrollback(&g_state, pipefd[0]);
+	close(pipefd[1]);
+	close(pipefd[0]);
+
+	assert(total_written >= target);
+	assert(drain_iters < 1000);
+	assert(g_state.scrollback_count > ring_before);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 int main(void) {
@@ -1010,6 +1113,8 @@ int main(void) {
 	TR_RUN(test_palette_close_returns_focus_to_repl_input);
 	TR_RUN(test_palette_dispatch_hook_contract);
 	TR_RUN(test_slash_mid_input_still_inserts);
+	TR_RUN(test_stdout_drain_during_typing_does_not_corrupt_input);
+	TR_RUN(test_long_output_does_not_deadlock_event_loop);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -1009,7 +1009,9 @@ static void test_stdout_drain_during_typing_does_not_corrupt_input(void) {
 	/* Create a test pipe, write one async line, then drain it */
 	int pipefd[2];
 	assert(pipe(pipefd) == 0);
-	fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
+	/* 2026-06-10 JES #691 Phase C.0.4: assert fcntl so a silent O_NONBLOCK
+	 * failure surfaces as a clear assertion rather than a read() hang. */
+	assert(fcntl(pipefd[0], F_SETFL, O_NONBLOCK) == 0);
 	const char *msg = "async-msg\n";
 	ssize_t w = write(pipefd[1], msg, strlen(msg));
 	assert(w == (ssize_t)strlen(msg));
@@ -1048,14 +1050,23 @@ static void test_stdout_drain_during_typing_does_not_corrupt_input(void) {
  * O_NONBLOCK, so drain loops until EAGAIN without blocking the event loop.
  * A full pipe triggers EAGAIN / EWOULDBLOCK on the write side; draining first
  * makes room for the next write.
+ *
+ * Realistic ceiling is ~3 drain iterations (100 KB target / 64 KB pipe / 256 B
+ * chunks).  The 1000 cap below is the deadlock guard, NOT a tight bound --
+ * hitting it would mean drain itself stopped consuming the pipe.  Future
+ * maintainers seeing flake at the cap should suspect a regression in
+ * drain_stdout_into_scrollback, not raise the cap.
  * ---------------------------------------------------------------------- */
 static void test_long_output_does_not_deadlock_event_loop(void) {
 	setup();
 
 	int pipefd[2];
 	assert(pipe(pipefd) == 0);
-	fcntl(pipefd[0], F_SETFL, O_NONBLOCK);
-	fcntl(pipefd[1], F_SETFL, O_NONBLOCK);
+	/* 2026-06-10 JES #691 Phase C.0.4: assert fcntls so silent O_NONBLOCK
+	 * failures surface as clear assertions rather than as a producer-side
+	 * write() hang (test 2 would deadlock silently otherwise). */
+	assert(fcntl(pipefd[0], F_SETFL, O_NONBLOCK) == 0);
+	assert(fcntl(pipefd[1], F_SETFL, O_NONBLOCK) == 0);
 
 	const size_t target = 100 * 1024;
 	char chunk[256];


### PR DESCRIPTION
## Summary

Hardening + regression guards for the boxen REPL's async stdout drain. Adds 2 behavioral tests that lock in the invariants the existing drain already upholds, plus one small production change (post-dispatch drain) that makes slash-command output appear sooner.

This is milestone **C.0.4** from [planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md](https://github.com/jsavin/Frontier/blob/develop/planning/phase_c/REPL_SCHISM_EXECUTION_PLAN.md) Section 4. Outcome A per the Plan agent's read of the existing code: the deadlock concerns the original execution plan flagged are already handled (read end is non-blocking; 10 Hz drain timer via 100ms poll timeout self-clears any producer stall on a full pipe).

## Changes

**Production change (`boxen_repl.c`)**
- One conditional + drain call added immediately after `boxen_repl_run_one_tick` in the event loop: slash dispatch / eval can write to stdout, so drain promptly so output reaches the scrollback before the next `boxen_present()`. Previously output waited up to 100ms (next drain trigger after poll). Now it appears immediately.

**Tests (`tests/boxen_repl_tests.c`)**
- `test_stdout_drain_during_typing_does_not_corrupt_input` — drain only mutates scrollback + partial_line; never touches input_buf or input_cursor. Regression guard.
- `test_long_output_does_not_deadlock_event_loop` — a >100KB workload completes within bounded drain iterations (read end is non-blocking; drain loops until EAGAIN). Regression guard.

Both tests pass against existing code (TDD with honest exception — invariants already hold; tests lock them in for future refactors).

**Doc tightening**
- `boxen_repl_internal.h` — `drain_stdout_into_scrollback` header doc now documents the async-input invariant explicitly
- `boxen_repl.c` — C.0 round-2 comment block updated with the 10 Hz drain timer rationale

## Why outcome A

The Plan agent traced every drain-related code path:
- Pipe read end is non-blocking (`fcntl(pipefd[0], F_SETFL, O_NONBLOCK)` at line 1370)
- Pipe write end stays blocking by design (documented in C.0 comment block)
- Drain runs BETWEEN `boxen_poll_event` (100ms timeout) and `boxen_repl_run_one_tick` — so minimum 10 Hz even with zero terminal input
- A 64KB-full pipe means the producer throttles at ~640 KB/s minimum (64KB / 100ms) — far above realistic Frontier stdout rates
- Drain never touches `input_buf` or `input_cursor` — only scrollback ring and `partial_line` accumulator

Adaptive poll timeout (suggested in the original execution plan) is unnecessary — fixed 100ms is sufficient.

## Test plan

- [x] Unit: 793/793 (+2 new; was 791 after C.0.3b)
- [x] Integration: 2186 pass / 21 baseline (character-for-character match)
- [x] `make -C frontier-cli` clean
- [ ] Manual (boxen REPL, optional): `dist/frontier-cli --debug-tui`, run a UserTalk loop that `msg`s while typing — verify (a) each msg appears within ~100ms, (b) input bar shows typed chars correctly without tearing, (c) REPL stays responsive under sustained output

## Out of scope (per execution plan)

- Separate async-drain thread — not needed
- stdout buffering tuning — not needed
- Capturing stderr separately

Refs: #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
