### PR TITLE
feat(repl): C.0.7e cursor-based input editing

### DIFF
--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -285,7 +285,7 @@ static void draw_input_bar(boxen_window_t *win, void *user_data) {
 	(void)n;
 
 	/* Overlay typed text starting at REPL_INPUT_PROMPT_LEN */
-	int text_len = s->input_cursor;
+	int text_len = s->input_len;
 	int text_avail = cap - REPL_INPUT_PROMPT_LEN;
 	if (text_len > text_avail) text_len = text_avail;
 	if (text_len > 0 && text_avail > 0) {
@@ -301,8 +301,10 @@ static void draw_input_bar(boxen_window_t *win, void *user_data) {
 	boxen_draw_text(win, 0, 0, linebuf,
 	                BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT, BOXEN_ATTR_NONE);
 
-	/* Position the cursor at the end of the typed text */
-	int cursor_col = REPL_INPUT_PROMPT_LEN + s->input_cursor;
+	/* 2026-06-17 JES Phase C.0.7e #691: position the terminal cursor at
+	 * input_cursor_pos (the caret), not at the end of input.  Before C.0.7e
+	 * both were always equal (append-only); now they diverge during editing. */
+	int cursor_col = REPL_INPUT_PROMPT_LEN + s->input_cursor_pos;
 	if (cursor_col >= cap) cursor_col = cap - 1;
 	boxen_window_set_cursor(win, cursor_col, 0);
 }
@@ -632,7 +634,8 @@ static void history_nav_up(boxen_repl_state_t *s) {
 	int ring_idx = (s->history_head - 1 - s->history_nav_idx
 	                + BOXEN_REPL_HISTORY_SIZE) % BOXEN_REPL_HISTORY_SIZE;
 	snprintf(s->input_buf, BOXEN_REPL_INPUT_MAX, "%s", s->history[ring_idx]);
-	s->input_cursor = (int)strlen(s->input_buf);
+	s->input_len        = (int)strlen(s->input_buf);
+	s->input_cursor_pos = s->input_len;   /* caret jumps to end after history recall */
 
 	if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 }
@@ -651,7 +654,8 @@ static void history_nav_down(boxen_repl_state_t *s) {
 		s->history_nav_idx        = -1;
 		s->history_saved_input[0] = '\0';
 	}
-	s->input_cursor = (int)strlen(s->input_buf);
+	s->input_len        = (int)strlen(s->input_buf);
+	s->input_cursor_pos = s->input_len;   /* caret jumps to end after history recall */
 
 	if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 }
@@ -686,7 +690,7 @@ static void submit_input(boxen_repl_state_t *s) {
 	/* 2026-06-10 JES #691 Phase C.0.5: empty-line guard.
 	 * In single-line mode, empty Enter is a no-op.  In multi-line mode, empty
 	 * Enter is a valid terminator (submits the accumulated buffer). */
-	if (s->input_cursor == 0 && s->multiline_lines == 0) {
+	if (s->input_len == 0 && s->multiline_lines == 0) {
 		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 		return;
 	}
@@ -696,7 +700,7 @@ static void submit_input(boxen_repl_state_t *s) {
 	 * A '\' inside a UserTalk string literal at end of line will still cause
 	 * continuation; this is intentional and consistent with bash/Python REPL
 	 * behavior. */
-	int src_len = s->input_cursor;
+	int src_len = s->input_len;
 	bool is_continuation = (src_len > 0 && s->input_buf[src_len - 1] == '\\');
 	if (is_continuation) {
 		src_len--;   /* strip the trailing backslash */
@@ -732,8 +736,9 @@ static void submit_input(boxen_repl_state_t *s) {
 			s->multiline_lines++;
 
 			/* Clear input and redraw */
-			s->input_buf[0] = '\0';
-			s->input_cursor = 0;
+			s->input_buf[0]     = '\0';
+			s->input_len        = 0;
+			s->input_cursor_pos = 0;
 			if (s->input_win  != NULL) boxen_window_invalidate(s->input_win);
 			if (s->output_win != NULL) boxen_window_invalidate(s->output_win);
 			return;
@@ -883,8 +888,9 @@ static void submit_input(boxen_repl_state_t *s) {
 	s->multiline_lines  = 0;
 
 	/* Clear input */
-	s->input_buf[0] = '\0';
-	s->input_cursor = 0;
+	s->input_buf[0]     = '\0';
+	s->input_len        = 0;
+	s->input_cursor_pos = 0;
 
 	if (s->input_win  != NULL) boxen_window_invalidate(s->input_win);
 	if (s->output_win != NULL) boxen_window_invalidate(s->output_win);
@@ -933,7 +939,8 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 			s->multiline_len    = 0;
 			s->multiline_lines  = 0;
 			s->input_buf[0]     = '\0';
-			s->input_cursor     = 0;
+			s->input_len        = 0;
+			s->input_cursor_pos = 0;
 			if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 			return;
 		}
@@ -968,7 +975,8 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 			const char *sel = boxen_completion_popup_selected(s->completion_popup);
 			if (sel != NULL) {
 				snprintf(s->input_buf, sizeof(s->input_buf), "%s", sel);
-				s->input_cursor = (int)strlen(s->input_buf);
+				s->input_len        = (int)strlen(s->input_buf);
+				s->input_cursor_pos = s->input_len;
 			}
 			boxen_completion_popup_close(s->completion_popup);
 			s->completion_popup = NULL;
@@ -1011,10 +1019,11 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 				s->history_nav_idx        = -1;
 				s->history_saved_input[0] = '\0';
 			}
-			if (s->input_cursor < BOXEN_REPL_INPUT_MAX - 1) {
-				s->input_buf[s->input_cursor]     = (char)ev->key.ch;
-				s->input_buf[s->input_cursor + 1] = '\0';
-				s->input_cursor++;
+			if (s->input_len < BOXEN_REPL_INPUT_MAX - 1) {
+				s->input_buf[s->input_len]     = (char)ev->key.ch;
+				s->input_buf[s->input_len + 1] = '\0';
+				s->input_len++;
+				s->input_cursor_pos = s->input_len;
 			}
 			if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 			return;
@@ -1028,7 +1037,8 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 	 * slash debounce -- 2026-06-17 JES #691 Phase C.0.7a). */
 	if (ev->key.key == BOXEN_KEY_ESCAPE) {
 		s->input_buf[0]           = '\0';
-		s->input_cursor           = 0;
+		s->input_len              = 0;
+		s->input_cursor_pos       = 0;
 		s->history_nav_idx        = -1;
 		s->history_saved_input[0] = '\0';
 		s->slash_pending_until_ms = 0;
@@ -1073,7 +1083,7 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 
 		char candidates[BOXEN_COMPLETION_MAX_CANDIDATES][BOXEN_COMPLETION_CANDIDATE_MAX];
 		int count = s->completion_hook(s->input_buf,
-		                               (size_t)s->input_cursor,
+		                               (size_t)s->input_len,
 		                               candidates,
 		                               BOXEN_COMPLETION_MAX_CANDIDATES);
 		if (count <= 0) return;  /* silent no-op */
@@ -1081,7 +1091,8 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 		if (count == 1) {
 			/* Single candidate: inline replace. */
 			snprintf(s->input_buf, sizeof(s->input_buf), "%s", candidates[0]);
-			s->input_cursor = (int)strlen(s->input_buf);
+			s->input_len        = (int)strlen(s->input_buf);
+			s->input_cursor_pos = s->input_len;
 			if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 			return;
 		}
@@ -1101,11 +1112,73 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 		return;
 	}
 
-	/* Backspace: delete last character.
+	/* 2026-06-17 JES Phase C.0.7e #691: LEFT arrow -- move caret left one char. */
+	if (ev->key.key == BOXEN_KEY_LEFT) {
+		if (s->input_cursor_pos > 0) {
+			s->input_cursor_pos--;
+		}
+		/* Underflow guard: already at col 0, nothing to do */
+		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+		return;
+	}
+
+	/* 2026-06-17 JES Phase C.0.7e #691: RIGHT arrow -- move caret right one char. */
+	if (ev->key.key == BOXEN_KEY_RIGHT) {
+		if (s->input_cursor_pos < s->input_len) {
+			s->input_cursor_pos++;
+		}
+		/* Overflow guard: already at end, nothing to do */
+		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+		return;
+	}
+
+	/* 2026-06-17 JES Phase C.0.7e #691: Ctrl-A -- jump caret to beginning of line. */
+	if (ev->key.key == BOXEN_KEY_CTRL_A) {
+		s->input_cursor_pos = 0;
+		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+		return;
+	}
+
+	/* 2026-06-17 JES Phase C.0.7e #691: Ctrl-E -- jump caret to end of line. */
+	if (ev->key.key == BOXEN_KEY_CTRL_E) {
+		s->input_cursor_pos = s->input_len;
+		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+		return;
+	}
+
+	/* 2026-06-17 JES Phase C.0.7e #691: Delete (forward-delete) -- remove char
+	 * at caret position, shift rest left, caret stays. */
+	if (ev->key.key == BOXEN_KEY_DELETE) {
+		if (s->input_cursor_pos < s->input_len) {
+			/* If user edits during history nav, abandon navigation. */
+			if (s->history_nav_idx != -1) {
+				s->history_nav_idx        = -1;
+				s->history_saved_input[0] = '\0';
+			}
+			/* Shift bytes left by one starting at cursor_pos */
+			memmove(s->input_buf + s->input_cursor_pos,
+			        s->input_buf + s->input_cursor_pos + 1,
+			        (size_t)(s->input_len - s->input_cursor_pos));
+			s->input_len--;
+			s->input_buf[s->input_len] = '\0';
+		}
+		/* No-op guard when cursor is at end */
+		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
+		return;
+	}
+
+	/* Backspace: delete char BEFORE caret.
+	 *
+	 * 2026-06-17 JES Phase C.0.7e #691: when caret is at end
+	 * (input_cursor_pos == input_len), this is the original append-only
+	 * backspace: decrement both len and pos, null-terminate.  When caret
+	 * is mid-buffer, shift the tail left by one and decrement len; caret
+	 * position also decrements (it now points to the same logical position).
+	 *
 	 * 2026-06-17 JES #691 Phase C.0.7a: if a slash debounce is pending,
-	 * Backspace cancels it (user changed their mind).  input_cursor is 0
-	 * during the debounce window, so the delete below is a no-op, leaving
-	 * input_buf empty -- exactly what the user expects after Backspace on '/'. */
+	 * Backspace cancels it (user changed their mind).  input_len is 0 during
+	 * the debounce window, so the delete below is a no-op, leaving input_buf
+	 * empty -- exactly what the user expects after Backspace on '/'. */
 	if (ev->key.key == BOXEN_KEY_BACKSPACE) {
 		s->slash_pending_until_ms = 0;  /* cancel pending open, if any */
 		/* If user edits during history nav, abandon navigation. */
@@ -1113,11 +1186,16 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 			s->history_nav_idx        = -1;
 			s->history_saved_input[0] = '\0';
 		}
-		if (s->input_cursor > 0) {
-			s->input_cursor--;
-			s->input_buf[s->input_cursor] = '\0';
+		if (s->input_cursor_pos > 0) {
+			/* Shift bytes left by one to fill the gap at cursor_pos - 1 */
+			memmove(s->input_buf + s->input_cursor_pos - 1,
+			        s->input_buf + s->input_cursor_pos,
+			        (size_t)(s->input_len - s->input_cursor_pos));
+			s->input_cursor_pos--;
+			s->input_len--;
+			s->input_buf[s->input_len] = '\0';
 		}
-		/* Underflow guard: cursor is already 0 when input is empty, nothing to do */
+		/* Underflow guard: caret already at 0, nothing to do */
 		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 		return;
 	}
@@ -1145,10 +1223,11 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 			/* Cancel the pending palette open. */
 			s->slash_pending_until_ms = 0;
 			/* Insert the deferred '/' into input_buf first. */
-			if (s->input_cursor < BOXEN_REPL_INPUT_MAX - 1) {
-				s->input_buf[s->input_cursor]     = '/';
-				s->input_buf[s->input_cursor + 1] = '\0';
-				s->input_cursor++;
+			if (s->input_len < BOXEN_REPL_INPUT_MAX - 1) {
+				s->input_buf[s->input_len]     = '/';
+				s->input_buf[s->input_len + 1] = '\0';
+				s->input_len++;
+				s->input_cursor_pos = s->input_len;
 			}
 			/* Fall through: the current char (e.g. 'h') inserts below. */
 		}
@@ -1157,7 +1236,7 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 		 *
 		 * Gates:
 		 *   ch == '/'           -- only the slash key triggers the menu
-		 *   input_cursor == 0   -- only at the start of an empty line; mid-line
+		 *   input_len == 0      -- only at the start of an empty line; mid-line
 		 *                         '/' (e.g. a path component) inserts normally
 		 *   palette_open_hook   -- NULL in test builds / when hook not installed
 		 *   palette_state       -- guard against re-entry (no double-open)
@@ -1175,7 +1254,7 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 		 * is receiving keys (i.e. the REPL input bar is the dispatch target),
 		 * which is exactly the right scope. */
 		if (ev->key.ch == '/' &&
-		    s->input_cursor == 0 &&
+		    s->input_len == 0 &&
 		    s->palette_open_hook != NULL &&
 		    s->palette_state == NULL) {
 			/* Start the debounce timer.  The palette fires when
@@ -1189,10 +1268,21 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 			s->history_nav_idx        = -1;
 			s->history_saved_input[0] = '\0';
 		}
-		if (s->input_cursor < BOXEN_REPL_INPUT_MAX - 1) {
-			s->input_buf[s->input_cursor]     = (char)ev->key.ch;
-			s->input_buf[s->input_cursor + 1] = '\0';
-			s->input_cursor++;
+
+		/* 2026-06-17 JES Phase C.0.7e #691: insert at caret position.
+		 *
+		 * When caret is at end (cursor_pos == input_len) this is identical to
+		 * the original append: write at [cursor_pos], NUL-terminate at [+1].
+		 * When caret is mid-buffer, shift tail right by one byte first. */
+		if (s->input_len < BOXEN_REPL_INPUT_MAX - 1) {
+			/* Shift bytes after caret right by one to make room */
+			memmove(s->input_buf + s->input_cursor_pos + 1,
+			        s->input_buf + s->input_cursor_pos,
+			        (size_t)(s->input_len - s->input_cursor_pos));
+			s->input_buf[s->input_cursor_pos] = (char)ev->key.ch;
+			s->input_len++;
+			s->input_cursor_pos++;
+			s->input_buf[s->input_len] = '\0';
 		}
 		if (s->input_win != NULL) boxen_window_invalidate(s->input_win);
 		return;
@@ -1282,9 +1372,10 @@ void boxen_repl_state_teardown(boxen_repl_state_t *s) {
 	}
 	s->scrollback_head  = 0;
 	s->scrollback_count = 0;
-	s->input_buf[0]     = '\0';
-	s->input_cursor     = 0;
-	s->should_quit      = false;
+	s->input_buf[0]        = '\0';
+	s->input_len           = 0;
+	s->input_cursor_pos    = 0;
+	s->should_quit         = false;
 	s->slash_dispatch_hook = NULL;
 	s->repl_eval_hook      = NULL;
 
@@ -1678,7 +1769,7 @@ int boxen_repl_main(const cli_options_t *opts) {
 	 *     with zero input.  A full pipe stalls the producer at most one drain
 	 *     period (100ms); no hang is possible because the read end is O_NONBLOCK
 	 *     and drain_stdout_into_scrollback always empties the pipe before returning.
-	 *   - drain never touches input_buf or input_cursor -- async output during
+	 *   - drain never touches input_buf, input_len, or input_cursor_pos -- async output during
 	 *     in-progress typing is safe.  See test_stdout_drain_during_typing_does_not_corrupt_input. */
 	int pipefd[2];
 	bool capture_active = false;

--- a/frontier-cli/boxen_repl_internal.h
+++ b/frontier-cli/boxen_repl_internal.h
@@ -203,9 +203,21 @@ typedef struct {
 	boxen_window_t *input_win;    /* single-line input bar (bottom row) */
 	boxen_window_t *footer_win;   /* optional hint footer (one row above input) */
 
-	/* Input line state */
+	/* Input line state.
+	 *
+	 * 2026-06-17 JES Phase C.0.7e #691: cursor-based editing.
+	 *
+	 * input_len        -- total number of valid characters in input_buf
+	 *                     (i.e. the buffer length, not the caret position).
+	 * input_cursor_pos -- 0-based caret column within input_buf.
+	 *                     Invariant: 0 <= input_cursor_pos <= input_len.
+	 *
+	 * Before C.0.7e the single field `input_cursor` served both roles
+	 * (append-only input kept them equal).  The rename makes the two
+	 * concepts explicit and allows the caret to sit anywhere in the buffer. */
 	char  input_buf[BOXEN_REPL_INPUT_MAX]; /* typed characters, NUL-terminated */
-	int   input_cursor;                    /* number of characters in input_buf */
+	int   input_len;                        /* number of characters in input_buf */
+	int   input_cursor_pos;                 /* caret position (0..input_len) */
 
 	/* Scrollback ring buffer.
 	 * Ring head points at the slot for the NEXT append.
@@ -449,7 +461,7 @@ void boxen_repl_set_history_path_for_test(const char *path);
  *
  * 2026-06-10 JES #691 Phase C.0.4: async-input invariant.
  * Drain only mutates state->scrollback + state->partial_line.  It NEVER
- * touches state->input_buf or state->input_cursor, so concurrent
+ * touches state->input_buf, state->input_len, or state->input_cursor_pos, so concurrent
  * typing (or any input-bar state) is preserved across drain calls.
  * Tested by test_stdout_drain_during_typing_does_not_corrupt_input.
  *

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -141,7 +141,8 @@ static void test_input_line_accumulates_chars(void) {
 	boxen_repl_run_one_tick(&g_state, &c);
 
 	assert(strcmp(g_state.input_buf, "abc") == 0);
-	assert(g_state.input_cursor == 3);
+	assert(g_state.input_len == 3);
+	assert(g_state.input_cursor_pos == 3);
 
 	teardown();
 }
@@ -158,7 +159,8 @@ static void test_enter_dispatches_slash_command(void) {
 	/* Pre-load the input buffer directly */
 	strncpy(g_state.input_buf, "/help",
 	        sizeof(g_state.input_buf) - 1);
-	g_state.input_cursor = (int)strlen(g_state.input_buf);
+	g_state.input_len        = (int)strlen(g_state.input_buf);
+	g_state.input_cursor_pos = g_state.input_len;
 
 	int ring_before = g_state.scrollback_count;
 
@@ -184,7 +186,8 @@ static void test_enter_dispatches_expression(void) {
 
 	strncpy(g_state.input_buf, "1 + 1",
 	        sizeof(g_state.input_buf) - 1);
-	g_state.input_cursor = (int)strlen(g_state.input_buf);
+	g_state.input_len        = (int)strlen(g_state.input_buf);
+	g_state.input_cursor_pos = g_state.input_len;
 
 	/* Simulate Enter */
 	boxen_event_t enter = make_key_event(BOXEN_KEY_ENTER);
@@ -217,24 +220,28 @@ static void test_backspace_deletes_char(void) {
 
 	strncpy(g_state.input_buf, "abcd",
 	        sizeof(g_state.input_buf) - 1);
-	g_state.input_cursor = 4;
+	g_state.input_len        = 4;
+	g_state.input_cursor_pos = 4;
 
 	boxen_event_t bs = make_key_event(BOXEN_KEY_BACKSPACE);
 
 	boxen_repl_run_one_tick(&g_state, &bs);
 	assert(strcmp(g_state.input_buf, "abc") == 0);
-	assert(g_state.input_cursor == 3);
+	assert(g_state.input_len        == 3);
+	assert(g_state.input_cursor_pos == 3);
 
 	boxen_repl_run_one_tick(&g_state, &bs);
 	boxen_repl_run_one_tick(&g_state, &bs);
 	boxen_repl_run_one_tick(&g_state, &bs);
 	assert(strcmp(g_state.input_buf, "") == 0);
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len        == 0);
+	assert(g_state.input_cursor_pos == 0);
 
 	/* Extra backspace on empty: no underflow */
 	boxen_repl_run_one_tick(&g_state, &bs);
 	assert(strcmp(g_state.input_buf, "") == 0);
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len        == 0);
+	assert(g_state.input_cursor_pos == 0);
 
 	teardown();
 }
@@ -422,7 +429,8 @@ static void test_history_up_arrow_loads_previous(void) {
 
 	/* Simulate user having typed "partial" into the input bar */
 	strncpy(g_state.input_buf, "partial", sizeof(g_state.input_buf) - 1);
-	g_state.input_cursor = (int)strlen("partial");
+	g_state.input_len        = (int)strlen("partial");
+	g_state.input_cursor_pos = g_state.input_len;
 
 	boxen_event_t up   = make_up_event();
 	boxen_event_t down = make_down_event();
@@ -711,7 +719,8 @@ static void test_tab_completes_single_slash_command(void) {
 
 	/* Single candidate: inline replace, no popup. */
 	assert(strcmp(g_state.input_buf, "/help") == 0);
-	assert(g_state.input_cursor == 5);
+	assert(g_state.input_len        == 5);
+	assert(g_state.input_cursor_pos == 5);
 	assert(g_state.completion_popup == NULL);
 
 	teardown();
@@ -779,7 +788,8 @@ static void test_tab_completes_odb_path_prefix(void) {
 
 	/* Single candidate: inline replace, no popup. */
 	assert(strcmp(g_state.input_buf, "system.test") == 0);
-	assert(g_state.input_cursor == 11);
+	assert(g_state.input_len        == 11);
+	assert(g_state.input_cursor_pos == 11);
 	assert(g_state.completion_popup == NULL);
 
 	teardown();
@@ -901,9 +911,16 @@ static void test_slash_key_defers_palette_open(void) {
 	assert(g_state.palette_state == NULL);
 	/* '/' must NOT have been inserted into input_buf. */
 	assert(g_state.input_buf[0] == '\0');
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len        == 0);
+	assert(g_state.input_cursor_pos == 0);
 	/* Debounce must be armed. */
 	assert(g_state.slash_pending_until_ms != 0);
+
+	/* Clean up sentinel before teardown (teardown would try to call
+	 * palette_close if palette_state != NULL and the production guard
+	 * is compiled in; in the test build BOXEN_REPL_OMIT_MAIN is defined
+	 * so the guard body is skipped, but clear it anyway to stay clean). */
+	g_state.palette_state = NULL;
 
 	teardown();
 }
@@ -947,7 +964,8 @@ static void test_palette_close_returns_focus_to_repl_input(void) {
 	boxen_event_t ev_a = make_char_event('a');
 	boxen_repl_run_one_tick(&g_state, &ev_a);
 	assert(strcmp(g_state.input_buf, "a") == 0);
-	assert(g_state.input_cursor == 1);
+	assert(g_state.input_len        == 1);
+	assert(g_state.input_cursor_pos == 1);
 
 	teardown();
 }
@@ -1052,7 +1070,8 @@ static void test_stdout_drain_during_typing_does_not_corrupt_input(void) {
 
 	/* Input bar must be completely untouched */
 	assert(strcmp(g_state.input_buf, "abc") == 0);
-	assert(g_state.input_cursor == 3);
+	assert(g_state.input_len        == 3);
+	assert(g_state.input_cursor_pos == 3);
 
 	/* Scrollback grew by exactly one line */
 	assert(g_state.scrollback_count == ring_before + 1);
@@ -1219,10 +1238,216 @@ static void test_ctrl_c_in_multiline_discards_buffer(void) {
 	assert(g_state.multiline_lines == 0);
 	assert(g_state.multiline_len   == 0);
 	assert(g_state.multiline_buf[0] == '\0');
-	assert(g_state.input_buf[0]     == '\0');
-	assert(g_state.input_cursor     == 0);
-	assert(g_state.should_quit      == false);  /* critical: must NOT exit */
-	assert(g_eval_result[0]         == '\0');   /* eval never called */
+	assert(g_state.input_buf[0]        == '\0');
+	assert(g_state.input_len           == 0);
+	assert(g_state.input_cursor_pos    == 0);
+	assert(g_state.should_quit         == false);  /* critical: must NOT exit */
+	assert(g_eval_result[0]            == '\0');   /* eval never called */
+
+	teardown();
+}
+
+/* =========================================================================
+ * 2026-06-17 JES Phase C.0.7e #691: cursor-based editing tests.
+ *
+ * All seven tests below reference input_cursor_pos and input_len.
+ * They will not compile until the rename is applied to boxen_repl_internal.h
+ * and boxen_repl.c -- that is the intended RED state.
+ * ========================================================================= */
+
+/* -------------------------------------------------------------------------
+ * Test 24: test_left_arrow_moves_cursor_left_within_buffer
+ *
+ * Pre-load "abc" (len 3, caret at 3).  Press LEFT twice.  Assert
+ * input_cursor_pos == 1, input_len == 3, input_buf unchanged.
+ * ---------------------------------------------------------------------- */
+static void test_left_arrow_moves_cursor_left_within_buffer(void) {
+	setup();
+
+	strncpy(g_state.input_buf, "abc", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 3;
+	g_state.input_cursor_pos = 3;
+
+	boxen_event_t left = make_key_event(BOXEN_KEY_LEFT);
+
+	boxen_repl_run_one_tick(&g_state, &left);
+	assert(g_state.input_cursor_pos == 2);
+	assert(g_state.input_len        == 3);
+	assert(strcmp(g_state.input_buf, "abc") == 0);
+
+	boxen_repl_run_one_tick(&g_state, &left);
+	assert(g_state.input_cursor_pos == 1);
+	assert(g_state.input_len        == 3);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 25: test_right_arrow_moves_cursor_right_within_buffer
+ *
+ * Pre-load "abc" with caret at 1.  Press RIGHT twice.  Assert
+ * input_cursor_pos == 3, input_len == 3, input_buf unchanged.
+ * ---------------------------------------------------------------------- */
+static void test_right_arrow_moves_cursor_right_within_buffer(void) {
+	setup();
+
+	strncpy(g_state.input_buf, "abc", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 3;
+	g_state.input_cursor_pos = 1;
+
+	boxen_event_t right = make_key_event(BOXEN_KEY_RIGHT);
+
+	boxen_repl_run_one_tick(&g_state, &right);
+	assert(g_state.input_cursor_pos == 2);
+	assert(g_state.input_len        == 3);
+	assert(strcmp(g_state.input_buf, "abc") == 0);
+
+	boxen_repl_run_one_tick(&g_state, &right);
+	assert(g_state.input_cursor_pos == 3);
+	assert(g_state.input_len        == 3);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 26: test_printable_mid_buffer_inserts_at_cursor
+ *
+ * Pre-load "ac" (len 2, caret at 1 between 'a' and 'c').
+ * Type 'b'.  Assert input_buf == "abc", input_len == 3,
+ * input_cursor_pos == 2.
+ * ---------------------------------------------------------------------- */
+static void test_printable_mid_buffer_inserts_at_cursor(void) {
+	setup();
+
+	strncpy(g_state.input_buf, "ac", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 2;
+	g_state.input_cursor_pos = 1;
+
+	boxen_event_t b_ev = make_char_event('b');
+	boxen_repl_run_one_tick(&g_state, &b_ev);
+
+	assert(strcmp(g_state.input_buf, "abc") == 0);
+	assert(g_state.input_len        == 3);
+	assert(g_state.input_cursor_pos == 2);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 27: test_backspace_mid_buffer_deletes_before_cursor
+ *
+ * Pre-load "abc" (len 3, caret at 2 between 'b' and 'c').
+ * Press Backspace.  Assert input_buf == "ac", input_len == 2,
+ * input_cursor_pos == 1.
+ * ---------------------------------------------------------------------- */
+static void test_backspace_mid_buffer_deletes_before_cursor(void) {
+	setup();
+
+	strncpy(g_state.input_buf, "abc", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 3;
+	g_state.input_cursor_pos = 2;
+
+	boxen_event_t bs = make_key_event(BOXEN_KEY_BACKSPACE);
+	boxen_repl_run_one_tick(&g_state, &bs);
+
+	assert(strcmp(g_state.input_buf, "ac") == 0);
+	assert(g_state.input_len        == 2);
+	assert(g_state.input_cursor_pos == 1);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 28: test_ctrl_a_jumps_cursor_to_start
+ *
+ * Pre-load "hello" (len 5, caret at 5).
+ * Press Ctrl-A.  Assert input_cursor_pos == 0, input_len == 5,
+ * input_buf unchanged.
+ * ---------------------------------------------------------------------- */
+static void test_ctrl_a_jumps_cursor_to_start(void) {
+	setup();
+
+	strncpy(g_state.input_buf, "hello", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 5;
+	g_state.input_cursor_pos = 5;
+
+	boxen_event_t ctrl_a = make_key_event(BOXEN_KEY_CTRL_A);
+	boxen_repl_run_one_tick(&g_state, &ctrl_a);
+
+	assert(g_state.input_cursor_pos == 0);
+	assert(g_state.input_len        == 5);
+	assert(strcmp(g_state.input_buf, "hello") == 0);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 29: test_ctrl_e_jumps_cursor_to_end
+ *
+ * Pre-load "hello" (len 5, caret at 2 mid-word).
+ * Press Ctrl-E.  Assert input_cursor_pos == 5, input_len == 5,
+ * input_buf unchanged.
+ * ---------------------------------------------------------------------- */
+static void test_ctrl_e_jumps_cursor_to_end(void) {
+	setup();
+
+	strncpy(g_state.input_buf, "hello", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 5;
+	g_state.input_cursor_pos = 2;
+
+	boxen_event_t ctrl_e = make_key_event(BOXEN_KEY_CTRL_E);
+	boxen_repl_run_one_tick(&g_state, &ctrl_e);
+
+	assert(g_state.input_cursor_pos == 5);
+	assert(g_state.input_len        == 5);
+	assert(strcmp(g_state.input_buf, "hello") == 0);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
+ * Test 30: test_cursor_stays_at_bounds
+ *
+ * Verify LEFT at col 0 is a no-op and RIGHT at end is a no-op.
+ *
+ * Also verify forward-delete (BOXEN_KEY_DELETE) at end is a no-op
+ * and at mid-buffer removes the char at cursor without moving it.
+ * ---------------------------------------------------------------------- */
+static void test_cursor_stays_at_bounds(void) {
+	setup();
+
+	/* --- LEFT at column 0 is a no-op --- */
+	strncpy(g_state.input_buf, "xy", sizeof(g_state.input_buf) - 1);
+	g_state.input_len        = 2;
+	g_state.input_cursor_pos = 0;
+
+	boxen_event_t left = make_key_event(BOXEN_KEY_LEFT);
+	boxen_repl_run_one_tick(&g_state, &left);
+	assert(g_state.input_cursor_pos == 0);   /* clamped at 0 */
+	assert(g_state.input_len        == 2);
+	assert(strcmp(g_state.input_buf, "xy") == 0);
+
+	/* --- RIGHT at end is a no-op --- */
+	g_state.input_cursor_pos = 2;
+	boxen_event_t right = make_key_event(BOXEN_KEY_RIGHT);
+	boxen_repl_run_one_tick(&g_state, &right);
+	assert(g_state.input_cursor_pos == 2);   /* clamped at len */
+	assert(g_state.input_len        == 2);
+	assert(strcmp(g_state.input_buf, "xy") == 0);
+
+	/* --- DELETE at end is a no-op --- */
+	boxen_event_t del = make_key_event(BOXEN_KEY_DELETE);
+	boxen_repl_run_one_tick(&g_state, &del);
+	assert(g_state.input_cursor_pos == 2);
+	assert(g_state.input_len        == 2);
+	assert(strcmp(g_state.input_buf, "xy") == 0);
+
+	/* --- DELETE mid-buffer removes char at cursor --- */
+	g_state.input_cursor_pos = 0;   /* caret before 'x'; delete removes 'x' */
+	boxen_repl_run_one_tick(&g_state, &del);
+	assert(strcmp(g_state.input_buf, "y") == 0);
+	assert(g_state.input_len        == 1);
+	assert(g_state.input_cursor_pos == 0);   /* cursor stays in place */
 
 	teardown();
 }
@@ -1270,7 +1495,7 @@ static void test_ctrl_c_in_multiline_with_popup_open_discards_both(void) {
 	/* Verify we are in multi-line mode */
 	assert(g_state.multiline_lines == 1);
 	assert(g_state.input_buf[0] == '\0');
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len == 0);
 
 	/* Step 2: type "/" to get a non-empty input buffer, then Tab to open popup.
 	 * palette_open_hook is NULL in test setup, so '/' inserts normally. */
@@ -1299,7 +1524,7 @@ static void test_ctrl_c_in_multiline_with_popup_open_discards_both(void) {
 
 	/* Input bar must be cleared */
 	assert(g_state.input_buf[0]  == '\0');
-	assert(g_state.input_cursor  == 0);
+	assert(g_state.input_len  == 0);
 
 	/* Critical: must NOT exit the REPL */
 	assert(g_state.should_quit == false);
@@ -1343,7 +1568,7 @@ static void test_slash_then_letter_within_window_inserts_both(void) {
 	assert(g_state.slash_pending_until_ms != 0);
 	/* input_buf still empty (the '/' is deferred). */
 	assert(g_state.input_buf[0] == '\0');
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len == 0);
 
 	/* Type 'h' -- mock time still 1000ms, well within the debounce window.
 	 * This must cancel the pending open and insert both '/' and 'h'. */
@@ -1355,7 +1580,7 @@ static void test_slash_then_letter_within_window_inserts_both(void) {
 	assert(g_state.palette_state == NULL);
 	/* input_buf must now contain "/h". */
 	assert(strcmp(g_state.input_buf, "/h") == 0);
-	assert(g_state.input_cursor == 2);
+	assert(g_state.input_len == 2);
 	/* Debounce cleared. */
 	assert(g_state.slash_pending_until_ms == 0);
 
@@ -1402,7 +1627,7 @@ static void test_slash_then_timeout_opens_palette(void) {
 	assert(g_state.palette_state != NULL);    /* sentinel installed */
 	/* input_buf must still be empty (the '/' was never inserted). */
 	assert(g_state.input_buf[0] == '\0');
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len == 0);
 	/* Debounce cleared. */
 	assert(g_state.slash_pending_until_ms == 0);
 
@@ -1638,7 +1863,7 @@ static void test_completion_popup_printable_letter_closes_popup_no_crash(void) {
 
 	/* 'x' must have been inserted after "/" */
 	assert(strcmp(g_state.input_buf, "/x") == 0);
-	assert(g_state.input_cursor == 2);
+	assert(g_state.input_len == 2);
 
 	/* No palette state (hook not wired) */
 	assert(g_state.palette_state == NULL);
@@ -1692,7 +1917,7 @@ static void test_completion_popup_slash_with_empty_input_inserts_not_palette(voi
 	/* Popup must be open */
 	assert(g_state.completion_popup != NULL);
 	/* input_buf must still be empty (Tab doesn't insert) */
-	assert(g_state.input_cursor == 0);
+	assert(g_state.input_len == 0);
 
 	/* Now press '/': "any other key" in popup mode.
 	 * Bug: with cursor==0 and palette_open_hook set, the '/' falls through
@@ -1706,7 +1931,7 @@ static void test_completion_popup_slash_with_empty_input_inserts_not_palette(voi
 
 	/* '/' must be inserted into input_buf (not swallowed by palette open) */
 	assert(strcmp(g_state.input_buf, "/") == 0);
-	assert(g_state.input_cursor == 1);
+	assert(g_state.input_len == 1);
 
 	/* Palette must NOT have opened -- this is the bug assertion */
 	assert(g_state.palette_state == NULL);
@@ -1753,6 +1978,13 @@ int main(void) {
 	TR_RUN(test_completion_popup_enter_accepts_selection_no_crash);
 	TR_RUN(test_completion_popup_printable_letter_closes_popup_no_crash);
 	TR_RUN(test_completion_popup_slash_with_empty_input_inserts_not_palette);
+	TR_RUN(test_left_arrow_moves_cursor_left_within_buffer);
+	TR_RUN(test_right_arrow_moves_cursor_right_within_buffer);
+	TR_RUN(test_printable_mid_buffer_inserts_at_cursor);
+	TR_RUN(test_backspace_mid_buffer_deletes_before_cursor);
+	TR_RUN(test_ctrl_a_jumps_cursor_to_start);
+	TR_RUN(test_ctrl_e_jumps_cursor_to_end);
+	TR_RUN(test_cursor_stays_at_bounds);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();


### PR DESCRIPTION
## Summary

Boxen REPL input bar gains cursor-based editing (LEFT/RIGHT arrows, Ctrl-A/Ctrl-E, mid-buffer insert + Backspace + forward Delete). Closes a parity gap with the linenoise REPL flagged by JES as a **C.6 blocker** during manual test of C.0.1–C.0.5 (Cluster E from the failure analysis).

## What's new

When popup/palette NOT open:
- **LEFT / RIGHT**: move caret within current input line (clamps at bounds)
- **Ctrl-A**: caret to start
- **Ctrl-E**: caret to end
- **DELETE** (forward): delete char at caret
- **Printable at caret**: insert, shift remainder right
- **Backspace at caret**: delete char before caret, shift remainder left

## State split (rename)

Before: single `input_cursor` field served as BOTH length AND caret position (append-only kept them equal).

After:
- `input_len` — total characters in buffer
- `input_cursor_pos` — caret position (0 ≤ `input_cursor_pos` ≤ `input_len`)

All call sites (history, completion, palette, multi-line, drain, eval dispatch) updated to use the new names. The rename preserves byte-equivalent observable behavior for append-only flows.

## Out of scope (per plan)

- Alt-B / Alt-F (word movement)
- Word-delete, kill/yank, undo
- Multi-line editing between accumulator lines (LEFT/RIGHT operate only within the current line; the multi-line accumulator is unaffected)

## Test plan

- [x] 7 new behavioral tests: left/right movement, mid-insert, mid-Backspace, Ctrl-A, Ctrl-E, bounds clamping
- [x] All 23 existing boxen tests still pass (the rename didn't break anything)
- [x] Unit: 802/802 (was 795 after C.0.5)
- [x] `make -C frontier-cli` clean
- [ ] Integration: 2186 pass / 21 baseline (in progress — will report when complete)
- [ ] Manual: `dist/frontier-cli --debug-tui` — verify cursor moves with LEFT/RIGHT, mid-insert works, Ctrl-A/Ctrl-E jump correctly

## Coordination

This PR is part of a 5-PR batch addressing the C.0.7 cluster of issues from JES's manual test:
- #778 (Cluster D) — landed
- #779 (Cluster C) — landed
- #780 (Cluster A) — landed
- Companion PR (Cluster B: crashes) — coming concurrently
- **This PR** (Cluster E: cursor editing)

This is the **largest** of the 5 PRs (~376 LOC, field rename touching many call sites). Most likely to need rebase work. Primary collision risk: every `boxen_repl.c::on_input` branch references `input_cursor` or its replacement names.

Refs: #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
