### PR TITLE
feat(repl): C.0.7g Phase 2B -- boxen-native file picker (file.* dialog verbs)

### DIFF
--- a/frontier-cli/boxen_ui.c
+++ b/frontier-cli/boxen_ui.c
@@ -14,12 +14,16 @@
 
 #include "boxen_ui.h"
 
+#include <dirent.h>
+#include <errno.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "boxen/boxen.h"
 #include "headless_threading.h"     /* frontier_gil, gil_available, hthreadglobals, save/restore */
@@ -1000,4 +1004,771 @@ int boxen_ui_button_select(const char *prompt,
 	if (host->restore_focus) host->restore_focus(host->restore_focus_ctx);
 	boxen_present();
 	return result;
+}
+
+/* -------------------------------------------------------------------------
+ * 2026-06-24 JES #691 Phase C.0.7g Phase 2B: file picker
+ * (file.getFileDialog / putFileDialog / getFolderDialog / getDiskDialog).
+ *
+ * Single-pane list with a breadcrumb header per JES decision
+ * 2026-06-24.  PUT_FILE adds a filename input row at the bottom; all
+ * other modes are list-only.  Type filter (GET_FILE) dims non-matching
+ * files but lets the user select them anyway -- "display-only filter"
+ * per JES decision.
+ *
+ * Layout (in window-content coords):
+ *
+ *   row 0          : prompt text (bold)
+ *   row 1          : breadcrumb of current path
+ *   row 2          : separator (horizontal line)
+ *   row 3..N-3     : visible slice of entries (scrolled, cursor highlighted)
+ *   row N-2        : separator (only for PUT_FILE)
+ *   row N-1        : filename input row (only for PUT_FILE)
+ *   row N          : hint row (Enter/Tab/Esc keys)
+ *
+ * Where N = content_h - 1.  GET_FILE / GET_FOLDER / GET_DISK skip the
+ * separator + filename row.
+ *
+ * GIL discipline: same shape as run_modal/run_input/run_alert/
+ * run_button_select -- see those for the inline rationale.
+ * ---------------------------------------------------------------------- */
+
+#define PICK_MAX_ENTRIES   2048
+#define PICK_PATH_MAX      1024
+#define PICK_NAME_MAX      256
+#define PICK_FILENAME_MAX  256
+
+typedef struct {
+	char name[PICK_NAME_MAX];
+	bool is_dir;
+	bool matches_filter;	/* GET_FILE only; true otherwise */
+} pick_entry_t;
+
+typedef struct {
+	boxen_ui_pick_mode_t mode;
+	const char *prompt;
+	const char *type_filter;	/* GET_FILE only; NULL otherwise */
+
+	char cur_dir[PICK_PATH_MAX];	/* always absolute, no trailing / except root */
+
+	pick_entry_t *entries;
+	int entry_count;
+	int entry_cap;
+
+	int cursor;		/* index into entries[] */
+	int scroll_top;	/* first visible entry index */
+
+	/* PUT_FILE only.  filename_focus == true: keyboard goes to the
+	 * filename input row instead of the list. */
+	bool filename_focus;
+	char filename[PICK_FILENAME_MAX];
+	int  filename_len;
+	int  filename_cursor;
+
+	/* Output. */
+	char *out_path;
+	size_t out_cap;
+
+	boxen_window_t *win;
+	int content_w;
+	int content_h;
+	bool done;
+	bool committed;	/* true: out_path populated; false: cancel */
+	const boxen_ui_host_t *host;
+} pick_ctx_t;
+
+/* -- directory enumeration & sort -- */
+
+static int pick_entry_cmp(const void *a, const void *b) {
+	const pick_entry_t *ea = (const pick_entry_t *)a;
+	const pick_entry_t *eb = (const pick_entry_t *)b;
+	/* Directories first, then files, both alpha within their group. */
+	if (ea->is_dir != eb->is_dir) return ea->is_dir ? -1 : 1;
+	return strcasecmp(ea->name, eb->name);
+}
+
+static bool name_matches_filter(const char *name, const char *filter) {
+	if (filter == NULL || filter[0] == '\0') return true;
+	size_t nlen = strlen(name);
+	size_t flen = strlen(filter);
+	if (nlen <= flen + 1) return false;	/* need at least "x.ext" */
+	if (name[nlen - flen - 1] != '.') return false;
+	return strcasecmp(name + nlen - flen, filter) == 0;
+}
+
+/* Populate ctx->entries from ctx->cur_dir.  Returns true on success.
+ * On failure (e.g. dir unreadable) leaves entries empty; caller can
+ * navigate back up. */
+static bool pick_load_directory(pick_ctx_t *ctx) {
+	ctx->entry_count = 0;
+	ctx->cursor = 0;
+	ctx->scroll_top = 0;
+
+	DIR *dp = opendir(ctx->cur_dir);
+	if (!dp) return false;
+
+	struct dirent *de;
+	while ((de = readdir(dp)) != NULL && ctx->entry_count < ctx->entry_cap) {
+		/* Skip "." -- present "../" entry always.  Hide hidden dotfiles
+		 * by default for cleaner UX; a future toggle could expose them. */
+		if (de->d_name[0] == '.' && strcmp(de->d_name, "..") != 0) continue;
+
+		size_t nlen = strlen(de->d_name);
+		if (nlen >= PICK_NAME_MAX) continue;
+
+		/* Stat to determine is_dir reliably across filesystems (some
+		 * don't fill d_type).  Use the full path to handle symlinks. */
+		char full[PICK_PATH_MAX];
+		int n = snprintf(full, sizeof(full), "%s%s%s",
+		                 ctx->cur_dir,
+		                 (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/",
+		                 de->d_name);
+		if (n < 0 || (size_t)n >= sizeof(full)) continue;
+
+		struct stat st;
+		bool is_dir = false;
+		if (stat(full, &st) == 0) {
+			is_dir = S_ISDIR(st.st_mode);
+		} else if (de->d_type == DT_DIR) {
+			is_dir = true;
+		}
+
+		pick_entry_t *e = &ctx->entries[ctx->entry_count++];
+		memcpy(e->name, de->d_name, nlen + 1);
+		e->is_dir = is_dir;
+		/* Filter: GET_FILE applies to files only; dirs always match. */
+		if (ctx->mode == BOXEN_UI_PICK_GET_FILE && !is_dir) {
+			e->matches_filter = name_matches_filter(de->d_name, ctx->type_filter);
+		} else {
+			e->matches_filter = true;
+		}
+	}
+	closedir(dp);
+
+	qsort(ctx->entries, (size_t)ctx->entry_count, sizeof(pick_entry_t),
+	      pick_entry_cmp);
+	return true;
+}
+
+/* Navigate into the directory named `child` (relative) or absolute
+ * path.  Updates cur_dir and reloads entries. */
+static void pick_navigate(pick_ctx_t *ctx, const char *child) {
+	if (!child || child[0] == '\0') return;
+
+	char joined[PICK_PATH_MAX];
+	if (child[0] == '/') {
+		/* Absolute. */
+		if (snprintf(joined, sizeof(joined), "%s", child) >= (int)sizeof(joined))
+			return;
+	} else if (strcmp(child, "..") == 0) {
+		/* Parent. */
+		if (snprintf(joined, sizeof(joined), "%s", ctx->cur_dir) >= (int)sizeof(joined))
+			return;
+		char *slash = strrchr(joined, '/');
+		if (slash == NULL) return;
+		if (slash == joined) joined[1] = '\0';	/* "/" */
+		else *slash = '\0';
+	} else {
+		const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+		if (snprintf(joined, sizeof(joined), "%s%s%s",
+		             ctx->cur_dir, sep, child) >= (int)sizeof(joined))
+			return;
+	}
+
+	/* Canonicalize: resolve symlinks and "." / ".." components.  realpath
+	 * needs the path to exist, which it does (we navigated to it). */
+	char resolved[PICK_PATH_MAX];
+	if (realpath(joined, resolved) == NULL) return;
+
+	if (strlen(resolved) >= sizeof(ctx->cur_dir)) return;
+	strcpy(ctx->cur_dir, resolved);
+	pick_load_directory(ctx);
+}
+
+/* -- rendering -- */
+
+static void pick_render_cb(boxen_window_t *win, void *user_data) {
+	(void)win;
+	pick_ctx_t *ctx = (pick_ctx_t *)user_data;
+	if (!ctx || !ctx->win) return;
+
+	int w = ctx->content_w;
+	int h = ctx->content_h;
+	if (w < 10 || h < 6) return;
+
+	/* Clear the entire content area first so stale glyphs don't leak. */
+	for (int y = 0; y < h; y++) {
+		for (int x = 0; x < w; x++) {
+			boxen_set_cell(ctx->win, x, y, ' ',
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+			               BOXEN_ATTR_NONE);
+		}
+	}
+
+	/* Row 0: prompt (bold). */
+	const char *p = ctx->prompt ? ctx->prompt : "";
+	for (int i = 0; i < w; i++) {
+		if (p[i] == '\0') break;
+		boxen_set_cell(ctx->win, i, 0, (uint32_t)(unsigned char)p[i],
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_BOLD);
+	}
+
+	/* Row 1: breadcrumb (dim).  Show the full cur_dir; if too wide,
+	 * truncate the leading part with "...". */
+	{
+		const char *bc = ctx->cur_dir;
+		size_t bclen = strlen(bc);
+		const char *show = bc;
+		char truncated[PICK_PATH_MAX + 4];
+		if ((int)bclen > w) {
+			size_t keep = (size_t)w - 3;
+			snprintf(truncated, sizeof(truncated), "...%s",
+			         bc + (bclen - keep));
+			show = truncated;
+		}
+		for (int i = 0; i < w; i++) {
+			if (show[i] == '\0') break;
+			boxen_set_cell(ctx->win, i, 1, (uint32_t)(unsigned char)show[i],
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+			               BOXEN_ATTR_DIM);
+		}
+	}
+
+	/* Row 2: separator. */
+	for (int i = 0; i < w; i++) {
+		boxen_set_cell(ctx->win, i, 2, 0x2500 /* light horizontal */,
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_DIM);
+	}
+
+	/* Compute the list region. */
+	int list_top = 3;
+	int hint_row = h - 1;
+	int filename_row = -1;
+	int sep2_row = -1;
+	if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
+		filename_row = hint_row - 1;
+		sep2_row = filename_row - 1;
+	}
+	int list_bottom = (sep2_row >= 0) ? sep2_row - 1 : hint_row - 1;
+	int list_h = list_bottom - list_top + 1;
+	if (list_h < 1) list_h = 1;
+
+	/* Adjust scroll_top so cursor is visible. */
+	if (ctx->cursor < ctx->scroll_top) ctx->scroll_top = ctx->cursor;
+	if (ctx->cursor >= ctx->scroll_top + list_h) {
+		ctx->scroll_top = ctx->cursor - list_h + 1;
+	}
+	if (ctx->scroll_top < 0) ctx->scroll_top = 0;
+
+	/* Render visible entries.  Include synthetic "../" at index -1 of
+	 * the visible list (treated as a virtual entry above index 0). */
+	for (int row = 0; row < list_h; row++) {
+		int idx = ctx->scroll_top + row;
+		int y = list_top + row;
+		if (idx >= ctx->entry_count) break;
+
+		const pick_entry_t *e = &ctx->entries[idx];
+		bool selected = (idx == ctx->cursor) && !ctx->filename_focus;
+		uint16_t base = selected ? BOXEN_ATTR_REVERSE : BOXEN_ATTR_NONE;
+		/* Dim non-matching files (GET_FILE display-only filter). */
+		if (!e->matches_filter && !selected) base |= BOXEN_ATTR_DIM;
+		uint16_t fg = BOXEN_COLOR_DEFAULT;
+
+		/* Render: "  name" with directories appended with '/'. */
+		int x = 0;
+		/* Two-cell indent so selection highlight has a clear edge. */
+		if (x < w) boxen_set_cell(ctx->win, x++, y, ' ',
+		                          fg, BOXEN_COLOR_DEFAULT, base);
+		if (x < w) boxen_set_cell(ctx->win, x++, y, ' ',
+		                          fg, BOXEN_COLOR_DEFAULT, base);
+		for (int k = 0; e->name[k] != '\0' && x < w; k++, x++) {
+			boxen_set_cell(ctx->win, x, y,
+			               (uint32_t)(unsigned char)e->name[k],
+			               fg, BOXEN_COLOR_DEFAULT, base);
+		}
+		if (e->is_dir && x < w) {
+			boxen_set_cell(ctx->win, x++, y, '/',
+			               fg, BOXEN_COLOR_DEFAULT, base);
+		}
+		/* Pad selection highlight to full width. */
+		while (selected && x < w) {
+			boxen_set_cell(ctx->win, x++, y, ' ',
+			               fg, BOXEN_COLOR_DEFAULT, base);
+		}
+	}
+
+	/* PUT_FILE: separator + filename input row. */
+	if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
+		for (int i = 0; i < w; i++) {
+			boxen_set_cell(ctx->win, i, sep2_row, 0x2500,
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+			               BOXEN_ATTR_DIM);
+		}
+		/* "> filename" with cursor block.  Reverse highlight on the
+		 * whole row when filename has focus. */
+		uint16_t fbase = ctx->filename_focus ? BOXEN_ATTR_REVERSE : BOXEN_ATTR_NONE;
+		const char *prefix = "> ";
+		int x = 0;
+		for (int k = 0; prefix[k] != '\0' && x < w; k++, x++) {
+			boxen_set_cell(ctx->win, x, filename_row,
+			               (uint32_t)(unsigned char)prefix[k],
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+			               fbase | BOXEN_ATTR_DIM);
+		}
+		int field_x0 = x;
+		int field_w = w - field_x0;
+		if (field_w < 1) field_w = 1;
+		int scroll = 0;
+		if (ctx->filename_cursor >= field_w) {
+			scroll = ctx->filename_cursor - field_w + 1;
+		}
+		for (int i = 0; i < field_w; i++) {
+			int bi = scroll + i;
+			char ch = (bi < ctx->filename_len) ? ctx->filename[bi] : ' ';
+			boxen_set_cell(ctx->win, field_x0 + i, filename_row,
+			               (uint32_t)(unsigned char)ch,
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+			               fbase);
+		}
+		if (ctx->filename_focus) {
+			int cc = field_x0 + (ctx->filename_cursor - scroll);
+			if (cc < field_x0) cc = field_x0;
+			if (cc >= w) cc = w - 1;
+			boxen_window_set_cursor(ctx->win, cc, filename_row);
+			boxen_window_set_cursor_visible(ctx->win, true);
+		} else {
+			boxen_window_set_cursor_visible(ctx->win, false);
+		}
+	} else {
+		boxen_window_set_cursor_visible(ctx->win, false);
+	}
+
+	/* Hint row. */
+	const char *hint;
+	if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
+		hint = ctx->filename_focus
+		       ? "Enter:save  Tab:list  Esc:cancel"
+		       : "Enter:open  Tab:filename  Esc:cancel";
+	} else if (ctx->mode == BOXEN_UI_PICK_GET_FOLDER) {
+		hint = "Enter:open  Space:select  Esc:cancel";
+	} else if (ctx->mode == BOXEN_UI_PICK_GET_DISK) {
+		hint = "Enter:select  Esc:cancel";
+	} else {
+		hint = "Enter:open/select  Esc:cancel";
+	}
+	for (int i = 0; i < w; i++) {
+		char ch = (hint[i] == '\0') ? ' ' : hint[i];
+		boxen_set_cell(ctx->win, i, hint_row, (uint32_t)(unsigned char)ch,
+		               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+		               BOXEN_ATTR_DIM);
+		if (hint[i] == '\0') {
+			/* Continue clearing rest of row. */
+			for (int j = i + 1; j < w; j++) {
+				boxen_set_cell(ctx->win, j, hint_row, ' ',
+				               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+				               BOXEN_ATTR_DIM);
+			}
+			break;
+		}
+	}
+}
+
+/* -- commit logic -- */
+
+/* Build the full output path for the current selection.  Returns true
+ * on success (out_path populated), false otherwise. */
+static bool pick_build_output(pick_ctx_t *ctx) {
+	if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
+		if (ctx->filename_len == 0) return false;
+		const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+		if (snprintf(ctx->out_path, ctx->out_cap, "%s%s%s",
+		             ctx->cur_dir, sep, ctx->filename) >= (int)ctx->out_cap) {
+			return false;
+		}
+		return true;
+	}
+
+	/* List-driven modes: take the entry at cursor. */
+	if (ctx->cursor < 0 || ctx->cursor >= ctx->entry_count) return false;
+	const pick_entry_t *e = &ctx->entries[ctx->cursor];
+
+	if (ctx->mode == BOXEN_UI_PICK_GET_FOLDER) {
+		/* Only commit when cursor is on a directory.  ".." commits the
+		 * current dir; named directories commit themselves. */
+		if (!e->is_dir) return false;
+		if (strcmp(e->name, "..") == 0) {
+			/* Selecting ".." == picking the parent. */
+			pick_navigate(ctx, "..");
+			if (snprintf(ctx->out_path, ctx->out_cap, "%s",
+			             ctx->cur_dir) >= (int)ctx->out_cap) {
+				return false;
+			}
+			return true;
+		}
+		const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+		if (snprintf(ctx->out_path, ctx->out_cap, "%s%s%s",
+		             ctx->cur_dir, sep, e->name) >= (int)ctx->out_cap) {
+			return false;
+		}
+		return true;
+	}
+
+	/* GET_FILE / GET_DISK: must be a file (not a directory). */
+	if (e->is_dir) return false;
+	const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+	if (snprintf(ctx->out_path, ctx->out_cap, "%s%s%s",
+	             ctx->cur_dir, sep, e->name) >= (int)ctx->out_cap) {
+		return false;
+	}
+	return true;
+}
+
+/* -- key handling -- */
+
+static void pick_filename_insert(pick_ctx_t *ctx, char c) {
+	if (ctx->filename_len + 1 >= PICK_FILENAME_MAX) return;
+	if (ctx->filename_cursor < ctx->filename_len) {
+		memmove(&ctx->filename[ctx->filename_cursor + 1],
+		        &ctx->filename[ctx->filename_cursor],
+		        (size_t)(ctx->filename_len - ctx->filename_cursor));
+	}
+	ctx->filename[ctx->filename_cursor++] = c;
+	ctx->filename_len++;
+	ctx->filename[ctx->filename_len] = '\0';
+}
+
+static void pick_filename_backspace(pick_ctx_t *ctx) {
+	if (ctx->filename_cursor == 0) return;
+	if (ctx->filename_cursor < ctx->filename_len) {
+		memmove(&ctx->filename[ctx->filename_cursor - 1],
+		        &ctx->filename[ctx->filename_cursor],
+		        (size_t)(ctx->filename_len - ctx->filename_cursor));
+	}
+	ctx->filename_cursor--;
+	ctx->filename_len--;
+	ctx->filename[ctx->filename_len] = '\0';
+}
+
+static void pick_handle_key(pick_ctx_t *ctx, const boxen_event_t *ev) {
+	if (ev->type != BOXEN_EV_KEY) return;
+
+	/* Filename-row focus path (PUT_FILE only). */
+	if (ctx->filename_focus) {
+		switch (ev->key.key) {
+		case BOXEN_KEY_ENTER:
+			if (pick_build_output(ctx)) {
+				ctx->committed = true;
+				ctx->done = true;
+			}
+			return;
+		case BOXEN_KEY_ESCAPE:
+		case BOXEN_KEY_CTRL_C:
+			ctx->done = true;
+			return;
+		case BOXEN_KEY_TAB:
+			ctx->filename_focus = false;
+			return;
+		case BOXEN_KEY_BACKSPACE:
+		case BOXEN_KEY_CTRL_H:
+			pick_filename_backspace(ctx);
+			return;
+		case BOXEN_KEY_LEFT:
+			if (ctx->filename_cursor > 0) ctx->filename_cursor--;
+			return;
+		case BOXEN_KEY_RIGHT:
+			if (ctx->filename_cursor < ctx->filename_len) ctx->filename_cursor++;
+			return;
+		case BOXEN_KEY_HOME:
+		case BOXEN_KEY_CTRL_A:
+			ctx->filename_cursor = 0;
+			return;
+		case BOXEN_KEY_END:
+		case BOXEN_KEY_CTRL_E:
+			ctx->filename_cursor = ctx->filename_len;
+			return;
+		case BOXEN_KEY_CTRL_U:
+			ctx->filename_len = 0;
+			ctx->filename_cursor = 0;
+			ctx->filename[0] = '\0';
+			return;
+		default:
+			if (ev->key.ch >= 0x20 && ev->key.ch < 0x7F) {
+				pick_filename_insert(ctx, (char)ev->key.ch);
+			}
+			return;
+		}
+	}
+
+	/* List focus path. */
+	switch (ev->key.key) {
+	case BOXEN_KEY_ESCAPE:
+	case BOXEN_KEY_CTRL_C:
+		ctx->done = true;
+		return;
+	case BOXEN_KEY_UP:
+		if (ctx->cursor > 0) ctx->cursor--;
+		return;
+	case BOXEN_KEY_DOWN:
+		if (ctx->cursor + 1 < ctx->entry_count) ctx->cursor++;
+		return;
+	case BOXEN_KEY_HOME:
+		ctx->cursor = 0;
+		return;
+	case BOXEN_KEY_END:
+		if (ctx->entry_count > 0) ctx->cursor = ctx->entry_count - 1;
+		return;
+	case BOXEN_KEY_PGUP: {
+		int list_h = ctx->content_h - 4;
+		if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) list_h -= 2;
+		if (list_h < 1) list_h = 1;
+		ctx->cursor -= list_h;
+		if (ctx->cursor < 0) ctx->cursor = 0;
+		return;
+	}
+	case BOXEN_KEY_PGDN: {
+		int list_h = ctx->content_h - 4;
+		if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) list_h -= 2;
+		if (list_h < 1) list_h = 1;
+		ctx->cursor += list_h;
+		if (ctx->cursor >= ctx->entry_count)
+			ctx->cursor = ctx->entry_count - 1;
+		return;
+	}
+	case BOXEN_KEY_BACKSPACE:
+		/* Backspace from list: navigate up one level. */
+		pick_navigate(ctx, "..");
+		return;
+	case BOXEN_KEY_TAB:
+		if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
+			ctx->filename_focus = true;
+		}
+		return;
+	case BOXEN_KEY_ENTER: {
+		if (ctx->cursor < 0 || ctx->cursor >= ctx->entry_count) return;
+		const pick_entry_t *e = &ctx->entries[ctx->cursor];
+		if (e->is_dir) {
+			pick_navigate(ctx, e->name);
+		} else {
+			/* GET_FOLDER on a file: ignore. */
+			if (ctx->mode == BOXEN_UI_PICK_GET_FOLDER) return;
+			if (pick_build_output(ctx)) {
+				ctx->committed = true;
+				ctx->done = true;
+			}
+		}
+		return;
+	}
+	default:
+		/* Space picks the current dir in GET_FOLDER mode (matches the
+		 * hint text). */
+		if (ev->key.ch == ' '
+		    && ctx->mode == BOXEN_UI_PICK_GET_FOLDER) {
+			if (snprintf(ctx->out_path, ctx->out_cap, "%s",
+			             ctx->cur_dir) < (int)ctx->out_cap) {
+				ctx->committed = true;
+				ctx->done = true;
+			}
+		}
+		return;
+	}
+}
+
+/* -- modal placement + entry point -- */
+
+static boxen_rect_t place_picker_modal(int screen_w, int screen_h) {
+	int win_w = screen_w - 4;
+	int win_h = screen_h - 4;
+	if (win_w < 40) win_w = 40;
+	if (win_h < 10) win_h = 10;
+	if (win_w > screen_w) win_w = screen_w;
+	if (win_h > screen_h) win_h = screen_h;
+	int x = (screen_w - win_w) / 2;
+	int y = (screen_h - win_h) / 2;
+	if (x < 0) x = 0;
+	if (y < 0) y = 0;
+	boxen_rect_t r = { x, y, win_w, win_h };
+	return r;
+}
+
+bool boxen_ui_pick_file(boxen_ui_pick_mode_t mode,
+                        const char *prompt,
+                        const char *start_path,
+                        const char *type_filter,
+                        char *out_path, size_t out_cap) {
+	if (!out_path || out_cap < 2) return false;
+	out_path[0] = '\0';
+
+	const boxen_ui_host_t *host = load_host();
+	if (!host) return false;
+
+	pick_ctx_t ctx;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.mode = mode;
+	ctx.prompt = (prompt && prompt[0]) ? prompt : "Select a file:";
+	ctx.type_filter = type_filter;
+	ctx.out_path = out_path;
+	ctx.out_cap = out_cap;
+	ctx.host = host;
+
+	/* Determine starting directory.  PUT_FILE: a start_path with a
+	 * trailing filename component is split -- dir part becomes
+	 * cur_dir, basename pre-populates filename. */
+	const char *initial_dir = start_path;
+	char split_dir[PICK_PATH_MAX];
+	if (mode == BOXEN_UI_PICK_PUT_FILE && start_path && start_path[0]) {
+		struct stat st;
+		if (stat(start_path, &st) == 0 && S_ISDIR(st.st_mode)) {
+			initial_dir = start_path;
+		} else {
+			/* Treat as path-with-filename. */
+			const char *slash = strrchr(start_path, '/');
+			if (slash && slash != start_path) {
+				size_t dlen = (size_t)(slash - start_path);
+				if (dlen < sizeof(split_dir)) {
+					memcpy(split_dir, start_path, dlen);
+					split_dir[dlen] = '\0';
+					initial_dir = split_dir;
+				}
+				size_t blen = strlen(slash + 1);
+				if (blen < sizeof(ctx.filename)) {
+					memcpy(ctx.filename, slash + 1, blen);
+					ctx.filename[blen] = '\0';
+					ctx.filename_len = (int)blen;
+					ctx.filename_cursor = ctx.filename_len;
+				}
+			} else {
+				/* Bare filename, no dir component. */
+				size_t blen = strlen(start_path);
+				if (blen < sizeof(ctx.filename)) {
+					memcpy(ctx.filename, start_path, blen);
+					ctx.filename[blen] = '\0';
+					ctx.filename_len = (int)blen;
+					ctx.filename_cursor = ctx.filename_len;
+				}
+			}
+		}
+	}
+
+	/* GET_DISK on macOS browses /Volumes/.  On other platforms fall
+	 * back to "/".  We hard-code this rather than enumerating mount
+	 * points via getfsstat (legacy file_browser does that) because
+	 * /Volumes/ already presents the mounted disks as directory
+	 * entries on macOS. */
+	if (mode == BOXEN_UI_PICK_GET_DISK) {
+#ifdef __APPLE__
+		initial_dir = "/Volumes";
+#else
+		initial_dir = "/";
+#endif
+	}
+
+	if (initial_dir && initial_dir[0] == '/') {
+		char resolved[PICK_PATH_MAX];
+		if (realpath(initial_dir, resolved) != NULL
+		    && strlen(resolved) < sizeof(ctx.cur_dir)) {
+			strcpy(ctx.cur_dir, resolved);
+		}
+	}
+	if (ctx.cur_dir[0] == '\0') {
+		if (getcwd(ctx.cur_dir, sizeof(ctx.cur_dir)) == NULL) {
+			strcpy(ctx.cur_dir, "/");
+		}
+	}
+
+	/* Allocate the entries array on the heap so it can hold a sizable
+	 * directory without exploding the stack. */
+	ctx.entry_cap = PICK_MAX_ENTRIES;
+	ctx.entries = (pick_entry_t *)calloc((size_t)ctx.entry_cap,
+	                                     sizeof(pick_entry_t));
+	if (!ctx.entries) return false;
+
+	if (!pick_load_directory(&ctx)) {
+		/* Couldn't read initial dir; fall back to "/". */
+		strcpy(ctx.cur_dir, "/");
+		pick_load_directory(&ctx);
+	}
+
+	/* Open window. */
+	int sw = 80, sh = 24;
+	boxen_get_screen_size(&sw, &sh);
+	if (sw < 20) sw = 20;
+	if (sh < 10) sh = 10;
+
+	boxen_rect_t rect = place_picker_modal(sw, sh);
+	boxen_window_t *win = boxen_window_open(NULL, rect, &ctx);
+	if (!win) {
+		free(ctx.entries);
+		return false;
+	}
+
+	ctx.win = win;
+	ctx.content_w = boxen_window_content_width(win);
+	ctx.content_h = boxen_window_content_height(win);
+
+	boxen_window_set_borders(win, true);
+	boxen_window_set_modal(win, true);
+	boxen_window_set_movable(win, false);
+	boxen_window_set_resizable(win, false);
+	boxen_window_set_draw(win, pick_render_cb);
+	boxen_window_focus(win);
+	boxen_window_raise(win);
+
+	boxen_window_invalidate(win);
+	if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
+	boxen_present();
+
+	/* Mini event loop (parallel to other run_* loops). */
+	while (!ctx.done) {
+		boxen_event_t ev;
+		memset(&ev, 0, sizeof(ev));
+
+		tcp_process_callbacks();
+
+		hdlthreadglobals saved = hthreadglobals;
+		headless_save_threadglobals(saved);
+		pthread_mutex_unlock(&frontier_gil);
+		pthread_cond_broadcast(&gil_available);
+		boxen_result_t rc = boxen_poll_event(&ev, 100);
+		pthread_mutex_lock(&frontier_gil);
+		headless_restore_threadglobals(saved);
+
+		if ((**saved).flthreadkilled) {
+			ctx.done = true;
+			break;
+		}
+
+		if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
+
+		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
+		if (rc != BOXEN_OK) { ctx.done = true; break; }
+
+		if (ev.type == BOXEN_EV_RESIZE) {
+			int new_sw = ev.resize.w, new_sh = ev.resize.h;
+			if (new_sw < 20) new_sw = 20;
+			if (new_sh < 10) new_sh = 10;
+			boxen_rect_t r = place_picker_modal(new_sw, new_sh);
+			boxen_window_set_rect(win, r);
+			ctx.content_w = boxen_window_content_width(win);
+			ctx.content_h = boxen_window_content_height(win);
+			boxen_window_invalidate(win);
+			boxen_present();
+			continue;
+		}
+
+		if (ev.type == BOXEN_EV_KEY) {
+			pick_handle_key(&ctx, &ev);
+			boxen_window_invalidate(win);
+			boxen_present();
+		}
+	}
+
+	boxen_window_set_cursor_visible(win, false);
+	boxen_window_close(win);
+	if (host->restore_focus) host->restore_focus(host->restore_focus_ctx);
+	boxen_present();
+
+	free(ctx.entries);
+	return ctx.committed;
 }

--- a/frontier-cli/boxen_ui.c
+++ b/frontier-cli/boxen_ui.c
@@ -58,6 +58,102 @@ static const boxen_ui_host_t *load_host(void) {
 }
 
 /* -------------------------------------------------------------------------
+ * Shared modal event loop
+ *
+ * Every boxen_ui_* entry point that opens a modal window runs the same
+ * GIL-yield / poll / drain / present skeleton.  Centralizing it here
+ * means any future modal (or any GIL-discipline fix) lands in one place
+ * instead of N+1 parallel copies.  Each caller passes its own ctx,
+ * done-flag pointer, and event-handling callbacks.
+ *
+ * Skeleton each iteration (matches headless_backgroundtask:693-728):
+ *   1. tcp_process_callbacks()                  -- pump pending TCP
+ *   2. save threadglobals + unlock GIL + broadcast gil_available
+ *   3. boxen_poll_event(&ev, 100ms)
+ *   4. lock GIL + restore threadglobals
+ *   5. check flthreadkilled: set *done = true; break
+ *   6. host->drain_capture_pipe (keep scrollback current)
+ *   7. dispatch event: timeout -> present + continue;
+ *      RESIZE -> on_resize cb; KEY -> on_key cb; other -> ignore
+ *
+ * 2026-06-25 JES #691 Phase C.0.7g Phase 2B gate-fix (#100):
+ * Replaces the four parallel mini-loops that grew during Phase 1, 2A,
+ * and 2B.  Reviewers flagged each new copy; this is the consolidation.
+ * ---------------------------------------------------------------------- */
+
+typedef void (*boxen_ui_resize_fn)(void *ctx, int sw, int sh);
+typedef void (*boxen_ui_key_fn)(void *ctx, const boxen_event_t *ev);
+
+static void run_modal_loop(boxen_window_t *win,
+                           const boxen_ui_host_t *host,
+                           void *ctx,
+                           bool *done,
+                           bool *cancelled,	/* optional; flthreadkilled/poll-err set if non-NULL */
+                           boxen_ui_resize_fn on_resize,
+                           boxen_ui_key_fn on_key) {
+	/* Initial paint before entering the wait loop. */
+	boxen_window_invalidate(win);
+	if (host && host->drain_capture_pipe) {
+		host->drain_capture_pipe(host->drain_ctx);
+	}
+	boxen_present();
+
+	while (!*done) {
+		boxen_event_t ev;
+		memset(&ev, 0, sizeof(ev));
+
+		tcp_process_callbacks();
+
+		hdlthreadglobals saved = hthreadglobals;
+		headless_save_threadglobals(saved);
+		pthread_mutex_unlock(&frontier_gil);
+		pthread_cond_broadcast(&gil_available);
+		boxen_result_t rc = boxen_poll_event(&ev, 100 /* ms */);
+		pthread_mutex_lock(&frontier_gil);
+		headless_restore_threadglobals(saved);
+
+		/* thread.kill on the dispatched script must break the modal.
+		 * Mirrors headless_backgroundtask:728. */
+		if ((**saved).flthreadkilled) {
+			if (cancelled) *cancelled = true;
+			*done = true;
+			break;
+		}
+
+		if (host && host->drain_capture_pipe) {
+			host->drain_capture_pipe(host->drain_ctx);
+		}
+
+		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
+		if (rc != BOXEN_OK) {
+			if (cancelled) *cancelled = true;
+			*done = true;
+			break;
+		}
+
+		if (ev.type == BOXEN_EV_RESIZE) {
+			if (on_resize) {
+				on_resize(ctx, ev.resize.w, ev.resize.h);
+				boxen_window_invalidate(win);
+				boxen_present();
+			}
+			continue;
+		}
+
+		if (ev.type == BOXEN_EV_KEY) {
+			if (on_key) {
+				on_key(ctx, &ev);
+				boxen_window_invalidate(win);
+				boxen_present();
+			}
+		}
+		/* Other event types (mouse): ignored.  Modal flag prevents
+		 * click-through; the user can still scroll the background with
+		 * the wheel via boxen's compositor. */
+	}
+}
+
+/* -------------------------------------------------------------------------
  * Modal context shared by the input primitives
  *
  * Each primitive constructs one of these on its stack, hands it to the
@@ -319,87 +415,23 @@ static void handle_key_event(ui_ctx_t *ctx, const boxen_event_t *ev) {
  * across the wait.
  * ---------------------------------------------------------------------- */
 
+/* String-input modal resize / key adapters for the shared loop. */
+static void run_modal_resize_cb(void *vctx, int sw, int sh) {
+	ui_ctx_t *ctx = (ui_ctx_t *)vctx;
+	if (sw < 20) sw = 20;
+	if (sh < 6)  sh = 6;
+	boxen_rect_t r = place_modal(sw, sh, ctx->content_w);
+	boxen_window_set_rect(ctx->win, r);
+	ctx->content_w = boxen_window_content_width(ctx->win);
+}
+
+static void run_modal_key_cb(void *vctx, const boxen_event_t *ev) {
+	handle_key_event((ui_ctx_t *)vctx, ev);
+}
+
 static void run_modal(ui_ctx_t *ctx, const boxen_ui_host_t *host) {
-	/* Initial paint before entering the wait loop. */
-	boxen_window_invalidate(ctx->win);
-	if (host && host->drain_capture_pipe) {
-		host->drain_capture_pipe(host->drain_ctx);
-	}
-	boxen_present();
-
-	while (!ctx->done) {
-		boxen_event_t ev;
-		memset(&ev, 0, sizeof(ev));
-
-		/* 2026-06-23 JES #691 Phase C.0.7g: pump pending TCP callbacks
-		 * before yielding so socket activity arriving during a long
-		 * modal does not accumulate in the queue.  Mirrors
-		 * headless_backgroundtask:693. */
-		tcp_process_callbacks();
-
-		hdlthreadglobals saved = hthreadglobals;
-		headless_save_threadglobals(saved);
-		pthread_mutex_unlock(&frontier_gil);
-		/* Broadcast that the GIL is available so sibling threads
-		 * waiting on gil_available cond don't stall for the duration
-		 * of the modal.  Mirrors headless_backgroundtask:699. */
-		pthread_cond_broadcast(&gil_available);
-		boxen_result_t rc = boxen_poll_event(&ev, 100 /* ms */);
-		pthread_mutex_lock(&frontier_gil);
-		headless_restore_threadglobals(saved);
-
-		/* Check if this script's thread was killed while we yielded
-		 * the GIL.  Mirrors headless_backgroundtask:728.  Without
-		 * this, thread.kill on the dispatched script would never
-		 * break the modal out of the wait loop. */
-		if ((**saved).flthreadkilled) {
-			ctx->cancelled = true;
-			ctx->done = true;
-			break;
-		}
-
-		if (host && host->drain_capture_pipe) {
-			host->drain_capture_pipe(host->drain_ctx);
-		}
-
-		if (rc == BOXEN_ERR_TIMEOUT) {
-			/* No input arrived; loop again.  The main REPL's
-			 * timeout path also presents on each tick to flush any
-			 * scrollback updates the drain produced. */
-			boxen_present();
-			continue;
-		}
-		if (rc != BOXEN_OK) {
-			ctx->cancelled = true;
-			ctx->done = true;
-			break;
-		}
-
-		if (ev.type == BOXEN_EV_RESIZE) {
-			/* Re-center the modal against the new screen dimensions.
-			 * Phase 1 keeps content_w fixed; clamp to the new screen
-			 * width if necessary. */
-			int sw = ev.resize.w, sh = ev.resize.h;
-			if (sw < 20) sw = 20;
-			if (sh < 6)  sh = 6;
-			boxen_rect_t r = place_modal(sw, sh, ctx->content_w);
-			boxen_window_set_rect(ctx->win, r);
-			ctx->content_w = boxen_window_content_width(ctx->win);
-			boxen_window_invalidate(ctx->win);
-			boxen_present();
-			continue;
-		}
-
-		if (ev.type == BOXEN_EV_KEY) {
-			handle_key_event(ctx, &ev);
-			boxen_window_invalidate(ctx->win);
-			boxen_present();
-		}
-		/* Other event types (mouse): ignored in Phase 1.  The modal
-		 * has focus; the user can still scroll the background with
-		 * the wheel via boxen's compositor, but click-through into
-		 * other windows is suppressed by the modal flag. */
-	}
+	run_modal_loop(ctx->win, host, ctx, &ctx->done, &ctx->cancelled,
+	               run_modal_resize_cb, run_modal_key_cb);
 }
 
 /* -------------------------------------------------------------------------
@@ -622,6 +654,28 @@ static boxen_rect_t place_centered_modal(int screen_w, int screen_h,
 	return r;
 }
 
+/* Alert modal resize / key adapters for the shared loop. */
+static void alert_resize_cb(void *vctx, int sw, int sh) {
+	alert_ctx_t *ctx = (alert_ctx_t *)vctx;
+	if (sw < 20) sw = 20;
+	if (sh < 6)  sh = 6;
+	boxen_rect_t r = place_centered_modal(sw, sh, ctx->content_w);
+	boxen_window_set_rect(ctx->win, r);
+	ctx->content_w = boxen_window_content_width(ctx->win);
+}
+
+static void alert_key_cb(void *vctx, const boxen_event_t *ev) {
+	alert_ctx_t *ctx = (alert_ctx_t *)vctx;
+	if (ev->key.key == BOXEN_KEY_ENTER) {
+		ctx->done = true;
+	} else if (ev->key.key == BOXEN_KEY_ESCAPE
+	           || ev->key.key == BOXEN_KEY_CTRL_C) {
+		ctx->cancelled = true;
+		ctx->done = true;
+	}
+	/* All other keys ignored -- alert is dismiss-only. */
+}
+
 bool boxen_ui_alert(const char *message, bool beep) {
 	const boxen_ui_host_t *host = load_host();
 	if (!host) {
@@ -674,61 +728,8 @@ bool boxen_ui_alert(const char *message, bool beep) {
 		host->ring_bell(host->ring_bell_ctx);
 	}
 
-	/* Mini event loop (parallel to run_modal). */
-	boxen_window_invalidate(win);
-	if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
-	boxen_present();
-
-	while (!ctx.done) {
-		boxen_event_t ev;
-		memset(&ev, 0, sizeof(ev));
-
-		tcp_process_callbacks();
-
-		hdlthreadglobals saved = hthreadglobals;
-		headless_save_threadglobals(saved);
-		pthread_mutex_unlock(&frontier_gil);
-		pthread_cond_broadcast(&gil_available);
-		boxen_result_t rc = boxen_poll_event(&ev, 100);
-		pthread_mutex_lock(&frontier_gil);
-		headless_restore_threadglobals(saved);
-
-		if ((**saved).flthreadkilled) {
-			ctx.cancelled = true;
-			ctx.done = true;
-			break;
-		}
-
-		if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
-
-		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
-		if (rc != BOXEN_OK) { ctx.cancelled = true; ctx.done = true; break; }
-
-		if (ev.type == BOXEN_EV_RESIZE) {
-			int new_sw = ev.resize.w, new_sh = ev.resize.h;
-			if (new_sw < 20) new_sw = 20;
-			if (new_sh < 6)  new_sh = 6;
-			boxen_rect_t r = place_centered_modal(new_sw, new_sh, ctx.content_w);
-			boxen_window_set_rect(win, r);
-			ctx.content_w = boxen_window_content_width(win);
-			boxen_window_invalidate(win);
-			boxen_present();
-			continue;
-		}
-
-		if (ev.type == BOXEN_EV_KEY) {
-			if (ev.key.key == BOXEN_KEY_ENTER) {
-				ctx.done = true;
-			} else if (ev.key.key == BOXEN_KEY_ESCAPE
-			           || ev.key.key == BOXEN_KEY_CTRL_C) {
-				ctx.cancelled = true;
-				ctx.done = true;
-			}
-			/* All other keys ignored -- alert is dismiss-only. */
-			boxen_window_invalidate(win);
-			boxen_present();
-		}
-	}
+	run_modal_loop(win, host, &ctx, &ctx.done, &ctx.cancelled,
+	               alert_resize_cb, alert_key_cb);
 
 	boxen_window_close(win);
 	if (host->restore_focus) host->restore_focus(host->restore_focus_ctx);
@@ -871,6 +872,56 @@ static int hotkey_match(const button_ctx_t *ctx, uint32_t ch) {
 	return -1;
 }
 
+/* Button-select modal resize / key adapters for the shared loop. */
+static void button_resize_cb(void *vctx, int sw, int sh) {
+	button_ctx_t *ctx = (button_ctx_t *)vctx;
+	if (sw < 20) sw = 20;
+	if (sh < 6)  sh = 6;
+	boxen_rect_t r = place_centered_modal(sw, sh, ctx->content_w);
+	boxen_window_set_rect(ctx->win, r);
+	ctx->content_w = boxen_window_content_width(ctx->win);
+}
+
+static void button_key_cb(void *vctx, const boxen_event_t *ev) {
+	button_ctx_t *ctx = (button_ctx_t *)vctx;
+	switch (ev->key.key) {
+	case BOXEN_KEY_ENTER:
+		ctx->done = true;
+		break;
+	case BOXEN_KEY_ESCAPE:
+	case BOXEN_KEY_CTRL_C:
+		ctx->cancelled = true;
+		ctx->done = true;
+		break;
+	case BOXEN_KEY_LEFT:
+		if (ctx->selection > 0) ctx->selection--;
+		break;
+	case BOXEN_KEY_RIGHT:
+		if (ctx->selection < ctx->count - 1) ctx->selection++;
+		break;
+	case BOXEN_KEY_HOME:
+		ctx->selection = 0;
+		break;
+	case BOXEN_KEY_END:
+		ctx->selection = ctx->count - 1;
+		break;
+	default:
+		/* Reaching `default` means ev->key.key == BOXEN_KEY_NONE
+		 * (every non-NONE key is named in a case above), so
+		 * ev->key.ch holds a Unicode codepoint.  Hotkey match:
+		 * printable ASCII first-letter == label's first letter
+		 * (case-insensitive) selects + activates that button. */
+		if (ev->key.ch >= 0x20 && ev->key.ch < 0x7F) {
+			int idx = hotkey_match(ctx, ev->key.ch);
+			if (idx >= 0) {
+				ctx->selection = idx;
+				ctx->done = true;
+			}
+		}
+		break;
+	}
+}
+
 int boxen_ui_button_select(const char *prompt,
                            const char *const *buttons, int count) {
 	if (count < 2 || count > BOXEN_UI_BUTTON_MAX) return 0;
@@ -914,90 +965,8 @@ int boxen_ui_button_select(const char *prompt,
 	boxen_window_focus(win);
 	boxen_window_raise(win);
 
-	boxen_window_invalidate(win);
-	if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
-	boxen_present();
-
-	while (!ctx.done) {
-		boxen_event_t ev;
-		memset(&ev, 0, sizeof(ev));
-
-		tcp_process_callbacks();
-
-		hdlthreadglobals saved = hthreadglobals;
-		headless_save_threadglobals(saved);
-		pthread_mutex_unlock(&frontier_gil);
-		pthread_cond_broadcast(&gil_available);
-		boxen_result_t rc = boxen_poll_event(&ev, 100);
-		pthread_mutex_lock(&frontier_gil);
-		headless_restore_threadglobals(saved);
-
-		if ((**saved).flthreadkilled) {
-			ctx.cancelled = true;
-			ctx.done = true;
-			break;
-		}
-
-		if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
-
-		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
-		if (rc != BOXEN_OK) { ctx.cancelled = true; ctx.done = true; break; }
-
-		if (ev.type == BOXEN_EV_RESIZE) {
-			int new_sw = ev.resize.w, new_sh = ev.resize.h;
-			if (new_sw < 20) new_sw = 20;
-			if (new_sh < 6)  new_sh = 6;
-			boxen_rect_t r = place_centered_modal(new_sw, new_sh, ctx.content_w);
-			boxen_window_set_rect(win, r);
-			ctx.content_w = boxen_window_content_width(win);
-			boxen_window_invalidate(win);
-			boxen_present();
-			continue;
-		}
-
-		if (ev.type == BOXEN_EV_KEY) {
-			switch (ev.key.key) {
-			case BOXEN_KEY_ENTER:
-				ctx.done = true;
-				break;
-			case BOXEN_KEY_ESCAPE:
-			case BOXEN_KEY_CTRL_C:
-				ctx.cancelled = true;
-				ctx.done = true;
-				break;
-			case BOXEN_KEY_LEFT:
-				if (ctx.selection > 0) ctx.selection--;
-				break;
-			case BOXEN_KEY_RIGHT:
-				if (ctx.selection < ctx.count - 1) ctx.selection++;
-				break;
-			case BOXEN_KEY_HOME:
-				ctx.selection = 0;
-				break;
-			case BOXEN_KEY_END:
-				ctx.selection = ctx.count - 1;
-				break;
-			default: {
-				/* Reaching `default` means ev.key.key == BOXEN_KEY_NONE
-				 * (every non-NONE key is named in a case above), so
-				 * ev.key.ch holds a Unicode codepoint.  Hotkey match:
-				 * printable ASCII first-letter == label's first
-				 * letter (case-insensitive) selects + activates that
-				 * button immediately. */
-				if (ev.key.ch >= 0x20 && ev.key.ch < 0x7F) {
-					int idx = hotkey_match(&ctx, ev.key.ch);
-					if (idx >= 0) {
-						ctx.selection = idx;
-						ctx.done = true;
-					}
-				}
-				break;
-			}
-			}
-			boxen_window_invalidate(win);
-			boxen_present();
-		}
-	}
+	run_modal_loop(win, host, &ctx, &ctx.done, &ctx.cancelled,
+	               button_resize_cb, button_key_cb);
 
 	int result = ctx.cancelled ? 0 : (ctx.selection + 1);
 	boxen_window_close(win);
@@ -1074,6 +1043,10 @@ typedef struct {
 	int content_h;
 	bool done;
 	bool committed;	/* true: out_path populated; false: cancel */
+	/* Set when the most recent pick_load_directory() couldn't open
+	 * cur_dir (permission, missing, etc.).  The renderer surfaces
+	 * "(directory unreadable)" so the user understands an empty list. */
+	bool load_failed;
 	const boxen_ui_host_t *host;
 } pick_ctx_t;
 
@@ -1099,19 +1072,37 @@ static bool name_matches_filter(const char *name, const char *filter) {
 /* Populate ctx->entries from ctx->cur_dir.  Returns true on success.
  * On failure (e.g. dir unreadable) leaves entries empty; caller can
  * navigate back up. */
+/* Returns "" if d ends in '/' (already separator-terminated), else "/".
+ * Safe for empty strings (returns "/" without indexing).  Used to join
+ * a directory path to a name without producing a double-slash. */
+static const char *dir_sep(const char *d) {
+	if (!d || d[0] == '\0') return "/";
+	size_t n = strlen(d);
+	return (d[n - 1] == '/') ? "" : "/";
+}
+
 static bool pick_load_directory(pick_ctx_t *ctx) {
 	ctx->entry_count = 0;
 	ctx->cursor = 0;
 	ctx->scroll_top = 0;
+	ctx->load_failed = false;
 
 	DIR *dp = opendir(ctx->cur_dir);
-	if (!dp) return false;
+	if (!dp) {
+		ctx->load_failed = true;
+		return false;
+	}
+
+	bool at_root = (strcmp(ctx->cur_dir, "/") == 0);
 
 	struct dirent *de;
 	while ((de = readdir(dp)) != NULL && ctx->entry_count < ctx->entry_cap) {
-		/* Skip "." -- present "../" entry always.  Hide hidden dotfiles
-		 * by default for cleaner UX; a future toggle could expose them. */
+		/* Skip "." always.  Hide ".." at filesystem root (Enter on
+		 * ".." there just realpath()'s back to "/" which looks like a
+		 * cosmetic flicker).  Hide hidden dotfiles by default for
+		 * cleaner UX; a future toggle could expose them. */
 		if (de->d_name[0] == '.' && strcmp(de->d_name, "..") != 0) continue;
+		if (at_root && strcmp(de->d_name, "..") == 0) continue;
 
 		size_t nlen = strlen(de->d_name);
 		if (nlen >= PICK_NAME_MAX) continue;
@@ -1121,7 +1112,7 @@ static bool pick_load_directory(pick_ctx_t *ctx) {
 		char full[PICK_PATH_MAX];
 		int n = snprintf(full, sizeof(full), "%s%s%s",
 		                 ctx->cur_dir,
-		                 (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/",
+		                 dir_sep(ctx->cur_dir),
 		                 de->d_name);
 		if (n < 0 || (size_t)n >= sizeof(full)) continue;
 
@@ -1169,16 +1160,23 @@ static void pick_navigate(pick_ctx_t *ctx, const char *child) {
 		if (slash == joined) joined[1] = '\0';	/* "/" */
 		else *slash = '\0';
 	} else {
-		const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+		const char *sep = dir_sep(ctx->cur_dir);
 		if (snprintf(joined, sizeof(joined), "%s%s%s",
 		             ctx->cur_dir, sep, child) >= (int)sizeof(joined))
 			return;
 	}
 
-	/* Canonicalize: resolve symlinks and "." / ".." components.  realpath
-	 * needs the path to exist, which it does (we navigated to it). */
+	/* Canonicalize: resolve symlinks and "." / ".." components.
+	 * realpath returns NULL on permission denied, missing directory,
+	 * ELOOP (symlink loop), etc.  Beep so the user notices the keypress
+	 * was seen but the navigation didn't take. */
 	char resolved[PICK_PATH_MAX];
-	if (realpath(joined, resolved) == NULL) return;
+	if (realpath(joined, resolved) == NULL) {
+		if (ctx->host && ctx->host->ring_bell) {
+			ctx->host->ring_bell(ctx->host->ring_bell_ctx);
+		}
+		return;
+	}
 
 	if (strlen(resolved) >= sizeof(ctx->cur_dir)) return;
 	strcpy(ctx->cur_dir, resolved);
@@ -1221,7 +1219,9 @@ static void pick_render_cb(boxen_window_t *win, void *user_data) {
 		size_t bclen = strlen(bc);
 		const char *show = bc;
 		char truncated[PICK_PATH_MAX + 4];
-		if ((int)bclen > w) {
+		/* w > 3 is guaranteed by the w < 10 early-return above, but
+		 * spell out the dependency: w - 3 must not underflow size_t. */
+		if (w > 3 && (int)bclen > w) {
 			size_t keep = (size_t)w - 3;
 			snprintf(truncated, sizeof(truncated), "...%s",
 			         bc + (bclen - keep));
@@ -1262,8 +1262,10 @@ static void pick_render_cb(boxen_window_t *win, void *user_data) {
 	}
 	if (ctx->scroll_top < 0) ctx->scroll_top = 0;
 
-	/* Render visible entries.  Include synthetic "../" at index -1 of
-	 * the visible list (treated as a virtual entry above index 0). */
+	/* Render visible entries.  ".." (when present in the filesystem's
+	 * readdir output) appears as an ordinary entry that the user can
+	 * Enter to navigate up; Backspace from the list does the same.
+	 * The hint row advertises both. */
 	for (int row = 0; row < list_h; row++) {
 		int idx = ctx->scroll_top + row;
 		int y = list_top + row;
@@ -1296,6 +1298,26 @@ static void pick_render_cb(boxen_window_t *win, void *user_data) {
 		while (selected && x < w) {
 			boxen_set_cell(ctx->win, x++, y, ' ',
 			               fg, BOXEN_COLOR_DEFAULT, base);
+		}
+	}
+
+	/* Empty directory hint: explain why the list is blank.  Distinguishes
+	 * "really empty" from "unreadable / permission denied" -- the latter
+	 * is the more confusing case for the user since the picker offers no
+	 * other feedback for an enumeration failure. */
+	if (ctx->entry_count == 0 && list_h >= 1) {
+		const char *msg = ctx->load_failed
+			? "(directory unreadable)"
+			: "(empty directory)";
+		int mlen = (int)strlen(msg);
+		int mx = (w - mlen) / 2;
+		if (mx < 0) mx = 0;
+		for (int i = 0; i < w; i++) {
+			char ch = (i >= mx && (i - mx) < mlen) ? msg[i - mx] : ' ';
+			boxen_set_cell(ctx->win, i, list_top,
+			               (uint32_t)(unsigned char)ch,
+			               BOXEN_COLOR_DEFAULT, BOXEN_COLOR_DEFAULT,
+			               BOXEN_ATTR_DIM);
 		}
 	}
 
@@ -1350,13 +1372,13 @@ static void pick_render_cb(boxen_window_t *win, void *user_data) {
 	if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
 		hint = ctx->filename_focus
 		       ? "Enter:save  Tab:list  Esc:cancel"
-		       : "Enter:open  Tab:filename  Esc:cancel";
+		       : "Enter:open  Bksp:up  Tab:filename  Esc:cancel";
 	} else if (ctx->mode == BOXEN_UI_PICK_GET_FOLDER) {
-		hint = "Enter:open  Space:select  Esc:cancel";
+		hint = "Enter:open  Space:select  Bksp:up  Esc:cancel";
 	} else if (ctx->mode == BOXEN_UI_PICK_GET_DISK) {
-		hint = "Enter:select  Esc:cancel";
+		hint = "Enter:select  Bksp:up  Esc:cancel";
 	} else {
-		hint = "Enter:open/select  Esc:cancel";
+		hint = "Enter:open/select  Bksp:up  Esc:cancel";
 	}
 	for (int i = 0; i < w; i++) {
 		char ch = (hint[i] == '\0') ? ' ' : hint[i];
@@ -1377,12 +1399,22 @@ static void pick_render_cb(boxen_window_t *win, void *user_data) {
 
 /* -- commit logic -- */
 
+/* PUT_FILE commit outcome.  Returned by pick_try_commit_put_file so the
+ * caller knows whether to set committed/done flags or just keep the
+ * picker open (e.g. "Choose different name" returns to filename row). */
+typedef enum {
+	PICK_PUT_COMMITTED,	/* out_path populated; close + return true */
+	PICK_PUT_KEEP_OPEN,	/* user rejected overwrite; keep picker up */
+	PICK_PUT_CANCEL_ALL,	/* user cancelled the whole picker */
+	PICK_PUT_NO_FILENAME,	/* empty filename; no-op (no beep) */
+} pick_put_result_t;
+
 /* Build the full output path for the current selection.  Returns true
  * on success (out_path populated), false otherwise. */
 static bool pick_build_output(pick_ctx_t *ctx) {
 	if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
 		if (ctx->filename_len == 0) return false;
-		const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+		const char *sep = dir_sep(ctx->cur_dir);
 		if (snprintf(ctx->out_path, ctx->out_cap, "%s%s%s",
 		             ctx->cur_dir, sep, ctx->filename) >= (int)ctx->out_cap) {
 			return false;
@@ -1407,7 +1439,7 @@ static bool pick_build_output(pick_ctx_t *ctx) {
 			}
 			return true;
 		}
-		const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+		const char *sep = dir_sep(ctx->cur_dir);
 		if (snprintf(ctx->out_path, ctx->out_cap, "%s%s%s",
 		             ctx->cur_dir, sep, e->name) >= (int)ctx->out_cap) {
 			return false;
@@ -1417,7 +1449,7 @@ static bool pick_build_output(pick_ctx_t *ctx) {
 
 	/* GET_FILE / GET_DISK: must be a file (not a directory). */
 	if (e->is_dir) return false;
-	const char *sep = (ctx->cur_dir[strlen(ctx->cur_dir) - 1] == '/') ? "" : "/";
+	const char *sep = dir_sep(ctx->cur_dir);
 	if (snprintf(ctx->out_path, ctx->out_cap, "%s%s%s",
 	             ctx->cur_dir, sep, e->name) >= (int)ctx->out_cap) {
 		return false;
@@ -1426,6 +1458,47 @@ static bool pick_build_output(pick_ctx_t *ctx) {
 }
 
 /* -- key handling -- */
+
+/* PUT_FILE commit with overwrite-confirm.  Matches the data-loss
+ * protection in the legacy file_browser put-mode (file_browser.c:485-650).
+ *
+ * Builds the candidate path; if a file already exists at that path,
+ * opens a 3-button modal ("Overwrite" / "Cancel" / "Choose different
+ * name") and routes by user choice.  Boxen modal reentrancy is
+ * supported -- the inner button modal runs its own mini event loop
+ * under the picker's stack frame; the outer picker's window stays
+ * marked modal and reclaims focus when the inner closes (via the
+ * host's restore_focus on close + Phase 1's known one-tick delay). */
+static pick_put_result_t pick_try_commit_put_file(pick_ctx_t *ctx) {
+	if (ctx->filename_len == 0) return PICK_PUT_NO_FILENAME;
+	if (!pick_build_output(ctx)) return PICK_PUT_NO_FILENAME;
+
+	struct stat st;
+	if (stat(ctx->out_path, &st) != 0) {
+		/* Doesn't exist -- clear to write. */
+		return PICK_PUT_COMMITTED;
+	}
+
+	/* File or directory already exists at the target.  Prompt the user.
+	 * Wipe out_path so a downstream caller that observes KEEP_OPEN /
+	 * CANCEL_ALL doesn't see a stale value if they forget to check the
+	 * return. */
+	const char *buttons[3] = { "Overwrite", "Cancel", "Choose different name" };
+	int choice = boxen_ui_button_select("File already exists.  What do you want to do?",
+	                                     buttons, 3);
+	switch (choice) {
+	case 1: /* Overwrite */
+		return PICK_PUT_COMMITTED;
+	case 3: /* Choose different name */
+		ctx->out_path[0] = '\0';
+		return PICK_PUT_KEEP_OPEN;
+	case 2: /* Cancel */
+	case 0: /* Esc/Ctrl-C on the modal == Cancel */
+	default:
+		ctx->out_path[0] = '\0';
+		return PICK_PUT_CANCEL_ALL;
+	}
+}
 
 static void pick_filename_insert(pick_ctx_t *ctx, char c) {
 	if (ctx->filename_len + 1 >= PICK_FILENAME_MAX) return;
@@ -1457,12 +1530,17 @@ static void pick_handle_key(pick_ctx_t *ctx, const boxen_event_t *ev) {
 	/* Filename-row focus path (PUT_FILE only). */
 	if (ctx->filename_focus) {
 		switch (ev->key.key) {
-		case BOXEN_KEY_ENTER:
-			if (pick_build_output(ctx)) {
+		case BOXEN_KEY_ENTER: {
+			pick_put_result_t r = pick_try_commit_put_file(ctx);
+			if (r == PICK_PUT_COMMITTED) {
 				ctx->committed = true;
 				ctx->done = true;
+			} else if (r == PICK_PUT_CANCEL_ALL) {
+				ctx->done = true;
 			}
+			/* PICK_PUT_KEEP_OPEN / PICK_PUT_NO_FILENAME: stay open. */
 			return;
+		}
 		case BOXEN_KEY_ESCAPE:
 		case BOXEN_KEY_CTRL_C:
 			ctx->done = true;
@@ -1534,6 +1612,10 @@ static void pick_handle_key(pick_ctx_t *ctx, const boxen_event_t *ev) {
 		ctx->cursor += list_h;
 		if (ctx->cursor >= ctx->entry_count)
 			ctx->cursor = ctx->entry_count - 1;
+		/* Empty directory: clamp negative cursor.  Without this PgDn at
+		 * entry_count==0 leaves cursor at -1 and the UP/DOWN guards
+		 * never recover. */
+		if (ctx->cursor < 0) ctx->cursor = 0;
 		return;
 	}
 	case BOXEN_KEY_BACKSPACE:
@@ -1553,6 +1635,25 @@ static void pick_handle_key(pick_ctx_t *ctx, const boxen_event_t *ev) {
 		} else {
 			/* GET_FOLDER on a file: ignore. */
 			if (ctx->mode == BOXEN_UI_PICK_GET_FOLDER) return;
+			/* PUT_FILE on a file: pre-populate the filename field with
+			 * the chosen name and route through the overwrite-confirm
+			 * helper.  Pure list-row "save as" gesture without having
+			 * to Tab to the filename row first. */
+			if (ctx->mode == BOXEN_UI_PICK_PUT_FILE) {
+				size_t nlen = strlen(e->name);
+				if (nlen >= PICK_FILENAME_MAX) return;
+				memcpy(ctx->filename, e->name, nlen + 1);
+				ctx->filename_len = (int)nlen;
+				ctx->filename_cursor = ctx->filename_len;
+				pick_put_result_t r = pick_try_commit_put_file(ctx);
+				if (r == PICK_PUT_COMMITTED) {
+					ctx->committed = true;
+					ctx->done = true;
+				} else if (r == PICK_PUT_CANCEL_ALL) {
+					ctx->done = true;
+				}
+				return;
+			}
 			if (pick_build_output(ctx)) {
 				ctx->committed = true;
 				ctx->done = true;
@@ -1590,6 +1691,21 @@ static boxen_rect_t place_picker_modal(int screen_w, int screen_h) {
 	if (y < 0) y = 0;
 	boxen_rect_t r = { x, y, win_w, win_h };
 	return r;
+}
+
+/* Picker resize / key adapters for the shared modal loop. */
+static void pick_resize_cb(void *vctx, int sw, int sh) {
+	pick_ctx_t *ctx = (pick_ctx_t *)vctx;
+	if (sw < 20) sw = 20;
+	if (sh < 10) sh = 10;
+	boxen_rect_t r = place_picker_modal(sw, sh);
+	boxen_window_set_rect(ctx->win, r);
+	ctx->content_w = boxen_window_content_width(ctx->win);
+	ctx->content_h = boxen_window_content_height(ctx->win);
+}
+
+static void pick_key_cb(void *vctx, const boxen_event_t *ev) {
+	pick_handle_key((pick_ctx_t *)vctx, ev);
 }
 
 bool boxen_ui_pick_file(boxen_ui_pick_mode_t mode,
@@ -1715,54 +1831,12 @@ bool boxen_ui_pick_file(boxen_ui_pick_mode_t mode,
 	boxen_window_focus(win);
 	boxen_window_raise(win);
 
-	boxen_window_invalidate(win);
-	if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
-	boxen_present();
-
-	/* Mini event loop (parallel to other run_* loops). */
-	while (!ctx.done) {
-		boxen_event_t ev;
-		memset(&ev, 0, sizeof(ev));
-
-		tcp_process_callbacks();
-
-		hdlthreadglobals saved = hthreadglobals;
-		headless_save_threadglobals(saved);
-		pthread_mutex_unlock(&frontier_gil);
-		pthread_cond_broadcast(&gil_available);
-		boxen_result_t rc = boxen_poll_event(&ev, 100);
-		pthread_mutex_lock(&frontier_gil);
-		headless_restore_threadglobals(saved);
-
-		if ((**saved).flthreadkilled) {
-			ctx.done = true;
-			break;
-		}
-
-		if (host->drain_capture_pipe) host->drain_capture_pipe(host->drain_ctx);
-
-		if (rc == BOXEN_ERR_TIMEOUT) { boxen_present(); continue; }
-		if (rc != BOXEN_OK) { ctx.done = true; break; }
-
-		if (ev.type == BOXEN_EV_RESIZE) {
-			int new_sw = ev.resize.w, new_sh = ev.resize.h;
-			if (new_sw < 20) new_sw = 20;
-			if (new_sh < 10) new_sh = 10;
-			boxen_rect_t r = place_picker_modal(new_sw, new_sh);
-			boxen_window_set_rect(win, r);
-			ctx.content_w = boxen_window_content_width(win);
-			ctx.content_h = boxen_window_content_height(win);
-			boxen_window_invalidate(win);
-			boxen_present();
-			continue;
-		}
-
-		if (ev.type == BOXEN_EV_KEY) {
-			pick_handle_key(&ctx, &ev);
-			boxen_window_invalidate(win);
-			boxen_present();
-		}
-	}
+	/* Picker uses the shared modal loop -- no cancelled out-param here
+	 * because the picker's commit/cancel is represented via
+	 * ctx.committed (set only on a successful commit; loop-driven
+	 * cancellation paths simply leave it false). */
+	run_modal_loop(win, host, &ctx, &ctx.done, NULL,
+	               pick_resize_cb, pick_key_cb);
 
 	boxen_window_set_cursor_visible(win, false);
 	boxen_window_close(win);

--- a/frontier-cli/boxen_ui.h
+++ b/frontier-cli/boxen_ui.h
@@ -26,6 +26,7 @@
 #define BOXEN_UI_H
 
 #include <stdbool.h>
+#include <stddef.h>		/* size_t */
 
 #ifdef __cplusplus
 extern "C" {
@@ -136,6 +137,50 @@ bool boxen_ui_alert(const char *message, bool beep);
  * Bridges dialog.twoway (count=2) and dialog.threeway (count=3). */
 int boxen_ui_button_select(const char *prompt,
                            const char *const *buttons, int count);
+
+/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B: file-picker modal.
+ *
+ * Bridges the four UserTalk file dialog verbs to a boxen-native
+ * single-pane list picker.  Layout: prompt + breadcrumb header, list
+ * of entries (directories first, then files), separator, hint row;
+ * PUT_FILE mode adds a filename input row above the hint.
+ *
+ * `mode` selects the dialog flavour:
+ *   - BOXEN_UI_PICK_GET_FILE   -- file.getFileDialog: pick existing file
+ *   - BOXEN_UI_PICK_PUT_FILE   -- file.putFileDialog: pick directory + type filename
+ *   - BOXEN_UI_PICK_GET_FOLDER -- file.getFolderDialog: pick existing folder
+ *   - BOXEN_UI_PICK_GET_DISK   -- file.getDiskDialog: pick a mount point
+ *
+ * `start_path` is the initial directory (NULL = current working dir).
+ *   PUT_FILE accepts a path with trailing filename component as the
+ *   default filename.  GET_DISK ignores it (browses /Volumes/ on
+ *   macOS).
+ *
+ * `type_filter` (GET_FILE only) is a file extension WITHOUT the dot
+ *   (e.g. "txt").  Non-matching files are dimmed but still selectable
+ *   per JES decision 2026-06-24.  NULL means no filter.
+ *
+ * `out_path` receives the absolute path of the chosen file/folder/
+ *   volume; for PUT_FILE this is the directory joined with the
+ *   filename input.  `out_cap` is the buffer capacity (caller-sized).
+ *
+ * Returns true on commit, false on Esc/Ctrl-C cancel (out_path
+ * untouched).
+ *
+ * Must be called with the GIL held.  Cooperative cancel only -- see
+ * the 2026-06-23 followup to decision #3 in the design doc.  */
+typedef enum {
+	BOXEN_UI_PICK_GET_FILE,
+	BOXEN_UI_PICK_PUT_FILE,
+	BOXEN_UI_PICK_GET_FOLDER,
+	BOXEN_UI_PICK_GET_DISK,
+} boxen_ui_pick_mode_t;
+
+bool boxen_ui_pick_file(boxen_ui_pick_mode_t mode,
+                        const char *prompt,
+                        const char *start_path,
+                        const char *type_filter,
+                        char *out_path, size_t out_cap);
 
 #ifdef __cplusplus
 }

--- a/frontier-cli/file_dialog.c
+++ b/frontier-cli/file_dialog.c
@@ -11,6 +11,7 @@
 #include "file_browser.h"
 #include "tab_completion.h"
 #include "terminal_control.h"
+#include "boxen_ui.h"		/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B */
 #include "../Common/headers/logging.h"
 
 #include <limits.h>
@@ -368,6 +369,21 @@ file_dialog_result file_dialog_get_file(const char *prompt,
                                          const char *type_filter) {
 	const char *effective_prompt = (prompt && prompt[0]) ? prompt : "Select an existing file:";
 
+	/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B: route through the
+	 * boxen-native file picker when the boxen REPL is active.  The
+	 * picker IS interactive even when isatty() would return false (tmux
+	 * subshells, non-TTY pipes), so the bridge check must precede the
+	 * isatty() branch below. */
+	if (boxen_ui_is_active()) {
+		file_dialog_result r;
+		r.path[0] = '\0';
+		r.success = boxen_ui_pick_file(BOXEN_UI_PICK_GET_FILE,
+		                                effective_prompt, start_path,
+		                                type_filter,
+		                                r.path, sizeof(r.path));
+		return r;
+	}
+
 	if (isatty(STDIN_FILENO))
 		return file_browser_get_file(effective_prompt, start_path, type_filter);
 
@@ -382,6 +398,16 @@ file_dialog_result file_dialog_get_file(const char *prompt,
 file_dialog_result file_dialog_put_file(const char *prompt,
                                          const char *start_path) {
 	const char *effective_prompt = (prompt && prompt[0]) ? prompt : "Choose location to save file:";
+
+	/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B: boxen picker. */
+	if (boxen_ui_is_active()) {
+		file_dialog_result r;
+		r.path[0] = '\0';
+		r.success = boxen_ui_pick_file(BOXEN_UI_PICK_PUT_FILE,
+		                                effective_prompt, start_path, NULL,
+		                                r.path, sizeof(r.path));
+		return r;
+	}
 
 	if (isatty(STDIN_FILENO))
 		return file_browser_put_file(effective_prompt, start_path);
@@ -398,6 +424,16 @@ file_dialog_result file_dialog_get_folder(const char *prompt,
                                            const char *start_path) {
 	const char *effective_prompt = (prompt && prompt[0]) ? prompt : "Select a directory:";
 
+	/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B: boxen picker. */
+	if (boxen_ui_is_active()) {
+		file_dialog_result r;
+		r.path[0] = '\0';
+		r.success = boxen_ui_pick_file(BOXEN_UI_PICK_GET_FOLDER,
+		                                effective_prompt, start_path, NULL,
+		                                r.path, sizeof(r.path));
+		return r;
+	}
+
 	if (isatty(STDIN_FILENO))
 		return file_browser_get_folder(effective_prompt, start_path);
 
@@ -411,6 +447,18 @@ file_dialog_result file_dialog_get_folder(const char *prompt,
 /* Routes to two-pane browser (TTY) or fallback numbered list (piped input). */
 file_dialog_result file_dialog_get_disk(const char *prompt) {
 	const char *effective_prompt = (prompt && prompt[0]) ? prompt : "Select a volume:";
+
+	/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B: boxen picker.
+	 * The boxen picker browses /Volumes/ on macOS (where mounted disks
+	 * appear as directory entries) rather than calling getfsstat. */
+	if (boxen_ui_is_active()) {
+		file_dialog_result r;
+		r.path[0] = '\0';
+		r.success = boxen_ui_pick_file(BOXEN_UI_PICK_GET_DISK,
+		                                effective_prompt, NULL, NULL,
+		                                r.path, sizeof(r.path));
+		return r;
+	}
 
 	if (isatty(STDIN_FILENO))
 		return file_browser_get_disk(effective_prompt);

--- a/portable/fileverbs_portable.c
+++ b/portable/fileverbs_portable.c
@@ -2041,8 +2041,16 @@ boolean portable_filefunctionvalue(short token, hdltreenode hparam1,
 				extern boolean isInteractiveMode(void);
 				extern boolean portable_file_dialog_verb(short token, hdltreenode hparam1,
 				                                         tyvaluerecord *vreturned, bigstring bserror);
+				/* 2026-06-24 JES #691 Phase C.0.7g Phase 2B: the boxen
+				 * UI bridge IS a real interactive UI even when isatty()
+				 * would say otherwise (tmux subshells, non-TTY pipes).
+				 * Allow the verb when boxen is owning the terminal so
+				 * file.* dialogs in dispatched scripts work under
+				 * --debug-tui.  Boxen ui_pick_file is the routing
+				 * destination via file_dialog_*. */
+				extern bool boxen_ui_is_active(void);
 
-				if (!isInteractiveMode()) {
+				if (!isInteractiveMode() && !boxen_ui_is_active()) {
 					/* In non-interactive mode, return false as the dialog result
 					 * (same as user clicking Cancel), not a verb error. This lets
 					 * scripts handle it gracefully via if/try. */

--- a/tools/tui-tests/tests/test_08_ui_bridge_phase2b.py
+++ b/tools/tui-tests/tests/test_08_ui_bridge_phase2b.py
@@ -128,6 +128,68 @@ def test_getfolderdialog_renders_modal():
 		time.sleep(0.3)
 
 
+def test_putfiledialog_overwrite_confirm_when_file_exists():
+	"""Phase 2B gate-fix: file.putFileDialog must prompt before
+	overwriting an existing file.  Legacy file_browser.c had this
+	check; the boxen picker initially shipped without it
+	(data-loss footgun caught by /gate review 2026-06-24).
+
+	Setup: pre-create a known file, then drive the picker with that
+	filename pre-typed.  Pressing Enter triggers the overwrite-confirm
+	modal, which must render box-drawing characters AND surface the
+	"File already exists" phrasing (so the user sees a real prompt
+	rather than a silent commit).
+	"""
+	# Use a tempfile under /tmp that we know exists.
+	target_dir = "/tmp"
+	target_name = "phase2b_overwrite_target.txt"
+	target_path = os.path.join(target_dir, target_name)
+	with open(target_path, "w") as f:
+		f.write("existing content")
+
+	try:
+		with TUI(boot_wait=1.5) as t:
+			t.wait_for(">", timeout=5)
+			# Pre-populate the picker's start_path with the target so the
+			# picker opens in /tmp with the filename pre-filled.
+			_eval(t, 'workspace.tmpPickResult = "/tmp/'
+			       + target_name + '"')
+			time.sleep(0.3)
+			_eval(t,
+				'file.putFileDialog ("PhaseTwoBOverwriteMarker", '
+				'@workspace.tmpPickResult)')
+			time.sleep(0.8)
+			# Focus the filename input row + press Enter to trigger commit.
+			t.send_key("Tab")
+			time.sleep(0.2)
+			t.send_key("Enter")
+			time.sleep(0.5)
+			snapshot(t, "ui-bridge-p2b-overwrite-confirm")
+
+			text = t.capture()
+			assert t.is_alive(), "REPL exited during overwrite-confirm"
+			assert _modal_visible(text), (
+				"Overwrite-confirm modal did not render box-drawing "
+				"characters.  Capture:\n" + text
+			)
+			assert _text_inside_modal(text, "already exists"), (
+				"Overwrite-confirm prompt missing 'already exists' "
+				"phrasing.  Silent overwrite would be a data-loss "
+				"regression vs the legacy file_browser.  Capture:\n"
+				+ text
+			)
+			# Cancel out so the test doesn't actually overwrite.
+			t.send_key("Escape")
+			time.sleep(0.3)
+			t.send_key("Escape")
+			time.sleep(0.3)
+	finally:
+		try:
+			os.remove(target_path)
+		except OSError:
+			pass
+
+
 def test_putfiledialog_renders_with_filename_input_row():
 	"""file.putFileDialog shows the list + a filename input row at the
 	bottom of the modal.  Typing characters should land in the filename

--- a/tools/tui-tests/tests/test_08_ui_bridge_phase2b.py
+++ b/tools/tui-tests/tests/test_08_ui_bridge_phase2b.py
@@ -1,0 +1,154 @@
+"""
+Phase 2B of the boxen <-> UserTalk UI bridge: file dialog verbs.
+
+Bridges file.* picker verbs to a boxen-native single-pane list picker:
+
+  - file.getFileDialog (prompt, @adr, type)  -- pick existing file
+  - file.putFileDialog (prompt, @adr)        -- choose save-to path
+  - file.getFolderDialog (prompt, @adr)      -- pick existing folder
+  - file.getDiskDialog (prompt, @adr)        -- pick volume / mount point
+
+Test surface:
+  - getFileDialog renders a boxen modal showing the current directory's
+    entries with a breadcrumb header (no raw-stderr fallback).
+  - typing into a putFileDialog filename row writes characters into the
+    bottom field of the modal (not the typed prompt line).
+  - Esc/Ctrl-C cancels and the verb returns false.
+  - Up/Down moves the cursor; Enter on a directory navigates into it.
+
+The full-dispatch path is exercised via UserTalk eval at the REPL
+prompt.  The verb stores its result in a workspace variable, so we
+check the modal renders correctly + the verb returns the expected
+shape (false on cancel, true with workspace var populated on commit).
+"""
+
+import os
+import time
+
+from tui_harness import TUI, snapshot
+
+
+def _eval(t, expr):
+	t.send(expr)
+	time.sleep(0.1)
+	t.send_key("Enter")
+
+
+def _modal_visible(text):
+	return "╔" in text or "║" in text
+
+
+def _text_inside_modal(text, marker):
+	"""Marker is visible OUTSIDE the typed prompt line ('> ')."""
+	prompt_marker = "> "
+	rows_with_marker = [
+		row for row in text.split("\n")
+		if marker in row and not row.lstrip().startswith(prompt_marker)
+	]
+	return len(rows_with_marker) > 0
+
+
+def test_getfiledialog_renders_modal_with_breadcrumb_and_entries():
+	"""file.getFileDialog(prompt, @adr, "") under boxen should render a
+	boxen modal with the dialog prompt, a breadcrumb of the current
+	directory, and the directory's entries listed.  Pre-fix this would
+	either no-op (gated by isInteractiveMode and ignored under tmux) or
+	corrupt the framebuffer via the legacy file_browser raw-terminal
+	path.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t,
+			'file.getFileDialog ("PhaseTwoBPickFileMarker", '
+			'@workspace.tmpPickResult, "")')
+		time.sleep(0.8)
+		snapshot(t, "ui-bridge-p2b-getfile-modal")
+
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during file.getFileDialog"
+		assert _modal_visible(text), (
+			"file.getFileDialog did not render a boxen modal.  "
+			"Capture:\n" + text
+		)
+		assert _text_inside_modal(text, "PhaseTwoBPickFileMarker"), (
+			"prompt text missing inside modal.  Capture:\n" + text
+		)
+		# Cancel so the test leaves the REPL clean.
+		t.send_key("Escape")
+		time.sleep(0.3)
+
+
+def test_getfiledialog_esc_cancels_returns_false():
+	"""Esc inside the picker cancels.  file.getFileDialog returns
+	false on cancel; UserTalk eval echoes the boolean result.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t,
+			'file.getFileDialog ("PhaseTwoBCancelTest", '
+			'@workspace.tmpPickResult, "")')
+		time.sleep(0.6)
+		t.send_key("Escape")
+		time.sleep(0.5)
+		snapshot(t, "ui-bridge-p2b-getfile-esc")
+
+		text = t.capture()
+		assert t.is_alive(), "REPL exited on Esc cancel"
+		# UserTalk prints `false` for a false-returning expression.
+		# Should appear OUTSIDE the typed prompt line.
+		assert _text_inside_modal(text, "false"), (
+			"file.getFileDialog did not return false on Esc cancel.  "
+			"Capture:\n" + text
+		)
+
+
+def test_getfolderdialog_renders_modal():
+	"""file.getFolderDialog opens the same picker shape, configured for
+	folder selection.  Renders the boxen modal; user-facing prompt
+	visible.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t,
+			'file.getFolderDialog ("PhaseTwoBPickFolderMarker", '
+			'@workspace.tmpPickResult)')
+		time.sleep(0.8)
+		snapshot(t, "ui-bridge-p2b-getfolder-modal")
+
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during file.getFolderDialog"
+		assert _modal_visible(text), (
+			"file.getFolderDialog did not render a boxen modal.  "
+			"Capture:\n" + text
+		)
+		assert _text_inside_modal(text, "PhaseTwoBPickFolderMarker"), (
+			"prompt text missing inside modal.  Capture:\n" + text
+		)
+		t.send_key("Escape")
+		time.sleep(0.3)
+
+
+def test_putfiledialog_renders_with_filename_input_row():
+	"""file.putFileDialog shows the list + a filename input row at the
+	bottom of the modal.  Typing characters should land in the filename
+	row, not the REPL prompt.
+	"""
+	with TUI(boot_wait=1.5) as t:
+		t.wait_for(">", timeout=5)
+		_eval(t,
+			'file.putFileDialog ("PhaseTwoBSaveMarker", '
+			'@workspace.tmpPickResult)')
+		time.sleep(0.8)
+		snapshot(t, "ui-bridge-p2b-putfile-modal")
+
+		text = t.capture()
+		assert t.is_alive(), "REPL exited during file.putFileDialog"
+		assert _modal_visible(text), (
+			"file.putFileDialog did not render a boxen modal.  "
+			"Capture:\n" + text
+		)
+		assert _text_inside_modal(text, "PhaseTwoBSaveMarker"), (
+			"prompt text missing inside modal.  Capture:\n" + text
+		)
+		t.send_key("Escape")
+		time.sleep(0.3)


### PR DESCRIPTION
## Summary

Phase 2B of the boxen ↔ UserTalk UI bridge — the final piece of the bridge work. Adds a boxen-native single-pane file picker for all four `file.*` dialog verbs (`getFileDialog` / `putFileDialog` / `getFolderDialog` / `getDiskDialog`).

After PR #800 (Phase 2A: 4 remaining dialog verbs) the dialog-verb half of the bridge was complete. This PR closes the bridge.

**Two-commit shape** (squash on merge):
1. `feat` — bridge skeleton: one new `boxen_ui_pick_file(mode, ...)` primitive serving all 4 verbs (~770 LOC). Single-pane layout with breadcrumb header, bottom-row filename input for PUT_FILE, display-only type filter for GET_FILE. 4 tui-tests.
2. `fix` — `/gate` review fixes (3 P1 + 7 P2): overwrite-confirm modal, cursor clamp, hint strings, `dir_sep` helper, root `..` suppression, breadcrumb underflow guard, empty/unreadable hint, realpath-failure beep, and **loop centralization** (4 parallel mini event loops → 1 shared `run_modal_loop`).

## What this PR does

Layout per JES decisions 2026-06-24:
- **Single-pane list** with breadcrumb header (vs the legacy 2-pane layout)
- **Bottom-row filename input** for PUT_FILE (single visual step)
- **Display-only type filter** for GET_FILE (dim non-matching, still selectable)
- All 4 verbs in one PR (shared picker code)

Bridge entry: `boxen_ui_pick_file(mode, prompt, start_path, type_filter, out_path, out_cap)` returning `bool`. Mode enum: `BOXEN_UI_PICK_GET_FILE / PUT_FILE / GET_FOLDER / GET_DISK`.

Wiring:
- `frontier-cli/file_dialog.c` — branch at top of all 4 dialog entries; routes through bridge when boxen is active
- `portable/fileverbs_portable.c` — `!boxen_ui_is_active()` escape on the `isInteractiveMode()` gate

Key bindings:
- Up/Down/PgUp/PgDn/Home/End — list navigation
- Enter on directory — navigate in
- Enter on file (GET_FILE, GET_DISK) — commit
- Enter on directory (GET_FOLDER) — navigate; Space picks current dir
- Backspace from list — navigate up
- PUT_FILE Tab — toggle focus list ↔ filename row
- Esc/Ctrl-C — cancel
- Hidden dotfiles hidden by default; `..` hidden at root
- Type filter: dim non-matching files; still selectable

## Overwrite-confirm (gate-fix P1)

`file.putFileDialog` no longer silently overwrites. On commit, if the target path exists, opens a nested 3-button modal (`Overwrite` / `Cancel` / `Choose different name`). Reuses the Phase 2A `boxen_ui_button_select` primitive — first practical exercise of the bridge's reentrancy story (picker → button modal → back to picker), verified end-to-end by a new regression test.

## Loop centralization (gate-fix P2)

Four near-identical mini event loops grew across Phase 1 / 2A / 2B (run_modal, alert, button_select, picker). Each ~30 lines of identical GIL skeleton:

```
tcp_process_callbacks();
save threadglobals + unlock + cond_broadcast;
boxen_poll_event(100ms);
lock + restore;
check flthreadkilled;
drain capture pipe;
dispatch event;
```

Bar-raiser AND concurrency reviewers both flagged the duplication. Extracted `run_modal_loop(win, host, ctx, done, cancelled, on_resize, on_key)` that owns the skeleton. Each entry point passes its own adapter callbacks. **~120 LOC of GIL-discipline drift surface removed**; any future modal (or any GIL-discipline fix) lands in one place.

## /gate findings addressed

| # | Severity | Finding | Status |
|---|----------|---------|--------|
| 1 | P1 | PUT_FILE silently overwrites existing files | Fixed — 3-button confirm modal |
| 2 | P1 | PgDn on empty dir leaves cursor at -1 | Fixed — clamp to 0 |
| 3 | P1 | Misleading "synthetic `../`" comment + no Backspace hint | Fixed — comment rewritten, `Bksp:up` added to all hints |
| 4 | P2 | 4-loop centralization | Fixed — `run_modal_loop` shared helper |
| 5 | P2 | Missing Backspace hint | Fixed (with #3) |
| 6 | P2 | `..` at root is cosmetic flicker | Fixed — hidden at root |
| 7 | P2 | `dir_sep` helper opportunity | Fixed — 5+ sites |
| 8 | P2 | Silent failure on initial-dir retry | Fixed — `(directory unreadable)` hint |
| 9 | P2 | realpath failure silent | Fixed — bell + beep |
| 10 | P2 | breadcrumb underflow latent risk | Fixed — explicit `w > 3` guard |

## Test plan

- [x] **tui-tests: 35/35** (5 new in `test_08_ui_bridge_phase2b.py`):
  - `test_getfiledialog_renders_modal_with_breadcrumb_and_entries`
  - `test_getfiledialog_esc_cancels_returns_false`
  - `test_getfolderdialog_renders_modal`
  - `test_putfiledialog_renders_with_filename_input_row`
  - `test_putfiledialog_overwrite_confirm_when_file_exists` (post-gate-fix)
- [x] **Unit: 814/814**
- [x] **Integration: 2186/21 — EXACT develop baseline match**
- [x] `/gate` review: 0 P0, 3 P1, 7 P2 — all P1s + 6 of 7 P2s fixed in commit 2
- [x] Manual: `file.getFileDialog`, `file.putFileDialog`, `file.getFolderDialog` typed at the REPL prompt all render proper boxen modals; overwrite-confirm works; navigation feels responsive

## Files

- `frontier-cli/boxen_ui.c` — new picker (~770 LOC) + shared `run_modal_loop` + overwrite-confirm helper
- `frontier-cli/boxen_ui.h` — `boxen_ui_pick_file` + `boxen_ui_pick_mode_t` enum
- `frontier-cli/file_dialog.c` — 4 branches at top of entries
- `portable/fileverbs_portable.c` — `!boxen_ui_is_active()` escape hatch
- `tools/tui-tests/tests/test_08_ui_bridge_phase2b.py` — 5 regression tests

## What's next

This completes the boxen ↔ UserTalk UI bridge (Phases 1 + 2A + 2B). All interactive UserTalk dialog and file verbs now compose with the boxen REPL.

- **C.6** (next milestone): flip default `frontier-cli` to boxen; deprecate `--debug-tui`
- Post-C.6 soak: delete legacy linenoise REPL
- Smaller follow-ups already filed: #794 (printKeyCodes guard), #795 (256-byte input buffer growth), #796 (UTF-8 input), #797 (getInt re-prompt), #798 (boxen modal stack), #799 (hard-kill via flthreadkilled)
