### PR TITLE
fix(repl): #804 -- boxen REPL swallowed slash-command error output

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,6 +4,24 @@ Most-recent first.  Each entry summarizes user-visible changes for the release.
 
 ---
 
+## C.6.2 — boxen REPL: visible errors for slash commands (2026-06-29)
+
+### Summary
+
+Fixes a silent-failure class in the boxen REPL: slash-command error messages (e.g. `/list builtins` when `builtins` is not a valid path) now appear in the scrollback, matching the behavior of the linenoise (`--plain`) REPL.
+
+### What changed
+
+- `/list <bad-path>` now prints `Error: '<path>' is not a valid table path (...)` in the boxen scrollback. Previously the line returned a fresh prompt with no output and no error (#804).
+- The same fix restores visibility for any other slash-command code path whose diagnostic was written via `fputs(stdout)` without an explicit `fflush(stdout)`.
+- Linenoise (`--plain`) behavior is unchanged.
+
+### Why it was silent
+
+When the boxen REPL captures `stdout`/`stderr` into its scrollback pipe, libc switches those streams from line-buffered (tty default) to block-buffered (pipe default). Any diagnostic that wrote a newline-terminated message via `fputs` without an explicit `fflush` sat in the libc buffer and never reached the scrollback drain. The fix forces line-buffering on the captured streams via `setvbuf(_, NULL, _IOLBF, 0)` immediately after the pipe redirect, so newline-terminated writes flush automatically — eliminating the entire class of missing-`fflush` silent-failure bugs.
+
+---
+
 ## C.6.1 — boxen REPL output-pane scrollback (2026-06-29)
 
 ### Summary

--- a/frontier-cli/boxen_repl.c
+++ b/frontier-cli/boxen_repl.c
@@ -1971,6 +1971,27 @@ int boxen_repl_main(const cli_options_t *opts) {
 				} else {
 					close(pipefd[1]);  /* write end is now duplicated into stdout/stderr */
 
+					/* 2026-06-29 JES #804: force stdout/stderr to line-buffered
+					 * after pipe redirect.  By default libc switches a FILE* to
+					 * block-buffered when its underlying fd is not a tty (which
+					 * the pipe is not), so any code that writes a newline-
+					 * terminated diagnostic via fputs/printf without an explicit
+					 * fflush(stdout) sits in the libc buffer and never reaches
+					 * drain_stdout_into_scrollback.  That swallowed the visible
+					 * error for `/list builtins` (and any other slash-command
+					 * error path that omitted fflush -- a whole class of
+					 * silent-failure bugs).  Restoring line-buffering matches
+					 * the linenoise/--plain semantics where stdout is a tty and
+					 * line-buffered by default, so error messages flush on the
+					 * trailing '\n' the same way they always have.
+					 *
+					 * setvbuf may fail (e.g. allocator pressure); the comment
+					 * notes the failure mode but we still want capture to come
+					 * up.  A silent revert to block-buffering is no worse than
+					 * the prior behavior, so we don't gate capture on success. */
+					(void)setvbuf(stdout, NULL, _IOLBF, 0);
+					(void)setvbuf(stderr, NULL, _IOLBF, 0);
+
 					state->saved_stdout = saved_out;
 					state->saved_stderr = saved_err;
 					state->pipe_read_fd = pipefd[0];

--- a/tools/tui-tests/tests/test_09_slash_list_errors.py
+++ b/tools/tui-tests/tests/test_09_slash_list_errors.py
@@ -1,0 +1,73 @@
+"""
+Issue #804 -- boxen REPL: `/list builtins` (and other invalid paths) must
+produce a visible error in the scrollback, matching the linenoise
+(--plain) REPL's behavior.
+
+Before the fix, slash-dispatched commands that wrote to stdout via the
+underlying replverbhost_* path produced no visible output in the boxen
+TUI. The error message "Error: 'builtins' is not a valid table path"
+was being lost between the slash dispatcher's stdout write and the
+boxen scrollback drain.
+
+These tests assert end-to-end visible parity for /list against three
+inputs:
+  - a non-existent single-component name (`builtins` -- bug #804)
+  - a deeply non-existent dotted path
+  - a real table path that should succeed and list contents
+"""
+import time
+
+from tui_harness import TUI, snapshot
+
+
+def _send_slash_list(t, arg, label):
+    """Type `/list <arg>` + Enter, give the drain a moment, snapshot."""
+    t.send(f"/list {arg}")
+    t.send_key("Enter")
+    # Give the event loop a few ticks to drain stdout into scrollback.
+    time.sleep(0.6)
+    text = t.capture()
+    snapshot(t, label)
+    return text
+
+
+def test_slash_list_undefined_single_component_shows_error():
+    """/list builtins -- issue #804 repro. Must produce a visible error."""
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        text = _send_slash_list(t, "builtins", "list-builtins-undefined")
+        # Match the linenoise error text. Boxen and linenoise share the
+        # underlying replverbhost_list code path; both must surface the
+        # same message.
+        assert "not a valid table path" in text or "not found" in text, (
+            "issue #804: /list builtins produced no visible error in boxen "
+            f"scrollback. Expected 'not a valid table path' or 'not found'. "
+            f"Got:\n{text}"
+        )
+
+
+def test_slash_list_deep_undefined_path_shows_error():
+    """/list nonexistent.bogus.path -- dotted-path error must be visible."""
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        text = _send_slash_list(
+            t, "nonexistent.bogus.path", "list-deep-undefined"
+        )
+        assert "not a valid table path" in text or "not found" in text, (
+            "/list of a non-existent dotted path produced no visible error. "
+            f"Got:\n{text}"
+        )
+
+
+def test_slash_list_valid_table_shows_contents():
+    """/list system.verbs -- success path must also produce visible output."""
+    with TUI(boot_wait=1.5) as t:
+        t.wait_for(">", timeout=5)
+        text = _send_slash_list(t, "system.verbs", "list-system-verbs")
+        # system.verbs has well-known children -- at least one of these
+        # MUST be visible if the list output reached scrollback.
+        expected_children = ("builtins", "apps", "constants", "colors")
+        assert any(child in text for child in expected_children), (
+            "/list system.verbs produced no visible output -- table-listing "
+            f"path is also broken. Got:\n{text}"
+        )


### PR DESCRIPTION
## Summary

Fixes #804 -- the boxen REPL was silently swallowing slash-command error output. `/list builtins` (a non-existent path) returned a fresh prompt with no error and no output, while the linenoise (`--plain`) REPL printed `Error: 'builtins' is not a valid table path` as expected.

Root cause: when boxen captures stdout/stderr into its scrollback pipe via `dup2`, libc switches those streams from line-buffered (tty default) to **block-buffered** (pipe default). Any diagnostic written via `fputs(stdout)` without an explicit `fflush(stdout)` sat in the libc buffer and never reached `drain_stdout_into_scrollback`. This was a whole class of silent-failure bugs, not just `/list` -- any error path in the slash-dispatch chain that omitted `fflush` was silently swallowed.

Fix: force line-buffering on the captured streams via `setvbuf(_, NULL, _IOLBF, 0)` immediately after the pipe redirect in `boxen_repl.c`. Newline-terminated diagnostics now flush on the trailing `\n` the same way they do when stdout is a tty -- restoring full visible-error parity with `--plain` and eliminating the entire class of missing-`fflush` bugs.

This is the principled, broad fix at the boxen capture layer rather than patching individual missing `fflush` calls one by one. Tests assert end-to-end behavior so any future regression in any slash-command output path would be caught.

## Test plan

- [x] TDD: 3 new tests in `tools/tui-tests/tests/test_09_slash_list_errors.py`. 2 of 3 fail at HEAD (RED), all 3 pass after fix (GREEN).
- [x] tui-tests: **42/42 pass** (3 new + 39 existing).
- [x] Unit tests: **814/814 pass** (`./tools/run_headless_tests.sh`).
- [x] Integration tests: 21 pre-existing failures unchanged, verified by running same selectors (`tcp.readStream - zero byte count`, `html.rundirectives - multiple directives`) on clean develop -- all in html/tcp/startup, none touching REPL or boxen.
- [x] Manual smoke: `/list builtins`, `/list nonexistent.bogus.path`, `/list system.verbs` against both `--plain` and default (boxen) -- identical visible output for all three.
- [x] Build clean: `make -C frontier-cli` no warnings, no errors.

## Files changed

- `frontier-cli/boxen_repl.c` -- `setvbuf` call after `dup2` (the actual fix, 21 LOC including comment).
- `tools/tui-tests/tests/test_09_slash_list_errors.py` -- new behavioral tests using the existing tmux-based TUI harness from PR #788.
- `docs/RELEASE_NOTES.md` -- new C.6.2 entry describing the user-visible change.

Closes #804
