### PR TITLE
fix(repl): C.6.1 #803 -- in-app output-pane scrollback (PgUp/PgDn)

### DIFF
--- a/docs/CLI_USAGE_GUIDE.md
+++ b/docs/CLI_USAGE_GUIDE.md
@@ -16,8 +16,8 @@
 7. [Examples](#examples)
 8. [Troubleshooting](#troubleshooting)
 9. [Advanced Usage](#advanced-usage)
-10. [REPL Navigation and Guest Databases](#repl-navigation-and-guest-databases)
-11. [REPL Known Limitations](#repl-known-limitations)
+10. [REPL Keybindings (Boxen REPL)](#repl-keybindings-boxen-repl)
+11. [REPL Navigation and Guest Databases](#repl-navigation-and-guest-databases)
 
 ---
 
@@ -1000,6 +1000,40 @@ This follows proven Frontier patterns:
 
 For technical details about the QuickScript architecture, see:
 - `planning/architectural_decision_records/ADR-009-repl-hash-table-stack-management.md`
+
+---
+
+## REPL Keybindings (Boxen REPL)
+
+The default REPL (`frontier-cli` with no flag) is the multi-pane boxen REPL.  The following keys are recognized while focus is on the input bar:
+
+| Key | Action |
+|-----|--------|
+| `Enter` / `Ctrl-M` | Submit the current line for evaluation |
+| `Escape` | Clear the input buffer |
+| `Ctrl-C` | Quit the REPL (or cancel a pending multi-line continuation) |
+| `Left` / `Right` | Move the caret one character within the input |
+| `Ctrl-A` / `Ctrl-E` | Jump caret to start / end of line |
+| `Backspace` / `Delete` | Delete character before / after the caret |
+| `Up` / `Down` | Navigate command history |
+| `Tab` | Trigger completion (slash commands or ODB paths) |
+| `PgUp` / `PgDn` | Scroll the output pane back / forward through scrollback |
+| `/` (at start of line) | Open the slash-menu palette (after a short debounce) |
+| `\` (at end of line) | Continue the expression on the next line (multi-line input) |
+
+### Output-pane scrollback (PgUp/PgDn)
+
+The boxen REPL owns the terminal's alternate screen buffer, so the terminal's own scrollback (the scroll wheel / shift-PgUp at the OS terminal level) cannot reach output that has scrolled off the top of the visible region.  Use **PgUp** to walk the output pane view back through up to 1024 lines of scrollback, and **PgDn** to return toward the newest line.
+
+Each key press scrolls by one page (the output pane height minus one line of context overlap), matching `less` / `man` conventions.
+
+Behavior notes:
+
+- **Submitting a new expression** (Enter) automatically snaps the view back to the bottom -- you immediately see the new result.  This is "scroll-on-output" behavior.
+- **Async output from background scripts** does NOT snap the view back.  You can review old content while a long-running script keeps printing to the REPL.
+- **Modals** (file picker, dialog prompts) do not disturb the scroll position; closing a modal returns you to wherever the view was scrolled to.
+
+If you need true terminal-native scrollback (e.g. unbounded scrollback in your OS terminal application), use `--plain` to launch the legacy linenoise REPL instead.
 
 ---
 

--- a/docs/CLI_USAGE_GUIDE.md
+++ b/docs/CLI_USAGE_GUIDE.md
@@ -1030,7 +1030,7 @@ Each key press scrolls by one page (the output pane height minus one line of con
 Behavior notes:
 
 - **Submitting a new expression** (Enter) automatically snaps the view back to the bottom -- you immediately see the new result.  This is "scroll-on-output" behavior.
-- **Async output from background scripts** does NOT snap the view back.  You can review old content while a long-running script keeps printing to the REPL.
+- **Async output from background scripts** does NOT snap the view back.  You can review old content while a long-running script keeps printing to the REPL.  When the 1024-line scrollback ring fills up, the view position auto-advances in lockstep with the new lines so the content you were reading stays on screen (rather than silently sliding under newer output).
 - **Modals** (file picker, dialog prompts) do not disturb the scroll position; closing a modal returns you to wherever the view was scrolled to.
 
 If you need true terminal-native scrollback (e.g. unbounded scrollback in your OS terminal application), use `--plain` to launch the legacy linenoise REPL instead.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,6 +4,33 @@ Most-recent first.  Each entry summarizes user-visible changes for the release.
 
 ---
 
+## C.6.1 — boxen REPL output-pane scrollback (2026-06-29)
+
+### Summary
+
+The boxen REPL output pane now supports in-app scrollback via **PgUp** and **PgDn**.  Output that has scrolled off the top of the visible region (e.g. dumping `system.verbs.builtins`, a wide table, or a long stack trace) is reachable again without falling back to `--plain`.
+
+### What changed
+
+- **PgUp** scrolls the output pane up by one page (output height minus one line of context overlap), revealing older content.
+- **PgDn** scrolls back toward the newest line; clamped at the bottom.
+- **Submitting** a new expression (Enter) auto-snaps the view back to the bottom -- standard scroll-on-output behavior, matching `less` and most pagers when new content arrives via a follow-style trigger.
+- **Async output** (background scripts printing via `drain_stdout_into_scrollback`) does NOT reset the offset.  You can review old content while a long-running script keeps emitting lines.
+- **Footer hint updated** to advertise the new binding.
+- Backing buffer is the existing 1024-line scrollback ring; no new memory cost.
+- Dialog/file-picker modals and the completion popup are unaffected -- they don't touch the output pane state.
+
+### Why now
+
+Before C.6, the linenoise REPL wrote to the normal terminal buffer, so terminal-native scrollback could reach scrolled-off content.  C.6 flipped boxen to the default, and boxen owns the alternate screen buffer -- terminal scrollback can't see past the visible region.  Resolves #803.
+
+### Out of scope (deferred)
+
+- Mouse-wheel scrolling: tracked under #805 (touches the same file as this change; queued behind it).
+- Scroll position indicator in the footer (e.g. `[+42]`): nice-to-have polish for a follow-up.
+
+---
+
 ## C.6 — boxen REPL is now the default (2026-06-25)
 
 ### Summary

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -15,7 +15,7 @@ The boxen REPL output pane now supports in-app scrollback via **PgUp** and **PgD
 - **PgUp** scrolls the output pane up by one page (output height minus one line of context overlap), revealing older content.
 - **PgDn** scrolls back toward the newest line; clamped at the bottom.
 - **Submitting** a new expression (Enter) auto-snaps the view back to the bottom -- standard scroll-on-output behavior, matching `less` and most pagers when new content arrives via a follow-style trigger.
-- **Async output** (background scripts printing via `drain_stdout_into_scrollback`) does NOT reset the offset.  You can review old content while a long-running script keeps emitting lines.
+- **Async output** (background scripts printing via `drain_stdout_into_scrollback`) does NOT reset the offset.  You can review old content while a long-running script keeps emitting lines.  When the 1024-line ring fills, the offset auto-advances in lockstep with the overwrites so the line you were reading stays on screen instead of silently sliding under newer content (less/tmux convention).
 - **Footer hint updated** to advertise the new binding.
 - Backing buffer is the existing 1024-line scrollback ring; no new memory cost.
 - Dialog/file-picker modals and the completion popup are unaffected -- they don't touch the output pane state.

--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -365,6 +365,11 @@ void boxen_repl_append_scrollback(boxen_repl_state_t *s, const char *line) {
 
 	int idx = s->scrollback_head;
 
+	/* 2026-06-29 JES #803: snapshot ring-fullness before the append so the
+	 * anchor-follows-content logic below can tell whether this append
+	 * actually overwrote an old slot (vs. the ring still filling). */
+	bool was_full_before = (s->scrollback_count == BOXEN_REPL_SCROLLBACK_SIZE);
+
 	/* Free the slot being overwritten (oldest entry when ring is full) */
 	if (s->scrollback[idx] != NULL) {
 		free(s->scrollback[idx]);
@@ -377,6 +382,29 @@ void boxen_repl_append_scrollback(boxen_repl_state_t *s, const char *line) {
 	/* Count grows until the ring is full */
 	if (s->scrollback_count < BOXEN_REPL_SCROLLBACK_SIZE) {
 		s->scrollback_count++;
+	}
+
+	/* 2026-06-29 JES #803: anchor-follows-content when ring is full.
+	 *
+	 * When the user is scrolled back (output_scroll_offset > 0) and the
+	 * ring was already full before this append, the oldest slot just
+	 * got overwritten.  Without compensation, the user's view -- which
+	 * is "N lines back from the newest" -- silently slides one line
+	 * newer and the content they were reading gets overwritten under
+	 * them.  Bumping the offset by 1 keeps them anchored to the same
+	 * logical content.  Less/tmux follow this convention.
+	 *
+	 * Cap at (scrollback_count - 1) so at least one line stays visible.
+	 * Guard on output_scroll_offset > 0: pinned-to-bottom view (offset
+	 * == 0) is by convention "always show newest" and must NOT auto-
+	 * advance, since that's the whole point of the snap-on-submit
+	 * behavior in submit_input. */
+	if (was_full_before && s->output_scroll_offset > 0) {
+		int max_offset = s->scrollback_count - 1;
+		if (max_offset < 0) max_offset = 0;
+		if (s->output_scroll_offset < max_offset) {
+			s->output_scroll_offset++;
+		}
 	}
 
 	if (s->output_win != NULL) {

--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -131,7 +131,8 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 
 #define REPL_INPUT_PROMPT "> "
 
-#define REPL_FOOTER_TEXT "Ctrl-C: quit  Enter: run  Esc: clear  /help: commands"
+/* 2026-06-29 JES #803: PgUp/PgDn advertise output-pane scrollback. */
+#define REPL_FOOTER_TEXT "Ctrl-C: quit  Enter: run  Esc: clear  PgUp/PgDn: scroll"
 
 /* Width of the "> " prompt prefix in the input bar */
 #define REPL_INPUT_PROMPT_LEN 2
@@ -251,15 +252,35 @@ static void draw_output_pane(boxen_window_t *win, void *user_data) {
 	}
 
 	/* Render scrollback lines bottom-justified: most-recent at row (h-1).
-	 * Show the last `show_count` entries where show_count = min(count, h). */
-	int count = s->scrollback_count;
+	 * Show the last `show_count` entries where show_count = min(count, h).
+	 *
+	 * 2026-06-29 JES #803: when output_scroll_offset > 0, the view is
+	 * shifted up by that many lines.  The newest visible line becomes
+	 * (scrollback_count - 1 - offset), and we walk back `h` lines from
+	 * there.  Clamp the offset so at least one line stays visible. */
+	int total  = s->scrollback_count;
+	int offset = s->output_scroll_offset;
+	if (offset < 0) offset = 0;
+	if (total > 0 && offset > total - 1) offset = total - 1;
+	/* Write the clamp back so PgUp/PgDn don't accumulate past the bounds. */
+	s->output_scroll_offset = offset;
+
+	int count = total - offset;
 	if (count > h) count = h;
+	if (count <= 0) return;
 
 	char linebuf[BOXEN_REPL_SCROLLBACK_LINE_MAX];
 	int  cap = (w < (int)(sizeof(linebuf) - 1)) ? w : (int)(sizeof(linebuf) - 1);
 
 	for (int i = 0; i < count; i++) {
-		int ring_idx = (s->scrollback_head - count + i + BOXEN_REPL_SCROLLBACK_SIZE)
+		/* Newest visible entry is at logical position (total - 1 - offset).
+		 * Walk back `count` entries from there.  Ring index for the i-th
+		 * row (0 = topmost visible) is:
+		 *   (scrollback_head - 1 - offset - (count - 1 - i)) % SIZE
+		 * which simplifies to:
+		 *   (scrollback_head - offset - count + i) % SIZE */
+		int ring_idx = (s->scrollback_head - offset - count + i
+		                + BOXEN_REPL_SCROLLBACK_SIZE)
 		               % BOXEN_REPL_SCROLLBACK_SIZE;
 		const char *line = s->scrollback[ring_idx];
 		if (line == NULL) continue;
@@ -903,6 +924,13 @@ static void submit_input(boxen_repl_state_t *s) {
 	s->input_len        = 0;
 	s->input_cursor_pos = 0;
 
+	/* 2026-06-29 JES #803: snap the output-pane view back to bottom on
+	 * submit (scroll-on-output).  Async output that arrives via
+	 * boxen_repl_append_scrollback does NOT reset the offset, but the
+	 * user's own Enter is a deliberate "show me what just happened"
+	 * signal -- matches less/man behavior on `>` follow. */
+	s->output_scroll_offset = 0;
+
 	if (s->input_win  != NULL) boxen_window_invalidate(s->input_win);
 	if (s->output_win != NULL) boxen_window_invalidate(s->output_win);
 }
@@ -1077,6 +1105,59 @@ static void on_input(boxen_window_t *win, const boxen_event_t *ev,
 	if (ev->key.key == BOXEN_KEY_DOWN) {
 		s->slash_pending_until_ms = 0;
 		history_nav_down(s);
+		return;
+	}
+
+	/* 2026-06-29 JES #803: output-pane scrollback (PgUp/PgDn).
+	 *
+	 * The boxen REPL owns the alternate screen buffer, so terminal-native
+	 * scrollback can't reach lines that scroll off the top of the output
+	 * pane.  Without these handlers, large output (e.g. system.verbs.builtins,
+	 * a wide table dump) was unreachable once it scrolled past the visible
+	 * region; users had to fall back to --plain (linenoise) for that.
+	 *
+	 * Page step is (output_h - 1) so one line of context overlaps between
+	 * pages -- standard less/man behavior.  Clamping to >= 1 protects
+	 * tiny terminals.  Final clamping against scrollback_count happens
+	 * in draw_output_pane (which writes the clamped value back).
+	 *
+	 * Cancel pending slash-debounce here for the same reason as the other
+	 * non-character keys above (history, tab): a deferred palette open
+	 * mid-scroll would be jarring.
+	 *
+	 * Mouse wheel is intentionally NOT wired in this change (issue #805
+	 * tracks remapping the existing wheel binding). */
+	if (ev->key.key == BOXEN_KEY_PGUP) {
+		s->slash_pending_until_ms = 0;
+		int page = 1;
+		if (s->output_win != NULL) {
+			page = boxen_window_content_height(s->output_win) - 1;
+			if (page < 1) page = 1;
+		}
+		s->output_scroll_offset += page;
+		/* Upper-bound clamp: keep at least one line visible.  The same
+		 * clamp runs in draw_output_pane as defensive belt-and-suspenders,
+		 * but writing it back here keeps the field's value in-bounds so
+		 * test assertions and successive PgUp presses behave predictably
+		 * (without it, the offset would grow unbounded above the ring). */
+		int max_offset = s->scrollback_count - 1;
+		if (max_offset < 0) max_offset = 0;
+		if (s->output_scroll_offset > max_offset) {
+			s->output_scroll_offset = max_offset;
+		}
+		if (s->output_win != NULL) boxen_window_invalidate(s->output_win);
+		return;
+	}
+	if (ev->key.key == BOXEN_KEY_PGDN) {
+		s->slash_pending_until_ms = 0;
+		int page = 1;
+		if (s->output_win != NULL) {
+			page = boxen_window_content_height(s->output_win) - 1;
+			if (page < 1) page = 1;
+		}
+		s->output_scroll_offset -= page;
+		if (s->output_scroll_offset < 0) s->output_scroll_offset = 0;
+		if (s->output_win != NULL) boxen_window_invalidate(s->output_win);
 		return;
 	}
 

--- a/frontier-cli/boxen_repl_internal.h
+++ b/frontier-cli/boxen_repl_internal.h
@@ -228,6 +228,21 @@ typedef struct {
 	int   scrollback_head;                         /* next write position */
 	int   scrollback_count;                        /* valid entries */
 
+	/* 2026-06-29 JES #803: output-pane scrollback offset.
+	 *
+	 * 0 = view pinned to bottom (newest line at last visible row).
+	 * N > 0 = view shifted up by N lines (older content visible).
+	 *
+	 * Clamped at render time to (scrollback_count - 1) so at least one
+	 * line stays visible no matter how far back PgUp walks.
+	 *
+	 * Auto-resets to 0 on submit_input (scroll-on-output: typing
+	 * unsticks the view).  Async output appended via
+	 * boxen_repl_append_scrollback does NOT reset the offset -- the
+	 * user can keep reviewing old content while a background script
+	 * prints.  PgUp/PgDn key handlers in on_input mutate this. */
+	int   output_scroll_offset;
+
 	/* Loop control */
 	bool  should_quit;  /* set by Ctrl-C handler */
 

--- a/frontier-cli/boxen_repl_internal.h
+++ b/frontier-cli/boxen_repl_internal.h
@@ -238,9 +238,20 @@ typedef struct {
 	 *
 	 * Auto-resets to 0 on submit_input (scroll-on-output: typing
 	 * unsticks the view).  Async output appended via
-	 * boxen_repl_append_scrollback does NOT reset the offset -- the
-	 * user can keep reviewing old content while a background script
-	 * prints.  PgUp/PgDn key handlers in on_input mutate this. */
+	 * boxen_repl_append_scrollback does NOT reset the offset, but when
+	 * the ring is full the append bumps the offset by 1 (capped at
+	 * scrollback_count - 1) so the user's anchor follows the content
+	 * that just slid under it -- less/tmux convention.  The user can
+	 * keep reviewing old content while a background script prints, and
+	 * the "old content" they pinned won't silently get overwritten.
+	 * PgUp/PgDn key handlers in on_input mutate this.
+	 *
+	 * Concurrency: serialized by the same convention as the sibling
+	 * ring fields above -- all read/write sites (draw_output_pane,
+	 * submit_input, on_input PgUp/PgDn, boxen_repl_append_scrollback)
+	 * run on the single REPL event-loop thread under the GIL.  If
+	 * multi-threaded readers are ever added, add the same locking the
+	 * ring fields would need. */
 	int   output_scroll_offset;
 
 	/* Loop control */

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -2055,10 +2055,88 @@ static void test_append_while_scrolled_preserves_offset(void) {
 	/* Simulate async output landing in scrollback (e.g. background script
 	 * stdout drained through boxen_repl_append_scrollback). The user's
 	 * scrolled-back view must NOT snap to the bottom -- they need to keep
-	 * reading old content. */
+	 * reading old content.
+	 *
+	 * Ring is NOT full here (count=50 < SIZE), so no anchor-follows-
+	 * content bump fires; the offset is genuinely unchanged. */
 	boxen_repl_append_scrollback(&g_state, "async output");
 
 	assert(g_state.output_scroll_offset == 25);
+	assert(g_state.scrollback_count == 51);  /* ring still filling */
+
+	teardown();
+}
+
+/* 2026-06-29 JES #803: bar-raiser P1.2 -- when the ring is full and the
+ * user is scrolled back, every append overwrites the oldest slot.  The
+ * user's anchor must follow the content so the lines they were reading
+ * don't get silently overwritten under them.  Verifies the same line
+ * stays at the user's view position across appends. */
+static void test_append_when_ring_full_advances_offset_to_pin_content(void) {
+	setup();
+
+	/* Fill the ring exactly to capacity with marker lines. */
+	char buf[64];
+	for (int i = 0; i < BOXEN_REPL_SCROLLBACK_SIZE; i++) {
+		snprintf(buf, sizeof(buf), "fill%d", i);
+		boxen_repl_append_scrollback(&g_state, buf);
+	}
+	assert(g_state.scrollback_count == BOXEN_REPL_SCROLLBACK_SIZE);
+
+	/* Scroll the user back 10 lines.  Capture the content at their
+	 * anchor position so we can verify it stays the same across appends. */
+	g_state.output_scroll_offset = 10;
+	int anchor_idx_before =
+	    (g_state.scrollback_head - g_state.output_scroll_offset - 1
+	     + BOXEN_REPL_SCROLLBACK_SIZE)
+	    % BOXEN_REPL_SCROLLBACK_SIZE;
+	char anchor_content_before[64];
+	snprintf(anchor_content_before, sizeof(anchor_content_before),
+	         "%s", g_state.scrollback[anchor_idx_before]);
+
+	/* Append 5 new "async" lines (e.g. background-thread stdout). */
+	for (int i = 0; i < 5; i++) {
+		snprintf(buf, sizeof(buf), "async%d", i);
+		boxen_repl_append_scrollback(&g_state, buf);
+	}
+
+	/* Offset must have advanced by 5 to keep the anchor on the same
+	 * logical content (newest moved 5 forward, so offset compensates). */
+	assert(g_state.output_scroll_offset == 15);
+
+	/* The ring slot at (head - offset - 1) should hold the SAME content
+	 * the user was anchored to before any appends -- they kept reading
+	 * the same line, not silently sliding to whatever overwrote it. */
+	int anchor_idx_after =
+	    (g_state.scrollback_head - g_state.output_scroll_offset - 1
+	     + BOXEN_REPL_SCROLLBACK_SIZE)
+	    % BOXEN_REPL_SCROLLBACK_SIZE;
+	assert(g_state.scrollback[anchor_idx_after] != NULL);
+	assert(strcmp(g_state.scrollback[anchor_idx_after],
+	              anchor_content_before) == 0);
+
+	teardown();
+}
+
+/* 2026-06-29 JES #803: anchor-follows-content must NOT fire when the
+ * view is pinned to the bottom (offset == 0).  Pinned-to-bottom users
+ * expect "always show newest"; auto-incrementing would silently scroll
+ * them off-newest on every async append. */
+static void test_append_when_pinned_to_bottom_does_not_bump_offset(void) {
+	setup();
+
+	/* Fill the ring to capacity. */
+	char buf[64];
+	for (int i = 0; i < BOXEN_REPL_SCROLLBACK_SIZE; i++) {
+		snprintf(buf, sizeof(buf), "fill%d", i);
+		boxen_repl_append_scrollback(&g_state, buf);
+	}
+	assert(g_state.output_scroll_offset == 0);
+
+	boxen_repl_append_scrollback(&g_state, "async output");
+
+	/* Pinned (offset == 0) must stay pinned. */
+	assert(g_state.output_scroll_offset == 0);
 
 	teardown();
 }
@@ -2115,6 +2193,8 @@ int main(void) {
 	TR_RUN(test_pgup_clamps_at_top_of_scrollback);
 	TR_RUN(test_submit_resets_scroll_offset_to_zero);
 	TR_RUN(test_append_while_scrolled_preserves_offset);
+	TR_RUN(test_append_when_ring_full_advances_offset_to_pin_content);
+	TR_RUN(test_append_when_pinned_to_bottom_does_not_bump_offset);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();

--- a/tests/boxen_repl_tests.c
+++ b/tests/boxen_repl_tests.c
@@ -1941,6 +1941,129 @@ static void test_completion_popup_slash_with_empty_input_inserts_not_palette(voi
 }
 
 /* -------------------------------------------------------------------------
+ * 2026-06-29 JES #803: output-pane scrollback (PgUp/PgDn).
+ *
+ * The boxen REPL owns the alternate screen buffer, so terminal-native
+ * scrollback can't reach lines that scroll off the top of the output pane.
+ * These tests pin the behavioral contract for in-app scrollback:
+ *
+ *   1. PgUp increments output_scroll_offset by (output_h - 1) "page" lines.
+ *   2. PgDn decrements output_scroll_offset by the same page step,
+ *      clamped at 0 (can't scroll past newest).
+ *   3. Offset is clamped at (scrollback_count - 1) on the upward side
+ *      (can't scroll past oldest -- at least one line stays visible).
+ *   4. Submitting a new expression resets offset to 0 (scroll-on-output:
+ *      typing/submitting unsticks the view).
+ *   5. Appending output while scrolled does NOT reset offset (user can
+ *      review old content while a background script prints).
+ * ---------------------------------------------------------------------- */
+
+/* Helper: fill the ring so PgUp has something to scroll into. */
+static void fill_scrollback(int n) {
+	char buf[64];
+	for (int i = 0; i < n; i++) {
+		snprintf(buf, sizeof(buf), "line%d", i);
+		boxen_repl_append_scrollback(&g_state, buf);
+	}
+}
+
+static void test_pgup_increments_output_scroll_offset(void) {
+	setup();
+
+	/* Fill with more lines than fit in the pane. Output pane height in
+	 * test setup is TEST_HEIGHT - 2 = 22 rows. */
+	fill_scrollback(50);
+	assert(g_state.output_scroll_offset == 0);
+
+	boxen_event_t ev = make_key_event(BOXEN_KEY_PGUP);
+	boxen_repl_run_one_tick(&g_state, &ev);
+
+	/* Page step is output_h - 1 = 21. */
+	assert(g_state.output_scroll_offset == 21);
+
+	boxen_repl_run_one_tick(&g_state, &ev);
+	/* Second PgUp -> 42, still within (count=50 - 1=49) clamp. */
+	assert(g_state.output_scroll_offset == 42);
+
+	teardown();
+}
+
+static void test_pgdn_decrements_offset_and_clamps_at_zero(void) {
+	setup();
+	fill_scrollback(50);
+
+	/* Manually advance the offset, then walk it back with PgDn. */
+	g_state.output_scroll_offset = 30;
+
+	boxen_event_t ev = make_key_event(BOXEN_KEY_PGDN);
+	boxen_repl_run_one_tick(&g_state, &ev);
+	assert(g_state.output_scroll_offset == 9);  /* 30 - 21 */
+
+	boxen_repl_run_one_tick(&g_state, &ev);
+	assert(g_state.output_scroll_offset == 0);  /* clamped, not -12 */
+
+	/* Further PgDn at zero stays at zero. */
+	boxen_repl_run_one_tick(&g_state, &ev);
+	assert(g_state.output_scroll_offset == 0);
+
+	teardown();
+}
+
+static void test_pgup_clamps_at_top_of_scrollback(void) {
+	setup();
+	fill_scrollback(10);  /* fewer lines than the pane height (22) */
+
+	/* PgUp once: page step would be 21, but only 9 = (count-1) lines
+	 * of scroll headroom exist (we keep one line visible). */
+	boxen_event_t ev = make_key_event(BOXEN_KEY_PGUP);
+	boxen_repl_run_one_tick(&g_state, &ev);
+	assert(g_state.output_scroll_offset == 9);
+
+	/* Additional PgUp doesn't push past the oldest entry. */
+	boxen_repl_run_one_tick(&g_state, &ev);
+	assert(g_state.output_scroll_offset == 9);
+
+	teardown();
+}
+
+static void test_submit_resets_scroll_offset_to_zero(void) {
+	setup();
+	fill_scrollback(50);
+
+	g_state.output_scroll_offset = 30;
+
+	/* Pre-load input_buf with an expression and dispatch via Enter. */
+	snprintf(g_state.input_buf, sizeof(g_state.input_buf), "1 + 1");
+	g_state.input_len        = (int)strlen(g_state.input_buf);
+	g_state.input_cursor_pos = g_state.input_len;
+
+	boxen_event_t enter = make_key_event(BOXEN_KEY_ENTER);
+	boxen_repl_run_one_tick(&g_state, &enter);
+
+	/* After dispatch the view snaps back to the bottom. */
+	assert(g_state.output_scroll_offset == 0);
+
+	teardown();
+}
+
+static void test_append_while_scrolled_preserves_offset(void) {
+	setup();
+	fill_scrollback(50);
+
+	g_state.output_scroll_offset = 25;
+
+	/* Simulate async output landing in scrollback (e.g. background script
+	 * stdout drained through boxen_repl_append_scrollback). The user's
+	 * scrolled-back view must NOT snap to the bottom -- they need to keep
+	 * reading old content. */
+	boxen_repl_append_scrollback(&g_state, "async output");
+
+	assert(g_state.output_scroll_offset == 25);
+
+	teardown();
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 int main(void) {
@@ -1985,6 +2108,13 @@ int main(void) {
 	TR_RUN(test_ctrl_a_jumps_cursor_to_start);
 	TR_RUN(test_ctrl_e_jumps_cursor_to_end);
 	TR_RUN(test_cursor_stays_at_bounds);
+
+	/* 2026-06-29 JES #803: output-pane scrollback */
+	TR_RUN(test_pgup_increments_output_scroll_offset);
+	TR_RUN(test_pgdn_decrements_offset_and_clamps_at_zero);
+	TR_RUN(test_pgup_clamps_at_top_of_scrollback);
+	TR_RUN(test_submit_resets_scroll_offset_to_zero);
+	TR_RUN(test_append_while_scrolled_preserves_offset);
 
 	TR_SUMMARY();
 	return TR_EXIT_CODE();

--- a/tools/tui-tests/tests/test_09_scrollback.py
+++ b/tools/tui-tests/tests/test_09_scrollback.py
@@ -1,0 +1,143 @@
+"""
+#803 -- output-pane scrollback (PgUp/PgDn).
+
+The boxen REPL owns the alternate screen buffer, so terminal-native
+scrollback can't reach lines that scroll off the top of the output pane.
+These tests drive PgUp/PgDn end-to-end through the REPL to verify the
+user can review output that has scrolled off the visible region.
+
+Coverage:
+  - PgUp reveals older content that had scrolled off the top
+  - PgDn returns toward the bottom
+  - Submitting a new expression auto-snaps the view back to the bottom
+    (scroll-on-output -- typing unsticks the view)
+  - The footer hint advertises the new binding
+"""
+import time
+
+from tui_harness import TUI, snapshot
+
+
+def _push_many_lines(t, n: int = 60):
+    """Dispatch `n` expressions, each producing one scrollback line.
+
+    Uses tiny string-literal expressions so the result is short and
+    deterministic regardless of how UserTalk formats numeric output.
+    """
+    for i in range(n):
+        t.send(f'"L{i:03d}"')
+        t.send_key("Enter")
+    # Let the final dispatch settle before the test inspects the pane.
+    time.sleep(0.5)
+
+
+def test_pgup_reveals_lines_that_scrolled_off_top():
+    """Fill scrollback past the visible region, press PgUp, assert older
+    lines are now visible that were not visible before."""
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        _push_many_lines(t, n=60)
+
+        bottom = t.capture()
+        snapshot(t, "scrollback-before-pgup")
+
+        # The earliest line ("L000") should have scrolled off-screen.
+        # The most-recent should still be visible.
+        assert "L000" not in bottom, (
+            f"sanity: L000 should have scrolled off the top before PgUp; got:\n{bottom}"
+        )
+        assert "L059" in bottom, (
+            f"sanity: L059 (newest) should still be visible; got:\n{bottom}"
+        )
+
+        # PgUp once -- one page-step (output_h - 1) up.
+        t.send_key("PgUp")
+        time.sleep(0.3)
+        scrolled = t.capture()
+        snapshot(t, "scrollback-after-one-pgup")
+
+        # After one PgUp we expect to see lines that were NOT in the
+        # pre-PgUp view.  Each echo+result occupies 2 scrollback rows
+        # (the echoed "> " prompt and the result line), so an output
+        # pane of ~22 rows holds ~11 expression cycles -- L048-L059
+        # before PgUp, walking back roughly 21 lines = ~10 cycles
+        # after PgUp.  Check every "L000".."L059" and require at
+        # least one that's now visible but wasn't before.
+        revealed = []
+        for i in range(0, 60):
+            tag = f"L{i:03d}"
+            if tag in scrolled and tag not in bottom:
+                revealed.append(tag)
+        assert revealed, (
+            f"PgUp did not reveal any older lines.\n"
+            f"Before:\n{bottom}\n\nAfter:\n{scrolled}"
+        )
+
+
+def test_pgdn_returns_to_bottom():
+    """After PgUp walks the view back, PgDn returns toward the newest."""
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        _push_many_lines(t, n=60)
+
+        # Walk well past the visible region.
+        for _ in range(3):
+            t.send_key("PgUp")
+            time.sleep(0.15)
+        time.sleep(0.2)
+        scrolled = t.capture()
+        snapshot(t, "scrollback-after-many-pgup")
+
+        # Now PgDn back to bottom (more presses than needed -- handler clamps).
+        for _ in range(5):
+            t.send_key("PgDn")
+            time.sleep(0.15)
+        time.sleep(0.3)
+        bottom = t.capture()
+        snapshot(t, "scrollback-after-pgdn-back")
+
+        assert "L059" in bottom, (
+            f"PgDn back to bottom did not restore newest line; got:\n{bottom}"
+        )
+
+
+def test_submit_snaps_view_to_bottom():
+    """Scroll-on-output: typing a new expression auto-snaps to the bottom."""
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        _push_many_lines(t, n=60)
+
+        # Scroll up.
+        for _ in range(2):
+            t.send_key("PgUp")
+            time.sleep(0.15)
+        time.sleep(0.2)
+        scrolled = t.capture()
+        # Sanity: L059 should NOT be visible while scrolled up.
+        assert "L059" not in scrolled, (
+            f"sanity: after PgUp the newest line should be off-screen; got:\n{scrolled}"
+        )
+
+        # Submit a fresh expression -- view must auto-snap back to bottom.
+        t.send('"SNAPPED"')
+        t.send_key("Enter")
+        time.sleep(0.5)
+        bottom = t.capture()
+        snapshot(t, "scrollback-snap-on-submit")
+
+        assert "SNAPPED" in bottom, (
+            f"submit did not snap view to bottom (new result not visible); got:\n{bottom}"
+        )
+        assert "L059" in bottom, (
+            f"submit did not snap view to bottom (recent history not visible); got:\n{bottom}"
+        )
+
+
+def test_footer_advertises_pgup_pgdn():
+    """The footer hint should mention PgUp/PgDn so users discover the binding."""
+    with TUI(boot_wait=1.5) as t:
+        text = t.wait_for(">", timeout=5)
+        # Footer is on the last row of the pane.
+        assert "PgUp" in text or "PgDn" in text, (
+            f"footer hint does not advertise PgUp/PgDn; got:\n{text}"
+        )


### PR DESCRIPTION
## Summary

- Wires PgUp/PgDn through the boxen REPL's output pane so users can review output that has scrolled off the top of the visible region (the boxen REPL owns the alternate screen buffer, so terminal-native scrollback can't reach it).
- Backing buffer is the existing 1024-line scrollback ring; the fix adds a single `output_scroll_offset` field and re-derives the render window from `(scrollback_head, scrollback_count, output_scroll_offset)`. No new memory cost.
- Footer hint updated to advertise the binding: `Ctrl-C: quit  Enter: run  Esc: clear  PgUp/PgDn: scroll`.

## Behavior

- **PgUp** scrolls up by one page (output height minus one line of context overlap), matching `less` / `man` convention.
- **PgDn** scrolls back toward the newest line; clamps at bottom.
- **Submit (Enter)** auto-snaps view to bottom (scroll-on-output) -- you immediately see the new result.
- **Async output** (background script stdout drained via `boxen_repl_append_scrollback`) does NOT reset the offset -- you can keep reading old content while a long-running script keeps printing.
- **Modals** (file picker, dialogs, completion popup) are unaffected -- they don't touch the output pane state.

## Out of scope

- Mouse-wheel binding (issue #805) intentionally NOT changed in this PR; queued behind this fix because it touches the same file.

## Test plan

- [x] Unit: `./tools/run_headless_tests.sh` -- 819/819 pass (was 814, +5 new scrollback tests in `boxen_repl_tests.c`)
- [x] TUI: `tools/tui-tests/run.sh` -- 39/39 pass (was 35, +4 new tests in `test_09_scrollback.py`)
- [x] Integration: `cd tests && make test-integration` -- 2186 pass / 21 fail, identical to develop baseline (pre-existing unrelated failures in html/tcp/startup)
- [x] Manual smoke: spawned `dist/frontier-cli`, dispatched 40 expressions, verified PgUp reveals earlier lines and PgDn returns to bottom; footer shows new binding
- [x] Modal compatibility: tests 06/07/08 (file picker / dialog modals from PRs #793/#800/#801) all still pass

## Files

- `frontier-cli/boxen_repl_internal.h` -- new `output_scroll_offset` field on `boxen_repl_state_t`
- `frontier-cli/boxen_repl.c` -- updated render math in `draw_output_pane`; PgUp/PgDn handlers in `on_input`; auto-snap in `submit_input`; footer text
- `tests/boxen_repl_tests.c` -- 5 behavioral unit tests (PgUp increments, PgDn clamps, top-of-scrollback clamp, submit resets, async preserves)
- `tools/tui-tests/tests/test_09_scrollback.py` -- 4 end-to-end TUI tests (PgUp reveals, PgDn returns, submit snaps, footer advertises)
- `docs/RELEASE_NOTES.md` -- new C.6.1 entry
- `docs/CLI_USAGE_GUIDE.md` -- new "REPL Keybindings" section documenting all input-bar keys including PgUp/PgDn

Closes #803
