### PR TITLE
feat(repl): C.0.7g Phase 2A -- bridge dialog.alert/notify/twoway/threeway to boxen modals

### DIFF
--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -1477,6 +1477,21 @@ void boxen_repl_restore_focus_thunk(void *ctx) {
 	boxen_window_focus(s->input_win);
 }
 
+/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: ring-bell thunk for the
+ * boxen_ui bridge.  Writes \a (BEL, 0x07) directly to the saved-stderr
+ * fd captured before the dup2 redirect, so the byte reaches the real
+ * terminal instead of being absorbed by the capture pipe + rendered as
+ * a visible ^G glyph in the scrollback.  No-op if the saved fd is
+ * absent (capture pipe disabled) -- writing to the captured stderr
+ * would be visibly wrong, and the user can survive a missed bell. */
+void boxen_repl_ring_bell_thunk(void *ctx) {
+	boxen_repl_state_t *s = (boxen_repl_state_t *)ctx;
+	if (s == NULL || s->saved_stderr < 0) return;
+	const char bel = '\a';
+	ssize_t w = write(s->saved_stderr, &bel, 1);
+	(void)w; /* best-effort; nothing useful to do on partial / failed write */
+}
+
 void drain_stdout_into_scrollback(boxen_repl_state_t *s, int fd) {
 	if (s == NULL || fd < 0) return;
 
@@ -1879,6 +1894,8 @@ int boxen_repl_main(const cli_options_t *opts) {
 		.drain_ctx          = state,
 		.restore_focus      = boxen_repl_restore_focus_thunk,
 		.restore_focus_ctx  = state,
+		.ring_bell          = boxen_repl_ring_bell_thunk,
+		.ring_bell_ctx      = state,
 	};
 	boxen_ui_set_active(&ui_host);
 

--- a/frontier-cli/boxen_ui.c
+++ b/frontier-cli/boxen_ui.c
@@ -526,3 +526,457 @@ bool boxen_ui_get_int(const char *prompt, long default_val, long *out) {
 char *boxen_ui_get_password(const char *prompt) {
 	return run_input(BOXEN_UI_MODE_PASSWORD, prompt, NULL);
 }
+
+/* -------------------------------------------------------------------------
+ * 2026-06-23 JES #691 Phase C.0.7g Phase 2A: info-and-wait + button-
+ * selector modals.  Shape parallels run_input but with different
+ * content and key handling, so the modal context and render callback
+ * are separate.  Kept inline in this TU rather than abstracted into a
+ * shared "generic modal" loop -- the variants diverge enough that a
+ * shared abstraction would cost more clarity than it'd save.
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+	const char *message;
+	int   content_w;
+	boxen_window_t *win;
+	bool  done;
+	bool  cancelled;
+} alert_ctx_t;
+
+#define BOXEN_UI_ALERT_HINT "[Enter] dismiss"
+
+static void render_alert_cb(boxen_window_t *win, void *user_data) {
+	(void)win;
+	alert_ctx_t *ctx = (alert_ctx_t *)user_data;
+	if (ctx == NULL || ctx->win == NULL) return;
+
+	int w = ctx->content_w;
+
+	/* Row 0: message, clipped to width. */
+	const char *m = ctx->message ? ctx->message : "";
+	int i;
+	for (i = 0; i < w; i++) {
+		char ch = m[i];
+		if (ch == '\0') break;
+		boxen_set_cell(ctx->win, i, 0, (uint32_t)(unsigned char)ch,
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_NONE);
+	}
+	for (; i < w; i++) {
+		boxen_set_cell(ctx->win, i, 0, ' ',
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_NONE);
+	}
+
+	/* Row 1: blank spacer. */
+	for (int j = 0; j < w; j++) {
+		boxen_set_cell(ctx->win, j, 1, ' ',
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_NONE);
+	}
+
+	/* Row 2: dismiss hint, dim. */
+	const char *hint = BOXEN_UI_ALERT_HINT;
+	int hint_len = (int)strlen(hint);
+	int hint_x = (w - hint_len) / 2;
+	if (hint_x < 0) hint_x = 0;
+	for (int k = 0; k < w; k++) {
+		char ch = (k >= hint_x && (k - hint_x) < hint_len) ? hint[k - hint_x] : ' ';
+		boxen_set_cell(ctx->win, k, 2, (uint32_t)(unsigned char)ch,
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_DIM);
+	}
+
+	boxen_window_set_cursor_visible(ctx->win, false);
+}
+
+static boxen_rect_t place_alert_modal(int screen_w, int screen_h,
+                                       int min_field_w) {
+	int content_w = min_field_w;
+	if (content_w < 30) content_w = 30;
+	int max_w = screen_w - 4;
+	if (max_w < 20) max_w = 20;
+	if (content_w > max_w) content_w = max_w;
+
+	int win_w = content_w + 2;
+	int win_h = 5;
+
+	int x = (screen_w - win_w) / 2;
+	if (x < 0) x = 0;
+	int y = screen_h / 3;
+	if (y + win_h > screen_h - 1) y = screen_h - win_h - 1;
+	if (y < 0) y = 0;
+
+	boxen_rect_t r = { x, y, win_w, win_h };
+	return r;
+}
+
+bool boxen_ui_alert(const char *message, bool beep) {
+	const boxen_ui_host_t *host = load_host();
+	if (!host) return false;
+
+	int sw = 80, sh = 24;
+	boxen_get_screen_size(&sw, &sh);
+	if (sw < 20) sw = 20;
+	if (sh < 6)  sh = 6;
+
+	int msg_w = message ? (int)strlen(message) : 0;
+	int hint_w = (int)strlen(BOXEN_UI_ALERT_HINT);
+	int field_w = msg_w > hint_w ? msg_w : hint_w;
+	field_w += 4; /* margin */
+	if (field_w < 40) field_w = 40;
+
+	alert_ctx_t ctx;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.message = message;
+
+	boxen_rect_t rect = place_alert_modal(sw, sh, field_w);
+	boxen_window_t *win = boxen_window_open(NULL, rect, &ctx);
+	if (!win) return false;
+
+	ctx.win = win;
+	ctx.content_w = boxen_window_content_width(win);
+
+	boxen_window_set_borders(win, true);
+	boxen_window_set_modal(win, true);
+	boxen_window_set_movable(win, false);
+	boxen_window_set_resizable(win, false);
+	boxen_window_set_draw(win, render_alert_cb);
+	boxen_window_focus(win);
+	boxen_window_raise(win);
+
+	if (beep) {
+		/* Bell character into the captured stderr; the drain inside
+		 * the mini-loop will deliver it.  This is the same beep the
+		 * legacy dialog_alert produces. */
+		fputc('\a', stderr);
+		fflush(stderr);
+	}
+
+	/* Mini event loop (parallel to run_modal). */
+	boxen_window_invalidate(win);
+	if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
+	boxen_present();
+
+	while (!ctx.done) {
+		boxen_event_t ev;
+		memset(&ev, 0, sizeof(ev));
+
+		tcp_process_callbacks();
+
+		hdlthreadglobals saved = hthreadglobals;
+		headless_save_threadglobals(saved);
+		pthread_mutex_unlock(&frontier_gil);
+		pthread_cond_broadcast(&gil_available);
+		boxen_result_t rc = boxen_poll_event(&ev, 100);
+		pthread_mutex_lock(&frontier_gil);
+		headless_restore_threadglobals(saved);
+
+		if ((**saved).flthreadkilled) {
+			ctx.cancelled = true;
+			ctx.done = true;
+			break;
+		}
+
+		if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
+
+		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
+		if (rc != BOXEN_OK) { ctx.cancelled = true; ctx.done = true; break; }
+
+		if (ev.type == BOXEN_EV_RESIZE) {
+			int new_sw = ev.resize.w, new_sh = ev.resize.h;
+			if (new_sw < 20) new_sw = 20;
+			if (new_sh < 6)  new_sh = 6;
+			boxen_rect_t r = place_alert_modal(new_sw, new_sh, ctx.content_w);
+			boxen_window_set_rect(win, r);
+			ctx.content_w = boxen_window_content_width(win);
+			boxen_window_invalidate(win);
+			boxen_present();
+			continue;
+		}
+
+		if (ev.type == BOXEN_EV_KEY) {
+			if (ev.key.key == BOXEN_KEY_ENTER) {
+				ctx.done = true;
+			} else if (ev.key.key == BOXEN_KEY_ESCAPE
+			           || ev.key.key == BOXEN_KEY_CTRL_C) {
+				ctx.cancelled = true;
+				ctx.done = true;
+			}
+			/* All other keys ignored -- alert is dismiss-only. */
+			boxen_window_invalidate(win);
+			boxen_present();
+		}
+	}
+
+	boxen_window_close(win);
+	if (host->restore_focus) host->restore_focus(host->restore_focus_ctx);
+	boxen_present();
+
+	/* Both Enter and Esc/Ctrl-C return true today (matches the legacy
+	 * dialog_alert / dialog_notify behavior of always returning true
+	 * once dismissed -- there's no "I disagree with this message"
+	 * outcome).  cancelled is tracked separately in case a future
+	 * caller wants a "user bailed via Esc" distinction. */
+	(void)ctx.cancelled;
+	return true;
+}
+
+/* -------------------------------------------------------------------------
+ * Button selector (dialog.twoway / dialog.threeway)
+ * ---------------------------------------------------------------------- */
+
+#define BOXEN_UI_BUTTON_MAX 4
+
+typedef struct {
+	const char *prompt;
+	const char *labels[BOXEN_UI_BUTTON_MAX];
+	int   count;
+	int   selection;     /* 0..count-1 */
+	int   content_w;
+	boxen_window_t *win;
+	bool  done;
+	bool  cancelled;
+} button_ctx_t;
+
+/* Total width of the button row laid out with single-space gutters. */
+static int button_row_width(const button_ctx_t *ctx) {
+	int total = 0;
+	for (int i = 0; i < ctx->count; i++) {
+		const char *l = ctx->labels[i] ? ctx->labels[i] : "";
+		total += 4 + (int)strlen(l); /* "[ " + label + " ]" */
+		if (i < ctx->count - 1) total += 2; /* gutter */
+	}
+	return total;
+}
+
+static void render_button_cb(boxen_window_t *win, void *user_data) {
+	(void)win;
+	button_ctx_t *ctx = (button_ctx_t *)user_data;
+	if (ctx == NULL || ctx->win == NULL) return;
+
+	int w = ctx->content_w;
+
+	/* Row 0: prompt, bold. */
+	const char *p = ctx->prompt ? ctx->prompt : "";
+	int i;
+	for (i = 0; i < w; i++) {
+		char ch = p[i];
+		if (ch == '\0') break;
+		boxen_set_cell(ctx->win, i, 0, (uint32_t)(unsigned char)ch,
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_BOLD);
+	}
+	for (; i < w; i++) {
+		boxen_set_cell(ctx->win, i, 0, ' ',
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_NONE);
+	}
+
+	/* Row 1: blank spacer. */
+	for (int j = 0; j < w; j++) {
+		boxen_set_cell(ctx->win, j, 1, ' ',
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_NONE);
+	}
+
+	/* Row 2: button row, centered.  Selected button drawn in reverse
+	 * video.  Each button rendered as "[ Label ]" with the label's
+	 * first letter (the hotkey) bold + underlined when non-selected
+	 * and just underlined when selected (reverse video makes bold
+	 * redundant). */
+	int row_w = button_row_width(ctx);
+	int x = (w - row_w) / 2;
+	if (x < 0) x = 0;
+	/* Clear the row first. */
+	for (int j = 0; j < w; j++) {
+		boxen_set_cell(ctx->win, j, 2, ' ',
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_NONE);
+	}
+	for (int b = 0; b < ctx->count; b++) {
+		const char *l = ctx->labels[b] ? ctx->labels[b] : "";
+		int ll = (int)strlen(l);
+		bool sel = (b == ctx->selection);
+		uint16_t base = sel ? BOXEN_ATTR_REVERSE : BOXEN_ATTR_NONE;
+
+		if (x < w) boxen_set_cell(ctx->win, x++, 2, '[',
+		                          BOXEN_COLOR_DEFAULT,
+		                          BOXEN_COLOR_DEFAULT, base);
+		if (x < w) boxen_set_cell(ctx->win, x++, 2, ' ',
+		                          BOXEN_COLOR_DEFAULT,
+		                          BOXEN_COLOR_DEFAULT, base);
+		for (int k = 0; k < ll && x < w; k++, x++) {
+			uint16_t a = base | ((k == 0 && !sel) ?
+			                     (BOXEN_ATTR_BOLD | BOXEN_ATTR_UNDERLINE)
+			                     : (k == 0 ? BOXEN_ATTR_UNDERLINE : 0));
+			boxen_set_cell(ctx->win, x, 2,
+			               (uint32_t)(unsigned char)l[k],
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT, a);
+		}
+		if (x < w) boxen_set_cell(ctx->win, x++, 2, ' ',
+		                          BOXEN_COLOR_DEFAULT,
+		                          BOXEN_COLOR_DEFAULT, base);
+		if (x < w) boxen_set_cell(ctx->win, x++, 2, ']',
+		                          BOXEN_COLOR_DEFAULT,
+		                          BOXEN_COLOR_DEFAULT, base);
+		if (b < ctx->count - 1) {
+			/* Gutter. */
+			if (x < w) boxen_set_cell(ctx->win, x++, 2, ' ',
+			                          BOXEN_COLOR_DEFAULT,
+			                          BOXEN_COLOR_DEFAULT, BOXEN_ATTR_NONE);
+			if (x < w) boxen_set_cell(ctx->win, x++, 2, ' ',
+			                          BOXEN_COLOR_DEFAULT,
+			                          BOXEN_COLOR_DEFAULT, BOXEN_ATTR_NONE);
+		}
+	}
+
+	boxen_window_set_cursor_visible(ctx->win, false);
+}
+
+static int hotkey_match(const button_ctx_t *ctx, uint32_t ch) {
+	if (ch == 0) return -1;
+	/* Case-insensitive first-letter match against each label. */
+	char up = (char)ch;
+	if (up >= 'a' && up <= 'z') up = (char)(up - 'a' + 'A');
+	for (int i = 0; i < ctx->count; i++) {
+		const char *l = ctx->labels[i];
+		if (!l || !l[0]) continue;
+		char first = l[0];
+		if (first >= 'a' && first <= 'z') first = (char)(first - 'a' + 'A');
+		if (first == up) return i;
+	}
+	return -1;
+}
+
+int boxen_ui_button_select(const char *prompt,
+                           const char *const *buttons, int count) {
+	if (count < 2 || count > BOXEN_UI_BUTTON_MAX) return 0;
+	if (!buttons) return 0;
+
+	const boxen_ui_host_t *host = load_host();
+	if (!host) return 0;
+
+	int sw = 80, sh = 24;
+	boxen_get_screen_size(&sw, &sh);
+	if (sw < 20) sw = 20;
+	if (sh < 6)  sh = 6;
+
+	button_ctx_t ctx;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.prompt = prompt;
+	ctx.count = count;
+	for (int i = 0; i < count; i++) ctx.labels[i] = buttons[i];
+	ctx.selection = 0;
+
+	/* Field width: max(prompt, button row) + margin. */
+	int prompt_w = prompt ? (int)strlen(prompt) : 0;
+	int row_w = button_row_width(&ctx);
+	int field_w = prompt_w > row_w ? prompt_w : row_w;
+	field_w += 4;
+	if (field_w < 40) field_w = 40;
+
+	boxen_rect_t rect = place_alert_modal(sw, sh, field_w);
+	boxen_window_t *win = boxen_window_open(NULL, rect, &ctx);
+	if (!win) return 0;
+
+	ctx.win = win;
+	ctx.content_w = boxen_window_content_width(win);
+
+	boxen_window_set_borders(win, true);
+	boxen_window_set_modal(win, true);
+	boxen_window_set_movable(win, false);
+	boxen_window_set_resizable(win, false);
+	boxen_window_set_draw(win, render_button_cb);
+	boxen_window_focus(win);
+	boxen_window_raise(win);
+
+	boxen_window_invalidate(win);
+	if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
+	boxen_present();
+
+	while (!ctx.done) {
+		boxen_event_t ev;
+		memset(&ev, 0, sizeof(ev));
+
+		tcp_process_callbacks();
+
+		hdlthreadglobals saved = hthreadglobals;
+		headless_save_threadglobals(saved);
+		pthread_mutex_unlock(&frontier_gil);
+		pthread_cond_broadcast(&gil_available);
+		boxen_result_t rc = boxen_poll_event(&ev, 100);
+		pthread_mutex_lock(&frontier_gil);
+		headless_restore_threadglobals(saved);
+
+		if ((**saved).flthreadkilled) {
+			ctx.cancelled = true;
+			ctx.done = true;
+			break;
+		}
+
+		if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
+
+		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
+		if (rc != BOXEN_OK) { ctx.cancelled = true; ctx.done = true; break; }
+
+		if (ev.type == BOXEN_EV_RESIZE) {
+			int new_sw = ev.resize.w, new_sh = ev.resize.h;
+			if (new_sw < 20) new_sw = 20;
+			if (new_sh < 6)  new_sh = 6;
+			boxen_rect_t r = place_alert_modal(new_sw, new_sh, ctx.content_w);
+			boxen_window_set_rect(win, r);
+			ctx.content_w = boxen_window_content_width(win);
+			boxen_window_invalidate(win);
+			boxen_present();
+			continue;
+		}
+
+		if (ev.type == BOXEN_EV_KEY) {
+			switch (ev.key.key) {
+			case BOXEN_KEY_ENTER:
+				ctx.done = true;
+				break;
+			case BOXEN_KEY_ESCAPE:
+			case BOXEN_KEY_CTRL_C:
+				ctx.cancelled = true;
+				ctx.done = true;
+				break;
+			case BOXEN_KEY_LEFT:
+				if (ctx.selection > 0) ctx.selection--;
+				break;
+			case BOXEN_KEY_RIGHT:
+				if (ctx.selection < ctx.count - 1) ctx.selection++;
+				break;
+			case BOXEN_KEY_HOME:
+				ctx.selection = 0;
+				break;
+			case BOXEN_KEY_END:
+				ctx.selection = ctx.count - 1;
+				break;
+			default: {
+				/* Printable hotkey?  Match first letter of any label;
+				 * if matched, select + activate immediately. */
+				if (ev.key.key == BOXEN_KEY_NONE
+				    && ev.key.ch >= 0x20 && ev.key.ch < 0x7F) {
+					int idx = hotkey_match(&ctx, ev.key.ch);
+					if (idx >= 0) {
+						ctx.selection = idx;
+						ctx.done = true;
+					}
+				}
+				break;
+			}
+			}
+			boxen_window_invalidate(win);
+			boxen_present();
+		}
+	}
+
+	int result = ctx.cancelled ? 0 : (ctx.selection + 1);
+	boxen_window_close(win);
+	if (host->restore_focus) host->restore_focus(host->restore_focus_ctx);
+	boxen_present();
+	return result;
+}

--- a/frontier-cli/boxen_ui.c
+++ b/frontier-cli/boxen_ui.c
@@ -542,6 +542,12 @@ typedef struct {
 	boxen_window_t *win;
 	bool  done;
 	bool  cancelled;
+	/* Host snapshot stashed for future renderer use.  Today the
+	 * renderer doesn't touch the host, but if it ever grows
+	 * host-mediated logic (a status line that drains the capture pipe,
+	 * a host-driven theme accessor), reading the file-static s_host
+	 * raw would be a race risk.  Phase-1-pattern parity. */
+	const boxen_ui_host_t *host;
 } alert_ctx_t;
 
 #define BOXEN_UI_ALERT_HINT "[Enter] dismiss"
@@ -591,7 +597,7 @@ static void render_alert_cb(boxen_window_t *win, void *user_data) {
 	boxen_window_set_cursor_visible(ctx->win, false);
 }
 
-static boxen_rect_t place_alert_modal(int screen_w, int screen_h,
+static boxen_rect_t place_centered_modal(int screen_w, int screen_h,
                                        int min_field_w) {
 	int content_w = min_field_w;
 	if (content_w < 30) content_w = 30;
@@ -614,7 +620,16 @@ static boxen_rect_t place_alert_modal(int screen_w, int screen_h,
 
 bool boxen_ui_alert(const char *message, bool beep) {
 	const boxen_ui_host_t *host = load_host();
-	if (!host) return false;
+	if (!host) {
+		/* Reachable only on a set_active(NULL) race that GIL discipline
+		 * prevents today, but if it ever happens we still need to honor
+		 * the documented contract: dialog.alert / dialog.notify always
+		 * return true once the user has "dismissed" the prompt.  No
+		 * prompt was shown here, but the verb's bool return must not
+		 * differ from the legacy "always true" semantics or scripts
+		 * branching on a falsy result will misbehave. */
+		return true;
+	}
 
 	int sw = 80, sh = 24;
 	boxen_get_screen_size(&sw, &sh);
@@ -630,8 +645,9 @@ bool boxen_ui_alert(const char *message, bool beep) {
 	alert_ctx_t ctx;
 	memset(&ctx, 0, sizeof(ctx));
 	ctx.message = message;
+	ctx.host = host;
 
-	boxen_rect_t rect = place_alert_modal(sw, sh, field_w);
+	boxen_rect_t rect = place_centered_modal(sw, sh, field_w);
 	boxen_window_t *win = boxen_window_open(NULL, rect, &ctx);
 	if (!win) return false;
 
@@ -646,12 +662,12 @@ bool boxen_ui_alert(const char *message, bool beep) {
 	boxen_window_focus(win);
 	boxen_window_raise(win);
 
-	if (beep) {
-		/* Bell character into the captured stderr; the drain inside
-		 * the mini-loop will deliver it.  This is the same beep the
-		 * legacy dialog_alert produces. */
-		fputc('\a', stderr);
-		fflush(stderr);
+	if (beep && host->ring_bell) {
+		/* Route through the host so the bell reaches the real terminal
+		 * fd rather than getting absorbed by the boxen stdout/stderr
+		 * capture pipe (which would render the byte as a visible ^G
+		 * glyph in the scrollback rather than ringing the bell). */
+		host->ring_bell(host->ring_bell_ctx);
 	}
 
 	/* Mini event loop (parallel to run_modal). */
@@ -688,7 +704,7 @@ bool boxen_ui_alert(const char *message, bool beep) {
 			int new_sw = ev.resize.w, new_sh = ev.resize.h;
 			if (new_sw < 20) new_sw = 20;
 			if (new_sh < 6)  new_sh = 6;
-			boxen_rect_t r = place_alert_modal(new_sw, new_sh, ctx.content_w);
+			boxen_rect_t r = place_centered_modal(new_sw, new_sh, ctx.content_w);
 			boxen_window_set_rect(win, r);
 			ctx.content_w = boxen_window_content_width(win);
 			boxen_window_invalidate(win);
@@ -717,9 +733,9 @@ bool boxen_ui_alert(const char *message, bool beep) {
 	/* Both Enter and Esc/Ctrl-C return true today (matches the legacy
 	 * dialog_alert / dialog_notify behavior of always returning true
 	 * once dismissed -- there's no "I disagree with this message"
-	 * outcome).  cancelled is tracked separately in case a future
-	 * caller wants a "user bailed via Esc" distinction. */
-	(void)ctx.cancelled;
+	 * outcome).  ctx.cancelled remains tracked inside the loop in case
+	 * a future caller wants the "user bailed via Esc" distinction;
+	 * unused in the current return. */
 	return true;
 }
 
@@ -738,6 +754,7 @@ typedef struct {
 	boxen_window_t *win;
 	bool  done;
 	bool  cancelled;
+	const boxen_ui_host_t *host;	/* see alert_ctx_t.host */
 } button_ctx_t;
 
 /* Total width of the button row laid out with single-space gutters. */
@@ -869,6 +886,7 @@ int boxen_ui_button_select(const char *prompt,
 	ctx.count = count;
 	for (int i = 0; i < count; i++) ctx.labels[i] = buttons[i];
 	ctx.selection = 0;
+	ctx.host = host;
 
 	/* Field width: max(prompt, button row) + margin. */
 	int prompt_w = prompt ? (int)strlen(prompt) : 0;
@@ -877,7 +895,7 @@ int boxen_ui_button_select(const char *prompt,
 	field_w += 4;
 	if (field_w < 40) field_w = 40;
 
-	boxen_rect_t rect = place_alert_modal(sw, sh, field_w);
+	boxen_rect_t rect = place_centered_modal(sw, sh, field_w);
 	boxen_window_t *win = boxen_window_open(NULL, rect, &ctx);
 	if (!win) return 0;
 
@@ -925,7 +943,7 @@ int boxen_ui_button_select(const char *prompt,
 			int new_sw = ev.resize.w, new_sh = ev.resize.h;
 			if (new_sw < 20) new_sw = 20;
 			if (new_sh < 6)  new_sh = 6;
-			boxen_rect_t r = place_alert_modal(new_sw, new_sh, ctx.content_w);
+			boxen_rect_t r = place_centered_modal(new_sw, new_sh, ctx.content_w);
 			boxen_window_set_rect(win, r);
 			ctx.content_w = boxen_window_content_width(win);
 			boxen_window_invalidate(win);
@@ -956,10 +974,13 @@ int boxen_ui_button_select(const char *prompt,
 				ctx.selection = ctx.count - 1;
 				break;
 			default: {
-				/* Printable hotkey?  Match first letter of any label;
-				 * if matched, select + activate immediately. */
-				if (ev.key.key == BOXEN_KEY_NONE
-				    && ev.key.ch >= 0x20 && ev.key.ch < 0x7F) {
+				/* Reaching `default` means ev.key.key == BOXEN_KEY_NONE
+				 * (every non-NONE key is named in a case above), so
+				 * ev.key.ch holds a Unicode codepoint.  Hotkey match:
+				 * printable ASCII first-letter == label's first
+				 * letter (case-insensitive) selects + activates that
+				 * button immediately. */
+				if (ev.key.ch >= 0x20 && ev.key.ch < 0x7F) {
 					int idx = hotkey_match(&ctx, ev.key.ch);
 					if (idx >= 0) {
 						ctx.selection = idx;

--- a/frontier-cli/boxen_ui.h
+++ b/frontier-cli/boxen_ui.h
@@ -67,6 +67,17 @@ typedef struct boxen_ui_host {
 	 * the default focus target is gone. */
 	void (*restore_focus)(void *ctx);
 	void *restore_focus_ctx;
+
+	/* Ring-bell callback: bridge invokes this when the user-facing
+	 * modal needs to produce an audible cue (currently only
+	 * dialog.alert).  The host writes \a (or equivalent) directly to
+	 * the real terminal fd, bypassing the boxen stdout/stderr capture
+	 * pipe -- if the bridge wrote \a to its own captured stderr the
+	 * byte would be drained into the scrollback as a visible ^G glyph
+	 * rather than ringing the terminal bell.  NULL is allowed (no-op
+	 * = silent). */
+	void (*ring_bell)(void *ctx);
+	void *ring_bell_ctx;
 } boxen_ui_host_t;
 
 void boxen_ui_set_active(const boxen_ui_host_t *host);

--- a/frontier-cli/boxen_ui.h
+++ b/frontier-cli/boxen_ui.h
@@ -103,6 +103,29 @@ bool boxen_ui_get_int(const char *prompt, long default_val, long *out);
 /* Masked password input (asterisks per char).  Returns NULL on cancel. */
 char *boxen_ui_get_password(const char *prompt);
 
+/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: info-and-wait modal.
+ * Shows `message` in a centered modal with a "Press Enter to continue"
+ * hint.  If `beep` is true, rings the terminal bell on open.  Returns
+ * true on Enter, false on Esc / Ctrl-C.
+ *
+ * Bridges dialog.alert(message) -> beep=true and dialog.notify(message)
+ * -> beep=false. */
+bool boxen_ui_alert(const char *message, bool beep);
+
+/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: button-selector modal.
+ * Shows `prompt` above a horizontal row of buttons; Left/Right move
+ * the selection; Enter chooses; Esc / Ctrl-C cancel.  Hotkey: a typed
+ * letter matching the first character of a button label (case-
+ * insensitive) selects + activates that button immediately, matching
+ * the legacy dialog_twoway/threeway behavior.
+ *
+ * `buttons` is an array of `count` C strings (must be 2..4).  Returns
+ * the 1-based index of the chosen button, or 0 on cancel.
+ *
+ * Bridges dialog.twoway (count=2) and dialog.threeway (count=3). */
+int boxen_ui_button_select(const char *prompt,
+                           const char *const *buttons, int count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/frontier-cli/dialog_prompts.c
+++ b/frontier-cli/dialog_prompts.c
@@ -468,11 +468,11 @@ bool dialog_twoway(const char *prompt, const char *button1, const char *button2)
 	const char *buttons[2] = { button1, button2 };
 
 	/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge.
-	 * Returns 1 for button1, 2 for button2, 0 on cancel.  Map back to
-	 * legacy bool: true == button1, false == button2 OR cancel (legacy
-	 * defaults to "true" in batch mode, so cancel -> false here is the
-	 * safer translation: a script that branches on the return won't
-	 * accidentally take the first-button path when the user bailed). */
+	 * Returns 1 for button1, 2 for button2, 0 on Esc/Ctrl-C cancel.
+	 * Map back to legacy bool: true iff button1.  Cancel (0) and
+	 * button2 (2) both map to false -- this matches the legacy
+	 * interactive dialog_twoway behavior, which returns false on Esc
+	 * (see dialog_prompts.c:525-530 below). */
 	if (boxen_ui_is_active()) {
 		int r = boxen_ui_button_select(prompt, buttons, 2);
 		return (r == 1);
@@ -572,12 +572,20 @@ int dialog_threeway(const char *prompt, const char *button1, const char *button2
 	const char *buttons[3] = { button1, button2, button3 };
 
 	/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge.
-	 * Returns 1/2/3 for the chosen button.  Map cancel (0) to 1
-	 * (button1) -- legacy threeway has no cancel return; defaulting
-	 * to button1 matches the batch-mode behavior below. */
+	 * Returns 1/2/3 for the chosen button, or 0 on Esc/Ctrl-C cancel.
+	 *
+	 * Legacy interactive dialog_threeway has no cancel return path (Esc
+	 * beeps and the user must pick a button).  The boxen modal cancel
+	 * is a new addition; we surface it as 0 so safety-sensitive scripts
+	 * can detect "user bailed" without mis-coercing it into button1
+	 * (which by convention is often the destructive default like
+	 * "Save").  Callers that always expect 1/2/3 should test `if r > 0`
+	 * before branching, or treat 0 as a no-op.  Button labels are
+	 * caller-defined, so the bridge cannot infer which button is the
+	 * "Cancel" by convention; 0-on-cancel is the only signal-preserving
+	 * mapping. */
 	if (boxen_ui_is_active()) {
-		int r = boxen_ui_button_select(prompt, buttons, 3);
-		return (r == 0) ? 1 : r;
+		return boxen_ui_button_select(prompt, buttons, 3);
 	}
 
 	if (!isInteractiveMode()) {

--- a/frontier-cli/dialog_prompts.c
+++ b/frontier-cli/dialog_prompts.c
@@ -331,6 +331,11 @@ char* dialog_get_password(const char *prompt) {
 
 /* Displays an alert message with audible beep, waits for Enter to continue. */
 bool dialog_alert(const char *message) {
+	/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge. */
+	if (boxen_ui_is_active()) {
+		return boxen_ui_alert(message, true /* beep */);
+	}
+
 	if (!isInteractiveMode()) {
 		return false;
 	}
@@ -383,6 +388,11 @@ bool dialog_alert(const char *message) {
 
 /* Displays a notification message without beep, waits for Enter to continue. */
 bool dialog_notify(const char *message) {
+	/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge. */
+	if (boxen_ui_is_active()) {
+		return boxen_ui_alert(message, false /* no beep */);
+	}
+
 	if (!isInteractiveMode()) {
 		return false;
 	}
@@ -456,6 +466,17 @@ bool dialog_twoway(const char *prompt, const char *button1, const char *button2)
 	int selection = 0;  /* 0 = button1, 1 = button2 */
 	terminal_state *term_state = NULL;
 	const char *buttons[2] = { button1, button2 };
+
+	/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge.
+	 * Returns 1 for button1, 2 for button2, 0 on cancel.  Map back to
+	 * legacy bool: true == button1, false == button2 OR cancel (legacy
+	 * defaults to "true" in batch mode, so cancel -> false here is the
+	 * safer translation: a script that branches on the return won't
+	 * accidentally take the first-button path when the user bailed). */
+	if (boxen_ui_is_active()) {
+		int r = boxen_ui_button_select(prompt, buttons, 2);
+		return (r == 1);
+	}
 
 	if (!isInteractiveMode()) {
 		return true;  /* Default to button1 in batch mode */
@@ -549,6 +570,15 @@ int dialog_threeway(const char *prompt, const char *button1, const char *button2
 	int selection = 0;  /* 0 = button1, 1 = button2, 2 = button3 */
 	terminal_state *term_state = NULL;
 	const char *buttons[3] = { button1, button2, button3 };
+
+	/* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge.
+	 * Returns 1/2/3 for the chosen button.  Map cancel (0) to 1
+	 * (button1) -- legacy threeway has no cancel return; defaulting
+	 * to button1 matches the batch-mode behavior below. */
+	if (boxen_ui_is_active()) {
+		int r = boxen_ui_button_select(prompt, buttons, 3);
+		return (r == 0) ? 1 : r;
+	}
 
 	if (!isInteractiveMode()) {
 		return 1;  /* Default to button1 in batch mode */

--- a/tests/headless_dialog_verbs.c
+++ b/tests/headless_dialog_verbs.c
@@ -60,7 +60,8 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             /* dialog.alert(message) - Display message with beep and OK button */
             bigstring bsmessage;
 
-            if (!isInteractiveMode()) {
+            /* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge bypass. */
+            if (!isInteractiveMode() && !boxen_ui_is_active()) {
                 if (bserror) copystring(PSTRING("\044", "Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
@@ -82,7 +83,8 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             /* dialog.notify(message) - Display message with OK button (no beep) */
             bigstring bsmessage;
 
-            if (!isInteractiveMode()) {
+            /* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge bypass. */
+            if (!isInteractiveMode() && !boxen_ui_is_active()) {
                 if (bserror) copystring(PSTRING("\044", "Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
@@ -104,7 +106,8 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             /* dialog.twoway(prompt, button1, button2) - Two-button choice */
             bigstring bsprompt, bsbutton1, bsbutton2;
 
-            if (!isInteractiveMode()) {
+            /* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge bypass. */
+            if (!isInteractiveMode() && !boxen_ui_is_active()) {
                 if (bserror) copystring(PSTRING("\044", "Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }
@@ -133,7 +136,8 @@ static boolean dialog_valueproc(short token, hdltreenode hparam1,
             /* dialog.threeway(prompt, button1, button2, button3) - Three-button choice */
             bigstring bsprompt, bsbutton1, bsbutton2, bsbutton3;
 
-            if (!isInteractiveMode()) {
+            /* 2026-06-23 JES #691 Phase C.0.7g Phase 2A: boxen UI bridge bypass. */
+            if (!isInteractiveMode() && !boxen_ui_is_active()) {
                 if (bserror) copystring(PSTRING("\044", "Can't use dialog verbs in batch mode"), bserror);
                 return false;
             }

--- a/tools/tui-tests/tests/test_07_ui_bridge_phase2.py
+++ b/tools/tui-tests/tests/test_07_ui_bridge_phase2.py
@@ -1,0 +1,187 @@
+"""
+Phase 2A of the boxen <-> UserTalk UI bridge (see
+planning/phase_c/BOXEN_USERTALK_UI_BRIDGE.md).
+
+Bridges the remaining 4 dialog verbs to boxen modals:
+
+  - dialog.alert(message)       -- beep + message + wait for Enter
+  - dialog.notify(message)      -- message + wait for Enter (no beep)
+  - dialog.twoway(prompt, b1, b2)    -- 2-button selector
+  - dialog.threeway(prompt, b1, b2, b3)   -- 3-button selector
+
+We drive these from a tiny ad-hoc UserTalk expression evaluated via the
+REPL prompt rather than via a slash-menu dispatched script, because the
+existing REPL menubar in Virgin.root only exercises dialog.getString
+through /R J (Jump).  Pre-fix these prompts go to raw stderr and are
+either invisible under boxen or corrupt the framebuffer.
+"""
+
+import time
+
+from tui_harness import TUI, snapshot
+
+
+def _eval(t, expr):
+	"""Type a UserTalk expression at the REPL prompt and press Enter.
+	The boxen REPL evaluates and shows the result in scrollback.
+	"""
+	t.send(expr)
+	time.sleep(0.1)
+	t.send_key("Enter")
+
+
+def _modal_visible(text):
+	"""A boxen modal renders with box-drawing characters around its
+	content.  The legacy raw-stderr path doesn't, so the presence of
+	the top-left corner glyph plus the modal's content is a reliable
+	"the bridge ran" signal."""
+	return "╔" in text or "║" in text
+
+
+def _text_inside_modal(text, marker):
+	"""Marker is visible OUTSIDE the typed prompt line.  The capture
+	puts the typed input on a line starting with "> ".  We want to see
+	the marker on a row that ISN'T the prompt row."""
+	prompt_marker = "> "
+	rows_with_marker = [
+		row for row in text.split("\n")
+		if marker in row and not row.lstrip().startswith(prompt_marker)
+	]
+	return len(rows_with_marker) > 0
+
+
+def test_dialog_notify_renders_modal_immediately():
+	"""dialog.notify("hello") should open a centered boxen modal
+	showing "hello" and a "Press Enter to continue" hint.  Pre-fix the
+	message went to captured stderr but the framebuffer wasn't
+	repainted, so the only thing visible was raw escape sequences
+	leaking into the scrollback after the dialog returned.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t, 'dialog.notify ("PhaseTwoNotifyMarker")')
+		time.sleep(0.6)
+		snapshot(t, "ui-bridge-p2-notify-visible")
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during dialog.notify"
+		assert _modal_visible(text), (
+			"dialog.notify did not render a boxen modal.  The legacy "
+			"raw-stderr path likely ran instead.  Capture:\n" + text
+		)
+		assert _text_inside_modal(text, "PhaseTwoNotifyMarker"), (
+			"dialog.notify message not visible inside the modal (only "
+			"appears on the typed prompt line, if at all).  Capture:\n"
+			+ text
+		)
+		# Dismiss with Enter so the test leaves the REPL clean.
+		t.send_key("Enter")
+		time.sleep(0.3)
+
+
+def test_dialog_alert_renders_modal_and_dismisses_on_enter():
+	"""dialog.alert("oops") should open a modal that the user dismisses
+	with Enter.  Beep (bell character) is sent via boxen rather than
+	stderr; we can't easily assert that, but we can assert the modal
+	renders and the REPL stays alive.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t, 'dialog.alert ("PhaseTwoAlertMarker")')
+		time.sleep(0.6)
+		snapshot(t, "ui-bridge-p2-alert-visible")
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during dialog.alert"
+		assert _modal_visible(text), (
+			"dialog.alert did not render a boxen modal.  Capture:\n" + text
+		)
+		assert _text_inside_modal(text, "PhaseTwoAlertMarker"), (
+			"dialog.alert message not visible inside the modal.  "
+			"Capture:\n" + text
+		)
+		t.send_key("Enter")
+		time.sleep(0.3)
+		# After dismissal, the REPL prompt should be reachable.
+		t.wait_for(">", timeout=2)
+
+
+def test_dialog_twoway_returns_first_button_via_left_arrow_enter():
+	"""dialog.twoway("Save?", "Save", "Discard") with Left+Enter selects
+	the first button (Save) and returns true (UserTalk: equivalent to
+	1).  We confirm via the result printed to scrollback after the
+	dialog dismisses.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t, 'dialog.twoway ("PhaseTwoTwowayQuestion", "Save", "Discard")')
+		time.sleep(0.6)
+		snapshot(t, "ui-bridge-p2-twoway-prompt")
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during dialog.twoway"
+		assert _modal_visible(text), (
+			"dialog.twoway did not render a boxen modal.  Capture:\n"
+			+ text
+		)
+		assert _text_inside_modal(text, "PhaseTwoTwowayQuestion"), (
+			"twoway prompt not visible inside the modal.  Capture:\n"
+			+ text
+		)
+		# Both button labels should be on screen inside the modal.
+		assert _text_inside_modal(text, "Save") and _text_inside_modal(text, "Discard"), (
+			"twoway button labels not visible inside the modal.  "
+			"Capture:\n" + text
+		)
+		# Pick the first button: arrow-left (or stay on default 0) + Enter.
+		t.send_key("Left")
+		time.sleep(0.1)
+		t.send_key("Enter")
+		time.sleep(0.4)
+		snapshot(t, "ui-bridge-p2-twoway-after-enter")
+		# UserTalk prints `true` for a true-returning expression.
+		text2 = t.capture()
+		assert t.is_alive(), "REPL exited after twoway returned"
+		assert "true" in text2, (
+			"dialog.twoway did not echo a true result after first-button "
+			"selection.  Capture:\n" + text2
+		)
+
+
+def test_dialog_threeway_returns_2_via_right_then_enter():
+	"""dialog.threeway returns the 1-based index of the chosen button.
+	Default selection starts on button 1; one Right arrow moves to
+	button 2; Enter returns 2.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t, 'dialog.threeway ("PhaseTwoThreewayQuestion", "Yes", "No", "Cancel")')
+		time.sleep(0.6)
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during dialog.threeway"
+		assert _modal_visible(text), (
+			"dialog.threeway did not render a boxen modal.  Capture:\n"
+			+ text
+		)
+		assert _text_inside_modal(text, "PhaseTwoThreewayQuestion"), (
+			"threeway prompt not visible inside the modal.  Capture:\n"
+			+ text
+		)
+		assert (
+			_text_inside_modal(text, "Yes")
+			and _text_inside_modal(text, "No")
+			and _text_inside_modal(text, "Cancel")
+		), (
+			"threeway button labels not visible inside the modal.  "
+			"Capture:\n" + text
+		)
+		# Move from default (button 1, "Yes") to button 2 ("No").
+		t.send_key("Right")
+		time.sleep(0.1)
+		t.send_key("Enter")
+		time.sleep(0.4)
+		snapshot(t, "ui-bridge-p2-threeway-after-enter")
+		text2 = t.capture()
+		assert t.is_alive(), "REPL exited after threeway returned"
+		# threeway returns 2 (the integer index of the chosen button).
+		assert "2" in text2, (
+			"dialog.threeway did not echo 2 after second-button selection.  "
+			"Capture:\n" + text2
+		)

--- a/tools/tui-tests/tests/test_07_ui_bridge_phase2.py
+++ b/tools/tui-tests/tests/test_07_ui_bridge_phase2.py
@@ -185,3 +185,40 @@ def test_dialog_threeway_returns_2_via_right_then_enter():
 			"dialog.threeway did not echo 2 after second-button selection.  "
 			"Capture:\n" + text2
 		)
+
+
+def test_dialog_threeway_esc_returns_zero():
+	"""Esc inside a threeway modal cancels and returns 0.  Phase 2A
+	gate-fix: legacy interactive threeway has no cancel return; the
+	boxen bridge surfaces cancel as 0 so safety-sensitive scripts can
+	detect "user bailed" without mis-coercing it into button1 (which by
+	convention is often a destructive default like "Save").  Scripts
+	that always expect 1/2/3 should test `if r > 0` before branching.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t, 'dialog.threeway ("PhaseTwoThreewayCancelQ", "Save", "Discard", "Cancel")')
+		time.sleep(0.6)
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during dialog.threeway pre-Esc"
+		assert _modal_visible(text), (
+			"threeway modal did not render.  Capture:\n" + text
+		)
+		# Cancel the modal.
+		t.send_key("Escape")
+		time.sleep(0.4)
+		snapshot(t, "ui-bridge-p2-threeway-esc-zero")
+		text2 = t.capture()
+		assert t.is_alive(), "REPL exited after threeway Esc-cancel"
+		# UserTalk eval prints the returned integer on its own line.
+		# 0 must appear as a standalone result, NOT as part of the
+		# typed prompt text.
+		lines = text2.split("\n")
+		zero_lines = [
+			ln for ln in lines
+			if ln.strip() == "0"
+		]
+		assert len(zero_lines) > 0, (
+			"dialog.threeway did not return 0 on Esc cancel.  "
+			"Expected a line containing just '0'.  Capture:\n" + text2
+		)


### PR DESCRIPTION
## Summary

Phase 2A of the boxen ↔ UserTalk UI bridge (see `planning/phase_c/BOXEN_USERTALK_UI_BRIDGE.md`). Bridges the remaining 4 dialog verbs — `dialog.alert`, `dialog.notify`, `dialog.twoway`, `dialog.threeway` — to boxen modals.

After PR #793 the 3 input prompts (`getString`/`getInt`/`getPassword`) were bridged; this PR closes the dialog-verb half of Phase 2. Phase 2B (file picker + `file_browser.c` rewrite) is the remaining work.

**Two-commit shape** (squash on merge):
1. `feat` — bridge skeleton: two new primitives (`boxen_ui_alert`, `boxen_ui_button_select`), 4 verb branches, 4 verb-glue escape hatches, 4 tui-tests
2. `fix` — `/gate` review fixes (3 P1 + 5 P2 + 1 new regression test)

## What's new

- `boxen_ui_alert(message, beep)` — info-and-wait modal; Enter dismisses; rings the terminal bell via the new `host->ring_bell` callback (writes `\a` directly to the saved-stderr fd, bypassing the capture pipe that would otherwise swallow it as a `^G` glyph in scrollback)
- `boxen_ui_button_select(prompt, buttons[], count)` — 2-4 button selector; Left/Right move, Enter chooses, first-letter hotkeys, Esc/Ctrl-C cancel (returns 0)
- Branches in `dialog_prompts.c` for `dialog_alert` / `dialog_notify` / `dialog_twoway` / `dialog_threeway`; linenoise path unchanged
- `!boxen_ui_is_active()` escape hatch in `tests/headless_dialog_verbs.c` for the 4 remaining verb-glue entries
- `host->ring_bell` callback in `boxen_ui_host_t`, wired from `boxen_repl.c`

## Cancel semantics (post-gate-fix)

- `dialog.alert` / `dialog.notify` — always return true once dismissed (Enter or Esc both "succeed"; matches legacy)
- `dialog.twoway` — cancel → false (button2); matches legacy interactive `dialog_twoway` Esc behavior
- `dialog.threeway` — **cancel → 0** (NEW signal). Legacy interactive `dialog_threeway` has no cancel return; the boxen bridge adds one to prevent silent coercion into the (often destructive) button1 default. Scripts that always expect 1/2/3 should test `if r > 0`. Button labels are caller-defined so the bridge can't infer which is "Cancel" by convention; 0-on-cancel is the only signal-preserving mapping.

## Test plan

- [x] **tui-tests: 30/30** (5 new in `test_07_ui_bridge_phase2.py`):
  - `test_dialog_notify_renders_modal_immediately`
  - `test_dialog_alert_renders_modal_and_dismisses_on_enter`
  - `test_dialog_twoway_returns_first_button_via_left_arrow_enter`
  - `test_dialog_threeway_returns_2_via_right_then_enter`
  - `test_dialog_threeway_esc_returns_zero` (post-gate-fix regression)
- [x] **Unit: 814/814**
- [x] **Integration: 2186 passed / 21 failed — EXACT develop baseline match**
- [x] `/gate` review: 0 P0, 3 P1, 7 P2 — all 3 P1s + 5 of 7 P2s fixed in commit 2
- [x] Manual: `dialog.alert("hi")`, `dialog.twoway("ok?", "Yes", "No")`, `dialog.threeway("?", "a", "b", "c")` typed at the REPL prompt all render proper boxen modals; bell rings; Esc cancels cleanly

## /gate findings addressed

| # | Severity | Finding | Status |
|---|----------|---------|--------|
| 1 | P1 | threeway cancel→1 silently coerced into destructive default | Fixed — cancel→0; new regression test |
| 2 | P1 | `boxen_ui_alert` returned false on host==NULL fall-through | Fixed — returns true to match contract |
| 3 | P1 | Bell character swallowed by capture pipe | Fixed — new `host->ring_bell` callback writes to saved_stderr |
| 4 | P2 | Renderer-vs-snapshot drift risk | Fixed — host stashed in ctx structs |
| 5 | P2 | `place_alert_modal` misnamed | Fixed — renamed to `place_centered_modal` |
| 6 | P2 | Dead `(void)ctx.cancelled` cast | Fixed |
| 7 | P2 | Redundant `BOXEN_KEY_NONE` guard | Fixed |
| 8 | P2 | Three near-identical mini-loops | Deferred — Phase 2B will force the issue with a 4th loop |
| 9 | P2 | Misstated `dialog_twoway` cancel rationale | Fixed — comment now states the actual legacy parity |
| 10 | P2 | `boxen_ui_button_select` host==NULL collides with cancel sentinel | Resolved as side effect of P1#1 (cancel=0 is documented) |

## Files

- `frontier-cli/boxen_ui.c` — `boxen_ui_alert`, `boxen_ui_button_select`, supporting render/place helpers
- `frontier-cli/boxen_ui.h` — public API + `ring_bell` callback
- `frontier-cli/boxen_repl.c` — `ring_bell` thunk + host wiring
- `frontier-cli/dialog_prompts.c` — 4 branches at the top of `dialog_alert`/`dialog_notify`/`dialog_twoway`/`dialog_threeway`
- `tests/headless_dialog_verbs.c` — `!boxen_ui_is_active()` escape hatch on the 4 verb entries
- `tools/tui-tests/tests/test_07_ui_bridge_phase2.py` — 5 regression tests

## What's next

- Phase 2B: file picker (`file.getFileDialog` etc.) — own PR, larger scope (~1000 LOC of `file_browser.c` rewritten against boxen primitives)
- C.6: flip default `frontier-cli` to boxen; deprecate `--debug-tui` flag
