### PR TITLE
fix(repl): C.0.7c Ctrl-C closes palette modal

### DIFF
--- a/frontier-cli/palette.c
+++ b/frontier-cli/palette.c
@@ -866,6 +866,18 @@ palette_done_t palette_feed_byte(palette_state_t *st, unsigned char b) {
 			return PALETTE_DONE_NONE;
 		}
 
+		/* 2026-06-17 JES #691 Phase C.0.7c: Ctrl-C (ETX, 0x03) cancels the
+		 * palette unconditionally from any state -- menubar, cascade, mid-CSI
+		 * escape (that path returns early above, so we don't reach here with
+		 * a partial CSI).  ESC collapses one cascade level at a time; Ctrl-C
+		 * is the "abort everything" key and must return DONE_CANCEL directly
+		 * regardless of open_depth.  The boxen backend routes Ctrl-C here
+		 * only when the modal is open (boxen_dispatch_event: global key handler
+		 * fires only when modal_win == NULL, so the modal always wins). */
+		if (b == 0x03) {
+			return PALETTE_DONE_CANCEL;
+		}
+
 		if (b == '\r' || b == '\n') {
 			if (st->open_depth == 0) {
 				open_level(st, 0);

--- a/tests/palette_state_tests.c
+++ b/tests/palette_state_tests.c
@@ -854,6 +854,70 @@ static void test_depth_cap_refuses_extra_open(void) {
 	palette_close(&st);
 }
 
+/* -------------------------------------------------------------------------
+ * 2026-06-17 JES #691 Phase C.0.7c: Ctrl-C (byte 0x03) must cancel the
+ * palette from ANY state -- menubar-only, one cascade level open, two
+ * cascade levels open.  Regression for the bug where 0x03 fell through
+ * the palette_feed_byte() switch with no handler and returned DONE_NONE.
+ * ---------------------------------------------------------------------- */
+
+static void test_ctrl_c_at_top_level_cancels(void) {
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+	palette_state_t st;
+	palette_menu_source_t src = make_default_source();
+	palette_open(&st, 24, 80, 0, &src);
+
+	/* Palette open, no cascade -- Ctrl-C must immediately cancel. */
+	assert(st.open_depth == 0);
+	palette_done_t r = palette_feed_byte(&st, 0x03);
+	assert(r == PALETTE_DONE_CANCEL);
+
+	palette_close(&st);
+}
+
+static void test_ctrl_c_with_cascade_open_cancels(void) {
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+	palette_state_t st;
+	palette_menu_source_t src = make_default_source();
+	palette_open(&st, 24, 80, 0, &src);
+
+	/* Open one cascade level (ENTER on the menubar). */
+	palette_feed_byte(&st, '\r');
+	assert(st.open_depth == 1);
+
+	/* Ctrl-C must cancel immediately, not just collapse one level. */
+	palette_done_t r = palette_feed_byte(&st, 0x03);
+	assert(r == PALETTE_DONE_CANCEL);
+
+	palette_close(&st);
+}
+
+static void test_ctrl_c_with_deep_cascade_cancels(void) {
+	compositor_test_reset();
+	compositor_on_resize(24, 80);
+	palette_state_t st;
+	palette_menu_source_t src = make_default_source();
+	palette_open(&st, 24, 80, 0, &src);
+
+	/* Navigate to File > Views (a submenu) and open it -- two levels deep.
+	 * 'F' opens File; RIGHT moves to Views; ENTER opens it. */
+	palette_feed_byte(&st, 'F');
+	assert(st.open_depth == 1);
+	/* Navigate right to "Views" (index 1). */
+	palette_feed_byte(&st, 0x1b); palette_feed_byte(&st, '['); palette_feed_byte(&st, 'C');
+	assert(st.levels[0].cursor == 1);
+	palette_feed_byte(&st, '\r');
+	assert(st.open_depth == 2);
+
+	/* Ctrl-C must cancel from two levels deep in one shot. */
+	palette_done_t r = palette_feed_byte(&st, 0x03);
+	assert(r == PALETTE_DONE_CANCEL);
+
+	palette_close(&st);
+}
+
 static void test_fast_timers_env_var_sets_short_esc_timeout(void) {
 	const char *saved = getenv("FRONTIER_PALETTE_FAST_TIMERS");
 	char saved_copy[64];
@@ -908,6 +972,9 @@ int main(void) {
 	TR_RUN(test_resize_clamps_menubar_cursor);
 	TR_RUN(test_depth_cap_refuses_extra_open);
 	TR_RUN(test_fast_timers_env_var_sets_short_esc_timeout);
+	TR_RUN(test_ctrl_c_at_top_level_cancels);
+	TR_RUN(test_ctrl_c_with_cascade_open_cancels);
+	TR_RUN(test_ctrl_c_with_deep_cascade_cancels);
 	TR_SUMMARY();
 	return TR_EXIT_CODE();
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `palette_feed_byte()` in `palette.c` had no handler for byte `0x03` (ETX/Ctrl-C). All other unrecognized bytes fall through to `PALETTE_DONE_NONE` at the end of the function, so Ctrl-C while the palette was open silently did nothing.
- **Why the C.0.3b mapping was correct**: `boxen_palette_feed_event()` in `boxen_palette_backend.c` correctly maps `BOXEN_KEY_CTRL_C -> palette_feed_byte(st, 0x03)`, and `boxen_dispatch_event()` correctly routes to the modal when `modal_win != NULL` (the global key handler guard is `if (modal_win == NULL && ...)`, so it is bypassed when the palette is up). The event arrived at the state machine correctly -- the state machine just dropped it.
- **Fix**: One new case in `palette_feed_byte()` between the ESC handler and the CR/LF handler: `if (b == 0x03) return PALETTE_DONE_CANCEL;`. Cancels unconditionally from any open_depth (menubar-only, single cascade, deep cascade) without collapsing levels one at a time as ESC does.

## Test plan

- [x] Three new behavioral tests in `tests/palette_state_tests.c` confirmed RED before the fix, GREEN after:
  - `test_ctrl_c_at_top_level_cancels` - menubar open, no cascade
  - `test_ctrl_c_with_cascade_open_cancels` - one cascade level open
  - `test_ctrl_c_with_deep_cascade_cancels` - two cascade levels deep (File > Views)
- [x] Full unit suite: 798/798 pass (palette_state_tests.opml: 29/29)
- [x] Integration failures are identical pre-existing set (startup, tcp, html -- not related to this change)

## Hypotheses evaluated

1. `palette_feed_byte` doesn't handle 0x03 -- **CONFIRMED root cause**
2. Global key handler intercepts Ctrl-C before modal -- ruled out (dispatch guard checks `modal_win == NULL` first)
3. `BOXEN_KEY_CTRL_C` never delivered to palette modal -- ruled out (same dispatch gate)
4. `boxen_palette_feed_event` mapping broken -- ruled out (mapping is correct, 0x03 arrives at the state machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
