### PR TITLE
fix(repl): C.0.7f --debug-tui crash on REPL menu activation (palette source lifetime)

### DIFF
--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -36,6 +36,16 @@
 #include "boxen/boxen.h"
 #include "../Common/headers/logging.h"
 
+/* 2026-06-21 JES #691 C.0.7f: forward-declare the palette source vtable
+ * struct + dispose entry point at file scope so the teardown path can free
+ * the palette_source field on the boxen_repl_state_t without pulling
+ * repl_palette_source.h up out of the BOXEN_REPL_OMIT_MAIN block further
+ * down.  File-scope declaration -- not function-scope -- so it does not
+ * shadow the typedef declared in palette.h when that header is included
+ * later in the production block. */
+struct palette_menu_source;
+extern void repl_palette_source_dispose(struct palette_menu_source *src);
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
@@ -1347,13 +1357,24 @@ void boxen_repl_state_teardown(boxen_repl_state_t *s) {
 	 * forward-declared in boxen_repl_internal.h). */
 #ifndef BOXEN_REPL_OMIT_MAIN
 	extern void palette_close(palette_state_t *st);
+	/* repl_palette_source_dispose forward-declared at file scope above so the
+	 * test build (OMIT_MAIN) compiles without pulling in palette.h. */
 	if (s->palette_state != NULL) {
 		palette_close(s->palette_state);
 		free(s->palette_state);
 		s->palette_state = NULL;
 	}
+	/* Free the paired source on crash/abort teardown so leaks are not
+	 * introduced when on_palette_done never runs. */
+	if (s->palette_source != NULL) {
+		repl_palette_source_dispose(
+			(struct palette_menu_source *)s->palette_source);
+		free(s->palette_source);
+		s->palette_source = NULL;
+	}
 #else
 	s->palette_state = NULL;
+	s->palette_source = NULL;
 #endif
 	/* 2026-06-09 JES #691 Phase C.0.2: close any open completion popup before
 	 * the windows it overlaps are destroyed.  Normal exit paths close it via
@@ -2046,6 +2067,16 @@ static void on_palette_done(void *repl_state_opaque, palette_done_t done,
 		s->palette_state = NULL;
 	}
 
+	/* 2026-06-21 JES #691 C.0.7f: dispose source AFTER palette_close so any
+	 * close-time callbacks the palette runs against st->source (currently
+	 * none, but the contract allows it) still see a live vtable. */
+	if (s->palette_source != NULL) {
+		repl_palette_source_dispose(
+			(palette_menu_source_t *)s->palette_source);
+		free(s->palette_source);
+		s->palette_source = NULL;
+	}
+
 	/* 3. Refocus the REPL input window. */
 	if (s->input_win != NULL) {
 		boxen_window_focus(s->input_win);
@@ -2075,11 +2106,26 @@ bool boxen_repl_real_palette_open(void *s_opaque) {
 		return false;
 	}
 
-	/* Build the ODB-backed source (all installed menubars). */
-	palette_menu_source_t src;
-	if (!repl_palette_source_init_all(&src)) {
+	/* Build the ODB-backed source (all installed menubars).
+	 *
+	 * 2026-06-21 JES #691 C.0.7f: heap-allocate the source so its address
+	 * stays valid for the palette's lifetime.  palette_open_ex stores a
+	 * borrowed pointer (st->source) and dereferences it lazily when the user
+	 * opens cascade levels via open_level().  A stack-local `src` (the prior
+	 * shape) became a dangling pointer the moment this function returned,
+	 * so any DOWN / RIGHT-arrow / hotkey activation that triggered
+	 * st->source->item_count() crashed with frame#0 PC=0 (NULL fp).
+	 * See test_99_repl_menu_crash.py. */
+	palette_menu_source_t *src = (palette_menu_source_t *)calloc(1, sizeof(*src));
+	if (src == NULL) {
+		log_warn(LOG_COMP_GENERAL, "boxen palette: OOM allocating palette_source");
+		free(pst);
+		return false;
+	}
+	if (!repl_palette_source_init_all(src)) {
 		log_warn(LOG_COMP_GENERAL,
 		         "boxen palette: no installed menubars (system.menus.data.*)");
+		free(src);
 		free(pst);
 		return false;
 	}
@@ -2095,11 +2141,12 @@ bool boxen_repl_real_palette_open(void *s_opaque) {
 	/* Prompt row: in boxen mode the palette's pane-row anchoring is irrelevant
 	 * (the boxen backend ignores prompt_row), but palette_open_ex validates
 	 * the row and we must pass something sane.  Use 0 (top of screen). */
-	if (!palette_open_ex(pst, sh, sw, 0, &src,
+	if (!palette_open_ex(pst, sh, sw, 0, src,
 	                     palette_render_boxen_backend())) {
 		log_warn(LOG_COMP_GENERAL,
 		         "boxen palette: palette_open_ex failed (terminal too small?)");
-		repl_palette_source_dispose(&src);
+		repl_palette_source_dispose(src);
+		free(src);
 		/* 2026-06-10 JES #691 Phase C.0.3b: clear stale registration so the
 		 * done_cb/repl_state set above don't outlive the failed open. */
 		palette_render_boxen_backend_set_done_cb(NULL, NULL);
@@ -2107,13 +2154,14 @@ bool boxen_repl_real_palette_open(void *s_opaque) {
 		return false;
 	}
 
-	/* Source lifetime: palette_open_ex has cached all items; the source is
-	 * no longer needed.  Dispose immediately so handles don't leak if the
-	 * palette is closed before the dispatch hook runs. */
-	repl_palette_source_dispose(&src);
-
-	/* Install state pointer -- palette is now "open". */
+	/* 2026-06-21 JES #691 C.0.7f: source lifetime is now tied to palette_state.
+	 * palette.c stores a borrowed st->source pointer and dereferences it
+	 * lazily when the user opens cascade levels (open_level -> item_count /
+	 * item_describe).  Keep `src` alive and pair it with palette_state; the
+	 * dispose+free fires on every close path (on_palette_done and the
+	 * teardown crash/abort guard). */
 	s->palette_state = pst;
+	s->palette_source = src;
 
 	/* Initial render. */
 	palette_render_state(pst);
@@ -2258,9 +2306,10 @@ bool boxen_repl_real_palette_dispatch(void *script_handle, const char *exec_arg)
 void boxen_repl_close_palette_for_test(void *s_opaque) {
 	boxen_repl_state_t *s = (boxen_repl_state_t *)s_opaque;
 	if (s == NULL) return;
-	/* Just NULL the pointer -- no real palette_close since palette.c is
-	 * not linked in the test binary. */
+	/* Just NULL the pointers -- no real palette_close / source_dispose since
+	 * palette.c / repl_palette_source.c are not linked in the test binary. */
 	s->palette_state = NULL;
+	s->palette_source = NULL;
 	/* Refocus input_win if it exists (mock backend creates real windows). */
 	if (s->input_win != NULL) {
 		boxen_window_focus(s->input_win);

--- a/frontier-cli/boxen_repl_internal.h
+++ b/frontier-cli/boxen_repl_internal.h
@@ -331,6 +331,17 @@ typedef struct {
 	palette_open_fn_t    palette_open_hook;
 	palette_dispatch_fn_t palette_dispatch_hook;
 
+	/* 2026-06-21 JES #691 C.0.7f: palette source lifetime.
+	 *
+	 * The palette holds a borrowed pointer to its source vtable (st->source)
+	 * and dereferences it lazily as the user opens cascade levels.  The source
+	 * must therefore outlive the palette_state.  Stored here as a heap pointer
+	 * paired 1:1 with palette_state; allocated in boxen_repl_real_palette_open
+	 * and disposed+freed on every palette close path (on_palette_done, the
+	 * teardown crash/abort guard).  Opaque void* so the test binary need not
+	 * pull in repl_palette_source.h. */
+	void                 *palette_source;
+
 	/* 2026-06-17 JES #691 Phase C.0.7a: slash-palette debounce.
 	 *
 	 * slash_pending_until_ms: absolute monotonic deadline (ms) at which the

--- a/tools/tui-tests/tests/test_99_repl_menu_crash.py
+++ b/tools/tui-tests/tests/test_99_repl_menu_crash.py
@@ -1,0 +1,85 @@
+"""
+Reproduction for the --debug-tui crash when activating the REPL menu in
+the /-menu.  Reported by JES 2026-06-20 manual testing.
+
+Steps:
+  1. Launch --debug-tui
+  2. Type / and wait for palette to open (350ms debounce)
+  3. Activate the REPL menu (4th top-level menu).  Hotkey is 'R'
+     (uppercase) per the underlined letter in the menubar.
+  4. Observe: app crashes.
+
+Expected post-fix: REPL submenu opens (cascade level 1), no crash.
+
+This test reproduces the crash via the harness so we can:
+  - Confirm the bug exists
+  - Capture a snapshot of the pre-crash state
+  - Verify the fix once landed
+"""
+import time
+
+from tui_harness import TUI, snapshot
+
+
+def test_repl_menu_activation_doesnt_crash():
+    """★ JES manual report 2026-06-20: --debug-tui crashes when REPL
+    menu activated via the /-menu.  Reproduce and capture diagnostics.
+    """
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        t.send("/")
+        # 350ms debounce — wait for palette to draw
+        time.sleep(0.6)
+        # Confirm palette opened
+        t.wait_for("╔", timeout=2)
+        snapshot(t, "repl-menu-crash-before-activation")
+
+        # Activate REPL menu via hotkey 'R'.  The palette uses the first
+        # uppercase letter as the hotkey for each menu (File / Edit /
+        # View / REPL).  Try lowercase first since some menubar
+        # implementations are case-insensitive.
+        t.send("R")
+        # Give the cascade time to draw — or crash
+        time.sleep(0.5)
+
+        snapshot(t, "repl-menu-crash-after-activation")
+
+        # Crash detection: is the REPL process still alive?
+        assert t.is_alive(), (
+            "REPL exited after pressing 'R' in palette menubar "
+            "— this is the reported crash"
+        )
+
+        # Also assert SOMETHING happened (REPL submenu opened) — capture
+        # should show MORE rows than before (cascade level added)
+        text = t.capture()
+        # Don't be strict about content; just verify no crash + something rendered
+        assert len(text) > 0
+
+
+def test_repl_menu_activation_via_arrows_doesnt_crash():
+    """Alternative repro path: navigate to REPL via RIGHT arrows instead
+    of hotkey.  This isolates whether the crash is hotkey-specific or
+    menu-activation-specific.
+    """
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        t.send("/")
+        time.sleep(0.6)
+        t.wait_for("╔", timeout=2)
+
+        # Navigate right 3 times to REPL (4th menu)
+        for _ in range(3):
+            t.send_key("Right")
+            time.sleep(0.1)
+        snapshot(t, "repl-menu-crash-navigated-to-repl")
+
+        # Activate via Down (opens cascade) or Enter
+        t.send_key("Down")
+        time.sleep(0.5)
+        snapshot(t, "repl-menu-crash-after-down")
+
+        assert t.is_alive(), (
+            "REPL exited after RIGHT-RIGHT-RIGHT-DOWN navigation to REPL "
+            "menu — crash is menu-activation, not hotkey-specific"
+        )


### PR DESCRIPTION
## Summary

Fixes a `SIGBUS` / dangling-pointer crash when activating any cascade menu in `--debug-tui`'s slash palette (typing `/` then `R` for the REPL menu, or RIGHT-arrow navigation followed by DOWN/Enter).

**Root cause.** `boxen_repl_real_palette_open` declared `palette_menu_source_t` as a stack-local, called `palette_open_ex` (which stores a borrowed pointer in `st->source`), then disposed the source immediately. But `palette.c` dereferences `st->source` *lazily* — `open_level()` calls `st->source->item_count` / `item_describe` only when the user opens a cascade level. Every such call hit a NULL function pointer (frame#0 PC=0 in the crash backtrace; `lr = palette_feed_byte +offset`).

**Fix.** Heap-allocate `palette_menu_source_t` and tie its lifetime to the `palette_state`. Stored as `void *palette_source` on `boxen_repl_state_t` (forward-declared struct tag avoids dragging `repl_palette_source.h` up out of the `BOXEN_REPL_OMIT_MAIN` block). Disposed + freed in `on_palette_done` after `palette_close`, in the teardown crash/abort guard, and on every failure branch of `boxen_repl_real_palette_open`.

## Test plan

- [x] tui-tests: 20/20 passed (previously 18/20 — new regression tests in `test_99_repl_menu_crash.py` covered both crash paths)
- [x] unit tests: 814/814 passed
- [x] integration tests: 2186 passed / 21 failed (matches documented baseline — html/tcp/startup pre-existing failures, unrelated)
- [x] `/gate` review: PASS (0 P0, 0 P1, 5 P2)
  - bar-raiser: ship it
  - security: APPROVE — memory-safe across every reachable path
  - concurrency: clean — GIL held end-to-end through the lazy vtable callbacks
- [x] Manual repro: `--debug-tui`, `/`, RIGHT, DOWN — no longer crashes; cascade opens.

## Files

- `frontier-cli/boxen_repl.c` — heap-allocate source, pair lifetime with `palette_state`, dispose on every close path
- `frontier-cli/boxen_repl_internal.h` — add `palette_source` field
- `tools/tui-tests/tests/test_99_repl_menu_crash.py` — regression tests for both activation paths

## Follow-up items (P2, deferred)

These came out of `/gate` review and are tracked for future cleanup, not in scope here:

- Extract `boxen_repl_palette_release(s)` helper used by both close sites (security P2)
- OOM defensive: call `dispose` before `free` on `init_all` failure path (concurrency P2)
- `palette_paint_teardown` asymmetry between `on_palette_done` and crash/abort guard (pre-existing, security P2)
- Cosmetic: unify cast spelling for the palette source pointer (security P3)
